### PR TITLE
Modified comment on WebSocketServlet$init() method.

### DIFF
--- a/jetty-websocket/src/main/java/org/eclipse/jetty/websocket/WebSocketServlet.java
+++ b/jetty-websocket/src/main/java/org/eclipse/jetty/websocket/WebSocketServlet.java
@@ -40,10 +40,10 @@ import org.eclipse.jetty.util.log.Logger;
  * The initParameter "maxIdleTime" can be used to set the time in ms
  * that a websocket may be idle before closing.
  * <p/>
- * The initParameter "maxTextMessagesSize" can be used to set the size in characters
+ * The initParameter "maxTextMessageSize" can be used to set the size in characters
  * that a websocket may be accept before closing.
  * <p/>
- * The initParameter "maxBinaryMessagesSize" can be used to set the size in bytes
+ * The initParameter "maxBinaryMessageSize" can be used to set the size in bytes
  * that a websocket may be accept before closing.
  */
 @SuppressWarnings("serial")


### PR DESCRIPTION
- Synchronized two parameter names between JavaDoc comment and source code,
  - as maxTextMessagesSize to maxTextMessageSize because getInitParameter() gets parameter with string "maxTextMessageSize" and
  - as maxBinaryMessagesSize to maxBinaryMessageSize because getInitParameter() gets parameter with string "maxBinaryMessageSize"
