### PR TITLE
Add a overridable 'onClose' method in HttpClientTransportOverHTTP2

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -137,6 +137,10 @@ public class HttpClientTransportOverHTTP2 extends ContainerLifeCycle implements 
         return new HttpConnectionOverHTTP2(destination, session);
     }
 
+    protected void onClose(HttpConnectionOverHTTP2 connection, GoAwayFrame frame) {
+        connection.close();
+    }
+
     private class SessionListenerPromise extends Session.Listener.Adapter implements Promise<Session>
     {
         private final HttpDestinationOverHTTP2 destination;
@@ -181,7 +185,7 @@ public class HttpClientTransportOverHTTP2 extends ContainerLifeCycle implements 
         @Override
         public void onClose(Session session, GoAwayFrame frame)
         {
-            connection.close();
+            HttpClientTransportOverHTTP2.this.onClose(connection, frame);
         }
 
         @Override


### PR DESCRIPTION
- Can override 'onClose' method and get GoAwayFrame.
- Related PR: https://github.com/eclipse/jetty.project/pull/389

Signed-off-by: Jinho Shin <drdoteam@gmail.com>