### PR TITLE
Issue #438 - File and Path Resources with control characters should be rejected

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -374,6 +374,53 @@ public class StringUtil
         }
     }
 
+    /**
+     * Find the index of a control characters in String
+     * <p>
+     * This will return a result on the first occurrence of a control character, regardless if
+     * there are more than one.
+     * </p>
+     * <p>
+     * Note: uses codepoint version of {@link Character#isISOControl(int)} to support Unicode better.
+     * </p>
+     *
+     * <pre>
+     *   indexOfControlChars(null)      == -1
+     *   indexOfControlChars("")        == -1
+     *   indexOfControlChars("\r\n")    == 0
+     *   indexOfControlChars("\t")      == 0
+     *   indexOfControlChars("   ")     == -1
+     *   indexOfControlChars("a")       == -1
+     *   indexOfControlChars(".")       == -1
+     *   indexOfControlChars(";\n")     == 1
+     *   indexOfControlChars("abc\f")   == 3
+     *   indexOfControlChars("z\010")   == 1
+     *   indexOfControlChars(":\u001c") == 1
+     * </pre>
+     *
+     * @param str
+     *            the string to test.
+     * @return the index of first control character in string, -1 if no control characters encountered
+     */
+    public static int indexOfControlChars(String str)
+    {
+        if (str == null)
+        {
+            return -1;
+        }
+        int len = str.length();
+        for (int i = 0; i < len; i++)
+        {
+            if (Character.isISOControl(str.codePointAt(i)))
+            {
+                // found a control character, we can stop searching  now
+                return i;
+            }
+        }
+        // no control characters
+        return -1;
+    }
+
     /* ------------------------------------------------------------ */
     /**
      * Test if a string is null or only has whitespace characters in it.

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -29,8 +29,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import java.security.Permission;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
@@ -50,6 +53,7 @@ import org.eclipse.jetty.util.log.Logger;
 public class FileResource extends Resource
 {
     private static final Logger LOG = Log.getLogger(FileResource.class);
+    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
     /* ------------------------------------------------------------ */
     private final File _file;
@@ -65,6 +69,7 @@ public class FileResource extends Resource
         {
             // Try standard API to convert URL to file.
             file =new File(url.toURI());
+            assertValidPath(file.toString());
         }
         catch (URISyntaxException e) 
         {
@@ -108,6 +113,7 @@ public class FileResource extends Resource
         _file=file;
         URI file_uri=_file.toURI();
         _uri=normalizeURI(_file,uri);
+        assertValidPath(file.toString());
 
         // Is it a URI alias?
         if (!URIUtil.equalsIgnoreEncodings(_uri,file_uri.toString()))
@@ -119,6 +125,7 @@ public class FileResource extends Resource
     /* -------------------------------------------------------- */
     FileResource(File file)
     {
+        assertValidPath(file.toString());
         _file=file;
         _uri=normalizeURI(_file,_file.toURI());
         _alias=checkFileAlias(_file);
@@ -179,6 +186,7 @@ public class FileResource extends Resource
     public Resource addPath(String path)
         throws IOException,MalformedURLException
     {
+        assertValidPath(path);
         path = org.eclipse.jetty.util.URIUtil.canonicalPath(path);
 
         if (path==null)
@@ -204,13 +212,21 @@ public class FileResource extends Resource
         }
         catch(final URISyntaxException e)
         {
-            throw new MalformedURLException(){{initCause(e);}};
+            throw new InvalidPathException(path, e.getMessage());
         }
 
         return new FileResource(uri);
     }
-   
-    
+
+    private void assertValidPath(String path)
+    {
+        Matcher mat = CNTRL_PATTERN.matcher(path);
+        if(mat.find())
+        {
+            throw new InvalidPathException(path, "Invalid Character at index " + mat.start());
+        }
+    }
+
     /* ------------------------------------------------------------ */
     @Override
     public URI getAlias()

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -32,10 +32,9 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import java.security.Permission;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -53,7 +52,6 @@ import org.eclipse.jetty.util.log.Logger;
 public class FileResource extends Resource
 {
     private static final Logger LOG = Log.getLogger(FileResource.class);
-    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
     /* ------------------------------------------------------------ */
     private final File _file;
@@ -220,10 +218,10 @@ public class FileResource extends Resource
 
     private void assertValidPath(String path)
     {
-        Matcher mat = CNTRL_PATTERN.matcher(path);
-        if(mat.find())
+        int idx = StringUtil.indexOfControlChars(path);
+        if (idx >= 0)
         {
-            throw new InvalidPathException(path, "Invalid Character at index " + mat.start());
+            throw new InvalidPathException(path, "Invalid Character at index " + idx);
         }
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -38,9 +38,8 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -50,7 +49,6 @@ import org.eclipse.jetty.util.log.Logger;
 public class PathResource extends Resource
 {
     private static final Logger LOG = Log.getLogger(PathResource.class);
-    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
     private final Path path;
     private final URI uri;
@@ -116,10 +114,11 @@ public class PathResource extends Resource
 
     private void assertValidPath(Path path)
     {
-        Matcher mat = CNTRL_PATTERN.matcher(path.toString());
-        if(mat.find())
+        String str = path.toString();
+        int idx = StringUtil.indexOfControlChars(str);
+        if(idx >= 0)
         {
-            throw new InvalidPathException(path.toString(), "Invalid Character at index " + mat.start());
+            throw new InvalidPathException(str, "Invalid Character at index " + idx);
         }
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -38,6 +38,8 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -48,6 +50,7 @@ import org.eclipse.jetty.util.log.Logger;
 public class PathResource extends Resource
 {
     private static final Logger LOG = Log.getLogger(PathResource.class);
+    private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
     private final Path path;
     private final URI uri;
@@ -61,6 +64,7 @@ public class PathResource extends Resource
     public PathResource(Path path)
     {
         this.path = path;
+        assertValidPath(path);
         this.uri = this.path.toUri();
     }
 
@@ -108,6 +112,15 @@ public class PathResource extends Resource
     public Resource addPath(String apath) throws IOException, MalformedURLException
     {
         return new PathResource(this.path.getFileSystem().getPath(path.toString(), apath));
+    }
+
+    private void assertValidPath(Path path)
+    {
+        Matcher mat = CNTRL_PATTERN.matcher(path.toString());
+        if(mat.find())
+        {
+            throw new InvalidPathException(path.toString(), "Invalid Character at index " + mat.start());
+        }
     }
 
     @Override

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
@@ -18,19 +18,19 @@
 
 package org.eclipse.jetty.util;
 
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import java.nio.charset.StandardCharsets;
-
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class StringUtilTest
 {
@@ -203,6 +203,25 @@ public class StringUtilTest
             System.err.println((s2-s1)+", "+(s3-s2)+", "+(s4-s3)+", "+(s5-s4));
         }
         System.err.println(calc);
+    }
+
+    @Test
+    public void testHasControlCharacter()
+    {
+        assertThat(StringUtil.indexOfControlChars("\r\n"), is(0));
+        assertThat(StringUtil.indexOfControlChars("\t"), is(0));
+        assertThat(StringUtil.indexOfControlChars(";\n"), is(1));
+        assertThat(StringUtil.indexOfControlChars("abc\fz"), is(3));
+        assertThat(StringUtil.indexOfControlChars("z\010"), is(1));
+        assertThat(StringUtil.indexOfControlChars(":\u001c"), is(1));
+
+        assertThat(StringUtil.indexOfControlChars(null), is(-1));
+        assertThat(StringUtil.indexOfControlChars(""), is(-1));
+        assertThat(StringUtil.indexOfControlChars("   "), is(-1));
+        assertThat(StringUtil.indexOfControlChars("a"), is(-1));
+        assertThat(StringUtil.indexOfControlChars("."), is(-1));
+        assertThat(StringUtil.indexOfControlChars(";"), is(-1));
+        assertThat(StringUtil.indexOfControlChars("Euro is \u20ac"), is(-1));
     }
 
     @Test

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileResourceTest.java
@@ -22,9 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 public class FileResourceTest extends AbstractFSResourceTest
 {
     @Override
@@ -37,17 +34,5 @@ public class FileResourceTest extends AbstractFSResourceTest
     public Resource newResource(File file) throws IOException
     {
         return new FileResource(file);
-    }
-    
-    @Ignore("Cannot get null to be seen by FileResource")
-    @Test
-    public void testExist_BadNull() throws Exception
-    {
-    }
-
-    @Ignore("Validation shouldn't be done in FileResource")
-    @Test
-    public void testExist_BadNullX() throws Exception
-    {
     }
 }


### PR DESCRIPTION
+ Adding testcases
+ Cleaning up unit tests, adding more
+ Fixing one testcase related to FileResource.addPath()
+ Adding validation of filesystem paths

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>