### PR TITLE
Ability to start shutdown listener on predefined IP Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ distribution for webapp deployment.
 
 - [https://projects.eclipse.org/projects/rt.jetty](https://projects.eclipse.org/projects/rt.jetty)
 
-This fork adds enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker.
+This fork adds enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker. Specifically flexible network binding mechanism that enables Jetty services to listen on IP/Port dynamically allocated by the container engine.
+

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ distribution for webapp deployment.
 
 - [https://projects.eclipse.org/projects/rt.jetty](https://projects.eclipse.org/projects/rt.jetty)
 
-This fork adds ability to create ShutdownListener on a specific local IP address assigend by a new STOP.HOST startup parameter. This is usefule in multi-home vurtualized environments like OpenShift with ability to listen on any address (0.0.0.0) or default 127.0.0.1 loopback not allowed.
+This fork adds ability to create ShutdownListener on a specific local IP address assigned by a new STOP.HOST startup parameter. This is usefule in multi-home vurtualized environments like OpenShift with ability to listen on any address (0.0.0.0) or default 127.0.0.1 loopback not allowed.
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,4 @@ distribution for webapp deployment.
 
 - [https://projects.eclipse.org/projects/rt.jetty](https://projects.eclipse.org/projects/rt.jetty)
 
-Documentation
-============
-
-Project documentation is located on our Eclipse website.
-
-- [http://www.eclipse.org/jetty/documentation](http://www.eclipse.org/jetty/documentation)
-
-Professional Services
-============
-
-Expert advice and production support are available through [http://webtide.com](Webtide.com).
+This fork introces enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ distribution for webapp deployment.
 
 - [https://projects.eclipse.org/projects/rt.jetty](https://projects.eclipse.org/projects/rt.jetty)
 
-This fork introces enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker.
+This fork adds enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker.

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ distribution for webapp deployment.
 
 - [https://projects.eclipse.org/projects/rt.jetty](https://projects.eclipse.org/projects/rt.jetty)
 
-This fork adds enhancements to Jetty to support auto-scaling in container engines like OpenShift or Docker. Specifically flexible network binding mechanism that enables Jetty services to listen on IP/Port dynamically allocated by the container engine.
+This fork adds ability to create ShutdownListener on a specific local IP address assigend by a new STOP.HOST startup parameter. This is usefule in multi-home vurtualized environments like OpenShift with ability to listen on any address (0.0.0.0) or default 127.0.0.1 loopback not allowed.
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java
@@ -294,7 +294,7 @@ public class ShutdownMonitor
 
             try
             {
-                serverSocket = new ServerSocket(port,1,InetAddress.getByName("127.0.0.1"));
+                serverSocket = new ServerSocket(port,1,InetAddress.getByName(host));
                 if (port == 0)
                 {
                     // server assigned port in use
@@ -329,6 +329,7 @@ public class ShutdownMonitor
     private boolean DEBUG;
     private int port;
     private String key;
+    private String host;
     private boolean exitVm;
     private ServerSocket serverSocket;
     private Thread thread;
@@ -337,6 +338,7 @@ public class ShutdownMonitor
      * Create a ShutdownMonitor using configuration from the System properties.
      * <p>
      * <code>STOP.PORT</code> = the port to listen on (empty, null, or values less than 0 disable the stop ability)<br>
+     * <code>STOP.HOST</code> = the IP address to listen on (empty, null values will default to 127.0.0.1)<br>
      * <code>STOP.KEY</code> = the magic key/passphrase to allow the stop (defaults to "eclipse")<br>
      * <p>
      * Note: server socket will only listen on localhost, and a successful stop will issue a System.exit() call.
@@ -350,6 +352,7 @@ public class ShutdownMonitor
         // Use values passed thru via /jetty-start/
         this.port = Integer.parseInt(props.getProperty("STOP.PORT","-1"));
         this.key = props.getProperty("STOP.KEY",null);
+        this.host = props.getProperty("STOP.HOST","127.0.0.1");
         this.exitVm = true;
     }
 
@@ -420,6 +423,11 @@ public class ShutdownMonitor
         }
     }
 
+    public String getHost()
+    {
+        return host;
+    }
+    
     public String getKey()
     {
         return key;

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -452,28 +452,26 @@ public class Main
     {
         int stopPort = Integer.parseInt(args.getProperties().getString("STOP.PORT"));
         String stopKey = args.getProperties().getString("STOP.KEY");
+        String host = args.getProperties().getString("STOP.HOST");
+        
+        if (host == null ) host = "127.0.0.1";
 
         if (args.getProperties().getString("STOP.WAIT") != null)
         {
             int stopWait = Integer.parseInt(args.getProperties().getString("STOP.WAIT"));
 
-            stop(stopPort,stopKey,stopWait);
+            stop(stopPort,host,stopKey,stopWait);
         }
         else
         {
-            stop(stopPort,stopKey);
+            stop(stopPort,host,stopKey,0);
         }
     }
 
     /**
      * Stop a running jetty instance.
      */
-    public void stop(int port, String key)
-    {
-        stop(port,key,0);
-    }
-
-    public void stop(int port, String key, int timeout)
+    public void stop(int port, String host, String key, int timeout)
     {
         int _port = port;
         String _key = key;
@@ -491,7 +489,7 @@ public class Main
                 System.err.println("Using empty key");
             }
 
-            try (Socket s = new Socket(InetAddress.getByName("127.0.0.1"),_port))
+            try (Socket s = new Socket(InetAddress.getByName(host),_port))
             {
                 if (timeout > 0)
                 {

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -112,6 +112,11 @@ Properties:
       The port to use to stop the running Jetty server.
       Required along with STOP.KEY if you want to use the --stop option above.
 
+    STOP.HOST=[alphanumeric]
+      The IP address to use to stop the running Jetty server. If not provided 
+      default 127.0.0.1 loopback is used.
+      Required along with STOP.KEY if you want to use the --stop option above.
+
     STOP.KEY=[alphanumeric]
       The passphrase defined to stop the server.
       Requried along with STOP.PORT if you want to use the --stop option above.


### PR DESCRIPTION
Ability to create ShutdownListener on a specific local IP address assigned by a new STOP.HOST startup parameter. This is usefule in multi-home vurtualized environments like OpenShift with ability to listen on any address (0.0.0.0) or default 127.0.0.1 loopback not allowed.