### PR TITLE
Fix issue with CDI and test scope

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyWebAppContext.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyWebAppContext.java
@@ -376,10 +376,10 @@ public class JettyWebAppContext extends WebAppContext
             setAttribute(WebInfConfiguration.WEBINF_JAR_PATTERN, _webInfIncludeJarPattern);
    
         //Set up the classes dirs that comprises the equivalent of WEB-INF/classes
-        if (_testClasses != null)
-            _webInfClasses.add(_testClasses);
         if (_classes != null)
             _webInfClasses.add(_classes);
+        if (_testClasses != null)
+            _webInfClasses.add(_testClasses);
         
         // Set up the classpath
         _classpathFiles = new ArrayList<File>();


### PR DESCRIPTION
The order of this two elements is mandatory for working with test scope and CDI.
Indeed in CDI source https://github.com/weld/core/blob/a872d0573e9cae8c26edbb109ee6b89ec0445d9a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java#L95
for the resource /WEB-INF/classes//META-INF/beans.xml the test-classes/META-INF/beans.xml file is returned but few line after at https://github.com/weld/core/blob/a872d0573e9cae8c26edbb109ee6b89ec0445d9a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java#L107
classes/META-INF is returned by Servlets.getRealFile(servletContext, WEB_INF_CLASSES)
So the test-classes BeanArchive is not discovered