### PR TITLE
Improve Proxy protocol to support fallback to non-Proxy connections transparently

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -48,7 +48,7 @@ import org.eclipse.jetty.util.log.Logger;
 /**
  * <p>A {@link Connection} that handles the HTTP protocol.</p>
  */
-public class HttpConnection extends AbstractConnection implements Runnable, HttpTransport, Connection.UpgradeFrom
+public class HttpConnection extends AbstractConnection implements Runnable, HttpTransport, Connection.UpgradeFrom, Connection.UpgradeTo
 {
     private static final Logger LOG = Log.getLogger(HttpConnection.class);
     public static final HttpField CONNECTION_CLOSE = new PreEncodedHttpField(HttpHeader.CONNECTION,HttpHeaderValue.CLOSE.asString());
@@ -192,6 +192,23 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
             return buffer;
         }
         return null;
+    }
+
+    @Override
+    public void onUpgradeTo(ByteBuffer prefilled) {
+        if (prefilled == null)
+        {
+            return;
+        }
+        if (_requestBuffer != null)
+        {
+            throw new IllegalStateException("upgrade after buffer has been allocated");
+        }
+
+        _requestBuffer = _bufferPool.acquire(getInputBufferSize(), false);
+        _requestBuffer.limit(prefilled.remaining());
+        _requestBuffer.put(prefilled);
+        _requestBuffer.position(0);
     }
 
     void releaseRequestBuffer()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -20,8 +20,6 @@ package org.eclipse.jetty.server;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -515,9 +513,9 @@ public class ProxyConnectionFactory extends AbstractConnectionFactory
                         {
                             byte[] addr=new byte[4];
                             _buffer.get(addr);
-                            src = Inet4Address.getByAddress(addr);
+                            src = InetAddress.getByAddress(addr);
                             _buffer.get(addr);
-                            dst = Inet4Address.getByAddress(addr);
+                            dst = InetAddress.getByAddress(addr);
                             sp = _buffer.getChar();
                             dp = _buffer.getChar();
 
@@ -528,9 +526,9 @@ public class ProxyConnectionFactory extends AbstractConnectionFactory
                         {
                             byte[] addr=new byte[16];
                             _buffer.get(addr);
-                            src = Inet6Address.getByAddress(addr);
+                            src = InetAddress.getByAddress(addr);
                             _buffer.get(addr);
-                            dst = Inet6Address.getByAddress(addr);
+                            dst = InetAddress.getByAddress(addr);
                             sp = _buffer.getChar();
                             dp = _buffer.getChar();
                             break;  

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -427,23 +427,25 @@ public class ProxyConnectionFactory extends AbstractConnectionFactory
             _local=(versionAndCommand&0xf)==0x00;
 
             int transportAndFamily = 0xff & buffer.get();
-            switch(transportAndFamily>>4)
+            final int family = transportAndFamily>>4;
+            switch(family)
             {
                 case 0: _family=Family.UNSPEC; break;
                 case 1: _family=Family.INET; break;
                 case 2: _family=Family.INET6; break;
                 case 3: _family=Family.UNIX; break;
                 default:
-                    throw new IllegalStateException("Bad PROXY protocol v2 family");
+                    throw new UnsupportedOperationException("Bad PROXY protocol v2 family " + family);
             }
-            
-            switch(0xf&transportAndFamily)
+
+            final int transport = 0xf & transportAndFamily;
+            switch(transport)
             {
                 case 0: _transport=Transport.UNSPEC; break;
                 case 1: _transport=Transport.STREAM; break;
                 case 2: _transport=Transport.DGRAM; break;
                 default:
-                    throw new IllegalStateException("Bad PROXY protocol v2 family");
+                    throw new UnsupportedOperationException("Bad PROXY protocol v2 transport " + transport);
             }
                         
             _length = buffer.getChar();

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -368,10 +368,9 @@ public class ProxyConnectionFactory extends AbstractConnectionFactory
             }
         }
     }
-    
-    
-    enum Family { UNSPEC, INET, INET6, UNIX };
-    enum Transport { UNSPEC, STREAM, DGRAM };
+
+    enum Family { UNSPEC, INET, INET6, UNIX }
+    enum Transport { UNSPEC, STREAM, DGRAM }
 
     public class ProxyProtocolV2Connection extends AbstractConnection
     {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
@@ -169,7 +169,10 @@ public class ProxyConnectionTest
                 "Host: server:80\n"+
                 "Connection: close\n"+
                 "\n");
-        Assert.assertThat(response,Matchers.equalTo(""));
+        Assert.assertThat(response,Matchers.containsString("HTTP/1.1 200"));
+        Assert.assertThat(response,Matchers.containsString("pathInfo=/path"));
+        Assert.assertThat(response,Matchers.containsString("local=127.0.0.1"));
+        Assert.assertThat(response,Matchers.containsString("remote=127.0.0.1"));
     }
 }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
@@ -171,9 +171,7 @@ public class ProxyConnectionTest
                 "\n");
         Assert.assertThat(response,Matchers.containsString("HTTP/1.1 200"));
         Assert.assertThat(response,Matchers.containsString("pathInfo=/path"));
-        Assert.assertThat(response,Matchers.containsString("local=127.0.0.1"));
-        Assert.assertThat(response,Matchers.containsString("remote=127.0.0.1"));
+        Assert.assertThat(response,Matchers.containsString("local=0.0.0.0"));
+        Assert.assertThat(response,Matchers.containsString("remote=0.0.0.0"));
     }
 }
-
-


### PR DESCRIPTION
* Rework ProxyV?Connection to handoff buffers via `UpgradeFrom`/`UpgradeTo` rather than a bespoke constructor
* Add HttpConnection `UpgradeTo` support
* ProxyConnectionFactory now allows a fallback for non-Proxy protocol connections

TODO:
* SslConnection needs `UpgradeTo` support, but how do I test it?  It seems that `SslSocket` doesn't allow you to send unencrypted data, which makes it difficult to create the necessary mixed unencrypted / encrypted data stream

This is a work in progress asking for feedback, please do not merge just yet!