### PR TITLE
Issue #438 - File and Path Resources with control characters should be rejected

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import java.security.Permission;
 
@@ -204,7 +205,7 @@ public class FileResource extends Resource
         }
         catch(final URISyntaxException e)
         {
-            throw new MalformedURLException(){{initCause(e);}};
+            throw new InvalidPathException(path, e.getMessage());
         }
 
         return new FileResource(uri);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -38,6 +38,8 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -48,6 +50,7 @@ import org.eclipse.jetty.util.log.Logger;
 public class PathResource extends Resource
 {
     private static final Logger LOG = Log.getLogger(PathResource.class);
+    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
     private final Path path;
     private final URI uri;
@@ -61,6 +64,7 @@ public class PathResource extends Resource
     public PathResource(Path path)
     {
         this.path = path;
+        assertValidPath(path);
         this.uri = this.path.toUri();
     }
 
@@ -108,6 +112,15 @@ public class PathResource extends Resource
     public Resource addPath(String apath) throws IOException, MalformedURLException
     {
         return new PathResource(this.path.getFileSystem().getPath(path.toString(), apath));
+    }
+
+    private void assertValidPath(Path path)
+    {
+        Matcher mat = CNTRL_PATTERN.matcher(path.toString());
+        if(mat.find())
+        {
+            throw new InvalidPathException(path.toString(), "Invalid Character at index " + mat.start());
+        }
     }
 
     @Override

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AbstractFSResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AbstractFSResourceTest.java
@@ -18,10 +18,6 @@
 
 package org.eclipse.jetty.util.resource;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -50,6 +46,14 @@ import org.eclipse.jetty.util.CollectionAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNoException;
 
 public abstract class AbstractFSResourceTest
 {
@@ -517,6 +521,70 @@ public abstract class AbstractFSResourceTest
         }
     }
     
+    @Test
+    public void testExist_BadControlChars() throws Exception
+    {
+        createEmptyFile("a.jsp");
+
+        try
+        {
+            // request with control characters
+            URI ref = testdir.getDir().toURI().resolve("a.jsp%1F%10");
+            assertThat("ControlCharacters URI",ref,notNullValue());
+
+            newResource(ref);
+            fail("Should have thrown " + InvalidPathException.class);
+        }
+        catch (InvalidPathException e)
+        {
+            // Expected path
+        }
+    }
+
+    @Test
+    public void testExist_AddPath_BadControlChars_Decoded() throws Exception
+    {
+        createEmptyFile("a.jsp");
+
+        try
+        {
+            // base resource
+            URI ref = testdir.getDir().toURI();
+            Resource base = newResource(ref);
+            assertThat("Base Resource URI",ref,notNullValue());
+
+            // add path with control characters
+            Resource fileref = base.addPath("/a.jsp\014\010");
+            fail("Should have thrown " + InvalidPathException.class);
+        }
+        catch (InvalidPathException e)
+        {
+            // Expected path
+        }
+    }
+
+    @Test
+    public void testExist_AddPath_BadControlChars_Encoded() throws Exception
+    {
+        createEmptyFile("a.jsp");
+
+        try
+        {
+            // base resource
+            URI ref = testdir.getDir().toURI();
+            Resource base = newResource(ref);
+            assertThat("Base Resource URI",ref,notNullValue());
+
+            // add path with control characters
+            Resource fileref = base.addPath("/a.jsp%14%10");
+            fail("Should have thrown " + InvalidPathException.class);
+        }
+        catch (InvalidPathException e)
+        {
+            // Expected path
+        }
+    }
+
     @Test
     public void testUtf8Dir() throws Exception
     {

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AbstractFSResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AbstractFSResourceTest.java
@@ -522,7 +522,7 @@ public abstract class AbstractFSResourceTest
     }
     
     @Test
-    public void testExist_BadControlChars() throws Exception
+    public void testExist_BadControlChars_Encoded() throws Exception
     {
         createEmptyFile("a.jsp");
 
@@ -532,7 +532,25 @@ public abstract class AbstractFSResourceTest
             URI ref = testdir.getDir().toURI().resolve("a.jsp%1F%10");
             assertThat("ControlCharacters URI",ref,notNullValue());
 
-            newResource(ref);
+            Resource fileref = newResource(ref);
+            assertThat("File Resource should not exists", fileref.exists(), is(false));
+        }
+        catch (InvalidPathException e)
+        {
+            // Expected path
+        }
+    }
+
+    @Test
+    public void testExist_BadControlChars_Decoded() throws Exception
+    {
+        createEmptyFile("a.jsp");
+
+        try
+        {
+            // request with control characters
+            File badFile = new File(testdir.getDir(), "a.jsp\014\010");
+            newResource(badFile);
             fail("Should have thrown " + InvalidPathException.class);
         }
         catch (InvalidPathException e)
@@ -553,8 +571,9 @@ public abstract class AbstractFSResourceTest
             Resource base = newResource(ref);
             assertThat("Base Resource URI",ref,notNullValue());
 
-            // add path with control characters
-            Resource fileref = base.addPath("/a.jsp\014\010");
+            // add path with control characters (raw/decoded control characters)
+            // This MUST fail
+            base.addPath("/a.jsp\014\010");
             fail("Should have thrown " + InvalidPathException.class);
         }
         catch (InvalidPathException e)
@@ -577,7 +596,7 @@ public abstract class AbstractFSResourceTest
 
             // add path with control characters
             Resource fileref = base.addPath("/a.jsp%14%10");
-            fail("Should have thrown " + InvalidPathException.class);
+            assertThat("File Resource should not exists", fileref.exists(), is(false));
         }
         catch (InvalidPathException e)
         {

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileResourceTest.java
@@ -22,9 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 public class FileResourceTest extends AbstractFSResourceTest
 {
     @Override
@@ -37,17 +34,5 @@ public class FileResourceTest extends AbstractFSResourceTest
     public Resource newResource(File file) throws IOException
     {
         return new FileResource(file);
-    }
-    
-    @Ignore("Cannot get null to be seen by FileResource")
-    @Test
-    public void testExist_BadNull() throws Exception
-    {
-    }
-
-    @Ignore("Validation shouldn't be done in FileResource")
-    @Test
-    public void testExist_BadNullX() throws Exception
-    {
     }
 }


### PR DESCRIPTION
Updating testcases + adding validation check on filesystem based paths.