### PR TITLE
Support UNC paths in PathResource

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
@@ -229,7 +230,7 @@ public class PathResource extends Resource
         Path path;
         try
         {
-            path = new File(uri).toPath();
+        	path = Paths.get(uri);
         }
         catch (InvalidPathException e)
         {


### PR DESCRIPTION
Hi team,

in my scenario the jetty server binaries are located in a remote file system accessible via UNC paths. In this case Jetty 9.3.x (tested with 9.3.10) is not able to startup correctly due to the following exception:

06:59:33:365|0120-00001:DEBUG|WebInfConfiguration - webapp=file://myserver.com/webserver/webapp/ 
06:59:33:857|0089-00001:WARN |Resource - java.lang.IllegalArgumentException: URI has an authority component 
06:59:33:860|2053-00001:DEBUG|Resource - EXCEPTION java.lang.IllegalArgumentException: URI has an authority component 
            at java.io.File.<init>(File.java:423) 
            at org.eclipse.jetty.util.resource.PathResource.<init>(PathResource.java:232) 
            at org.eclipse.jetty.util.resource.PathResource.<init>(PathResource.java:274) 
            at org.eclipse.jetty.util.resource.Resource.newResource(Resource.java:117) 
            at org.eclipse.jetty.util.resource.Resource.newResource(Resource.java:97) 
            at org.eclipse.jetty.util.resource.Resource.newResource(Resource.java:87) 
            at org.eclipse.jetty.webapp.WebInfConfiguration$2.matched(WebInfConfiguration.java:125) 
            at org.eclipse.jetty.util.PatternMatcher.matchPatterns(PatternMatcher.java:100) 
            at org.eclipse.jetty.util.PatternMatcher.match(PatternMatcher.java:82) 
            at org.eclipse.jetty.webapp.WebInfConfiguration.preConfigure(WebInfConfiguration.java:141) 
            at org.eclipse.jetty.webapp.WebAppContext.preConfigure(WebAppContext.java:483) 
            at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:519) 
            at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) 
            at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) 
            at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) 
            at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) 
            at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) 
            at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) 
            at org.eclipse.jetty.server.Server.start(Server.java:411) 
            at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:106) 
            at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) 
            at org.eclipse.jetty.server.Server.doStart(Server.java:378) 
            at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) 
            at ...

My scenario works kinking latest Jetty 9.2.x.

Can you double check my changes and eventually merge them on 9.3.x?

Thanks,
Marco