### PR TITLE
Allow JETTY_USER to run without `su`

### DIFF
--- a/jetty-distribution/src/main/resources/bin/jetty.sh
+++ b/jetty-distribution/src/main/resources/bin/jetty.sh
@@ -443,7 +443,7 @@ case "$ACTION" in
         exit 1
       fi
 
-      if [ -n "$JETTY_USER" ] 
+      if [ -n "$JETTY_USER" ] && [ `whoami` != "$JETTY_USER" ]
       then
         unset SU_SHELL
         if [ "$JETTY_SHELL" ]


### PR DESCRIPTION
Allow JETTY_USER to run without `su`