### PR TITLE
jetty-9.3.x: Support Direct Byte Buffers

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -64,6 +64,7 @@ public class HttpConfiguration
     private boolean _delayDispatchUntilContent = true;
     private boolean _persistentConnectionsEnabled = true;
     private int _maxErrorDispatches = 10;
+    private boolean _useDirectByteBuffers = false;
 
     /* ------------------------------------------------------------ */
     /** 
@@ -305,6 +306,22 @@ public class HttpConfiguration
     public boolean isDelayDispatchUntilContent()
     {
         return _delayDispatchUntilContent;
+    }
+
+    /* ------------------------------------------------------------ */
+    /**
+     * @param delay if true, use direct byte buffers for requests
+     */
+    public void setUseDirectByteBuffers(boolean useDirectByteBuffers)
+    {
+        _useDirectByteBuffers = useDirectByteBuffers;
+    }
+
+    /* ------------------------------------------------------------ */
+    @ManagedAttribute("if true, use direct byte buffers for requests")
+    public boolean isUseDirectByteBuffers()
+    {
+        return _useDirectByteBuffers;
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -52,9 +52,6 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     private static final Logger LOG = Log.getLogger(HttpConnection.class);
     public static final HttpField CONNECTION_CLOSE = new PreEncodedHttpField(HttpHeader.CONNECTION,HttpHeaderValue.CLOSE.asString());
     public static final String UPGRADE_CONNECTION_ATTRIBUTE = "org.eclipse.jetty.server.HttpConnection.UPGRADE";
-    private static final boolean REQUEST_BUFFER_DIRECT=false;
-    private static final boolean HEADER_BUFFER_DIRECT=false;
-    private static final boolean CHUNK_BUFFER_DIRECT=false;
     private static final ThreadLocal<HttpConnection> __currentConnection = new ThreadLocal<>();
 
     private final HttpConfiguration _config;
@@ -199,7 +196,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     public ByteBuffer getRequestBuffer()
     {
         if (_requestBuffer == null)
-            _requestBuffer = _bufferPool.acquire(getInputBufferSize(), REQUEST_BUFFER_DIRECT);
+            _requestBuffer = _bufferPool.acquire(getInputBufferSize(), _config.isUseDirectByteBuffers());
         return _requestBuffer;
     }
 
@@ -694,13 +691,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
                         
                     case NEED_HEADER:
                     {
-                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), HEADER_BUFFER_DIRECT);
-
+                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), _config.isUseDirectByteBuffers());
                         continue;
                     }
                     case NEED_CHUNK:
                     {
-                        chunk = _chunk = _bufferPool.acquire(HttpGenerator.CHUNK_SIZE, CHUNK_BUFFER_DIRECT);
+                        chunk = _chunk = _bufferPool.acquire(HttpGenerator.CHUNK_SIZE, _config.isUseDirectByteBuffers());
                         continue;
                     }
                     case FLUSH:


### PR DESCRIPTION
Support using direct byte buffers in the internal Jetty buffer pool (see: issue #351).