### PR TITLE
busyThreads JMX attribute

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -406,6 +406,16 @@ public class QueuedThreadPool extends AbstractLifeCycle implements SizedThreadPo
     }
 
     /**
+     * @return The number of busy threads in the pool
+     */
+    @Override
+    @ManagedAttribute("total number of busy threads in the pool")
+    public int getBusyThreads()
+    {
+        return getThreads() - getIdleThreads();
+    }
+
+    /**
      * @return True if the pool is at maxThreads and there are not more idle threads than queued jobs
      */
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
@@ -55,6 +55,13 @@ public interface ThreadPool extends Executor
     
     /* ------------------------------------------------------------ */
     /**
+     * @return The number of busy threads in the pool
+     */
+    @ManagedAttribute("number of busy threads in pool")
+    public int getBusyThreads();
+
+    /* ------------------------------------------------------------ */
+    /**
      * @return True if the pool is low on threads
      */
     @ManagedAttribute("indicates the pool is low on available threads")


### PR DESCRIPTION
There are `threads` and `idleThreads` JMX attributes. `busyThreads` = `threads` - `idleThreads` might seem redundant but it's actually quite useful when monitoring container load.

I signed CLA.
