### PR TITLE
FastFileServer throws exception on any GET file due to wrong Content-…

### DIFF
--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
@@ -128,6 +128,7 @@ public class FastFileServer
             // Jetty DefaultServlet will cache formatted date strings, but we
             // will reformat for each request here
             response.setDateHeader("Last-Modified", file.lastModified());
+			response.setContentLengthLong(file.length());
             response.setContentType(mimeTypes.getMimeByExtension(file.getName()));
 
             // send "small" files blocking directly from an input stream

--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
@@ -128,7 +128,6 @@ public class FastFileServer
             // Jetty DefaultServlet will cache formatted date strings, but we
             // will reformat for each request here
             response.setDateHeader("Last-Modified", file.lastModified());
-            response.setDateHeader("Content-Length", file.length());
             response.setContentType(mimeTypes.getMimeByExtension(file.getName()));
 
             // send "small" files blocking directly from an input stream

--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/FastFileServer.java
@@ -128,7 +128,7 @@ public class FastFileServer
             // Jetty DefaultServlet will cache formatted date strings, but we
             // will reformat for each request here
             response.setDateHeader("Last-Modified", file.lastModified());
-			response.setContentLengthLong(file.length());
+            response.setContentLengthLong(file.length());
             response.setContentType(mimeTypes.getMimeByExtension(file.getName()));
 
             // send "small" files blocking directly from an input stream


### PR DESCRIPTION
Proposed fix for issue [https://github.com/eclipse/jetty.project/issues/598](url)
Any GET file request, e.g. curl http://localhost:8080/pom.xml
results in FastFileServer returning a "HTTP/1.1 500 Server Error".
The root-cause for the error is the following line in handle()
response.setDateHeader("Content-Length", file.length());
which attempts to set the content-length header using a date-function.
Deleting the above line fixes the error: The Jetty HTTP-classes
set the content-length correctly.

Signed-off-by: Hauke Wulff <hauk3wu1ff@gmail.com>