### PR TITLE
Fetch user roles after a successful forced binded ldap login.

### DIFF
--- a/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
+++ b/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
@@ -415,32 +415,35 @@ public class LdapLoginModule extends AbstractLoginModule
                 return isAuthenticated();
             }
 
+            boolean authed = false;
+
             if (_forceBindingLogin)
             {
-                return bindingLogin(webUserName, webCredential);
+                authed = bindingLogin(webUserName, webCredential);
             }
-
-            // This sets read and the credential
-            UserInfo userInfo = getUserInfo(webUserName);
-
-            if (userInfo == null)
-            {
-                setAuthenticated(false);
-                return false;
-            }
-
-            setCurrentUser(new JAASUserInfo(userInfo));
-
-            boolean authed = false;            
-            if (webCredential instanceof String)
-                authed = credentialLogin(Credential.getCredential((String) webCredential));
             else
-                authed = credentialLogin(webCredential);
-            
+            {
+                // This sets read and the credential
+                UserInfo userInfo = getUserInfo(webUserName);
+
+                if (userInfo == null)
+                {
+                    setAuthenticated(false);
+                    return false;
+                }
+
+                setCurrentUser(new JAASUserInfo(userInfo));
+
+                if (webCredential instanceof String)
+                    authed = credentialLogin(Credential.getCredential((String) webCredential));
+                else
+                    authed = credentialLogin(webCredential);
+            }
+
             //only fetch roles if authenticated
             if (authed)
                 getCurrentUser().fetchRoles();
-            
+
             return authed;
         }
         catch (UnsupportedCallbackException e)


### PR DESCRIPTION
After https://github.com/eclipse/jetty.project/commit/6e37f4886a4e04c0505d478e57122c13e6c25fd3, login using LdapLoginContext with _forceBindingLogin set to true would cause a NPE in AbstractLoginModule line 90 and 97 because roles are not fetched when _forceBindingLogin is true.
This PR fixes this issue.