### PR TITLE
fix link to webtide.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Project documentation is located on our Eclipse website.
 Professional Services
 ============
 
-Expert advice and production support are available through [http://webtide.com](Webtide.com).
+Expert advice and production support are available through http://webtide.com.


### PR DESCRIPTION
Previously it was a link to `https://github.com/eclipse/jetty.project/blob/jetty-9.3.x/Webtide.com`