### PR TITLE
Print full RUN_CMD when jetty.sh -d is called

### DIFF
--- a/jetty-distribution/src/main/resources/bin/jetty.sh
+++ b/jetty-distribution/src/main/resources/bin/jetty.sh
@@ -410,7 +410,7 @@ then
   echo "JETTY_ARGS     =  ${JETTY_ARGS[*]}"
   echo "JAVA_OPTIONS   =  ${JAVA_OPTIONS[*]}"
   echo "JAVA           =  $JAVA"
-  echo "RUN_CMD        =  ${RUN_CMD}"
+  echo "RUN_CMD        =  ${RUN_CMD[*]}"
 fi
 
 ##################################################


### PR DESCRIPTION
I was trying to debug the behavior of `jetty.sh` by passing the `-d` flag and noticed that `RUN_CMD` was not being dumped correctly. This patch should fix things.