### PR TITLE
Update MongoSessionManager.java

### DIFF
--- a/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionManager.java
+++ b/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionManager.java
@@ -268,8 +268,8 @@ public class MongoSessionManager extends NoSqlSessionManager
                         Long currentExpiry = (Long)o.get(__EXPIRY);
                         if (currentMaxIdle != null && getMaxInactiveInterval() > 0 && getMaxInactiveInterval() < currentMaxIdle)
                             sets.put(__MAX_IDLE, getMaxInactiveInterval());
-                        if (currentExpiry != null && expiry > 0 && expiry < currentExpiry)
-                            sets.put(__EXPIRY, currentExpiry);
+                        if (currentExpiry != null && expiry > 0 && expiry > currentExpiry)
+                            sets.put(__EXPIRY, expiry);
                     }
                 }
                 


### PR DESCRIPTION
This change is required to update 'expiry' attribute of the current session, every time when user is active. Otherwise 'expiry' timestamp is never changed, so session expires when (created + maxIdle) time is met.
