### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AbstractDiscoverableAnnotationHandler.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AbstractDiscoverableAnnotationHandler.java
@@ -18,7 +18,7 @@
 
 package org.eclipse.jetty.annotations;
 
-import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
+import org.eclipse.jetty.annotations.AnnotationParser.Handler;
 import org.eclipse.jetty.webapp.DiscoveredAnnotation;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -28,7 +28,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
  * Base class for handling the discovery of an annotation.
  * 
  */
-public abstract class AbstractDiscoverableAnnotationHandler extends AbstractHandler
+public abstract class AbstractDiscoverableAnnotationHandler implements Handler
 {
     protected WebAppContext _context;
   

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -31,6 +31,9 @@ import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
+import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
+import org.eclipse.jetty.annotations.AnnotationParser.FieldInfo;
+import org.eclipse.jetty.annotations.AnnotationParser.MethodInfo;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.MultiException;
@@ -298,12 +301,24 @@ public class AnnotationParser
      */
     public static interface Handler
     {
-        public void handle(ClassInfo classInfo);
-        public void handle(MethodInfo methodInfo);
-        public void handle (FieldInfo fieldInfo);
-        public void handle (ClassInfo info, String annotationName);
-        public void handle (MethodInfo info, String annotationName);
-        public void handle (FieldInfo info, String annotationName);
+        public default void handle(ClassInfo classInfo) {
+		   //no-op
+		}
+        public default void handle(MethodInfo methodInfo) {
+		    // no-op           
+		}
+        public default void handle (FieldInfo fieldInfo) {
+		    // no-op 
+		}
+        public default void handle (ClassInfo info, String annotationName) {
+		    // no-op 
+		}
+        public default void handle (MethodInfo info, String annotationName) {
+		    // no-op            
+		}
+        public default void handle (FieldInfo info, String annotationName) {
+		   // no-op
+		}
     }
     
     /**
@@ -312,43 +327,7 @@ public class AnnotationParser
      * Convenience base class to provide no-ops for all Handler methods.
      */
     public static abstract class AbstractHandler implements Handler
-    {
-
-        @Override
-        public void handle(ClassInfo classInfo)
-        {
-           //no-op
-        }
-
-        @Override
-        public void handle(MethodInfo methodInfo)
-        {
-            // no-op           
-        }
-
-        @Override
-        public void handle(FieldInfo fieldInfo)
-        {
-            // no-op 
-        }
-
-        @Override
-        public void handle(ClassInfo info, String annotationName)
-        {
-            // no-op 
-        }
-
-        @Override
-        public void handle(MethodInfo info, String annotationName)
-        {
-            // no-op            
-        }
-
-        @Override
-        public void handle(FieldInfo info, String annotationName)
-        {
-           // no-op
-        }        
+    {        
     }
 
     

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -321,14 +321,6 @@ public class AnnotationParser
 		}
     }
     
-    /**
-     * AbstractHandler
-     *
-     * Convenience base class to provide no-ops for all Handler methods.
-     */
-    public static abstract class AbstractHandler implements Handler
-    {        
-    }
 
     
     

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -301,22 +301,28 @@ public class AnnotationParser
      */
     public static interface Handler
     {
-        public default void handle(ClassInfo classInfo) {
+        public default void handle(ClassInfo classInfo)
+        {
            //no-op
         }
-        public default void handle(MethodInfo methodInfo) {
+        public default void handle(MethodInfo methodInfo)
+        {
             // no-op           
         }
-        public default void handle (FieldInfo fieldInfo) {
+        public default void handle (FieldInfo fieldInfo)
+        {
             // no-op 
         }
-        public default void handle (ClassInfo info, String annotationName) {
+        public default void handle (ClassInfo info, String annotationName)
+        {
             // no-op 
         }
-        public default void handle (MethodInfo info, String annotationName) {
+        public default void handle (MethodInfo info, String annotationName)
+        {
             // no-op            
         }
-        public default void handle (FieldInfo info, String annotationName) {
+        public default void handle (FieldInfo info, String annotationName)
+        {
            // no-op
         }
     }

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -302,23 +302,23 @@ public class AnnotationParser
     public static interface Handler
     {
         public default void handle(ClassInfo classInfo) {
-		   //no-op
-		}
+           //no-op
+        }
         public default void handle(MethodInfo methodInfo) {
-		    // no-op           
-		}
+            // no-op           
+        }
         public default void handle (FieldInfo fieldInfo) {
-		    // no-op 
-		}
+            // no-op 
+        }
         public default void handle (ClassInfo info, String annotationName) {
-		    // no-op 
-		}
+            // no-op 
+        }
         public default void handle (MethodInfo info, String annotationName) {
-		    // no-op            
-		}
+            // no-op            
+        }
         public default void handle (FieldInfo info, String annotationName) {
-		   // no-op
-		}
+           // no-op
+        }
     }
     
 

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ClassInheritanceHandler.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ClassInheritanceHandler.java
@@ -20,7 +20,7 @@ package org.eclipse.jetty.annotations;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
+import org.eclipse.jetty.annotations.AnnotationParser.Handler;
 import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.log.Log;
@@ -31,7 +31,7 @@ import org.eclipse.jetty.util.log.Logger;
  *
  * As asm scans for classes, remember the type hierarchy.
  */
-public class ClassInheritanceHandler extends AbstractHandler
+public class ClassInheritanceHandler implements Handler
 {
     private static final Logger LOG = Log.getLogger(ClassInheritanceHandler.class);
     

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ContainerInitializerAnnotationHandler.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ContainerInitializerAnnotationHandler.java
@@ -20,7 +20,7 @@
 package org.eclipse.jetty.annotations;
 
 
-import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
+import org.eclipse.jetty.annotations.AnnotationParser.Handler;
 import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.FieldInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.MethodInfo;
@@ -33,7 +33,7 @@ import org.eclipse.jetty.plus.annotation.ContainerInitializer;
  *  method level. The specified annotation is derived from an <code>&#064;HandlesTypes</code> on
  *  a ServletContainerInitializer class.
  */
-public class ContainerInitializerAnnotationHandler extends AbstractHandler
+public class ContainerInitializerAnnotationHandler implements Handler
 {
     final ContainerInitializer _initializer;
     final Class _annotation;

--- a/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationInheritance.java
+++ b/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationInheritance.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
-import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
+import org.eclipse.jetty.annotations.AnnotationParser.Handler;
 import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.FieldInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.MethodInfo;
@@ -47,7 +47,7 @@ public class TestAnnotationInheritance
     List<String> classNames = new ArrayList<String>();
   
     
-    class SampleHandler extends AbstractHandler
+    class SampleHandler implements Handler
     {
         public final List<String> annotatedClassNames = new ArrayList<String>();
         public final List<String> annotatedMethods = new ArrayList<String>();

--- a/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationParser.java
+++ b/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationParser.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 
 public class TestAnnotationParser
 {
-    public static class TrackingAnnotationHandler extends AnnotationParser.AbstractHandler
+    public static class TrackingAnnotationHandler implements Handler
     {
         private final String annotationName;
         public final Set<String> foundClasses;
@@ -80,7 +80,7 @@ public class TestAnnotationParser
         { "org.eclipse.jetty.annotations.ClassA" };
         AnnotationParser parser = new AnnotationParser();
 
-        class SampleAnnotationHandler extends AnnotationParser.AbstractHandler
+        class SampleAnnotationHandler implements AnnotationParser.Handler
         {
             private List<String> methods = Arrays.asList("a","b","c","d","l");
 
@@ -136,7 +136,7 @@ public class TestAnnotationParser
         { "org.eclipse.jetty.annotations.ClassB" };
         AnnotationParser parser = new AnnotationParser();
 
-        class MultiAnnotationHandler extends AnnotationParser.AbstractHandler
+        class MultiAnnotationHandler implements AnnotationParser.Handler
         {
             public void handle(ClassInfo info, String annotation)
             {

--- a/jetty-cdi/cdi-websocket/src/main/java/org/eclipse/jetty/cdi/websocket/AbstractContainerListener.java
+++ b/jetty-cdi/cdi-websocket/src/main/java/org/eclipse/jetty/cdi/websocket/AbstractContainerListener.java
@@ -44,30 +44,4 @@ public abstract class AbstractContainerListener implements LifeCycle.Listener, C
         }
     }
 
-    @Override
-    public void lifeCycleFailure(LifeCycle event, Throwable cause)
-    {
-    }
-
-    @Override
-    public void lifeCycleStarted(LifeCycle event)
-    {
-    }
-
-    @Override
-    public void lifeCycleStarting(LifeCycle event)
-    {
-    }
-
-    @Override
-    public void lifeCycleStopped(LifeCycle event)
-    {
-
-    }
-
-    @Override
-    public void lifeCycleStopping(LifeCycle event)
-    {
-    }
-
 }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppProvider.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.deploy;
 
 import java.io.IOException;
 
+import org.eclipse.jetty.osgi.boot.AbstractContextProvider.OSGiApp;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.LifeCycle;
 
@@ -44,5 +45,14 @@ public interface AppProvider extends LifeCycle
      * @throws IOException if unable to create context
      * @throws Exception if unable to create context
      */
-    ContextHandler createContextHandler(App app) throws Exception;
+    default ContextHandler createContextHandler(App app) throws Exception {
+	    if (app == null)
+	        return null;
+	    if (!(app instanceof OSGiApp))
+	        throw new IllegalStateException(app+" is not a BundleApp");
+	    
+	    //Create a ContextHandler suitable to deploy in OSGi
+	    ContextHandler h = ((OSGiApp)app).createContextHandler();           
+	    return h;
+	}
 }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppProvider.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.deploy;
 
 import java.io.IOException;
 
-import org.eclipse.jetty.osgi.boot.AbstractContextProvider.OSGiApp;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.LifeCycle;
 
@@ -45,14 +44,5 @@ public interface AppProvider extends LifeCycle
      * @throws IOException if unable to create context
      * @throws Exception if unable to create context
      */
-    default ContextHandler createContextHandler(App app) throws Exception {
-	    if (app == null)
-	        return null;
-	    if (!(app instanceof OSGiApp))
-	        throw new IllegalStateException(app+" is not a BundleApp");
-	    
-	    //Create a ContextHandler suitable to deploy in OSGi
-	    ContextHandler h = ((OSGiApp)app).createContextHandler();           
-	    return h;
-	}
+    ContextHandler createContextHandler(App app) throws Exception;
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1734,19 +1734,24 @@ public class HttpParser
         /** Called to signal that an EOF was received unexpectedly
          * during the parsing of a HTTP message
          */
-        public void earlyEOF();
+        public default void earlyEOF() {
+		}
 
         /* ------------------------------------------------------------ */
         /** Called to signal that a bad HTTP message has been received.
          * @param status The bad status to send
          * @param reason The textual reason for badness
          */
-        public void badMessage(int status, String reason);
+        public default void badMessage(int status, String reason) {
+		    throw new RuntimeException(reason);
+		}
 
         /* ------------------------------------------------------------ */
         /** @return the size in bytes of the per parser header cache
          */
-        public int getHeaderCacheSize();
+        public default int getHeaderCacheSize() {
+		    return 0;
+		}
     }
 
     /* ------------------------------------------------------------------------------- */

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1734,7 +1734,8 @@ public class HttpParser
         /** Called to signal that an EOF was received unexpectedly
          * during the parsing of a HTTP message
          */
-        public default void earlyEOF() {
+        public default void earlyEOF()
+        {
         }
 
         /* ------------------------------------------------------------ */
@@ -1742,14 +1743,16 @@ public class HttpParser
          * @param status The bad status to send
          * @param reason The textual reason for badness
          */
-        public default void badMessage(int status, String reason) {
+        public default void badMessage(int status, String reason)
+        {
             throw new RuntimeException(reason);
         }
 
         /* ------------------------------------------------------------ */
         /** @return the size in bytes of the per parser header cache
          */
-        public default int getHeaderCacheSize() {
+        public default int getHeaderCacheSize()
+        {
             return 0;
         }
     }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1735,7 +1735,7 @@ public class HttpParser
          * during the parsing of a HTTP message
          */
         public default void earlyEOF() {
-		}
+        }
 
         /* ------------------------------------------------------------ */
         /** Called to signal that a bad HTTP message has been received.
@@ -1743,15 +1743,15 @@ public class HttpParser
          * @param reason The textual reason for badness
          */
         public default void badMessage(int status, String reason) {
-		    throw new RuntimeException(reason);
-		}
+            throw new RuntimeException(reason);
+        }
 
         /* ------------------------------------------------------------ */
         /** @return the size in bytes of the per parser header cache
          */
         public default int getHeaderCacheSize() {
-		    return 0;
-		}
+            return 0;
+        }
     }
 
     /* ------------------------------------------------------------------------------- */

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpTester.java
@@ -315,11 +315,6 @@ public class HttpTester
         }
 
         @Override
-        public void earlyEOF()
-        {
-        }
-
-        @Override
         public boolean content(ByteBuffer ref)
         {
             try
@@ -331,12 +326,6 @@ public class HttpTester
                 throw new RuntimeException(e);
             }
             return false;
-        }
-
-        @Override
-        public void badMessage(int status, String reason)
-        {
-            throw new RuntimeException(reason);
         }
 
         public ByteBuffer generate()
@@ -404,12 +393,6 @@ public class HttpTester
 
         }
         abstract public MetaData getInfo();
-
-        @Override
-        public int getHeaderCacheSize()
-        {
-            return 0;
-        }
 
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/AbstractFlowControlStrategy.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/AbstractFlowControlStrategy.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.http2;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -234,11 +233,5 @@ public abstract class AbstractFlowControlStrategy implements FlowControlStrategy
     public String dump()
     {
         return ContainerLifeCycle.dump(this);
-    }
-
-    @Override
-    public void dump(Appendable out, String indent) throws IOException
-    {
-        out.append(toString()).append(System.lineSeparator());
     }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -221,36 +221,6 @@ public abstract class AbstractConnection implements Connection
     }
 
     @Override
-    public boolean onIdleExpired()
-    {
-        return true;
-    }
-
-    @Override
-    public int getMessagesIn()
-    {
-        return -1;
-    }
-
-    @Override
-    public int getMessagesOut()
-    {
-        return -1;
-    }
-
-    @Override
-    public long getBytesIn()
-    {
-        return -1;
-    }
-
-    @Override
-    public long getBytesOut()
-    {
-        return -1;
-    }
-
-    @Override
     public long getCreatedTimeStamp()
     {
         return _created;

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
@@ -93,12 +93,6 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
     }
 
     @Override
-    public boolean isOptimizedForDirectBuffers()
-    {
-        return false;
-    }
-
-    @Override
     public void onOpen()
     {
         if (LOG.isDebugEnabled())

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
@@ -85,21 +85,21 @@ public interface Connection extends Closeable
      *         false to tell the EndPoint to halt the handling of the idle timeout.
      */
     public default boolean onIdleExpired() {
-	    return true;
-	}
+        return true;
+    }
 
     public default int getMessagesIn() {
-	    return -1;
-	}
+        return -1;
+    }
     public default int getMessagesOut() {
-	    return -1;
-	}
+        return -1;
+    }
     public default long getBytesIn() {
-	    return -1;
-	}
+        return -1;
+    }
     public default long getBytesOut() {
-	    return -1;
-	}
+        return -1;
+    }
     public long getCreatedTimeStamp();
 
     public interface UpgradeFrom extends Connection

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
@@ -84,12 +84,22 @@ public interface Connection extends Closeable
      * @return true to let the EndPoint handle the idle timeout,
      *         false to tell the EndPoint to halt the handling of the idle timeout.
      */
-    public boolean onIdleExpired();
+    public default boolean onIdleExpired() {
+	    return true;
+	}
 
-    public int getMessagesIn();
-    public int getMessagesOut();
-    public long getBytesIn();
-    public long getBytesOut();
+    public default int getMessagesIn() {
+	    return -1;
+	}
+    public default int getMessagesOut() {
+	    return -1;
+	}
+    public default long getBytesIn() {
+	    return -1;
+	}
+    public default long getBytesOut() {
+	    return -1;
+	}
     public long getCreatedTimeStamp();
 
     public interface UpgradeFrom extends Connection

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/Connection.java
@@ -88,16 +88,20 @@ public interface Connection extends Closeable
         return true;
     }
 
-    public default int getMessagesIn() {
+    public default int getMessagesIn()
+    {
         return -1;
     }
-    public default int getMessagesOut() {
+    public default int getMessagesOut()
+    {
         return -1;
     }
-    public default long getBytesIn() {
+    public default long getBytesIn()
+    {
         return -1;
     }
-    public default long getBytesOut() {
+    public default long getBytesOut()
+    {
         return -1;
     }
     public long getCreatedTimeStamp();

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
@@ -250,8 +250,8 @@ public interface EndPoint extends Closeable
      * @return True if direct buffers can be used optimally.
      */
     default boolean isOptimizedForDirectBuffers() {
-	    return false;
-	}
+        return false;
+    }
 
 
     /** Upgrade connections.

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
@@ -249,7 +249,8 @@ public interface EndPoint extends Closeable
     /** Is the endpoint optimized for DirectBuffer usage
      * @return True if direct buffers can be used optimally.
      */
-    default boolean isOptimizedForDirectBuffers() {
+    default boolean isOptimizedForDirectBuffers()
+    {
         return false;
     }
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
@@ -249,7 +249,9 @@ public interface EndPoint extends Closeable
     /** Is the endpoint optimized for DirectBuffer usage
      * @return True if direct buffers can be used optimally.
      */
-    boolean isOptimizedForDirectBuffers();
+    default boolean isOptimizedForDirectBuffers() {
+	    return false;
+	}
 
 
     /** Upgrade connections.

--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/AbstractContextProvider.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/AbstractContextProvider.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.Dictionary;
 import java.util.HashMap;
 
-import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppProvider;
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.osgi.boot.internal.serverfactory.ServerInstanceWrapper;
@@ -227,22 +226,6 @@ public abstract class AbstractContextProvider extends AbstractLifeCycle implemen
     public ServerInstanceWrapper getServerInstanceWrapper()
     {
         return _serverWrapper;
-    }
-    
-    /* ------------------------------------------------------------ */
-    /** 
-     * @see org.eclipse.jetty.deploy.AppProvider#createContextHandler(org.eclipse.jetty.deploy.App)
-     */
-    public ContextHandler createContextHandler(App app) throws Exception
-    {
-        if (app == null)
-            return null;
-        if (!(app instanceof OSGiApp))
-            throw new IllegalStateException(app+" is not a BundleApp");
-        
-        //Create a ContextHandler suitable to deploy in OSGi
-        ContextHandler h = ((OSGiApp)app).createContextHandler();           
-        return h;
     }
     
     /* ------------------------------------------------------------ */

--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/AbstractContextProvider.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/AbstractContextProvider.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Dictionary;
 import java.util.HashMap;
 
+import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppProvider;
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.osgi.boot.internal.serverfactory.ServerInstanceWrapper;
@@ -226,6 +227,22 @@ public abstract class AbstractContextProvider extends AbstractLifeCycle implemen
     public ServerInstanceWrapper getServerInstanceWrapper()
     {
         return _serverWrapper;
+    }
+    
+    /* ------------------------------------------------------------ */
+    /** 
+     * @see org.eclipse.jetty.deploy.AppProvider#createContextHandler(org.eclipse.jetty.deploy.App)
+     */
+    public ContextHandler createContextHandler(App app) throws Exception
+    {
+        if (app == null)
+            return null;
+        if (!(app instanceof OSGiApp))
+            throw new IllegalStateException(app+" is not a BundleApp");
+        
+        //Create a ContextHandler suitable to deploy in OSGi
+        ContextHandler h = ((OSGiApp)app).createContextHandler();           
+        return h;
     }
     
     /* ------------------------------------------------------------ */

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
@@ -69,8 +69,8 @@ public interface Authenticator
      * @param request the request to manipulate
      */
     default void prepareRequest(ServletRequest request) {
-	    //empty implementation as the default
-	}
+        //empty implementation as the default
+    }
     
 
     /* ------------------------------------------------------------ */

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
@@ -68,7 +68,9 @@ public interface Authenticator
      * 
      * @param request the request to manipulate
      */
-    void prepareRequest(ServletRequest request);
+    default void prepareRequest(ServletRequest request) {
+	    //empty implementation as the default
+	}
     
 
     /* ------------------------------------------------------------ */

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
@@ -68,7 +68,8 @@ public interface Authenticator
      * 
      * @param request the request to manipulate
      */
-    default void prepareRequest(ServletRequest request) {
+    default void prepareRequest(ServletRequest request)
+    {
         //empty implementation as the default
     }
     

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -48,14 +48,6 @@ public abstract class LoginAuthenticator implements Authenticator
     }
 
     /* ------------------------------------------------------------ */
-    @Override
-    public void prepareRequest(ServletRequest request)
-    {
-        //empty implementation as the default
-    }
-
-
-    /* ------------------------------------------------------------ */
     public UserIdentity login(String username, Object password, ServletRequest request)
     {
         UserIdentity user = _loginService.login(username,password, request);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
@@ -73,9 +73,9 @@ public interface SessionIdManager extends LifeCycle
      * @return the cluster id
      */
     public default String getClusterId(String nodeId) {
-	    int dot=nodeId.lastIndexOf('.');
-	    return (dot>0)?nodeId.substring(0,dot):nodeId;
-	}
+        int dot=nodeId.lastIndexOf('.');
+        return (dot>0)?nodeId.substring(0,dot):nodeId;
+    }
     
     /* ------------------------------------------------------------ */
     /** Get a node ID from a cluster ID and a request

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
@@ -72,7 +72,10 @@ public interface SessionIdManager extends LifeCycle
      * @param nodeId the node id
      * @return the cluster id
      */
-    public String getClusterId(String nodeId);
+    public default String getClusterId(String nodeId) {
+	    int dot=nodeId.lastIndexOf('.');
+	    return (dot>0)?nodeId.substring(0,dot):nodeId;
+	}
     
     /* ------------------------------------------------------------ */
     /** Get a node ID from a cluster ID and a request

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SessionIdManager.java
@@ -72,7 +72,8 @@ public interface SessionIdManager extends LifeCycle
      * @param nodeId the node id
      * @return the cluster id
      */
-    public default String getClusterId(String nodeId) {
+    public default String getClusterId(String nodeId)
+    {
         int dot=nodeId.lastIndexOf('.');
         return (dot>0)?nodeId.substring(0,dot):nodeId;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionIdManager.java
@@ -264,17 +264,5 @@ public abstract class AbstractSessionIdManager extends AbstractLifeCycle impleme
         return clusterId;
     }
 
-    /** Get the session ID without any worker ID.
-     *
-     * @param nodeId the node id
-     * @return sessionId without any worker ID.
-     */
-    @Override
-    public String getClusterId(String nodeId)
-    {
-        int dot=nodeId.lastIndexOf('.');
-        return (dot>0)?nodeId.substring(0,dot):nodeId;
-    }
-
 
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/AbstractTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/AbstractTrie.java
@@ -18,10 +18,6 @@
 
 package org.eclipse.jetty.util;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-
-
 /** 
  * Abstract Trie implementation.
  * <p>Provides some common implementations, which may not be the most
@@ -37,44 +33,6 @@ public abstract class AbstractTrie<V> implements Trie<V>
     protected AbstractTrie(boolean insensitive)
     {
         _caseInsensitive=insensitive;
-    }
-
-    @Override
-    public boolean put(V v)
-    {
-        return put(v.toString(),v);
-    }
-
-    @Override
-    public V remove(String s)
-    {
-        V o=get(s);
-        put(s,null);
-        return o;
-    }
-
-    @Override
-    public V get(String s)
-    {
-        return get(s,0,s.length());
-    }
-
-    @Override
-    public V get(ByteBuffer b)
-    {
-        return get(b,0,b.remaining());
-    }
-
-    @Override
-    public V getBest(String s)
-    {
-        return getBest(s,0,s.length());
-    }
-    
-    @Override
-    public V getBest(byte[] b, int offset, int len)
-    {
-        return getBest(new String(b,offset,len,StandardCharsets.ISO_8859_1));
     }
 
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
@@ -43,15 +43,15 @@ public interface Trie<V>
      * @return True if the Trie had capacity to add the field.
      */
     public default boolean put(V v) {
-	    return put(v.toString(),v);
-	}
+        return put(v.toString(),v);
+    }
 
     /* ------------------------------------------------------------ */
     public default V remove(String s) {
-	    V o=get(s);
-	    put(s,null);
-	    return o;
-	}
+        V o=get(s);
+        put(s,null);
+        return o;
+    }
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a String key
@@ -59,8 +59,8 @@ public interface Trie<V>
      * @return the value for the string key
      */
     public default V get(String s) {
-	    return get(s,0,s.length());
-	}
+        return get(s,0,s.length());
+    }
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a String key
@@ -77,8 +77,8 @@ public interface Trie<V>
      * @return The value or null if not found
      */
     public default V get(ByteBuffer b) {
-	    return get(b,0,b.remaining());
-	}
+        return get(b,0,b.remaining());
+    }
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a segment of a ByteBuufer as key
@@ -95,8 +95,8 @@ public interface Trie<V>
      * @return The value or null if not found
      */
     public default V getBest(String s) {
-	    return getBest(s,0,s.length());
-	}
+        return getBest(s,0,s.length());
+    }
     
     /* ------------------------------------------------------------ */
     /** Get the best match from key in a String.
@@ -116,8 +116,8 @@ public interface Trie<V>
      * @return The value or null if not found
      */
     public default V getBest(byte[] b,int offset,int len) {
-	    return getBest(new String(b,offset,len,StandardCharsets.ISO_8859_1));
-	}
+        return getBest(new String(b,offset,len,StandardCharsets.ISO_8859_1));
+    }
 
     /* ------------------------------------------------------------ */
     /** Get the best match from key in a byte buffer.

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
@@ -42,12 +42,14 @@ public interface Trie<V>
      * @param v The value and key
      * @return True if the Trie had capacity to add the field.
      */
-    public default boolean put(V v) {
+    public default boolean put(V v)
+    {
         return put(v.toString(),v);
     }
 
     /* ------------------------------------------------------------ */
-    public default V remove(String s) {
+    public default V remove(String s)
+    {
         V o=get(s);
         put(s,null);
         return o;
@@ -58,7 +60,8 @@ public interface Trie<V>
      * @param s The key
      * @return the value for the string key
      */
-    public default V get(String s) {
+    public default V get(String s)
+    {
         return get(s,0,s.length());
     }
 
@@ -76,7 +79,8 @@ public interface Trie<V>
      * @param b The buffer
      * @return The value or null if not found
      */
-    public default V get(ByteBuffer b) {
+    public default V get(ByteBuffer b)
+    {
         return get(b,0,b.remaining());
     }
 
@@ -94,7 +98,8 @@ public interface Trie<V>
      * @param s The string
      * @return The value or null if not found
      */
-    public default V getBest(String s) {
+    public default V getBest(String s)
+    {
         return getBest(s,0,s.length());
     }
     
@@ -115,7 +120,8 @@ public interface Trie<V>
      * @param len the length of the key
      * @return The value or null if not found
      */
-    public default V getBest(byte[] b,int offset,int len) {
+    public default V getBest(byte[] b,int offset,int len)
+    {
         return getBest(new String(b,offset,len,StandardCharsets.ISO_8859_1));
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Trie.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.util;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 
@@ -41,17 +42,25 @@ public interface Trie<V>
      * @param v The value and key
      * @return True if the Trie had capacity to add the field.
      */
-    public boolean put(V v);
+    public default boolean put(V v) {
+	    return put(v.toString(),v);
+	}
 
     /* ------------------------------------------------------------ */
-    public V remove(String s);
+    public default V remove(String s) {
+	    V o=get(s);
+	    put(s,null);
+	    return o;
+	}
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a String key
      * @param s The key
      * @return the value for the string key
      */
-    public V get(String s);
+    public default V get(String s) {
+	    return get(s,0,s.length());
+	}
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a String key
@@ -67,7 +76,9 @@ public interface Trie<V>
      * @param b The buffer
      * @return The value or null if not found
      */
-    public V get(ByteBuffer b);
+    public default V get(ByteBuffer b) {
+	    return get(b,0,b.remaining());
+	}
 
     /* ------------------------------------------------------------ */
     /** Get and exact match from a segment of a ByteBuufer as key
@@ -83,7 +94,9 @@ public interface Trie<V>
      * @param s The string
      * @return The value or null if not found
      */
-    public V getBest(String s);
+    public default V getBest(String s) {
+	    return getBest(s,0,s.length());
+	}
     
     /* ------------------------------------------------------------ */
     /** Get the best match from key in a String.
@@ -102,7 +115,9 @@ public interface Trie<V>
      * @param len the length of the key
      * @return The value or null if not found
      */
-    public V getBest(byte[] b,int offset,int len);
+    public default V getBest(byte[] b,int offset,int len) {
+	    return getBest(new String(b,offset,len,StandardCharsets.ISO_8859_1));
+	}
 
     /* ------------------------------------------------------------ */
     /** Get the best match from key in a byte buffer.

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -30,6 +30,6 @@ public interface Dumpable
     String dump();
     
     default void dump(Appendable out,String indent) throws IOException {
-	    out.append(toString()).append(System.lineSeparator());
-	}
+        out.append(toString()).append(System.lineSeparator());
+    }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -29,5 +29,7 @@ public interface Dumpable
     @ManagedOperation(value="Dump the nested Object state as a String", impact="INFO")
     String dump();
     
-    void dump(Appendable out,String indent) throws IOException;
+    default void dump(Appendable out,String indent) throws IOException {
+	    out.append(toString()).append(System.lineSeparator());
+	}
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
@@ -117,15 +117,15 @@ public interface LifeCycle
     public interface Listener extends EventListener
     {
         public default void lifeCycleStarting(LifeCycle event) {
-		}
+        }
         public default void lifeCycleStarted(LifeCycle event) {
-		}
+        }
         public default void lifeCycleFailure(LifeCycle event,Throwable cause) {
-		}
+        }
         public default void lifeCycleStopping(LifeCycle event) {
-		}
+        }
         public default void lifeCycleStopped(LifeCycle event) {
-		
-		}
+        
+        }
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
@@ -116,10 +116,16 @@ public interface LifeCycle
      */
     public interface Listener extends EventListener
     {
-        public void lifeCycleStarting(LifeCycle event);
-        public void lifeCycleStarted(LifeCycle event);
-        public void lifeCycleFailure(LifeCycle event,Throwable cause);
-        public void lifeCycleStopping(LifeCycle event);
-        public void lifeCycleStopped(LifeCycle event);
+        public default void lifeCycleStarting(LifeCycle event) {
+		}
+        public default void lifeCycleStarted(LifeCycle event) {
+		}
+        public default void lifeCycleFailure(LifeCycle event,Throwable cause) {
+		}
+        public default void lifeCycleStopping(LifeCycle event) {
+		}
+        public default void lifeCycleStopped(LifeCycle event) {
+		
+		}
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java
@@ -116,15 +116,20 @@ public interface LifeCycle
      */
     public interface Listener extends EventListener
     {
-        public default void lifeCycleStarting(LifeCycle event) {
+        public default void lifeCycleStarting(LifeCycle event)
+        {
         }
-        public default void lifeCycleStarted(LifeCycle event) {
+        public default void lifeCycleStarted(LifeCycle event)
+        {
         }
-        public default void lifeCycleFailure(LifeCycle event,Throwable cause) {
+        public default void lifeCycleFailure(LifeCycle event,Throwable cause)
+        {
         }
-        public default void lifeCycleStopping(LifeCycle event) {
+        public default void lifeCycleStopping(LifeCycle event)
+        {
         }
-        public default void lifeCycleStopped(LifeCycle event) {
+        public default void lifeCycleStopped(LifeCycle event)
+        {
         
         }
     }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/AbstractLogger.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/AbstractLogger.java
@@ -213,13 +213,4 @@ public abstract class AbstractLogger implements Logger
         dense.append(parts[parts.length - 1]);
         return dense.toString();
     }
-
-
-    public void debug(String msg, long arg)
-    {
-        if (isDebugEnabled())
-        {
-            debug(msg,new Object[] { new Long(arg) });
-        }
-    }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
@@ -93,7 +93,8 @@ public interface Logger
      * @param msg the formatting string
      * @param value long value
      */
-    public default void debug(String msg, long arg) {
+    public default void debug(String msg, long arg)
+    {
         if (isDebugEnabled())
         {
             debug(msg,new Object[] { new Long(arg) });

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
@@ -93,7 +93,12 @@ public interface Logger
      * @param msg the formatting string
      * @param value long value
      */
-    public void debug(String msg, long value);
+    public default void debug(String msg, long arg) {
+	    if (isDebugEnabled())
+	    {
+	        debug(msg,new Object[] { new Long(arg) });
+	    }
+	}
 
     /**
      * Logs the given Throwable information at debug level

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/Logger.java
@@ -94,11 +94,11 @@ public interface Logger
      * @param value long value
      */
     public default void debug(String msg, long arg) {
-	    if (isDebugEnabled())
-	    {
-	        debug(msg,new Object[] { new Long(arg) });
-	    }
-	}
+        if (isDebugEnabled())
+        {
+            debug(msg,new Object[] { new Long(arg) });
+        }
+    }
 
     /**
      * Logs the given Throwable information at debug level

--- a/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/AbstractJsrEventDriver.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/AbstractJsrEventDriver.java
@@ -27,7 +27,6 @@ import javax.websocket.EndpointConfig;
 import javax.websocket.Session;
 
 import org.eclipse.jetty.websocket.api.WebSocketPolicy;
-import org.eclipse.jetty.websocket.api.extensions.Frame;
 import org.eclipse.jetty.websocket.common.CloseInfo;
 import org.eclipse.jetty.websocket.common.WebSocketSession;
 import org.eclipse.jetty.websocket.common.events.AbstractEventDriver;
@@ -81,12 +80,6 @@ public abstract class AbstractJsrEventDriver extends AbstractEventDriver
     }
 
     protected abstract void onClose(CloseReason closereason);
-
-    @Override
-    public void onFrame(Frame frame)
-    {
-        /* Ignored, not supported by JSR-356 */
-    }
 
     @Override
     public final void openSession(WebSocketSession session)

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
@@ -20,6 +20,8 @@ package org.eclipse.jetty.websocket.api.extensions;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.websocket.api.extensions.Frame.Type;
+
 /**
  * An immutable websocket frame.
  */
@@ -93,7 +95,9 @@ public interface Frame
      */
     public int getPayloadLength();
 
-    public Type getType();
+    public default Type getType() {
+	    return Type.from(getOpCode());
+	}
 
     public boolean hasPayload();
 

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
@@ -96,8 +96,8 @@ public interface Frame
     public int getPayloadLength();
 
     public default Type getType() {
-	    return Type.from(getOpCode());
-	}
+        return Type.from(getOpCode());
+    }
 
     public boolean hasPayload();
 

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/Frame.java
@@ -95,7 +95,8 @@ public interface Frame
      */
     public int getPayloadLength();
 
-    public default Type getType() {
+    public default Type getType()
+    {
         return Type.from(getOpCode());
     }
 

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketFrame.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketFrame.java
@@ -236,12 +236,6 @@ public abstract class WebSocketFrame implements Frame
     }
 
     @Override
-    public Type getType()
-    {
-        return Type.from(getOpCode());
-    }
-
-    @Override
     public int hashCode()
     {
         final int prime = 31;

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/AbstractEventDriver.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/AbstractEventDriver.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.util.Utf8Appendable.NotUtf8Exception;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.websocket.api.BatchMode;
 import org.eclipse.jetty.websocket.api.CloseException;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.WebSocketPolicy;
@@ -197,24 +196,6 @@ public abstract class AbstractEventDriver extends AbstractLifeCycle implements I
         }
 
         appendMessage(buffer,fin);
-    }
-
-    @Override
-    public void onPong(ByteBuffer buffer)
-    {
-        /* TODO: provide annotation in future */
-    }
-
-    @Override
-    public void onPing(ByteBuffer buffer)
-    {
-        /* TODO: provide annotation in future */
-    }
-
-    @Override
-    public BatchMode getBatchMode()
-    {
-        return null;
     }
 
     @Override

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
@@ -36,7 +36,9 @@ public interface EventDriver extends IncomingFrames
 
     public WebSocketSession getSession();
     
-    public BatchMode getBatchMode();
+    public default BatchMode getBatchMode() {
+	    return null;
+	}
 
     public void onBinaryFrame(ByteBuffer buffer, boolean fin) throws IOException;
 
@@ -50,13 +52,19 @@ public interface EventDriver extends IncomingFrames
 
     public void onError(Throwable t);
 
-    public void onFrame(Frame frame);
+    public default void onFrame(Frame frame) {
+	    /* Ignored, not supported by JSR-356 */
+	}
 
     public void onInputStream(InputStream stream) throws IOException;
 
-    public void onPing(ByteBuffer buffer);
+    public default void onPing(ByteBuffer buffer) {
+	    /* TODO: provide annotation in future */
+	}
     
-    public void onPong(ByteBuffer buffer);
+    public default void onPong(ByteBuffer buffer) {
+	    /* TODO: provide annotation in future */
+	}
 
     public void onReader(Reader reader) throws IOException;
 

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
@@ -36,7 +36,8 @@ public interface EventDriver extends IncomingFrames
 
     public WebSocketSession getSession();
     
-    public default BatchMode getBatchMode() {
+    public default BatchMode getBatchMode()
+    {
         return null;
     }
 
@@ -52,17 +53,20 @@ public interface EventDriver extends IncomingFrames
 
     public void onError(Throwable t);
 
-    public default void onFrame(Frame frame) {
+    public default void onFrame(Frame frame)
+    {
         /* Ignored, not supported by JSR-356 */
     }
 
     public void onInputStream(InputStream stream) throws IOException;
 
-    public default void onPing(ByteBuffer buffer) {
+    public default void onPing(ByteBuffer buffer)
+    {
         /* TODO: provide annotation in future */
     }
     
-    public default void onPong(ByteBuffer buffer) {
+    public default void onPong(ByteBuffer buffer)
+    {
         /* TODO: provide annotation in future */
     }
 

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/events/EventDriver.java
@@ -37,8 +37,8 @@ public interface EventDriver extends IncomingFrames
     public WebSocketSession getSession();
     
     public default BatchMode getBatchMode() {
-	    return null;
-	}
+        return null;
+    }
 
     public void onBinaryFrame(ByteBuffer buffer, boolean fin) throws IOException;
 
@@ -53,18 +53,18 @@ public interface EventDriver extends IncomingFrames
     public void onError(Throwable t);
 
     public default void onFrame(Frame frame) {
-	    /* Ignored, not supported by JSR-356 */
-	}
+        /* Ignored, not supported by JSR-356 */
+    }
 
     public void onInputStream(InputStream stream) throws IOException;
 
     public default void onPing(ByteBuffer buffer) {
-	    /* TODO: provide annotation in future */
-	}
+        /* TODO: provide annotation in future */
+    }
     
     public default void onPong(ByteBuffer buffer) {
-	    /* TODO: provide annotation in future */
-	}
+        /* TODO: provide annotation in future */
+    }
 
     public void onReader(Reader reader) throws IOException;
 


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. Specifically, it only performs a migration if the target interface is unambiguous. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes. We believe such methods to be likely suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.