### PR TITLE
Improve start up performance by initializing servlets only once

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
@@ -75,6 +75,7 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
     private static final Logger LOG = Log.getLogger(ServletHolder.class);
     private int _initOrder = -1;
     private boolean _initOnStartup=false;
+    private boolean initialized = false;
     private Map<String, String> _roleMap;
     private String _forcedPath;
     private String _runAsRole;
@@ -82,7 +83,6 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
     private IdentityService _identityService;
     private ServletRegistration.Dynamic _registration;
     private JspContainer _jspContainer;
-
 
     private transient Servlet _servlet;
     private transient Config _config;
@@ -378,7 +378,7 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
 
         if (_class!=null && javax.servlet.SingleThreadModel.class.isAssignableFrom(_class))
             _servlet = new SingleThreadedWrapper();
-     
+
     }
     
     
@@ -387,21 +387,24 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
     public void initialize ()
     throws Exception
     {
-        super.initialize();
-        if (_extInstance || _initOnStartup)
-        {
-            try
+        if(!initialized){
+            super.initialize();
+            if (_extInstance || _initOnStartup)
             {
-                initServlet();
-            }
-            catch(Exception e)
-            {
-                if (_servletHandler.isStartWithUnavailable())
-                    LOG.ignore(e);
-                else
-                    throw e;
+                try
+                {
+                    initServlet();
+                }
+                catch(Exception e)
+                {
+                    if (_servletHandler.isStartWithUnavailable())
+                        LOG.ignore(e);
+                    else
+                        throw e;
+                }
             }
         }
+        initialized = true;
     }
     
     


### PR DESCRIPTION
In Jetty 9+ the ServletHandler.initialize method will do calls to ServletHolder.start and ServletHolder.initialize. In Jetty 8, initialization was part of the ServletHolder.start method. Since the initialization was part of the start method, its execution was also bound on the same conditions (being: the servlet is not started or starting). In Jetty 9, ServletHolder.initialize is called regardless of the state of the servlet. This new behavior is causing a great increase in start-up times of some applications. 

To tackle this issue, a new 'initialized' property is introduced on the ServletHolder which will be set to true after the first call to ServletHolder.initialize to prevent re-initializing initialized servlets.

It's not possible to fix this issue by making the ServletHolder.initialize part of the ServletHolder.start again because this will result in IllegalStateExceptions because the servlet has to be started (AbstractLifeCycle.setStarted) before ServletHolder.initialize can be called. 