### PR TITLE
[Jetty-Client] fix: don't add host automaticaly on http2 request.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -111,7 +111,7 @@ public abstract class HttpConnection implements Connection
         }
 
         // If we are HTTP 1.1, add the Host header
-        if (version.getVersion() > 10)
+        if (version.getVersion() == 11)
         {
             if (!headers.containsKey(HttpHeader.HOST.asString()))
                 headers.put(getHttpDestination().getHostField());


### PR DESCRIPTION
All google server answer bad request when Host field is filled in h2 protocol.

Change-Id: I9e16f8c9f56bc26df0b0a933cee0b3a3d6c31921