### PR TITLE
Remove Session.setMaximumMessageSize(long) example

### DIFF
--- a/jetty-documentation/src/main/asciidoc/development/websockets/jetty/jetty-websocket-api-session.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/websockets/jetty/jetty-websocket-api-session.adoc
@@ -61,10 +61,3 @@ Get and Set the Idle Timeout
 ----
 session.setIdleTimeout(2000); // 2 second timeout
 ----
-
-Get and Set the Maximum Message Size
-
-[source,java]
-----
-session.setMaximumMessageSize(64*1024); // accept messages up to 64k, fail if larger
-----


### PR DESCRIPTION
Because that method has been removed in jetty-9.1 branch according to Bug 412439

Signed-off-by: Alexander Farber <Alexander.Farber@gmail.com>