### PR TITLE
Fix bug in GzipHandler class

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/gzip/GzipHandler.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/gzip/GzipHandler.java
@@ -262,6 +262,7 @@ public class GzipHandler extends HandlerWrapper
                 _mimeTypes.add("application/gzip");
             }
         }
+        super.doStart();
     }
 
     /* ------------------------------------------------------------ */


### PR DESCRIPTION
In Jetty 9.1.3, a doStart() method was added to the GzipHandler class. However, this method does not call super.doStart(), so the code in super.doStart() is no longer being executed. This was causing the GzipHandler to not function properly. This PR adds in the requisite call to super.doStart().
