### PR TITLE
Bug 467434 - SslContextFactory throws null pointer exception due to w…

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -18,6 +18,28 @@
 
 package org.eclipse.jetty.util.ssl;
 
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.security.CertificateUtils;
+import org.eclipse.jetty.util.security.CertificateValidator;
+import org.eclipse.jetty.util.security.Password;
+
+import javax.net.ssl.CertPathTrustManagerParameters;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,28 +62,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.net.ssl.CertPathTrustManagerParameters;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLServerSocket;
-import javax.net.ssl.SSLServerSocketFactory;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
-
-import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.security.CertificateUtils;
-import org.eclipse.jetty.util.security.CertificateValidator;
-import org.eclipse.jetty.util.security.Password;
 
 
 /* ------------------------------------------------------------ */
@@ -111,12 +111,12 @@ public class SslContextFactory extends AbstractLifeCycle
     /** Excluded protocols. */
     private final Set<String> _excludeProtocols = new LinkedHashSet<String>();
     /** Included protocols. */
-    private Set<String> _includeProtocols = null;
+    private Set<String> _includeProtocols = new LinkedHashSet<String>();
 
     /** Excluded cipher suites. */
     private final Set<String> _excludeCipherSuites = new LinkedHashSet<String>();
     /** Included cipher suites. */
-    private Set<String> _includeCipherSuites = null;
+    private Set<String> _includeCipherSuites = new LinkedHashSet<String>();
 
     /** Keystore path. */
     private String _keyStorePath;
@@ -323,7 +323,6 @@ public class SslContextFactory extends AbstractLifeCycle
     public void setExcludeProtocols(String... protocols)
     {
         checkNotStarted();
-
         _excludeProtocols.clear();
         _excludeProtocols.addAll(Arrays.asList(protocols));
     }
@@ -357,8 +356,8 @@ public class SslContextFactory extends AbstractLifeCycle
     public void setIncludeProtocols(String... protocols)
     {
         checkNotStarted();
-
-        _includeProtocols = new LinkedHashSet<String>(Arrays.asList(protocols));
+        _includeProtocols.clear();
+        _includeProtocols.addAll(Arrays.asList(protocols));
     }
 
     /* ------------------------------------------------------------ */
@@ -413,8 +412,8 @@ public class SslContextFactory extends AbstractLifeCycle
     public void setIncludeCipherSuites(String... cipherSuites)
     {
         checkNotStarted();
-
-        _includeCipherSuites = new LinkedHashSet<String>(Arrays.asList(cipherSuites));
+        _includeCipherSuites.clear();
+        _includeCipherSuites.addAll(Arrays.asList(cipherSuites));
     }
 
     /* ------------------------------------------------------------ */
@@ -1214,7 +1213,7 @@ public class SslContextFactory extends AbstractLifeCycle
         Set<String> selected_protocols = new LinkedHashSet<String>();
 
         // Set the starting protocols - either from the included or enabled list
-        if (_includeProtocols!=null)
+        if (!_includeProtocols.isEmpty())
         {
             // Use only the supported included protocols
             for (String protocol : _includeProtocols)
@@ -1246,7 +1245,7 @@ public class SslContextFactory extends AbstractLifeCycle
         Set<String> selected_ciphers = new LinkedHashSet<String>();
 
         // Set the starting ciphers - either from the included or enabled list
-        if (_includeCipherSuites!=null)
+        if (!_includeCipherSuites.isEmpty())
         {
             // Use only the supported included ciphers
             for (String cipherSuite : _includeCipherSuites)

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
@@ -42,12 +42,14 @@ public class SslContextFactoryTest {
     private SslContextFactory cf;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws Exception 
+    {
         cf = new SslContextFactory();
     }
 
     @Test
-    public void testNoTsFileKs() throws Exception {
+    public void testNoTsFileKs() throws Exception 
+    {
         String keystorePath = System.getProperty("basedir", ".") + "/src/test/resources/keystore";
         cf.setKeyStorePassword("storepwd");
         cf.setKeyManagerPassword("keypwd");
@@ -58,7 +60,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testNoTsStreamKs() throws Exception {
+    public void testNoTsStreamKs() throws Exception 
+    {
         InputStream keystoreInputStream = this.getClass().getResourceAsStream("keystore");
 
         cf.setKeyStoreInputStream(keystoreInputStream);
@@ -71,7 +74,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testNoTsSetKs() throws Exception {
+    public void testNoTsSetKs() throws Exception 
+    {
         InputStream keystoreInputStream = this.getClass().getResourceAsStream("keystore");
 
         KeyStore ks = KeyStore.getInstance("JKS");
@@ -86,19 +90,22 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testNoTsNoKs() throws Exception {
+    public void testNoTsNoKs() throws Exception 
+    {
         cf.start();
         assertTrue(cf.getSslContext() != null);
     }
 
     @Test
-    public void testTrustAll() throws Exception {
+    public void testTrustAll() throws Exception 
+    {
         cf.start();
         assertTrue(cf.getSslContext() != null);
     }
 
     @Test
-    public void testNoTsResourceKs() throws Exception {
+    public void testNoTsResourceKs() throws Exception 
+    {
         Resource keystoreResource = Resource.newSystemResource("keystore");
 
         cf.setKeyStoreResource(keystoreResource);
@@ -111,7 +118,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testResourceTsResourceKs() throws Exception {
+    public void testResourceTsResourceKs() throws Exception 
+    {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -127,7 +135,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testResourceTsResourceKsWrongPW() throws Exception {
+    public void testResourceTsResourceKsWrongPW() throws Exception 
+    {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -146,7 +155,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testResourceTsWrongPWResourceKs() throws Exception {
+    public void testResourceTsWrongPWResourceKs() throws Exception 
+    {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -165,7 +175,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testNoKeyConfig() throws Exception {
+    public void testNoKeyConfig() throws Exception 
+    {
         try {
             ((StdErrLog) Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
             cf.setTrustStore("/foo");
@@ -179,7 +190,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testSetIncludeCipherSuitesPreservesOrder() {
+    public void testSetIncludeCipherSuitesPreservesOrder() 
+    {
         String[] supportedCipherSuites = new String[]{"cipher4", "cipher2", "cipher1", "cipher3"};
         String[] includeCipherSuites = {"cipher1", "cipher3", "cipher4"};
 
@@ -190,7 +202,8 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testSetIncludeProtocolsPreservesOrder() {
+    public void testSetIncludeProtocolsPreservesOrder() 
+    {
         String[] supportedProtocol = new String[]{"cipher4", "cipher2", "cipher1", "cipher3"};
         String[] includeProtocol = {"cipher1", "cipher3", "cipher4"};
 
@@ -200,7 +213,8 @@ public class SslContextFactoryTest {
         assertSelectedMatchesIncluded(includeProtocol, selectedProtocol);
     }
 
-    private void assertSelectedMatchesIncluded(String[] includeStrings, String[] selectedStrings) {
+    private void assertSelectedMatchesIncluded(String[] includeStrings, String[] selectedStrings) 
+    {
         assertThat(includeStrings.length + " strings are selected", selectedStrings.length, is(includeStrings.length));
         assertThat("order from includeStrings is preserved", selectedStrings[0], equalTo(includeStrings[0]));
         assertThat("order from includeStrings is preserved", selectedStrings[1], equalTo(includeStrings[1]));
@@ -208,11 +222,11 @@ public class SslContextFactoryTest {
     }
 
     @Test
-    public void testProtocolAndCipherSettingsAreNPESafe() {
+    public void testProtocolAndCipherSettingsAreNPESafe() 
+    {
         assertNotNull(cf.getExcludeProtocols());
         assertNotNull(cf.getIncludeProtocols());
         assertNotNull(cf.getExcludeCipherSuites());
         assertNotNull(cf.getIncludeCipherSuites());
     }
-
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
@@ -18,10 +18,6 @@
 
 package org.eclipse.jetty.util.ssl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.KeyStore;
-
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.StdErrLog;
@@ -30,52 +26,52 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertTrue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
-public class SslContextFactoryTest
-{
+public class SslContextFactoryTest {
 
     private SslContextFactory cf;
 
     @Before
-    public void setUp() throws Exception
-    {
+    public void setUp() throws Exception {
         cf = new SslContextFactory();
     }
 
     @Test
-    public void testNoTsFileKs() throws Exception
-    {
-        String keystorePath = System.getProperty("basedir",".") + "/src/test/resources/keystore";
+    public void testNoTsFileKs() throws Exception {
+        String keystorePath = System.getProperty("basedir", ".") + "/src/test/resources/keystore";
         cf.setKeyStorePassword("storepwd");
         cf.setKeyManagerPassword("keypwd");
-        
+
         cf.start();
-        
-        assertTrue(cf.getSslContext()!=null);
+
+        assertTrue(cf.getSslContext() != null);
     }
-    
+
     @Test
-    public void testNoTsStreamKs() throws Exception
-    {
+    public void testNoTsStreamKs() throws Exception {
         InputStream keystoreInputStream = this.getClass().getResourceAsStream("keystore");
 
         cf.setKeyStoreInputStream(keystoreInputStream);
         cf.setKeyStorePassword("storepwd");
         cf.setKeyManagerPassword("keypwd");
-        
+
         cf.start();
-        
-        assertTrue(cf.getSslContext()!=null);
+
+        assertTrue(cf.getSslContext() != null);
     }
-    
+
     @Test
-    public void testNoTsSetKs() throws Exception
-    {
+    public void testNoTsSetKs() throws Exception {
         InputStream keystoreInputStream = this.getClass().getResourceAsStream("keystore");
 
         KeyStore ks = KeyStore.getInstance("JKS");
@@ -83,29 +79,26 @@ public class SslContextFactoryTest
 
         cf.setKeyStore(ks);
         cf.setKeyManagerPassword("keypwd");
-        
+
         cf.start();
-        
-        assertTrue(cf.getSslContext()!=null);
-    }
-    
-    @Test
-    public void testNoTsNoKs() throws Exception
-    {
-        cf.start();
-        assertTrue(cf.getSslContext()!=null);
-    }
-    
-    @Test
-    public void testTrustAll() throws Exception
-    {
-        cf.start();
-        assertTrue(cf.getSslContext()!=null);
+
+        assertTrue(cf.getSslContext() != null);
     }
 
     @Test
-    public void testNoTsResourceKs() throws Exception
-    {
+    public void testNoTsNoKs() throws Exception {
+        cf.start();
+        assertTrue(cf.getSslContext() != null);
+    }
+
+    @Test
+    public void testTrustAll() throws Exception {
+        cf.start();
+        assertTrue(cf.getSslContext() != null);
+    }
+
+    @Test
+    public void testNoTsResourceKs() throws Exception {
         Resource keystoreResource = Resource.newSystemResource("keystore");
 
         cf.setKeyStoreResource(keystoreResource);
@@ -114,12 +107,11 @@ public class SslContextFactoryTest
 
         cf.start();
 
-        assertTrue(cf.getSslContext()!=null);
+        assertTrue(cf.getSslContext() != null);
     }
 
     @Test
-    public void testResourceTsResourceKs() throws Exception
-    {
+    public void testResourceTsResourceKs() throws Exception {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -131,12 +123,11 @@ public class SslContextFactoryTest
 
         cf.start();
 
-        assertTrue(cf.getSslContext()!=null);
+        assertTrue(cf.getSslContext() != null);
     }
 
     @Test
-    public void testResourceTsResourceKsWrongPW() throws Exception
-    {
+    public void testResourceTsResourceKsWrongPW() throws Exception {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -146,20 +137,16 @@ public class SslContextFactoryTest
         cf.setKeyManagerPassword("wrong_keypwd");
         cf.setTrustStorePassword("storepwd");
 
-        try
-        {
-            ((StdErrLog)Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
+        try {
+            ((StdErrLog) Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
             cf.start();
             Assert.fail();
-        }
-        catch(java.security.UnrecoverableKeyException e)
-        {
+        } catch (java.security.UnrecoverableKeyException e) {
         }
     }
 
     @Test
-    public void testResourceTsWrongPWResourceKs() throws Exception
-    {
+    public void testResourceTsWrongPWResourceKs() throws Exception {
         Resource keystoreResource = Resource.newSystemResource("keystore");
         Resource truststoreResource = Resource.newSystemResource("keystore");
 
@@ -169,40 +156,30 @@ public class SslContextFactoryTest
         cf.setKeyManagerPassword("keypwd");
         cf.setTrustStorePassword("wrong_storepwd");
 
-        try
-        {
-            ((StdErrLog)Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
+        try {
+            ((StdErrLog) Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
             cf.start();
             Assert.fail();
-        }
-        catch(IOException e)
-        {
+        } catch (IOException e) {
         }
     }
-    
+
     @Test
-    public void testNoKeyConfig() throws Exception
-    {
-        try
-        {
-            ((StdErrLog)Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
+    public void testNoKeyConfig() throws Exception {
+        try {
+            ((StdErrLog) Log.getLogger(AbstractLifeCycle.class)).setHideStacks(true);
             cf.setTrustStore("/foo");
             cf.start();
             Assert.fail();
-        }
-        catch (IllegalStateException e)
-        {
-            
-        }
-        catch (Exception e)
-        {
+        } catch (IllegalStateException e) {
+
+        } catch (Exception e) {
             Assert.fail("Unexpected exception");
         }
     }
 
     @Test
-    public void testSetIncludeCipherSuitesPreservesOrder()
-    {
+    public void testSetIncludeCipherSuitesPreservesOrder() {
         String[] supportedCipherSuites = new String[]{"cipher4", "cipher2", "cipher1", "cipher3"};
         String[] includeCipherSuites = {"cipher1", "cipher3", "cipher4"};
 
@@ -213,8 +190,7 @@ public class SslContextFactoryTest
     }
 
     @Test
-    public void testSetIncludeProtocolsPreservesOrder()
-    {
+    public void testSetIncludeProtocolsPreservesOrder() {
         String[] supportedProtocol = new String[]{"cipher4", "cipher2", "cipher1", "cipher3"};
         String[] includeProtocol = {"cipher1", "cipher3", "cipher4"};
 
@@ -224,11 +200,19 @@ public class SslContextFactoryTest
         assertSelectedMatchesIncluded(includeProtocol, selectedProtocol);
     }
 
-    private void assertSelectedMatchesIncluded(String[] includeStrings, String[] selectedStrings)
-    {
+    private void assertSelectedMatchesIncluded(String[] includeStrings, String[] selectedStrings) {
         assertThat(includeStrings.length + " strings are selected", selectedStrings.length, is(includeStrings.length));
         assertThat("order from includeStrings is preserved", selectedStrings[0], equalTo(includeStrings[0]));
         assertThat("order from includeStrings is preserved", selectedStrings[1], equalTo(includeStrings[1]));
         assertThat("order from includeStrings is preserved", selectedStrings[2], equalTo(includeStrings[2]));
     }
+
+    @Test
+    public void testProtocolAndCipherSettingsAreNPESafe() {
+        assertNotNull(cf.getExcludeProtocols());
+        assertNotNull(cf.getIncludeProtocols());
+        assertNotNull(cf.getExcludeCipherSuites());
+        assertNotNull(cf.getIncludeCipherSuites());
+    }
+
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
@@ -37,7 +37,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 
-public class SslContextFactoryTest {
+public class SslContextFactoryTest 
+{
 
     private SslContextFactory cf;
 


### PR DESCRIPTION
…rong initialisation

* Merging changes of bugs 467276 and 467434 back to the 8.x series.
* Fix NPE due to wrong initialisation to null; use isEmpty instead of null in ifs.

Signed-off-by: P. Ottlinger <phil@edojo.org>