### PR TITLE
Send 429 when rejecting request

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -331,7 +331,7 @@ public class DoSFilter implements Filter
                     LOG.warn("DOS ALERT: Request rejected ip={}, session={}, user={}", request.getRemoteAddr(), request.getRequestedSessionId(), request.getUserPrincipal());
                     if (insertHeaders)
                         response.addHeader("DoSFilter", "unavailable");
-                    response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+                    response.sendError(429, "Too Many Requests");
                     return;
                 }
                 case 0:


### PR DESCRIPTION
429 Too Many Requests seems to be more appropriate than 503 Service Unavailable