### PR TITLE
Issue #464: Revert regression in handshake failure handling

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -677,7 +677,7 @@ public class SslConnection extends AbstractConnection
             }
             catch (Exception e)
             {
-                close();
+                getEndPoint().close();
                 throw e;
             }
             finally


### PR DESCRIPTION
Commit d36e5864dbd4e7044a601be3f4d9b62b3a9cc110 replaced a close of the endpoint with
a close of this. As the SslConnection was in a PENDING state, that close attempt immediately
threw a ClosedChannelException, causing the exception describing the real condition to be lost.