### PR TITLE
HttpRequest has a wrong HTTP Version.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
@@ -27,6 +27,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Map;
 
 import org.eclipse.jetty.client.api.Connection;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.ManagedSelector;
 import org.eclipse.jetty.io.SelectChannelEndPoint;
@@ -142,6 +143,11 @@ public abstract class AbstractHttpClientTransport extends ContainerLifeCycle imp
             }
         }
     }
+
+	@Override
+	public HttpVersion getHttpVersion() {
+		return HttpVersion.HTTP_1_1;
+	}
 
     protected void connectFailed(Map<String, Object> context, Throwable x)
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
@@ -144,10 +144,10 @@ public abstract class AbstractHttpClientTransport extends ContainerLifeCycle imp
         }
     }
 
-	@Override
-	public HttpVersion getHttpVersion() {
-		return HttpVersion.HTTP_1_1;
-	}
+    @Override
+    public HttpVersion getHttpVersion() {
+        return HttpVersion.HTTP_1_1;
+    }
 
     protected void connectFailed(Map<String, Object> context, Throwable x)
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -426,7 +426,7 @@ public class HttpClient extends ContainerLifeCycle
      */
     public Request newRequest(URI uri)
     {
-        return newHttpRequest(newConversation(), uri);
+        return newHttpRequest(newConversation(), uri).version(transport.getHttpVersion());
     }
 
     protected Request copyRequest(HttpRequest oldRequest, URI newURI)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
@@ -71,9 +71,9 @@ public interface HttpClientTransport extends ClientConnectionFactory
     public void connect(InetSocketAddress address, Map<String, Object> context);
     
     /**
-     * Return HTTP version that is implemented in this class.
+     * Return a {@link HttpClientTransport}'s HTTP version, transport-specific, {@link HttpVersion} enum
      * 
-     * @return a transport's http version, transport-specific, {@link HttpVersion} enum
+     * @return a {@link HttpClientTransport}'s HTTP version, transport-specific, {@link HttpVersion} enum
      */
     public HttpVersion getHttpVersion();
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.client;
 import java.net.InetSocketAddress;
 import java.util.Map;
 
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 
 /**
@@ -64,8 +65,15 @@ public interface HttpClientTransport extends ClientConnectionFactory
     /**
      * Establishes a physical connection to the given {@code address}.
      *
-     *  @param address the address to connect to
+     * @param address the address to connect to
      * @param context the context information to establish the connection
      */
     public void connect(InetSocketAddress address, Map<String, Object> context);
+    
+    /**
+     * Return HTTP version that is implemented in this class.
+     * 
+     * @return a transport's http version, transport-specific, {@link HttpVersion} enum
+     */
+    public HttpVersion getHttpVersion();
 }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.HTTP2ClientConnectionFactory;
@@ -196,4 +197,9 @@ public class HttpClientTransportOverHTTP2 extends ContainerLifeCycle implements 
             connection.close(failure);
         }
     }
+
+	@Override
+	public HttpVersion getHttpVersion() {
+		return HttpVersion.HTTP_2;
+	}
 }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -132,6 +132,11 @@ public class HttpClientTransportOverHTTP2 extends ContainerLifeCycle implements 
             factory = new ALPNClientConnectionFactory(client.getExecutor(), factory, client.getProtocols());
         return factory.newConnection(endPoint, context);
     }
+    
+    @Override
+    public HttpVersion getHttpVersion() {
+            return HttpVersion.HTTP_2;
+    }
 
     protected HttpConnectionOverHTTP2 newHttpConnection(HttpDestination destination, Session session)
     {
@@ -197,9 +202,4 @@ public class HttpClientTransportOverHTTP2 extends ContainerLifeCycle implements 
             connection.close(failure);
         }
     }
-
-	@Override
-	public HttpVersion getHttpVersion() {
-		return HttpVersion.HTTP_2;
-	}
 }


### PR DESCRIPTION
# Problem
- When I use HttpClient with HTTP/2(HTTP2Client, HttpClientTransportOverHTTP2), it creates HttpRequest Objects has wrong HTTP Version(HTTP/1.1)
- HttpRequest is never assigned a HTTP Version.  
(But, HttpResponse is assigned a right HTTP Version.)  
- Wrong version is printed.
```
[HttpClient@627185331-17] DEBUG org.eclipse.jetty.client.HttpSender.queuedToBegin(219) - Request begin HttpRequest[POST /3/device/bad-token HTTP/1.1]@cb51256
[HttpClient@627185331-17] DEBUG org.eclipse.jetty.client.HttpSender.headersToCommit(255) - Request committed HttpRequest[POST /3/device/bad-token HTTP/1.1]@cb51256
```

# Changes
- Add 'getHttpVersion' method to HttpClientTransport interface.  
Because, HttpClientTransport represents what transport implementations.
- Its children implements  'getHttpVersion' method.  
AbstractHttpClientTransport returns HTTP_1_1.   
HttpClientTransportOverHTTP2 returns HTTP_2.  
- HttpClient assign HttpClientTransport's HTTP Version when HttpRequest is being created.

