### PR TITLE
Fix NCSA request log in case of missing useragent.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNCSARequestLog.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNCSARequestLog.java
@@ -242,7 +242,7 @@ public abstract class AbstractNCSARequestLog extends AbstractLifeCycle implement
 
         String agent = request.getHeader(HttpHeader.USER_AGENT.toString());
         if (agent == null)
-            b.append("\"-\" ");
+            b.append("\"-\"");
         else
         {
             b.append('"');

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/RequestLogTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/RequestLogTest.java
@@ -188,11 +188,31 @@ public class RequestLogTest
         assertThat(log,containsString("GET /foo "));
         assertThat(log,containsString(" 400 0 "));
     }
-    
+
+    @Test
+    public void testUseragentWithout() throws Exception
+    {
+        _connector.getResponses("GET http://[:1]/foo HTTP/1.1\nReferer: http://other.site\n\n");
+        String log = _log.exchange(null,5,TimeUnit.SECONDS);
+        assertThat(log,containsString("GET http://[:1]/foo "));
+        assertThat(log,containsString(" 400 0 \"http://other.site\" \"-\" - "));
+    }
+
+    @Test
+    public void testUseragentWith() throws Exception
+    {
+        _connector.getResponses("GET http://[:1]/foo HTTP/1.1\nReferer: http://other.site\nUser-Agent: Mozilla/5.0 (test)\n\n");
+        String log = _log.exchange(null,5,TimeUnit.SECONDS);
+        assertThat(log,containsString("GET http://[:1]/foo "));
+        assertThat(log,containsString(" 400 0 \"http://other.site\" \"Mozilla/5.0 (test)\" - "));
+    }
+
     private class Log extends AbstractNCSARequestLog
     {
         {
             super.setExtended(true);
+            super.setLogLatency(true);
+            super.setLogCookies(true);
         }
 
         @Override


### PR DESCRIPTION
It was brought to my attention ( https://github.com/nielsbasjes/logparser/issues/30 ) that when using the extended NCSARequestLog and there was no User-Agent request header that the resulting logfile has an additional space that should not be there.
This pull request fixes this and introduces a few tests to validate it.