### PR TITLE
jetty-9.2.x: Support Direct Byte Buffers

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -55,6 +55,7 @@ public class HttpConfiguration
     private boolean _sendXPoweredBy = false;
     private boolean _sendDateHeader = true;
     private boolean _delayDispatchUntilContent = false;
+    private boolean _useDirectByteBuffers = false;
 
     /* ------------------------------------------------------------ */
     /** 
@@ -234,6 +235,22 @@ public class HttpConfiguration
     public boolean isDelayDispatchUntilContent()
     {
         return _delayDispatchUntilContent;
+    }
+
+    /* ------------------------------------------------------------ */
+    /**
+     * @param delay if true, use direct byte buffers for requests
+     */
+    public void setUseDirectByteBuffers(boolean useDirectByteBuffers)
+    {
+        _useDirectByteBuffers = useDirectByteBuffers;
+    }
+
+    /* ------------------------------------------------------------ */
+    @ManagedAttribute("if true, use direct byte buffers for requests")
+    public boolean isUseDirectByteBuffers()
+    {
+        return _useDirectByteBuffers;
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -48,9 +48,6 @@ import org.eclipse.jetty.util.log.Logger;
 public class HttpConnection extends AbstractConnection implements Runnable, HttpTransport, Connection.UpgradeFrom
 {
     public static final String UPGRADE_CONNECTION_ATTRIBUTE = "org.eclipse.jetty.server.HttpConnection.UPGRADE";
-    private static final boolean REQUEST_BUFFER_DIRECT=false;
-    private static final boolean HEADER_BUFFER_DIRECT=false;
-    private static final boolean CHUNK_BUFFER_DIRECT=false;
     private static final Logger LOG = Log.getLogger(HttpConnection.class);
     private static final ThreadLocal<HttpConnection> __currentConnection = new ThreadLocal<>();
 
@@ -188,7 +185,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     public ByteBuffer getRequestBuffer()
     {
         if (_requestBuffer == null)
-            _requestBuffer = _bufferPool.acquire(getInputBufferSize(), REQUEST_BUFFER_DIRECT);
+            _requestBuffer = _bufferPool.acquire(getInputBufferSize(), _config.isUseDirectByteBuffers());
         return _requestBuffer;
     }
 
@@ -666,12 +663,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
                 {
                     case NEED_HEADER:
                     {
-                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), HEADER_BUFFER_DIRECT);
+                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), _config.isUseDirectByteBuffers());
                         continue;
                     }
                     case NEED_CHUNK:
                     {
-                        chunk = _chunk = _bufferPool.acquire(HttpGenerator.CHUNK_SIZE, CHUNK_BUFFER_DIRECT);
+                        chunk = _chunk = _bufferPool.acquire(HttpGenerator.CHUNK_SIZE, _config.isUseDirectByteBuffers());
                         continue;
                     }
                     case FLUSH:


### PR DESCRIPTION
Support using direct byte buffers in the internal Jetty buffer pool (see: issue #351).