### PR TITLE
Fix #480 [jetty-osgi] org.eclipse.jetty.annotations should be optional

### DIFF
--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -115,6 +115,7 @@
  org.slf4j.helpers;resolution:=optional,
  org.xml.sax,
  org.xml.sax.helpers,
+ org.eclipse.jetty.annotations;resolution:=optional,
  *
                         </Import-Package>
                         <_nouses>true</_nouses>


### PR DESCRIPTION
Signed-off-by: laeubi <laeubi@laeubi-soft.de>

Makes the import optional.