### PR TITLE
Add unit test to verify that decoders' initializers are called OnMessage

### DIFF
--- a/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/annotations/IntegerBinarySocket.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/annotations/IntegerBinarySocket.java
@@ -1,0 +1,77 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2016 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.jsr356.annotations;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.concurrent.TimeoutException;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.Session;
+
+import org.eclipse.jetty.websocket.jsr356.decoders.BinaryStreamIntegerDecoder;
+
+@ClientEndpoint(decoders =
+{ BinaryStreamIntegerDecoder.class })
+public class IntegerBinarySocket
+{
+    public LinkedList<Throwable> errors = new LinkedList<>();
+    private LinkedList<Integer> received = new LinkedList<>();
+
+    public Integer popReceived(long ms) throws TimeoutException {
+    	long togo = ms;
+    	synchronized(received) {
+    		while (togo > 0 && received.isEmpty()) {
+    			long start = System.currentTimeMillis();
+    			try {
+    				received.wait(togo);
+    			}
+    			catch (InterruptedException e) {
+    				throw new RuntimeException("Wait for reception interrupted: " + e.toString(), e);
+    			}
+    			long waited = System.currentTimeMillis() - start;
+    			togo -= waited;
+    		}
+    		
+    		if (received.isEmpty()) {
+    			throw new TimeoutException("Did not receive any integers after " + ms + "ms");
+    		}
+    		
+			return received.pop();
+    	}
+    }
+    
+    @OnMessage
+    public void onMessage(Integer i) throws IOException
+    {
+    	synchronized(received) {
+    		received.push(i);
+    		received.notifyAll();
+    	}
+    }
+
+    @OnError
+    public void onError(Session session, Throwable thr)
+    {
+    	System.err.println("Error on session " + session.getId() + ": " + thr.toString());
+        errors.add(thr);
+    }
+}

--- a/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/annotations/OnMessageBinaryStreamDecoderTest.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/annotations/OnMessageBinaryStreamDecoderTest.java
@@ -1,0 +1,95 @@
+package org.eclipse.jetty.websocket.jsr356.annotations;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+
+import javax.websocket.ContainerProvider;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.log.StacklessLogging;
+import org.eclipse.jetty.websocket.jsr356.EchoHandler;
+import org.eclipse.jetty.websocket.jsr356.endpoints.JsrEndpointEventDriver;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OnMessageBinaryStreamDecoderTest {
+	private static Server server;
+	private static EchoHandler handler;
+	private static URI serverUri;
+
+	@BeforeClass
+	public static void startServer() throws Exception
+	{
+		server = new Server();
+		ServerConnector connector = new ServerConnector(server);
+		server.addConnector(connector);
+
+		handler = new EchoHandler();
+
+		ContextHandler context = new ContextHandler();
+		context.setContextPath("/");
+		context.setHandler(handler);
+		server.setHandler(context);
+
+		// Start Server
+		server.start();
+
+		String host = connector.getHost();
+		if (host == null)
+		{
+			host = "localhost";
+		}
+		int port = connector.getLocalPort();
+		serverUri = new URI(String.format("ws://%s:%d/",host,port));
+	}
+
+
+	@AfterClass
+	public static void stopServer()
+	{
+		try
+		{
+			server.stop();
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace(System.err);
+		}
+	}
+
+	@Test
+	public void testAnnotationInitializedOnMessage() throws Exception
+	{
+		WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+		IntegerBinarySocket socket = new IntegerBinarySocket();
+
+		try (StacklessLogging logging = new StacklessLogging(IntegerBinarySocket.class,JsrEndpointEventDriver.class))
+		{
+			// expecting ArrayIndexOutOfBoundsException during onOpen
+			Session session = container.connectToServer(socket,serverUri);
+
+			assertThat("Session.isOpen",session.isOpen(),is(true));
+			assertThat("Should have had 0 errors so far",socket.errors.size(),is(0));
+
+			Integer sent = new Integer(1234);
+			ByteBuffer integerBuffer = ByteBuffer.allocate(Integer.BYTES);
+			integerBuffer.putInt(sent);
+			
+			session.getAsyncRemote().sendBinary(integerBuffer);
+			Integer received = socket.popReceived(1000);
+			assertThat("Received integer", received, is(sent));
+
+			Throwable cause = socket.errors.pop();
+			assertThat("Error",cause,instanceOf(ArrayIndexOutOfBoundsException.class));
+		}
+	}
+}

--- a/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/decoders/BinaryStreamIntegerDecoder.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/decoders/BinaryStreamIntegerDecoder.java
@@ -1,0 +1,50 @@
+package org.eclipse.jetty.websocket.jsr356.decoders;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.websocket.DecodeException;
+import javax.websocket.Decoder;
+import javax.websocket.EndpointConfig;
+
+public class BinaryStreamIntegerDecoder implements Decoder.BinaryStream<Integer> {
+
+	private int initialized = 0;
+	private int destroyed = 0;
+
+	public int getInitialised() {
+		return initialized;
+	}
+	
+	public int getDestroyed() {
+		return destroyed;
+	}
+	
+	@Override
+	public void init(EndpointConfig config) {
+		synchronized(this) {
+			++initialized;
+		}
+	}
+
+	@Override
+	public void destroy() {
+		synchronized(this) {
+			++destroyed;
+		}
+	}
+
+	@Override
+	public Integer decode(InputStream is) throws DecodeException, IOException {
+		if (initialized != 1) {
+			throw new DecodeException("", "Decoder initialization count is " + initialized + ", expected 1");
+		}
+		if (destroyed != 0) {
+			throw new DecodeException("", "Decoder destroyed count is " + destroyed + ", expected 0");
+		}
+
+		DataInputStream data = new DataInputStream(is);
+		return data.readInt();
+	}
+}

--- a/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/encoders/BinaryStreamIntegerEncoder.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/encoders/BinaryStreamIntegerEncoder.java
@@ -1,0 +1,50 @@
+package org.eclipse.jetty.websocket.jsr356.encoders;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.websocket.EncodeException;
+import javax.websocket.Encoder;
+import javax.websocket.EndpointConfig;
+
+public class BinaryStreamIntegerEncoder implements Encoder.BinaryStream<Integer> {
+
+	private int initialized = 0;
+	private int destroyed = 0;
+	
+	public int getInitialized() {
+		return initialized;
+	}
+	
+	public int getDestroyed() {
+		return destroyed;
+	}
+
+	@Override
+	public void init(EndpointConfig config) {
+		synchronized(this) {
+			++initialized;
+		}
+	}
+
+	@Override
+	public void destroy() {
+		synchronized(this) {
+			++destroyed;
+		}
+	}
+
+	@Override
+	public void encode(Integer object, OutputStream os) throws EncodeException, IOException {
+		if (initialized != 1) {
+			throw new EncodeException(object, "Encoder initialization count is " + initialized + ", expected 1");
+		}
+		if (destroyed != 0) {
+			throw new EncodeException(object, "Encoder destroyed count is " + destroyed + ", expected 0");
+		}
+		
+		DataOutputStream data = new DataOutputStream(os);
+		data.writeInt(object);
+	}
+}


### PR DESCRIPTION
I had a brief chat on #jetty IRC channel with @joakime re uninitialized binary decoders being called in OnMessage handling. I'm yet to develop a fix but this test case demonstrates the issue. The test case currently fails. Is this a reasonable test case?

