### PR TITLE
Bug 459478: Fixed performance issue in JarFileResource exist method

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2014 Mort Bay Consulting Pty. Ltd.
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0
@@ -48,7 +48,7 @@ public class URLResource extends Resource
     protected URLResource(URL url, URLConnection connection)
     {
         _url = url;
-        _urlString=_url.toExternalForm();
+        _urlString=_url.toExternalForm().replaceAll("/+|\\\\+", "/");
         _connection=connection;
     }
     


### PR DESCRIPTION
The implementation of exist resort to enumerating and name matching all entries of a jar file to determine the type and existence of an entry.
That is very inefficient, especially in the worst case when the resource does not exist and the jar file contains lots of entries.

A better approach is to use the JarFile.getJarEntry() method and the following algorithm:

1) entry = getJarEntry(path)
2) if entry == null then the entry does not exist (done)
3) else if entry.isDirectory() then the entry exists and it is a directory (done)
4) else the entry exists but we need to confirm is a file then consider
5) directory = getJarEntry(path + '/')
6) if (directory != null) then entry=directory exists and it is a directory (done)
7) else the entry exist and it is a file (done)