### PR TITLE
Issue #124 - Don't produce text/html if the request doesn't accept it

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
@@ -112,8 +113,8 @@ public class ErrorHandler extends AbstractHandler
         baseRequest.setHandled(true);
 
         // Issue #124 - Don't produce text/html if the request doesn't accept it
-        String reqAccept = request.getHeader("Accept");
-        if (reqAccept == null || reqAccept.contains("text/html") || reqAccept.contains("*/*"))
+        HttpField accept = baseRequest.getHttpFields().getField(HttpHeader.ACCEPT);
+        if (accept == null || accept.contains("text/html") || accept.contains("*/*"))
         {
             response.setContentType(MimeTypes.Type.TEXT_HTML_8859_1.asString());
             if (_cacheControl != null)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -110,16 +110,22 @@ public class ErrorHandler extends AbstractHandler
         }
         
         baseRequest.setHandled(true);
-        response.setContentType(MimeTypes.Type.TEXT_HTML_8859_1.asString());    
-        if (_cacheControl!=null)
-            response.setHeader(HttpHeader.CACHE_CONTROL.asString(), _cacheControl);
-        ByteArrayISO8859Writer writer= new ByteArrayISO8859Writer(4096);
-        String reason=(response instanceof Response)?((Response)response).getReason():null;
-        handleErrorPage(request, writer, response.getStatus(), reason);
-        writer.flush();
-        response.setContentLength(writer.size());
-        writer.writeTo(response.getOutputStream());
-        writer.destroy();
+
+        // Issue #124 - Don't produce text/html if the request doesn't accept it
+        String reqAccept = request.getHeader("Accept");
+        if (reqAccept == null || reqAccept.contains("text/html") || reqAccept.contains("*/*"))
+        {
+            response.setContentType(MimeTypes.Type.TEXT_HTML_8859_1.asString());
+            if (_cacheControl != null)
+                response.setHeader(HttpHeader.CACHE_CONTROL.asString(), _cacheControl);
+            ByteArrayISO8859Writer writer = new ByteArrayISO8859Writer(4096);
+            String reason = (response instanceof Response) ? ((Response) response).getReason() : null;
+            handleErrorPage(request, writer, response.getStatus(), reason);
+            writer.flush();
+            response.setContentLength(writer.size());
+            writer.writeTo(response.getOutputStream());
+            writer.destroy();
+        }
     }
 
     /* ------------------------------------------------------------ */


### PR DESCRIPTION
+ If request has no 'Accept' header, produce text/html as before.
+ If request has 'Accept' header, then test for 'text/html' or '*/*'
  entries before producing html output.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>