### PR TITLE
Fix defect in DoSFilter where semaphore acquires my be leaked

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -427,25 +427,31 @@ public class DoSFilter implements Filter
         {
             if (accepted)
             {
-                // Wake up the next highest priority request.
-                for (int p = _queues.length - 1; p >= 0; --p)
+                try
                 {
-                    AsyncContext asyncContext = _queues[p].poll();
-                    if (asyncContext != null)
+                    // Wake up the next highest priority request.
+                    for (int p = _queues.length - 1; p >= 0; --p)
                     {
-                        ServletRequest candidate = asyncContext.getRequest();
-                        Boolean suspended = (Boolean)candidate.getAttribute(_suspended);
-                        if (suspended == Boolean.TRUE)
+                        AsyncContext asyncContext = _queues[p].poll();
+                        if (asyncContext != null)
                         {
-                            if (LOG.isDebugEnabled())
-                                LOG.debug("Resuming {}", request);
-                            candidate.setAttribute(_resumed, Boolean.TRUE);
-                            asyncContext.dispatch();
-                            break;
+                            ServletRequest candidate = asyncContext.getRequest();
+                            Boolean suspended = (Boolean)candidate.getAttribute(_suspended);
+                            if (suspended == Boolean.TRUE)
+                            {
+                                if (LOG.isDebugEnabled())
+                                    LOG.debug("Resuming {}", request);
+                                candidate.setAttribute(_resumed, Boolean.TRUE);
+                                asyncContext.dispatch();
+                                break;
+                            }
                         }
                     }
                 }
-                _passes.release();
+                finally
+                {
+                    _passes.release();
+                }
             }
         }
     }


### PR DESCRIPTION
When trying to release the semaphore in the finally block, 'asyncContext.dispatch()' may throw a "RejectedExecutionException".  If this occurs, then the semaphore will never be released.
Ultimately the condition will result in all threads blocking to acquire the semaphore as the DoSFilter is continue to be used.