### PR TITLE
Issue #356 (Element error-page/location must start with a '/')

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
@@ -1113,6 +1113,8 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
             code=Integer.valueOf(error);
 
         String location = node.getString("location", false, true);
+        if (!location.startsWith("/"))
+            throw new IllegalStateException("Missing leading '/' for location: " + location);
         ErrorPageErrorHandler handler = (ErrorPageErrorHandler)context.getErrorHandler();
         String originName = "error."+error;
         switch (context.getMetaData().getOrigin(originName))


### PR DESCRIPTION
Enforcing check on Element error-page/location to have a leading '/' as per the Servlet specification, section 14.4.15
Signed-off-by: Mehtab Singh Mann <mehtabsinghmann@gmail.com>