### PR TITLE
Delete README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-jetty-fcgi
-==========
-
-Jetty FastCGI Support


### PR DESCRIPTION
It's useless and inaccurate, but GitHub automatically displays it. When it's removed, GitHub displays `README.TXT` instead.