### PR TITLE
[447816] - Jetty Startup - java.lang.IllegalArgumentException: Comparison method violates its general contract!

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
@@ -207,15 +207,29 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
     {
         if (sh==this)
             return 0;
+
         if (sh._initOrder<_initOrder)
             return 1;
+
         if (sh._initOrder>_initOrder)
             return -1;
 
-        int c=(_className!=null && sh._className!=null)?_className.compareTo(sh._className):0;
+        // consider _className, need to position properly when one is configured but not the other
+        int c;
+        if (_className==null && sh._className==null)
+            c=0;
+        else if (_className==null)
+            c=-1;
+        else if (sh._className==null)
+            c=1;
+        else
+            c=_className.compareTo(sh._className);
+
+        // if _initOrder and _className are the same, consider the _name
         if (c==0)
             c=_name.compareTo(sh._name);
-            return c;
+
+        return c;
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletHolderTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletHolderTest.java
@@ -1,0 +1,55 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.servlet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class ServletHolderTest {
+
+    @Test
+    public void testTransitiveCompareTo() throws Exception
+    {
+        // example of jsp-file referenced in web.xml
+        final ServletHolder one = new ServletHolder();
+        one.setInitOrder(-1);
+        one.setName("Login");
+        one.setClassName(null);
+
+        // example of pre-compiled jsp
+        final ServletHolder two = new ServletHolder();
+        two.setInitOrder(-1);
+        two.setName("org.my.package.jsp.WEB_002dINF.pages.precompiled_002dpage_jsp");
+        two.setClassName("org.my.package.jsp.WEB_002dINF.pages.precompiled_002dpage_jsp");
+
+        // example of servlet referenced in web.xml
+        final ServletHolder three = new ServletHolder();
+        three.setInitOrder(-1);
+        three.setName("Download");
+        three.setClassName("org.my.package.web.DownloadServlet");
+
+        // verify compareTo transitivity
+        Assert.assertTrue(one.compareTo(two) < 0);
+        Assert.assertTrue(two.compareTo(three) < 0);
+        Assert.assertTrue(one.compareTo(three) < 0);
+    }
+}


### PR DESCRIPTION
Hi!

I was going to open a new issue but saw 447816 [1] while I was filling out the form. This ticket is currently CLOSED but the latest comments mentioned reopening if appropriate.

We have also seen this same error in certain occasions. It appears that ServletHolder#compareTo is not transitive when falling back to comparing by className and name. From the Java API

> The implementor must also ensure that the relation is transitive: ((compare(x, y)>0) && (compare(y, z)>0)) implies compare(x, z)>0.

This could fail with the following scenario:

```java
// example of jsp-file referenced in web.xml
final ServletHolder one = new ServletHolder();
one.setInitOrder(-1);
one.setName("Login");
one.setClassName(null);

// example of pre-compiled jsp
final ServletHolder two = new ServletHolder();
two.setInitOrder(-1);
two.setName("org.my.package.jsp.WEB_002dINF.pages.precompiled_002dpage_jsp");
two.setClassName("org.my.package.jsp.WEB_002dINF.pages.precompiled_002dpage_jsp");

// example of servlet referenced in web.xml
final ServletHolder three = new ServletHolder();
three.setInitOrder(-1);
three.setName("Download");
three.setClassName("org.my.package.web.DownloadServlet");
```

In the scenario outlined: one < two and two < three but three < one.

Let me know if you need anything else.

Thanks!

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=447816