### PR TITLE
maven build does not work because of missing property npn.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <build-support-version>1.1</build-support-version>
     <slf4j-version>1.6.1</slf4j-version>
     <jetty-test-policy-version>1.2</jetty-test-policy-version>
+    <npn.version>1.1.0.v20120525</npn.version>
     <npn.api.version>1.1.0.v20120525</npn.api.version>
   </properties>
   <scm>


### PR DESCRIPTION
Hello,

I tried:

```bash
git clone http://git.eclipse.org/gitroot/jetty/org.eclipse.jetty.project.git
mvn clean package
```

and I got the following error:

```
[INFO] Scanning for projects...
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.eclipse.jetty.osgi:test-jetty-osgi:9.1.1-SNAPSHOT (/workspace/jetty/jetty-osgi/test-jetty-osgi/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for org.mortbay.jetty.npn:npn-boot:jar must be a valid version but is '${npn.version}'. @ line 303, column 16
```

after applying the commit above I was able to start building process.

Do you think it could be the correct fix for this issue?

Regards,

Eduardo.