### PR TITLE
Add ability to limit purge query results

### DIFF
--- a/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionIdManager.java
+++ b/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionIdManager.java
@@ -34,7 +34,6 @@ import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.session.AbstractSessionIdManager;
 import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -71,21 +70,21 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     final static DBObject __valid_true = new BasicDBObject(MongoSessionManager.__VALID,true);
 
     final static long __defaultScavengePeriod = 30 * 60 * 1000; // every 30 minutes
-
-
+   
+    
     final DBCollection _sessions;
     protected Server _server;
     private Scheduler _scheduler;
     private boolean _ownScheduler;
     private Scheduler.Task _scavengerTask;
     private Scheduler.Task _purgerTask;
+ 
 
-
-
+    
     private long _scavengePeriod = __defaultScavengePeriod;
+    
 
-
-    /**
+    /** 
      * purge process is enabled by default
      */
     private boolean _purge = true;
@@ -94,7 +93,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
      * purge process would run daily by default
      */
     private long _purgeDelay = 24 * 60 * 60 * 1000; // every day
-
+    
     /**
      * how long do you want to persist sessions that are no longer
      * valid before removing them completely
@@ -107,19 +106,18 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
      */
     private long _purgeValidAge = 7 * 24 * 60 * 60 * 1000; // default 1 week
 
-
+    
     /**
      * the collection of session ids known to this manager
      */
     protected final Set<String> _sessionsIds = new ConcurrentHashSet<>();
 
-
     /**
      * The maximum number of items to return from a purge query.
      */
-    private int __purgeLimit = 0;
-
-
+    private int _purgeLimit = 0;
+    
+    
     /**
      * Scavenger
      *
@@ -138,10 +136,10 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
                 if (_scheduler != null && _scheduler.isRunning())
                     _scavengerTask = _scheduler.schedule(this, _scavengePeriod, TimeUnit.MILLISECONDS);
             }
-        }
+        } 
     }
-
-
+    
+    
     /**
      * Purger
      *
@@ -162,9 +160,9 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
             }
         }
     }
-
-
-
+    
+    
+    
 
     /* ------------------------------------------------------------ */
     public MongoSessionIdManager(Server server) throws UnknownHostException, MongoException
@@ -176,7 +174,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     public MongoSessionIdManager(Server server, DBCollection sessions)
     {
         super(new Random());
-
+        
         _server = server;
         _sessions = sessions;
 
@@ -184,8 +182,8 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
                 BasicDBObjectBuilder.start().add("id",1).get(),
                 BasicDBObjectBuilder.start().add("unique",true).add("sparse",false).get());
         _sessions.ensureIndex(
-                BasicDBObjectBuilder.start().add("id", 1).add("version", 1).get(),
-                BasicDBObjectBuilder.start().add("unique", true).add("sparse", false).get());
+                BasicDBObjectBuilder.start().add("id",1).add("version",1).get(),
+                BasicDBObjectBuilder.start().add("unique",true).add("sparse",false).get());
 
         // index our accessed and valid fields so that purges are faster, note that the "valid" field is first
         // so that we can take advantage of index prefixes
@@ -193,51 +191,49 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         _sessions.ensureIndex(
                 BasicDBObjectBuilder.start().add(MongoSessionManager.__VALID, 1).add(MongoSessionManager.__ACCESSED, 1).get(),
                 BasicDBObjectBuilder.start().add("sparse", false).add("background", true).get());
-
     }
  
     /* ------------------------------------------------------------ */
     /**
      * Scavenge is a process that periodically checks the tracked session
-     * ids of this given instance of the session id manager to see if they
+     * ids of this given instance of the session id manager to see if they 
      * are past the point of expiration.
      */
     protected void scavenge()
     {
         long now = System.currentTimeMillis();
-        __log.debug("SessionIdManager:scavenge:at {}", now);
-
+        __log.debug("SessionIdManager:scavenge:at {}", now);        
         /*
          * run a query returning results that:
          *  - are in the known list of sessionIds
          *  - the expiry time has passed
-         *
+         *  
          *  we limit the query to return just the __ID so we are not sucking back full sessions
          */
-        BasicDBObject query = new BasicDBObject();
+        BasicDBObject query = new BasicDBObject();     
         query.put(MongoSessionManager.__ID,new BasicDBObject("$in", _sessionsIds ));
         query.put(MongoSessionManager.__EXPIRY, new BasicDBObject("$gt", 0));
         query.put(MongoSessionManager.__EXPIRY, new BasicDBObject("$lt", now));
-
-
+        
+            
         DBCursor checkSessions = _sessions.find(query, new BasicDBObject(MongoSessionManager.__ID, 1));
-
+                        
         for ( DBObject session : checkSessions )
-        {
+        {             
             __log.debug("SessionIdManager:scavenge: expiring session {}", (String)session.get(MongoSessionManager.__ID));
             expireAll((String)session.get(MongoSessionManager.__ID));
-        }
+        }      
     }
     
     /* ------------------------------------------------------------ */
     /**
      * ScavengeFully will expire all sessions. In most circumstances
      * you should never need to call this method.
-     *
+     * 
      * <b>USE WITH CAUTION</b>
      */
     protected void scavengeFully()
-    {
+    {        
         __log.debug("SessionIdManager:scavengeFully");
 
         DBCursor checkSessions = _sessions.find();
@@ -253,18 +249,18 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     /**
      * Purge is a process that cleans the mongodb cluster of old sessions that are no
      * longer valid.
-     *
+     * 
      * There are two checks being done here:
-     *
+     * 
      *  - if the accessed time is older than the current time minus the purge invalid age
      *    and it is no longer valid then remove that session
      *  - if the accessed time is older then the current time minus the purge valid age
      *    then we consider this a lost record and remove it
-     *
+     *    
      *  NOTE: if your system supports long lived sessions then the purge valid age should be
      *  set to zero so the check is skipped.
-     *
-     *  The second check was added to catch sessions that were being managed on machines
+     *  
+     *  The second check was added to catch sessions that were being managed on machines 
      *  that might have crashed without marking their sessions as 'valid=false'
      */
     protected void purge()
@@ -274,20 +270,20 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
 
         invalidQuery.put(MongoSessionManager.__VALID, false);
         invalidQuery.put(MongoSessionManager.__ACCESSED, new BasicDBObject("$lt",System.currentTimeMillis() - _purgeInvalidAge));
-
+        
         DBCursor oldSessions = _sessions.find(invalidQuery, new BasicDBObject(MongoSessionManager.__ID, 1));
 
-        if (__purgeLimit > 0)
+        if (_purgeLimit > 0)
         {
-            oldSessions.limit(__purgeLimit);
+            oldSessions.limit(_purgeLimit);
         }
 
         for (DBObject session : oldSessions)
         {
             String id = (String)session.get("id");
-
+            
             __log.debug("MongoSessionIdManager:purging invalid session {}", id);
-
+            
             _sessions.remove(session);
         }
 
@@ -300,9 +296,9 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
 
             oldSessions = _sessions.find(validQuery,new BasicDBObject(MongoSessionManager.__ID,1));
 
-            if (__purgeLimit > 0)
+            if (_purgeLimit > 0)
             {
-                oldSessions.limit(__purgeLimit);
+                oldSessions.limit(_purgeLimit);
             }
 
             for (DBObject session : oldSessions)
@@ -321,40 +317,40 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     /**
      * Purge is a process that cleans the mongodb cluster of old sessions that are no
      * longer valid.
-     *
+     * 
      */
     protected void purgeFully()
     {
         BasicDBObject invalidQuery = new BasicDBObject();
         invalidQuery.put(MongoSessionManager.__VALID, false);
-
+        
         DBCursor oldSessions = _sessions.find(invalidQuery, new BasicDBObject(MongoSessionManager.__ID, 1));
-
+        
         for (DBObject session : oldSessions)
         {
             String id = (String)session.get(MongoSessionManager.__ID);
-
+            
             __log.debug("MongoSessionIdManager:purging invalid session {}", id);
-
+            
             _sessions.remove(session);
         }
 
     }
-
-
+    
+    
     /* ------------------------------------------------------------ */
     public DBCollection getSessions()
     {
         return _sessions;
     }
-
-
+    
+    
     /* ------------------------------------------------------------ */
     public boolean isPurgeEnabled()
     {
         return _purge;
     }
-
+    
     /* ------------------------------------------------------------ */
     public void setPurge(boolean purge)
     {
@@ -363,9 +359,9 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
 
 
     /* ------------------------------------------------------------ */
-    /**
+    /** 
      * The period in seconds between scavenge checks.
-     *
+     * 
      * @param scavengePeriod
      */
     public void setScavengePeriod(long scavengePeriod)
@@ -383,10 +379,10 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         {
             throw new IllegalStateException();
         }
-
+        
         this._purgeDelay = purgeDelay;
     }
-
+ 
     /* ------------------------------------------------------------ */
     public long getPurgeInvalidAge()
     {
@@ -401,8 +397,8 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     public void setPurgeInvalidAge(long purgeValidAge)
     {
         this._purgeInvalidAge = purgeValidAge;
-    }
-
+    } 
+    
     /* ------------------------------------------------------------ */
     public long getPurgeValidAge()
     {
@@ -411,15 +407,15 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
 
     /* ------------------------------------------------------------ */
     /**
-     * sets how old a session is to be persist past the point it is
+     * sets how old a session is to be persist past the point it is 
      * considered no longer viable and should be removed
-     *
+     * 
      * NOTE: set this value to 0 to disable purging of valid sessions
      */
     public void setPurgeValidAge(long purgeValidAge)
     {
         this._purgeValidAge = purgeValidAge;
-    }
+    } 
 
     /* ------------------------------------------------------------ */
     /**
@@ -427,15 +423,14 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
      */
     public void setPurgeLimit(int purgeLimit)
     {
-        __purgeLimit = purgeLimit;
+        _purgeLimit = purgeLimit;
     }
 
     /* ------------------------------------------------------------ */
     public int getPurgeLimit()
     {
-        return __purgeLimit;
+        return _purgeLimit;
     }
-
 
     /* ------------------------------------------------------------ */
     @Override
@@ -525,7 +520,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         /*
          * optimize this query to only return the valid variable
          */
-        DBObject o = _sessions.findOne(new BasicDBObject("id",sessionId));
+        DBObject o = _sessions.findOne(new BasicDBObject("id",sessionId), __valid_true);
         
         if ( o != null )
         {                    
@@ -557,6 +552,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         __log.debug("MongoSessionIdManager:addSession {}", session.getId());
         
         _sessionsIds.add(session.getId());
+        
     }
 
     /* ------------------------------------------------------------ */
@@ -567,6 +563,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         {
             return;
         }
+        
         _sessionsIds.remove(session.getId());
     }
 
@@ -580,14 +577,14 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     public void invalidateAll(String sessionId)
     {
         _sessionsIds.remove(sessionId);
-
+            
         //tell all contexts that may have a session object with this id to
         //get rid of them
         Handler[] contexts = _server.getChildHandlersByClass(ContextHandler.class);
         for (int i=0; contexts!=null && i<contexts.length; i++)
         {
             SessionHandler sessionHandler = ((ContextHandler)contexts[i]).getChildHandlerByClass(SessionHandler.class);
-            if (sessionHandler != null)
+            if (sessionHandler != null) 
             {
                 SessionManager manager = sessionHandler.getSessionManager();
 
@@ -597,7 +594,8 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
                 }
             }
         }
-    } 
+    }      
+ 
 
     /* ------------------------------------------------------------ */
     /**
@@ -608,14 +606,15 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
     public void expireAll (String sessionId)
     {
         _sessionsIds.remove(sessionId);
-
+            
+            
         //tell all contexts that may have a session object with this id to
         //get rid of them
         Handler[] contexts = _server.getChildHandlersByClass(ContextHandler.class);
         for (int i=0; contexts!=null && i<contexts.length; i++)
         {
             SessionHandler sessionHandler = ((ContextHandler)contexts[i]).getChildHandlerByClass(SessionHandler.class);
-            if (sessionHandler != null)
+            if (sessionHandler != null) 
             {
                 SessionManager manager = sessionHandler.getSessionManager();
 
@@ -624,7 +623,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
                     ((MongoSessionManager)manager).expire(sessionId);
                 }
             }
-        }
+        }      
     }
     
     /* ------------------------------------------------------------ */
@@ -637,12 +636,12 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         _sessionsIds.remove(oldClusterId);//remove the old one from the list
         _sessionsIds.add(newClusterId); //add in the new session id to the list
 
-        //tell all contexts to update the id
+        //tell all contexts to update the id 
         Handler[] contexts = _server.getChildHandlersByClass(ContextHandler.class);
         for (int i=0; contexts!=null && i<contexts.length; i++)
         {
             SessionHandler sessionHandler = ((ContextHandler)contexts[i]).getChildHandlerByClass(SessionHandler.class);
-            if (sessionHandler != null)
+            if (sessionHandler != null) 
             {
                 SessionManager manager = sessionHandler.getSessionManager();
 
@@ -653,4 +652,5 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
             }
         }
     }
+
 }

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/PurgeInvalidSessionTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/PurgeInvalidSessionTest.java
@@ -153,8 +153,9 @@ public class PurgeInvalidSessionTest
         int port=server.getPort();
         try
         {
-            // cleanup any previous sessions so that we are starting fresh
+            // cleanup any previous sessions that are invalid so that we are starting fresh
             idManager.purgeFully();
+            int sessionCountAtTestStart = sessionManager.getSessionStoreCount();
 
             HttpClient client = new HttpClient();
             client.start();
@@ -181,12 +182,12 @@ public class PurgeInvalidSessionTest
                 Thread.sleep(purgeInvalidAge * 2);
 
                 // validate that we have the right number of sessions before we purge
-                assertEquals("Expected to find right number of sessions before purge", purgeLimit * 2, sessionManager.getSessionStoreCount());
+                assertEquals("Expected to find right number of sessions before purge", sessionCountAtTestStart + (purgeLimit * 2), sessionManager.getSessionStoreCount());
 
                 // run our purge we should still have items in the DB
                 idManager.purge();
                 assertEquals("Expected to find sessions remaining in db after purge run with limit set",
-                        purgeLimit, sessionManager.getSessionStoreCount());
+                        sessionCountAtTestStart + purgeLimit, sessionManager.getSessionStoreCount());
             }
             finally
             {

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/PurgeInvalidSessionTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/PurgeInvalidSessionTest.java
@@ -73,7 +73,7 @@ public class PurgeInvalidSessionTest
         MongoTestServer server = createServer(0, 1, 0);
         ServletContextHandler context = server.addContext(contextPath);
         context.addServlet(TestServlet.class, servletMapping);
-        
+
         MongoSessionManager sessionManager = (MongoSessionManager)context.getSessionHandler().getSessionManager();
         MongoSessionIdManager idManager = (MongoSessionIdManager)server.getServer().getSessionIdManager();
         idManager.setPurge(true);
@@ -124,8 +124,82 @@ public class PurgeInvalidSessionTest
         }
 
     }
-    
-    
+
+
+    @Test
+    public void testPurgeInvalidSessionsWithLimit() throws Exception
+    {
+        String contextPath = "";
+        String servletMapping = "/server";
+        long purgeInvalidAge = 1000; //1 sec
+        int purgeLimit = 5; // only purge 5 sessions for each purge run
+
+        //ensure scavenging is turned off so the purger gets a chance to find the session
+        MongoTestServer server = createServer(0, 1, 0);
+        ServletContextHandler context = server.addContext(contextPath);
+        context.addServlet(TestServlet.class, servletMapping);
+
+        // disable purging so we can call it manually below
+        MongoSessionManager sessionManager = (MongoSessionManager)context.getSessionHandler().getSessionManager();
+        MongoSessionIdManager idManager = (MongoSessionIdManager)server.getServer().getSessionIdManager();
+        idManager.setPurge(false);
+        idManager.setPurgeLimit(purgeLimit);
+        idManager.setPurgeInvalidAge(purgeInvalidAge);
+        // don't purge valid sessions
+        idManager.setPurgeValidAge(0);
+
+
+        server.start();
+        int port=server.getPort();
+        try
+        {
+            // cleanup any previous sessions so that we are starting fresh
+            idManager.purgeFully();
+
+            HttpClient client = new HttpClient();
+            client.start();
+            try
+            {
+                // create double the purge limit of sessions, and make them all invalid
+                for (int i = 0; i < purgeLimit * 2; i++)
+                {
+                    ContentResponse response = client.GET("http://localhost:" + port + contextPath + servletMapping + "?action=create");
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+                    String sessionCookie = response.getHeaders().get("Set-Cookie");
+                    assertTrue(sessionCookie != null);
+                    // Mangle the cookie, replacing Path with $Path, etc.
+                    sessionCookie = sessionCookie.replaceFirst("(\\W)(P|p)ath=", "$1\\$Path=");
+
+
+                    Request request = client.newRequest("http://localhost:" + port + contextPath + servletMapping + "?action=invalidate");
+                    request.header("Cookie", sessionCookie);
+                    response = request.send();
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+                }
+
+                // sleep for our invalid age period so that the purge below does something
+                Thread.sleep(purgeInvalidAge * 2);
+
+                // validate that we have the right number of sessions before we purge
+                assertEquals("Expected to find right number of sessions before purge", purgeLimit * 2, sessionManager.getSessionStoreCount());
+
+                // run our purge we should still have items in the DB
+                idManager.purge();
+                assertEquals("Expected to find sessions remaining in db after purge run with limit set",
+                        purgeLimit, sessionManager.getSessionStoreCount());
+            }
+            finally
+            {
+                client.stop();
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+
     public static class TestServlet extends HttpServlet
     {
         DBCollection _sessions;
@@ -163,6 +237,8 @@ public class PurgeInvalidSessionTest
                 dbSession = _sessions.findOne(new BasicDBObject("id", id));       
                 assertNotNull(dbSession);
                 assertTrue(dbSession.containsField(MongoSessionManager.__INVALIDATED));
+                assertTrue(dbSession.containsField(MongoSessionManager.__VALID));
+                assertTrue(dbSession.get(MongoSessionManager.__VALID).equals(false));
             }
             else if ("test".equals(action))
             {


### PR DESCRIPTION
-Add configurable limits to purge queries
-Add indexes to be used by purge queries
-Move to use of Concurrent HashSet for session id store instead of synchronizing around it so that scavenge doesn't block session creation/removal.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=464839