### PR TITLE
Update activity tracking of NoSqlSession to prevent decrementing of _active below 0

### DIFF
--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -43,7 +43,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>true</skipTests>
+          <skipTests>false</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/CreateInForwardedRequestTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/CreateInForwardedRequestTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.nosql.mongodb;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.nosql.NoSqlSession;
 import org.eclipse.jetty.server.session.AbstractTestServer;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -33,10 +34,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class CreateInForwardedRequestTest
@@ -44,7 +45,6 @@ public class CreateInForwardedRequestTest
     public static final String TEST_CONTEXT_PATH = "/testContext";
     public static final String TEST_FORWARD_SERVLET_PATH = "/forward";
     public static final String TEST_FORWARD_HANDLER_SERVLET_PATH = "/forwardHandler";
-    public static final String RESPONSE_BODY_VALUE = "Success From TestForwardHandlerServlet";
     private static AtomicReference<HttpSession> capturedSession = new AtomicReference<>();
 
     public AbstractTestServer createServer(int port)
@@ -60,22 +60,48 @@ public class CreateInForwardedRequestTest
         testServletContextHandler.addServlet(TestForwardServlet.class, TEST_FORWARD_SERVLET_PATH);
         testServletContextHandler.addServlet(TestForwardHandlerServlet.class, TEST_FORWARD_HANDLER_SERVLET_PATH);
 
+		AbstractTestServer testServer2 = createServer(0);
+		ServletContextHandler testServletContextHandler2 = testServer2.addContext(TEST_CONTEXT_PATH);
+		testServletContextHandler2.addServlet(TestForwardServlet.class, TEST_FORWARD_SERVLET_PATH);
+		testServletContextHandler2.addServlet(TestForwardHandlerServlet.class, TEST_FORWARD_HANDLER_SERVLET_PATH);
+
         try
         {
             testServer.start();
+			testServer2.start();
             int serverPort=testServer.getPort();
+			int serverPort2=testServer2.getPort();
             HttpClient client = new HttpClient();
             client.start();
             try
             {
-                ContentResponse response = client.GET("http://localhost:" + serverPort + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH);
+				// set the value on server 1
+				String value = "TEST_VALUE";
+                ContentResponse response = client.GET("http://localhost:" + serverPort + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH + "?action=set&value=" + value);
                 assertEquals(HttpServletResponse.SC_OK, response.getStatus());
                 String sessionCookie = response.getHeaders().get("Set-Cookie");
                 assertTrue(sessionCookie != null);
-                assertEquals(RESPONSE_BODY_VALUE, response.getContentAsString());
-                assertNotNull(capturedSession.get());
-                assertEquals(NoSqlSession.class, capturedSession.get().getClass());
-                assertEquals(0, ((NoSqlSession) capturedSession.get()).getActive());
+                assertEquals(value, response.getContentAsString().trim());
+
+
+				// use the same cookie to get the value on server 2, should be the same as server 1
+				ContentResponse response2 = client.GET("http://localhost:" + serverPort2 + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH + "?action=get");
+				assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
+				assertEquals(value, response2.getContentAsString().trim());
+
+
+				// now update the value on server 2
+				String value2 = "TEST_VALUE2";
+				ContentResponse response3 = client.GET("http://localhost:" + serverPort2 + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH + "?action=set&value=" + value2);
+				assertEquals(HttpServletResponse.SC_OK, response3.getStatus());
+				assertEquals(value2, response3.getContentAsString().trim());
+
+
+				// now get the value on server 1 should be the same as server 2
+				ContentResponse response4 = client.GET("http://localhost:" + serverPort + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH + "?action=get");
+				assertEquals(HttpServletResponse.SC_OK, response4.getStatus());
+				assertEquals(value2, response4.getContentAsString().trim());
+
             }
             finally
             {
@@ -105,11 +131,26 @@ public class CreateInForwardedRequestTest
         @Override
         protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
         {
-            HttpSession session = request.getSession();
-            capturedSession.set(session);
-            session.setAttribute("TEST_ATTRIBUTE", "TEST_ATTRIBUTE_VALUE");
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.getWriter().write(RESPONSE_BODY_VALUE);
+            HttpSession session = request.getSession(false);
+
+			String action = request.getParameter("action");
+			if ("set".equals(action))
+			{
+				if (session == null) session = request.getSession(true);
+				session.setAttribute("value", request.getParameter("value"));
+				PrintWriter writer = response.getWriter();
+				writer.println(session.getAttribute("value"));
+				writer.flush();
+			}
+			else if ("get".equals(action))
+			{
+				String value = (String) session.getAttribute("value");
+				int x = session.getMaxInactiveInterval();
+				assertTrue(x > 0);
+				PrintWriter writer = response.getWriter();
+				writer.println(value);
+				writer.flush();
+			}
         }
     }
 }

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/CreateInForwardedRequestTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/CreateInForwardedRequestTest.java
@@ -1,0 +1,115 @@
+//
+//  ========================================================================
+//  Copyright (c) 2015 Epic Games Inc.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.nosql.mongodb;
+
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.nosql.NoSqlSession;
+import org.eclipse.jetty.server.session.AbstractTestServer;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Test;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CreateInForwardedRequestTest
+{
+    public static final String TEST_CONTEXT_PATH = "/testContext";
+    public static final String TEST_FORWARD_SERVLET_PATH = "/forward";
+    public static final String TEST_FORWARD_HANDLER_SERVLET_PATH = "/forwardHandler";
+    public static final String RESPONSE_BODY_VALUE = "Success From TestForwardHandlerServlet";
+    private static AtomicReference<HttpSession> capturedSession = new AtomicReference<>();
+
+    public AbstractTestServer createServer(int port)
+    {
+        return new MongoTestServer(port);
+    }
+
+    @Test
+    public void testCreationOfSessionInForward() throws Exception
+    {
+        AbstractTestServer testServer = createServer(0);
+        ServletContextHandler testServletContextHandler = testServer.addContext(TEST_CONTEXT_PATH);
+        testServletContextHandler.addServlet(TestForwardServlet.class, TEST_FORWARD_SERVLET_PATH);
+        testServletContextHandler.addServlet(TestForwardHandlerServlet.class, TEST_FORWARD_HANDLER_SERVLET_PATH);
+
+        try
+        {
+            testServer.start();
+            int serverPort=testServer.getPort();
+            HttpClient client = new HttpClient();
+            client.start();
+            try
+            {
+                ContentResponse response = client.GET("http://localhost:" + serverPort + TEST_CONTEXT_PATH + TEST_FORWARD_SERVLET_PATH);
+                assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+                String sessionCookie = response.getHeaders().get("Set-Cookie");
+                assertTrue(sessionCookie != null);
+                assertEquals(RESPONSE_BODY_VALUE, response.getContentAsString());
+                assertNotNull(capturedSession.get());
+                assertEquals(NoSqlSession.class, capturedSession.get().getClass());
+                assertEquals(0, ((NoSqlSession) capturedSession.get()).getActive());
+            }
+            finally
+            {
+                client.stop();
+            }
+        }
+        finally
+        {
+            testServer.stop();
+        }
+    }
+
+    public static class TestForwardServlet extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            // forward to our other servlet
+            RequestDispatcher dispatcher = request.getServletContext().getContext(TEST_CONTEXT_PATH)
+                .getRequestDispatcher(TEST_FORWARD_HANDLER_SERVLET_PATH);
+            dispatcher.forward(request, response);
+        }
+    }
+
+    public static class TestForwardHandlerServlet extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            HttpSession session = request.getSession();
+            capturedSession.set(session);
+            session.setAttribute("TEST_ATTRIBUTE", "TEST_ATTRIBUTE_VALUE");
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.getWriter().write(RESPONSE_BODY_VALUE);
+        }
+    }
+}


### PR DESCRIPTION
Using grails and mongo sessions, we discovered a subtle bug, that causes a session's _active value becoming -1 if a session is created in a forwarded request. When this occurs, subsequent requests that make changes to the session will not cause the changes to be persisted, because _active never goes from 0 to 1.

This patch fixes, the issue, but adds synchronization, so it's possible that it could have a perf impact.

I couldn't find an open issue for this, let me know if you want one to be created.