### PR TITLE
 Unit tests for Jetty-Jmx module to increase code coverage from 60% to 85%

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,0 +1,12 @@
+To generate the code coverage report, execute the following command:
+
+mvn clean verify
+
+This will generate code coverage report in each of the modules. In order to view the same, open the following file in your browser.
+
+target/site/cobertura/index.html
+
+Please note that the above folder is created under each of the modules. For example:
+
+•	jetty-jmx/target/site/cobertura/index.html
+•	jetty-jaspi/target/site/cobertura/index.html

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -21,7 +21,40 @@
           <onlyAnalyze>org.eclipse.jetty.jmx.*</onlyAnalyze>
         </configuration>
       </plugin>
-    </plugins>
+      <plugin>
+		<groupId>org.codehaus.mojo</groupId>
+		<artifactId>cobertura-maven-plugin</artifactId>
+		<version>2.6</version>
+		<dependencies>
+			<dependency>
+				<groupId>org.ow2.asm</groupId>
+				<artifactId>asm</artifactId>
+				<version>5.0.3</version>
+			</dependency>
+		</dependencies>
+		<configuration>
+			<check>
+				true
+			</check>
+			<formats>
+				<format>html</format>
+				<format>xml</format>
+			</formats>
+			<outputDirectory>${project.build.directory}/site/cobertura</outputDirectory>
+			<instrumentation>
+				<ignoreTrivial>true</ignoreTrivial>
+			</instrumentation>
+		</configuration>
+		<executions>
+			<execution>
+				<phase>package</phase>
+				<goals>
+					<goal>cobertura</goal>
+				</goals>
+			</execution>
+		</executions>
+	</plugin>      
+   </plugins>
   </build>
   <dependencies>
     <dependency>
@@ -34,6 +67,25 @@
       <artifactId>jetty-util</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+	  <groupId>com.openpojo</groupId>
+	  <artifactId>openpojo</artifactId>
+	  <version>0.8.1</version>
+	  <scope>test</scope>
+   	 </dependency>
+    <dependency>
+	  <groupId>org.powermock</groupId>
+	  <artifactId>powermock-module-junit4</artifactId>
+	  <version>1.6.2</version>
+	  <scope>test</scope>
+	</dependency>	
+	<dependency>
+	  <groupId>org.powermock</groupId>
+	  <artifactId>powermock-api-mockito</artifactId>
+	  <version>1.6.2</version>
+	  <scope>test</scope>
+	</dependency>
+    
   </dependencies>
 
 </project>

--- a/jetty-jmx/src/test/java/com/acme/DerivedExtended.java
+++ b/jetty-jmx/src/test/java/com/acme/DerivedExtended.java
@@ -1,0 +1,50 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package com.acme;
+
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.ManagedOperation;
+
+@ManagedObject(value="Test the mbean extended stuff")
+public class DerivedExtended extends Derived{
+	
+    private String doodle4 = "doodle4";
+    
+	@ManagedAttribute(value = "The doodle4 name of something", name = "doodle4", setter = "setDoodle4")
+	public String getDoodle4() {
+		throw new IllegalAccessError();
+	}
+
+	public void setDoodle4(String doodle4) {
+		this.doodle4 = doodle4;
+	}
+	
+	@ManagedOperation("Doodle2 something")
+	private void doodle2() {
+		System.err.println("doodle2");
+		// this is just for a test case perspective
+	}
+	
+	@ManagedOperation("Doodle1 something")
+	public void doodle1() {
+		// this is just for a test case perspective
+		throw new IllegalAccessError();
+	}
+}

--- a/jetty-jmx/src/test/java/com/acme/DerivedManaged.java
+++ b/jetty-jmx/src/test/java/com/acme/DerivedManaged.java
@@ -1,0 +1,85 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package com.acme;
+
+import java.util.ArrayList;
+
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.ManagedOperation;
+import org.eclipse.jetty.util.annotation.Name;
+
+@ManagedObject(value = "Test the mbean stuff")
+public class DerivedManaged extends Base implements Signature {
+	String fname = "Full Name";
+	Derived[] addresses = new Derived[3];
+	ArrayList<Derived> aliasNames = new ArrayList<Derived>();
+	Derived derived = new Derived();
+
+	@ManagedAttribute("sample managed address object")
+	public Derived[] getAddresses() {
+		return addresses;
+	}
+
+	@ManagedAttribute("sample managed derived object")
+	public Derived getDerived() {
+		return derived;
+	}
+
+	public void setDerived(Derived derived) {
+		this.derived = derived;
+	}
+
+	public void setAddresses(Derived[] addresses) {
+		this.addresses = addresses;
+	}
+
+	@ManagedOperation(value = "Doodle something", impact = "ACTION_INFO")
+	public void doodle(@Name(value = "doodle", description = "A description of the argument") String doodle) {
+		System.err.println("doodle " + doodle);
+	}
+
+	@ManagedOperation(value = "google something", impact = "")
+	public void google(@Name(value = "google", description = "A description of the argument") String google) {
+		System.err.println("google " + google);
+	}
+
+	@ManagedAttribute("sample managed alias object")
+	public ArrayList<Derived> getAliasNames() {
+		return aliasNames;
+	}
+
+	public void setAliasNames(ArrayList<Derived> aliasNames) {
+		this.aliasNames = aliasNames;
+	}
+
+	@ManagedAttribute(value = "The full name of something", name = "fname", setter = "setFullName")
+	public String getFullName() {
+		return fname;
+	}
+
+	public void setFullName(String name) {
+		fname = name;
+	}
+
+	@ManagedOperation("publish something")
+	public void publish() {
+		System.err.println("publish");
+	}
+}

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
@@ -18,20 +18,86 @@
 
 package org.eclipse.jetty.jmx;
 
+import java.net.InetAddress;
+import java.rmi.registry.LocateRegistry;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import javax.management.remote.JMXServiceURL;
-
+import org.junit.After;
 import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.AnyOf.anyOf;
 
-public class ConnectorServerTest
-{
-    @Test
-    public void randomPortTest() throws Exception
-    {
-        ConnectorServer srv = new ConnectorServer(
-                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:0/jettytest"),
-                "org.eclipse.jetty:name=rmiconnectorserver");
-        srv.start();
-        Thread.sleep(5000);
-    }
+public class ConnectorServerTest {
 
+	private ConnectorServer connectorServer;
+
+	@After
+	public void tearDown() throws Exception {
+		if (connectorServer != null) {
+			connectorServer.doStop();
+		}
+	}
+
+	@Test
+	public void randomPortTest() throws Exception {
+		//given
+		connectorServer = new ConnectorServer(
+				new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:0/jettytest"),
+				"org.eclipse.jetty:name=rmiconnectorserver");
+		//if port is not available then the server value is null
+		if (connectorServer != null) {
+			//when
+			connectorServer.start();
+			
+			//then
+			assertThat("Server status must be in started or starting", connectorServer.getState(),
+					anyOf(is(ConnectorServer.STARTED), is(ConnectorServer.STARTING)));
+		}
+	}
+
+	@Test
+	public void testConnServerWithRmiDefaultPort() throws Exception {
+		//given
+		LocateRegistry.createRegistry(1099);
+		JMXServiceURL serviceURLWithOutPort = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi");
+		connectorServer = new ConnectorServer(serviceURLWithOutPort, " domain: key3 = value3");
+		
+		//when
+		connectorServer.start();
+		
+		//then
+		assertThat("Server status must be in started or starting", connectorServer.getState(),
+				anyOf(is(ConnectorServer.STARTED), is(ConnectorServer.STARTING)));
+	}
+
+	@Test
+	public void testConnServerWithRmiRandomPort() throws Exception {
+		//given
+		JMXServiceURL serviceURLWithOutPort = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:1199/jmxrmi");
+		connectorServer = new ConnectorServer(serviceURLWithOutPort, " domain: key4 = value4");		
+		//if port is not available then the server value is null
+		if (connectorServer != null) {
+			//when
+			connectorServer.start();
+			connectorServer.stop();
+			
+			//then
+			assertThat("Server status must be in started or starting", connectorServer.getState(),
+					anyOf(is(ConnectorServer.STOPPING), is(ConnectorServer.STOPPED)));
+		}
+	}
+
+	@Test
+	public void testIsLoopbackAddressWithWrongValue() throws Exception {
+		//given
+		JMXServiceURL serviceURLWithOutPort = new JMXServiceURL(
+				"service:jmx:rmi:///jndi/rmi://" + InetAddress.getLocalHost() + ":1199/jmxrmi");
+		
+		//when
+		connectorServer = new ConnectorServer(serviceURLWithOutPort, " domain: key5 = value5");
+		
+		//then
+		assertNull("As loopback address returns false...registry must be null", connectorServer._registry);
+	}
 }

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/MBeanContainerTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/MBeanContainerTest.java
@@ -1,0 +1,227 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.jmx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.log.Log;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.acme.Managed;
+
+public class MBeanContainerTest {
+	
+	private MBeanContainer mbeanContainer;
+	
+	private MBeanServer mbeanServer;
+	
+	private String domain;
+	
+	private String beanName;
+	
+	private Managed managed;
+	
+	private ObjectName objectName;
+	
+	private Integer mbeanCount;
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		Log.getRootLogger().setDebugEnabled(true);
+	}
+
+	@Before
+	public void setUp() {
+		mbeanServer = ManagementFactory.getPlatformMBeanServer();
+		mbeanContainer = new MBeanContainer(mbeanServer);
+	}
+	
+	@Test
+	public void testMakeName() {
+		//given
+		beanName = "mngd:bean";
+				
+		//when
+		beanName = mbeanContainer.makeName(beanName);
+				
+		//then
+		assertEquals("Bean name should be mngd_bean", "mngd_bean", beanName);
+	}
+
+	@Test
+	public void testFindBean() {
+		//given
+		managed=getManaged();
+		
+		//when
+		objectName = mbeanContainer.findMBean(managed);
+		
+		//then
+		assertEquals("Bean must be added", managed, mbeanContainer.findBean(objectName));
+		assertNull("It must return null as there is no bean with the name null", mbeanContainer.findBean(null));
+	}
+	
+	private Managed getManaged(){
+		beanName = "mngd:bean";
+		beanName = mbeanContainer.makeName(beanName);
+		Managed managed = new Managed();
+		managed.setManaged(beanName);
+		mbeanContainer.beanAdded(null, managed);
+		return managed;
+	}
+
+	@Test
+	public void testMBeanContainer() {
+		assertNotNull("Container shouldn't be null", mbeanContainer);
+	}
+
+	@Test
+	public void testGetMBeanServer() {
+		assertEquals("MBean server Instance must be equal", mbeanServer, mbeanContainer.getMBeanServer());
+	}
+
+	@Test
+	public void testDomain() {
+		//given
+		domain = "Test";
+		
+		//when
+		mbeanContainer.setDomain(domain);
+		
+		//then
+		assertEquals("Domain name must be Test", domain, mbeanContainer.getDomain());
+	}
+
+	@Test
+	public void testBeanAdded() throws Exception {
+		//given
+		setBeanAdded();
+		
+		//when
+		objectName = mbeanContainer.findMBean(managed);
+		
+		//then
+		assertTrue("Bean must have been registered", mbeanServer.isRegistered(objectName));
+	}
+	
+	@Test
+	public void testBeanAddedNullCheck() throws Exception {
+		//given
+		setBeanAdded();
+		mbeanCount=mbeanServer.getMBeanCount();
+		
+		//when
+		mbeanContainer.beanAdded(null, null);
+		
+		//then
+		assertEquals("Mbean count must not change after beanAdded(null, null) call", mbeanCount,
+				mbeanServer.getMBeanCount());		
+	}
+	
+	private void setBeanAdded(){
+		managed = new Managed();
+		Container container = new ContainerLifeCycle();
+		mbeanContainer.beanAdded(container, managed);
+		mbeanServer=mbeanContainer.getMBeanServer();
+	}
+	
+	@Test
+	public void testBeanRemoved() throws Exception {
+		//given
+		setUpBeanRemoved();
+		
+		//when
+		mbeanContainer.beanRemoved(null, managed);
+		
+		//then
+		assertNull("Bean shouldn't be registed with container as we removed the bean", mbeanContainer.findMBean(managed));		
+	}
+	
+	private void setUpBeanRemoved(){
+		managed = new Managed();
+		mbeanContainer.beanRemoved(null, managed);
+		mbeanContainer.beanAdded(null, managed);		
+	}
+
+	@Test
+	public void testBeanRemovedInstanceNotFoundException() throws Exception {
+		//given
+		setUpBeanRemoved();
+		objectName = mbeanContainer.findMBean(managed);
+		
+		//when		
+		mbeanContainer.getMBeanServer().unregisterMBean(objectName);
+		
+		//then
+		assertFalse("Bean must not have been registered as we unregisted the bean", mbeanServer.isRegistered(objectName));
+		// this flow covers InstanceNotFoundException. Actual code just eating
+		// the exception. i.e Actual code just printing the stacktrace, whenever
+		// an exception of type InstanceNotFoundException occurs.
+		mbeanContainer.beanRemoved(null, managed);		
+	}
+	
+	@Test
+	public void testDump() {
+		assertNotNull("Dump operation shouldn't return null if operation is success", mbeanContainer.dump());
+	}
+	
+	private void setUpDestoy(){
+		managed = new Managed();
+		mbeanContainer.beanAdded(null, managed);
+	}
+
+	@Test
+	public void testDestroy() throws Exception {
+		//given
+		setUpDestoy();
+		
+		//when
+		mbeanContainer.destroy();
+		objectName = mbeanContainer.findMBean(managed);
+		
+		//then
+		assertFalse("Unregisted bean-  managed", mbeanContainer.getMBeanServer().isRegistered(objectName));
+	}
+	
+	@Test
+	public void testDestroyInstanceNotFoundException() throws Exception {
+		//given
+		setUpDestoy();
+		objectName = mbeanContainer.findMBean(managed);
+		
+		//when
+		mbeanContainer.getMBeanServer().unregisterMBean(objectName);
+		
+		//then
+		assertFalse("Unregisted bean-  managed", mbeanContainer.getMBeanServer().isRegistered(objectName));
+		// this flow covers InstanceNotFoundException. Actual code just eating
+		// the exception. i.e Actual code just printing the stacktrace, whenever
+		// an exception of type InstanceNotFoundException occurs.
+		mbeanContainer.destroy();
+	}
+}

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanUtilTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanUtilTest.java
@@ -1,0 +1,317 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.jmx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.ReflectionException;
+
+import org.eclipse.jetty.util.log.Log;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.acme.Derived;
+import com.acme.DerivedExtended;
+import com.acme.DerivedManaged;
+
+public class ObjectMBeanUtilTest {
+
+	private ObjectMBean objectMBean;
+
+	private DerivedExtended derivedExtended;
+
+	private MBeanContainer container;
+
+	private MBeanInfo objectMBeanInfo;
+
+	private Object mBean;
+
+	private String value;
+
+	private Attribute attribute;
+
+	private AttributeList attributes;
+
+	private ObjectMBean mBeanDerivedManaged;
+
+	private Derived[] derivedes;
+
+	private ArrayList<Derived> aliasNames;
+
+	private DerivedManaged derivedManaged;
+	
+	private static final int EMPTY=0;
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		Log.getRootLogger().setDebugEnabled(true);
+	}
+
+	@Before
+	public void setUp() {
+		derivedExtended = new DerivedExtended();
+		objectMBean = new ObjectMBean(derivedExtended);
+		container = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
+		objectMBean.setMBeanContainer(container);
+		objectMBeanInfo = objectMBean.getMBeanInfo();
+	}
+
+	@Test
+	public void testBasicOperations() {
+		assertEquals("Managed objects should be equal", derivedExtended, objectMBean.getManagedObject());
+		assertNull("This method call always returns null in the actual code", objectMBean.getObjectName());
+		assertNull("This method call always returns null in the actual code", objectMBean.getObjectNameBasis());
+		assertNull("This method call always returns null in the actual code", objectMBean.getObjectContextBasis());
+		assertEquals("Mbean container should be equal", container, objectMBean.getMBeanContainer());
+		assertEquals("Mbean description must be equal to : Test the mbean extended stuff", "Test the mbean extended stuff",
+				objectMBeanInfo.getDescription());
+	}
+
+	@Test
+	public void testMbeanForNullCheck() {
+		// when
+		mBean = ObjectMBean.mbeanFor(null);
+
+		// then
+		assertNull("As we are passing null value the output should be null", mBean);
+	}
+
+	@Test(expected = ReflectionException.class)
+	public void testGetAttributeReflectionException() throws Exception {
+		// given
+		setUpGetAttribute("doodle4", "charu");
+
+		// when
+		objectMBean.getAttribute("doodle4");
+
+		// then
+		fail("An InvocationTargetException must have occured by now as doodle4() internally throwing exception");
+	}
+
+	private void setUpGetAttribute(String property, String value) throws Exception {
+		Attribute attribute = new Attribute(property, value);
+		objectMBean.setAttribute(attribute);
+	}
+
+	@Test(expected = AttributeNotFoundException.class)
+	public void testGetAttributeAttributeNotFoundException() throws Exception {
+		// when
+		objectMBean.getAttribute("ffname");
+
+		// then
+		fail("An AttributeNotFoundException must have occured by now as there is no "
+				+ "attribute with the name ffname in bean");
+	}
+
+	@Test
+	public void testSetAttributeWithCorrectAttrName() throws Exception {
+		// given
+		setUpGetAttribute("fname", "charu");
+
+		// when
+		value = (String) objectMBean.getAttribute("fname");
+
+		// then
+		assertEquals("Attribute(fname) value must be equl to charu", "charu", value);
+	}
+
+	@Test(expected = AttributeNotFoundException.class)
+	public void testSetAttributeNullCheck() throws Exception {
+		// given
+		objectMBean.setAttribute(null);
+
+		// when
+		objectMBean.getAttribute(null);
+
+		// then
+		fail("An AttributeNotFoundException must have occured by now as there is no attribute with the name null");
+	}
+
+	@Test(expected = AttributeNotFoundException.class)
+	public void testSetAttributeAttributeWithWrongAttrName() throws Exception {
+		// given
+		attribute = new Attribute("fnameee", "charu");
+
+		// when
+		objectMBean.setAttribute(attribute);
+
+		// then
+		fail("An AttributeNotFoundException must have occured by now as there is no attribute "
+				+ "with the name ffname in bean");
+	}
+
+	@Test
+	public void testSetAttributesWithCorrectValues() throws Exception {
+		// given
+		attributes = getAttributes("fname", "vijay");
+		attributes = objectMBean.setAttributes(attributes);
+
+		// when
+		attributes = objectMBean.getAttributes(new String[] { "fname" });
+
+		// then
+		assertEquals("Fname value must be equal to vijay", "vijay", ((Attribute) (attributes.get(0))).getValue());
+	}
+
+	@Test
+	public void testSetAttributesForArrayTypeAttribue() throws Exception {
+		// given
+		derivedes = getArrayTypeAttribute();
+
+		// when
+		derivedManaged.setAddresses(derivedes);
+		mBeanDerivedManaged.getMBeanInfo();
+
+		// then
+		assertNotNull("Address object shouldn't be null", mBeanDerivedManaged.getAttribute("addresses"));
+	}
+
+	@Test
+	public void testSetAttributesForCollectionTypeAttribue() throws Exception {
+		// given
+		aliasNames = getCollectionTypeAttribute();
+
+		// when
+		derivedManaged.setAliasNames(aliasNames);
+		mBeanDerivedManaged.getMBeanInfo();
+
+		// then
+		assertNotNull("Address object shouldn't be null", mBeanDerivedManaged.getAttribute("aliasNames"));
+		assertNull("Derived object shouldn't registerd with container so its value will be null",
+				mBeanDerivedManaged.getAttribute("derived"));
+	}
+
+	private Derived[] getArrayTypeAttribute() {
+		derivedManaged = new DerivedManaged();
+		mBeanDerivedManaged = new ObjectMBean(derivedManaged);
+		MBeanContainer mBeanDerivedManagedContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
+		mBeanDerivedManaged.setMBeanContainer(mBeanDerivedManagedContainer);
+		Derived derived0 = new Derived();
+		mBeanDerivedManagedContainer.beanAdded(null, derived0);
+		Derived[] derivedes = new Derived[3];
+		for (int i = 0; i < 3; i++) {
+			derivedes[i] = new Derived();
+		}
+		derivedManaged.setAddresses(derivedes);
+		mBeanDerivedManaged.getMBeanInfo();
+		ArrayList<Derived> aliasNames = new ArrayList<Derived>(Arrays.asList(derivedes));
+		derivedManaged.setAliasNames(aliasNames);
+		return derivedes;
+	}
+
+	private ArrayList<Derived> getCollectionTypeAttribute() {
+		ArrayList<Derived> aliasNames = new ArrayList<Derived>(Arrays.asList(getArrayTypeAttribute()));
+		return aliasNames;
+	}
+
+	@Test
+	public void testSetAttributesException() {
+		// given
+		attributes = getAttributes("fnameee", "charu");
+
+		// when
+		attributes = objectMBean.setAttributes(attributes);
+
+		// then
+		// Original code eating the exception and returning zero size list
+		assertEquals("As there is no attribute with the name fnameee, this should return empty", EMPTY,
+				attributes.size());
+	}
+
+	private AttributeList getAttributes(String name, String value) {
+		Attribute attribute = new Attribute(name, value);
+		AttributeList attributes = new AttributeList();
+		attributes.add(attribute);
+		return attributes;
+	}
+
+	@Test(expected = MBeanException.class)
+	public void testInvokeMBeanException() throws Exception {
+		// given
+		setMBeanInfoForInvoke();
+
+		// when
+		objectMBean.invoke("doodle2", new Object[] {}, new String[] {});
+
+		// then
+		fail("An MBeanException must have occured by now as doodle2() in Derived bean throwing exception");
+	}
+
+	@Test(expected = ReflectionException.class)
+	public void testInvokeReflectionException() throws Exception {
+		// given
+		setMBeanInfoForInvoke();
+
+		// when
+		objectMBean.invoke("doodle1", new Object[] {}, new String[] {});
+
+		// then
+		fail("An ReflectionException must have occured by now as doodle1() has private access in Derived bean");
+	}
+
+	@Test
+	public void testInvoke() throws Exception {
+		// given
+		setMBeanInfoForInvoke();
+
+		// when
+		value = (String) objectMBean.invoke("good", new Object[] {}, new String[] {});
+
+		// then
+		assertEquals("Method(good) invocation on objectMBean must return not bad", "not bad", value);
+	}
+
+	@Test(expected = ReflectionException.class)
+	public void testInvokeNoSuchMethodException() throws Exception {
+		// given
+		setMBeanInfoForInvoke();
+
+		// when
+		// DerivedMBean contains a managed method with the name good,we must
+		// call this method without any arguments
+		objectMBean.invoke("good", new Object[] {}, new String[] { "int aone" });
+
+		// then
+		fail("An ReflectionException must have occured by now as we cannot call a methow with wrong signature");
+	}
+
+	private void setMBeanInfoForInvoke() {
+		objectMBean = (ObjectMBean) ObjectMBean.mbeanFor(derivedExtended);
+		container.beanAdded(null, derivedExtended);
+		objectMBean.getMBeanInfo();
+	}
+
+	@Test
+	public void testToVariableName() {
+		assertEquals("fullName", objectMBean.toVariableName("isfullName"));
+	}
+}

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/PojoTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/PojoTest.java
@@ -1,0 +1,46 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.jmx;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.jetty.util.log.jmx.LogMBean;
+import org.junit.Test;
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.Validator;
+import com.openpojo.validation.ValidatorBuilder;
+import com.openpojo.validation.test.impl.GetterTester;
+import com.openpojo.validation.test.impl.SetterTester;
+
+/*
+ * This class tests all the getters and setters for a given list of classes.
+ */
+public class PojoTest {
+
+	private Validator validator;
+
+	@Test
+	public void testOpenPojo() {
+		validator = ValidatorBuilder.create().with(new SetterTester()).with(new GetterTester()).build();
+		List<Class> classes = Arrays.asList(MBeanContainer.class, ObjectMBean.class, LogMBean.class);
+		for (Class clazz : classes) {
+			validator.validate(PojoClassFactory.getPojoClass(clazz));
+		}
+	}
+}

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/util/log/jmx/LogMBeanTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/util/log/jmx/LogMBeanTest.java
@@ -1,0 +1,53 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util.log.jmx;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.Test;
+import com.acme.Managed;
+
+public class LogMBeanTest {
+
+	private Managed managed;
+
+	private LogMBean logMBean;
+
+	private static final String MANAGED_CLASS = "Managed";
+
+	@Before
+	public void setUp() {
+		managed = new Managed();
+		logMBean = new LogMBean(managed);
+	}
+
+	@Test
+	public void testKeySet() {
+		// given
+		assertFalse("Managed is not registered with loggers", logMBean.getLoggers().contains(MANAGED_CLASS));
+
+		// when
+		logMBean.setDebugEnabled(MANAGED_CLASS, true);
+
+		// then
+		assertTrue("Managed must be registered with loggers", logMBean.getLoggers().contains(MANAGED_CLASS));
+		assertTrue("This must return true as debug is enabled for this class", logMBean.isDebugEnabled(MANAGED_CLASS));
+	}
+}


### PR DESCRIPTION
This pull request is focused on module Jetty-Jmx. Code coverage is measured using Cobertura. This pull request increases code coverage of the whole project by 25%.

Metric                |Before     |After
--------------------|------------|--------
Coverage%       |60%        |85%
Lines Covered  |308         |433
Total Lines       |505         |505


Please let me know if you have any questions. 

Vijay
DevFactory - Code Quality Team