### PR TITLE
Fix #482 The CCL while parsing the xml files should be set to a combination of Jetty and Bundle-Classloader

### DIFF
--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/serverfactory/DefaultJettyAtJettyHomeHelper.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/serverfactory/DefaultJettyAtJettyHomeHelper.java
@@ -31,6 +31,7 @@ import java.util.StringTokenizer;
 import org.eclipse.jetty.osgi.boot.JettyBootstrapActivator;
 import org.eclipse.jetty.osgi.boot.OSGiServerConstants;
 import org.eclipse.jetty.osgi.boot.utils.BundleFileLocatorHelperFactory;
+import org.eclipse.jetty.osgi.boot.utils.OSGiClassLoader;
 import org.eclipse.jetty.osgi.boot.utils.Util;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.log.Log;
@@ -166,7 +167,16 @@ public class DefaultJettyAtJettyHomeHelper
         ClassLoader contextCl = Thread.currentThread().getContextClassLoader();
         try
         {
-            Thread.currentThread().setContextClassLoader(JettyBootstrapActivator.class.getClassLoader());
+            ClassLoader cl;
+            if (jettyHomeBundle != null)
+            {
+                cl = new OSGiClassLoader(JettyBootstrapActivator.class.getClassLoader(),jettyHomeBundle);
+            }
+            else
+            {
+                cl = JettyBootstrapActivator.class.getClassLoader();
+            }
+            Thread.currentThread().setContextClassLoader(cl);
             
             // these properties usually are the ones passed to this type of
             // configuration.

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -67,6 +67,13 @@
       <version>${url.version}</version>
       <scope>test</scope>
     </dependency>
+    
+	<dependency>
+		<groupId>org.ops4j.pax.tinybundles</groupId>
+		<artifactId>tinybundles</artifactId>
+		<version>2.1.1</version>
+	</dependency>
+
 
     <!-- OSGi R4 frameworks -->
 <!--

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-with-custom-class.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-with-custom-class.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+
+<!-- =============================================================== -->
+<!-- Configure the Jetty Server                                      -->
+<!--                                                                 -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- =============================================================== -->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+    <!-- =========================================================== -->
+    <!-- Server Thread Pool                                          -->
+    <!-- =========================================================== -->
+    <Get name="ThreadPool">
+      <Set name="minThreads">10</Set>
+      <Set name="maxThreads">200</Set>
+    </Get>
+
+	<New class="org.eclipse.jetty.osgi.test.SomeCustomBean" id="mycustombean"></New>
+
+
+    <!-- =========================================================== -->
+    <!-- Set handler Collection Structure                            -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+           <Item>
+             <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme">https</Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
+      <Set name="outputBufferSize">32768</Set>
+      <Set name="requestHeaderSize">8192</Set>
+      <Set name="responseHeaderSize">8192</Set>
+      <Set name="sendServerVersion">true</Set>
+      <Set name="sendDateHeader">false</Set>
+      <Set name="headerCacheSize">512</Set>
+    </New>
+
+
+    <!-- =========================================================== -->
+    <!-- extra options                                               -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown">true</Set>
+    <Set name="stopTimeout">1000</Set>
+    <Set name="dumpAfterStart">false</Set>
+    <Set name="dumpBeforeStop">false</Set>
+
+
+    <!-- =========================================================== -->
+    <!-- Set up the list of default configuration classes            -->
+    <!-- =========================================================== -->    
+    <Call name="setAttribute">
+       <Arg>org.eclipse.jetty.webapp.configuration</Arg>
+       <Arg>
+        <New class="org.eclipse.jetty.webapp.Configuration$ClassList">
+          <Arg>
+            <Array type="String">
+              <Item>org.eclipse.jetty.osgi.boot.OSGiWebInfConfiguration</Item>
+              <Item>org.eclipse.jetty.webapp.WebXmlConfiguration</Item>
+              <Item>org.eclipse.jetty.webapp.MetaInfConfiguration</Item>
+              <Item>org.eclipse.jetty.webapp.FragmentConfiguration</Item>
+              <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>  
+            </Array>
+          </Arg>
+        </New>
+       </Arg>
+    </Call>
+   
+
+    <Call class="java.lang.System" name="setProperty">
+      <Arg>java.naming.factory.initial</Arg>
+      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
+    </Call>
+    <Call class="java.lang.System" name="setProperty">
+      <Arg>java.naming.factory.url.pkgs</Arg>
+      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
+    </Call>
+
+</Configure>

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/SomeCustomBean.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/SomeCustomBean.java
@@ -1,0 +1,27 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2016 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+package org.eclipse.jetty.osgi.test;
+
+/**
+ * Just a simple bean
+ * 
+ * @author laeubi
+ *
+ */
+public class SomeCustomBean {
+
+}

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -1,0 +1,139 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2016 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.osgi.test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+
+import org.codehaus.plexus.util.IOUtil;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.osgi.boot.OSGiServerConstants;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.CoreOptions;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.tinybundles.core.TinyBundle;
+import org.ops4j.pax.tinybundles.core.TinyBundles;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+/**
+ * TestJettyOSGiBootWithBundle
+ * 
+ * Tests reading config from a bundle and loading clases from it
+ * 
+ * Tests the ServiceContextProvider.
+ * 
+ */
+@RunWith(PaxExam.class)
+public class TestJettyOSGiBootWithBundle
+{
+    private static final String TEST_JETTY_HOME_BUNDLE = "test-jetty-xml-bundle";
+
+
+	private static final String LOG_LEVEL = "WARN";
+
+
+    @Inject
+    BundleContext bundleContext = null;
+
+    @Configuration
+    public static Option[] configure() throws IOException
+    {
+        ArrayList<Option> options = new ArrayList<Option>();
+        options.add(CoreOptions.junitBundles());
+        options.addAll(configureJettyHomeAndPort("jetty-http.xml"));
+        options.add(CoreOptions.bootDelegationPackages("org.xml.sax", "org.xml.*", "org.w3c.*", "javax.xml.*"));
+        options.addAll(TestJettyOSGiBootCore.coreJettyDependencies());
+
+        options.addAll(Arrays.asList(options(systemProperty("pax.exam.logging").value("none"))));
+        options.addAll(Arrays.asList(options(systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value(LOG_LEVEL))));
+        options.addAll(Arrays.asList(options(systemProperty("org.eclipse.jetty.LEVEL").value(LOG_LEVEL))));
+        TinyBundle bundle = TinyBundles.bundle();
+        bundle.add(SomeCustomBean.class);
+        bundle.set( Constants.BUNDLE_SYMBOLICNAME, TEST_JETTY_HOME_BUNDLE );
+        File etcFolder = new File("src/test/config/etc");
+        bundle.add("jettyhome/etc/jetty-http.xml", new FileInputStream(new File(etcFolder, "jetty-http.xml")));
+        bundle.add("jettyhome/etc/jetty-with-custom-class.xml", new FileInputStream(new File(etcFolder, "jetty-with-custom-class.xml")));
+		options.add(CoreOptions.streamBundle(bundle.build()).startLevel(1));
+        return options.toArray(new Option[options.size()]);
+    }
+
+    public static List<Option> configureJettyHomeAndPort(String jettySelectorFileName)
+    {
+        List<Option> options = new ArrayList<Option>();
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value("etc/jetty-with-custom-class.xml,etc/jetty-http.xml"));
+        options.add(systemProperty("jetty.http.port").value(String.valueOf(TestJettyOSGiBootCore.DEFAULT_HTTP_PORT)));
+        options.add(systemProperty("jetty.ssl.port").value(String.valueOf(TestJettyOSGiBootCore.DEFAULT_SSL_PORT)));
+        options.add(systemProperty("jetty.home.bundle").value(TEST_JETTY_HOME_BUNDLE));
+        return options;
+    }
+
+    @Ignore
+    @Test
+    public void assertAllBundlesActiveOrResolved()
+    {
+        TestOSGiUtil.assertAllBundlesActiveOrResolved(bundleContext);
+    }
+
+
+    /**
+     */
+    @Test
+    public void testContextHandlerAsOSGiService() throws Exception
+    {
+        // now test the context
+        HttpClient client = new HttpClient();
+        try
+        {
+            client.start();
+            ContentResponse response = client.GET("http://127.0.0.1:" + TestJettyOSGiBootCore.DEFAULT_HTTP_PORT);
+            assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
+            String content = new String(response.getContent());
+            assertNotNull(content);
+        }
+        finally
+        {
+            client.stop();
+        }
+    }
+}


### PR DESCRIPTION
For any reason this contains a commit for #480, please ignore this and just merge the commit for #482