### PR TITLE
Update jetty.sh

### DIFF
--- a/jetty-distribution/src/main/resources/bin/jetty.sh
+++ b/jetty-distribution/src/main/resources/bin/jetty.sh
@@ -350,7 +350,7 @@ then
   CYGWIN*) JETTY_LOGS="`cygpath -w $JETTY_LOGS`";;
   esac
 
-  JAVA_OPTIONS=(${JAVA_OPTIONS[*]} "-Djetty.logs=$JETTY_LOGS")
+  JAVA_OPTIONS=(${JAVA_OPTIONS[*]} "-Djetty.logging.dir=$JETTY_LOGS")
 fi
 
 #####################################################


### PR DESCRIPTION
Addendum to "460671 - Rationalize property names"

`jetty.logs` is deprecated now, that's why `jetty.sh` always caused a warning.