### PR TITLE
Correctly set _expired flag upon timeout

### DIFF
--- a/jetty-continuation/src/main/java/org/eclipse/jetty/continuation/Servlet3Continuation.java
+++ b/jetty-continuation/src/main/java/org/eclipse/jetty/continuation/Servlet3Continuation.java
@@ -77,6 +77,7 @@ public class Servlet3Continuation implements Continuation
             public void onTimeout(AsyncEvent event) throws IOException
             {
                 _initial=false;
+				_expired=false;
                 event.getAsyncContext().dispatch();
             }
         });
@@ -104,7 +105,8 @@ public class Servlet3Continuation implements Continuation
 
             public void onTimeout(AsyncEvent event) throws IOException
             {
-                _expired=true;
+				_initial=false;                
+				_expired=true;
                 listener.onTimeout(Servlet3Continuation.this);
             }
         };


### PR DESCRIPTION
The effect of this change is to set continuation.isExpired() correctly so that servlets can properly detect timeouts on Servlet3 containers.
