### PR TITLE
jetty-plus JNDI tests should use unique JNDI paths

### DIFF
--- a/jetty-plus/src/test/java/org/eclipse/jetty/plus/jndi/TestNamingEntries.java
+++ b/jetty-plus/src/test/java/org/eclipse/jetty/plus/jndi/TestNamingEntries.java
@@ -246,14 +246,14 @@ public class TestNamingEntries
     {
         ScopeA scope = new ScopeA();
         InitialContext icontext = new InitialContext();
-        Link link = new Link ("resourceA", "resourceB");
-        NamingEntry ne = NamingEntryUtil.lookupNamingEntry(null, "resourceA");
+        Link link = new Link ("linked-resourceA", "resourceB");
+        NamingEntry ne = NamingEntryUtil.lookupNamingEntry(null, "linked-resourceA");
         assertNotNull(ne);
         assertTrue(ne instanceof Link);
-        assertEquals(icontext.lookup("resourceA"), "resourceB");
+        assertEquals(icontext.lookup("linked-resourceA"), "resourceB");
 
-        link = new Link (scope, "jdbc/resourceX", "jdbc/resourceY");
-        ne = NamingEntryUtil.lookupNamingEntry(scope, "jdbc/resourceX");
+        link = new Link (scope, "jdbc/linked-resourceX", "jdbc/linked-resourceY");
+        ne = NamingEntryUtil.lookupNamingEntry(scope, "jdbc/linked-resourceX");
         assertNotNull(ne);
         assertTrue(ne instanceof Link);
     }


### PR DESCRIPTION
Fix occasional Jetty test failure. JNDI context seems to leave some state lying around so all the tests should use unique JNDI names, so they do not conflict with each-other. Unfortunately, testLink() and testResource() both use "resourceA" as a name, resulting in a
ClassCastException in case testLink() is ran before testResource() (as order of methods returned from reflection is undefined, this can happen).

Better would be to clean the JNDI context between tests but I'm unaware of any good way of doing that. Context.close() does not have much effect.

The stacktrace:

```
java.lang.ClassCastException: org.eclipse.jetty.plus.jndi.Link cannot be cast to javax.naming.Context
    at org.eclipse.jetty.jndi.NamingUtil.bind(NamingUtil.java:69)
    at org.eclipse.jetty.plus.jndi.NamingEntry.save(NamingEntry.java:187)
    at org.eclipse.jetty.plus.jndi.Resource.<init>(Resource.java:33)
    at org.eclipse.jetty.plus.jndi.TestNamingEntries.testResource(TestNamingEntries.java:185)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
