### PR TITLE
Changes for Issue #824

### DIFF
--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AbstractTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AbstractTest.java
@@ -87,7 +87,7 @@ public class AbstractTest
         server.addConnector(connector);
     }
 
-    private void prepareClient()
+    protected void prepareClient()
     {
         client = new HTTP2Client();
         QueuedThreadPool clientExecutor = new QueuedThreadPool();

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AsyncServletTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AsyncServletTest.java
@@ -1,0 +1,286 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2016 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.http2.client;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.api.server.ServerSessionListener;
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FuturePromise;
+import org.eclipse.jetty.util.Promise;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AsyncServletTest extends AbstractTest
+{
+    @Test
+    public void testAsyncContextWithDispatch() throws Exception
+    {
+        byte[] content = new byte[1024];
+        new Random().nextBytes(content);
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                AsyncContext asyncContext = (AsyncContext)request.getAttribute(AsyncContext.class.getName());
+                if (asyncContext == null)
+                {
+                    AsyncContext context = request.startAsync();
+                    context.setTimeout(0);
+                    request.setAttribute(AsyncContext.class.getName(), context);
+                    context.start(() ->
+                    {
+                        sleep(1000);
+                        context.dispatch();
+                    });
+                }
+                else
+                {
+                    response.getOutputStream().write(content);
+                }
+            }
+        });
+
+        Session session = newClient(new Session.Listener.Adapter());
+
+        HttpFields fields = new HttpFields();
+        MetaData.Request metaData = newRequest("GET", fields);
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        CountDownLatch latch = new CountDownLatch(1);
+        session.newStream(frame, new Promise.Adapter<>(), new Stream.Listener.Adapter()
+        {
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback)
+            {
+                try
+                {
+                    buffer.write(BufferUtil.toArray(frame.getData()));
+                    callback.succeeded();
+                    if (frame.isEndStream())
+                        latch.countDown();
+                }
+                catch (IOException x)
+                {
+                    callback.failed(x);
+                }
+            }
+        });
+
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+        Assert.assertArrayEquals(content, buffer.toByteArray());
+    }
+
+    @Test
+    public void testAsyncContextWithClientSessionIdleTimeout() throws Exception
+    {
+        testAsyncContextWithClientIdleTimeout(1000, 10 * 1000);
+    }
+
+    @Test
+    public void testAsyncContextWithClientStreamIdleTimeout() throws Exception
+    {
+        testAsyncContextWithClientIdleTimeout(10 * 1000, 1000);
+    }
+
+    private void testAsyncContextWithClientIdleTimeout(long sessionTimeout, long streamTimeout) throws Exception
+    {
+        CountDownLatch serverLatch = new CountDownLatch(1);
+        start(new AsyncOnErrorServlet(serverLatch));
+        client.setIdleTimeout(sessionTimeout);
+
+        Session session = newClient(new Session.Listener.Adapter());
+        HttpFields fields = new HttpFields();
+        MetaData.Request metaData = newRequest("GET", fields);
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        FuturePromise<Stream> promise = new FuturePromise<>();
+        CountDownLatch clientLatch = new CountDownLatch(1);
+        session.newStream(frame, promise, new AsyncOnErrorStreamListener(clientLatch));
+        Stream stream = promise.get(5, TimeUnit.SECONDS);
+        stream.setIdleTimeout(streamTimeout);
+
+        Thread.sleep(2 * Math.min(sessionTimeout, streamTimeout));
+
+        Assert.assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testAsyncContextWithServerSessionIdleTimeout() throws Exception
+    {
+        testAsyncContextWithServerIdleTimeout(1000, 10 * 1000);
+    }
+
+    @Test
+    public void testAsyncContextWithServerStreamIdleTimeout() throws Exception
+    {
+        testAsyncContextWithServerIdleTimeout(10 * 1000, 1000);
+    }
+
+    private void testAsyncContextWithServerIdleTimeout(long sessionTimeout, long streamTimeout) throws Exception
+    {
+        CountDownLatch serverLatch = new CountDownLatch(1);
+        prepareServer(new HTTP2ServerConnectionFactory(new HttpConfiguration())
+        {
+            @Override
+            protected ServerSessionListener newSessionListener(Connector connector, EndPoint endPoint)
+            {
+                return new HTTPServerSessionListener(connector, endPoint)
+                {
+                    @Override
+                    public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+                    {
+                        stream.setIdleTimeout(streamTimeout);
+                        return super.onNewStream(stream, frame);
+                    }
+                };
+            }
+        });
+        connector.setIdleTimeout(sessionTimeout);
+        ServletContextHandler context = new ServletContextHandler(server, "/", true, false);
+        context.addServlet(new ServletHolder(new AsyncOnErrorServlet(serverLatch)), servletPath + "/*");
+        server.start();
+
+        prepareClient();
+        client.start();
+
+        Session session = newClient(new Session.Listener.Adapter());
+        HttpFields fields = new HttpFields();
+        MetaData.Request metaData = newRequest("GET", fields);
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        FuturePromise<Stream> promise = new FuturePromise<>();
+        CountDownLatch clientLatch = new CountDownLatch(1);
+        session.newStream(frame, promise, new AsyncOnErrorStreamListener(clientLatch));
+        Stream stream = promise.get(5, TimeUnit.SECONDS);
+        stream.setIdleTimeout(streamTimeout);
+
+        Thread.sleep(2 * Math.min(sessionTimeout, streamTimeout));
+
+        Assert.assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    private void sleep(long ms)
+    {
+        try
+        {
+            Thread.sleep(ms);
+        }
+        catch (InterruptedException x)
+        {
+            x.printStackTrace();
+        }
+    }
+
+    private static class AsyncOnErrorServlet extends HttpServlet implements AsyncListener
+    {
+        private final CountDownLatch latch;
+
+        public AsyncOnErrorServlet(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            AsyncContext asyncContext = (AsyncContext)request.getAttribute(AsyncContext.class.getName());
+            if (asyncContext == null)
+            {
+                AsyncContext context = request.startAsync();
+                context.setTimeout(0);
+                request.setAttribute(AsyncContext.class.getName(), context);
+                context.addListener(this);
+            }
+            else
+            {
+                throw new ServletException();
+            }
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException
+        {
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException
+        {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException
+        {
+            HttpServletResponse response = (HttpServletResponse)event.getSuppliedResponse();
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+            event.getAsyncContext().complete();
+            latch.countDown();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException
+        {
+        }
+    }
+
+    private static class AsyncOnErrorStreamListener extends Stream.Listener.Adapter
+    {
+        private final CountDownLatch clientLatch;
+
+        public AsyncOnErrorStreamListener(CountDownLatch clientLatch)
+        {
+            this.clientLatch = clientLatch;
+        }
+
+        @Override
+        public void onHeaders(Stream stream, HeadersFrame frame)
+        {
+            MetaData.Response response = (MetaData.Response)frame.getMetaData();
+            if (response.getStatus() == HttpStatus.INTERNAL_SERVER_ERROR_500)
+                clientLatch.countDown();
+            if (frame.isEndStream())
+                clientLatch.countDown();
+        }
+    }
+}

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/IdleTimeoutTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/IdleTimeoutTest.java
@@ -78,8 +78,7 @@ public class IdleTimeoutTest extends AbstractTest
             @Override
             public void onClose(Session session, GoAwayFrame frame)
             {
-                if (session.isClosed() && ((HTTP2Session)session).isDisconnected())
-                    latch.countDown();
+                latch.countDown();
             }
         });
 
@@ -117,8 +116,7 @@ public class IdleTimeoutTest extends AbstractTest
             @Override
             public void onClose(Session session, GoAwayFrame frame)
             {
-                if (session.isClosed() && ((HTTP2Session)session).isDisconnected())
-                    latch.countDown();
+                latch.countDown();
             }
         });
 
@@ -213,8 +211,7 @@ public class IdleTimeoutTest extends AbstractTest
             @Override
             public void onClose(Session session, GoAwayFrame frame)
             {
-                if (session.isClosed() && ((HTTP2Session)session).isDisconnected())
-                    closeLatch.countDown();
+                closeLatch.countDown();
             }
         });
         client.setIdleTimeout(idleTimeout);
@@ -251,8 +248,7 @@ public class IdleTimeoutTest extends AbstractTest
             @Override
             public void onClose(Session session, GoAwayFrame frame)
             {
-                if (session.isClosed() && ((HTTP2Session)session).isDisconnected())
-                    closeLatch.countDown();
+                closeLatch.countDown();
             }
         });
         client.setIdleTimeout(idleTimeout);

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/IdleTimeoutTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/IdleTimeoutTest.java
@@ -357,10 +357,11 @@ public class IdleTimeoutTest extends AbstractTest
             }
 
             @Override
-            public void onTimeout(Stream stream, Throwable x)
+            public boolean onIdleTimeout(Stream stream, Throwable x)
             {
                 Assert.assertThat(x, Matchers.instanceOf(TimeoutException.class));
                 timeoutLatch.countDown();
+                return true;
             }
         });
 
@@ -387,9 +388,10 @@ public class IdleTimeoutTest extends AbstractTest
                 return new Stream.Listener.Adapter()
                 {
                     @Override
-                    public void onTimeout(Stream stream, Throwable x)
+                    public boolean onIdleTimeout(Stream stream, Throwable x)
                     {
                         timeoutLatch.countDown();
+                        return true;
                     }
                 };
             }
@@ -431,9 +433,10 @@ public class IdleTimeoutTest extends AbstractTest
                 return new Stream.Listener.Adapter()
                 {
                     @Override
-                    public void onTimeout(Stream stream, Throwable x)
+                    public boolean onIdleTimeout(Stream stream, Throwable x)
                     {
                         timeoutLatch.countDown();
+                        return true;
                     }
                 };
             }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -115,10 +115,13 @@ public class HTTP2Connection extends AbstractConnection
     @Override
     public boolean onIdleExpired()
     {
-        boolean close = session.onIdleTimeout();
         boolean idle = isFillInterested();
-        if (close && idle)
-            session.close(ErrorCode.NO_ERROR.code, "idle_timeout", Callback.NOOP);
+        if (idle)
+        {
+            boolean close = session.onIdleTimeout();
+            if (close)
+                session.close(ErrorCode.NO_ERROR.code, "idle_timeout", Callback.NOOP);
+        }
         return false;
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -413,20 +413,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
                     {
                         // We received a GO_AWAY, so try to write
                         // what's in the queue and then disconnect.
-                        control(null, new Callback()
-                        {
-                            @Override
-                            public void succeeded()
-                            {
-                                notifyClose(HTTP2Session.this, frame);
-                            }
-
-                            @Override
-                            public void failed(Throwable x)
-                            {
-                                notifyClose(HTTP2Session.this, frame);
-                            }
-                        }, new DisconnectFrame());
+                        notifyClose(this, frame);
+                        control(null, Callback.NOOP, new DisconnectFrame());
                         return;
                     }
                     break;

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -160,15 +160,12 @@ public class HTTP2Stream extends IdleTimeout implements IStream
         if (LOG.isDebugEnabled())
             LOG.debug("Idle timeout {}ms expired on {}", getIdleTimeout(), this);
 
-        // The stream is now gone, we must close it to
-        // avoid that its idle timeout is rescheduled.
-        close();
-
-        // Tell the other peer that we timed out.
-        reset(new ResetFrame(getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
-
         // Notify the application.
-        notifyTimeout(this, timeout);
+        if (notifyIdleTimeout(this, timeout))
+        {
+            // Tell the other peer that we timed out.
+            reset(new ResetFrame(getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+        }
     }
 
     private ConcurrentMap<String, Object> attributes()
@@ -397,18 +394,19 @@ public class HTTP2Stream extends IdleTimeout implements IStream
         }
     }
 
-    private void notifyTimeout(Stream stream, Throwable failure)
+    private boolean notifyIdleTimeout(Stream stream, Throwable failure)
     {
         Listener listener = this.listener;
         if (listener == null)
-            return;
+            return true;
         try
         {
-            listener.onTimeout(stream, failure);
+            return listener.onIdleTimeout(stream, failure);
         }
         catch (Throwable x)
         {
             LOG.info("Failure while notifying listener " + listener, x);
+            return true;
         }
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -178,8 +178,26 @@ public interface Stream
          * @param stream the stream
          * @param x      the timeout failure
          * @see #getIdleTimeout()
+         * @deprecated
          */
-        public void onTimeout(Stream stream, Throwable x);
+        @Deprecated
+        public default void onTimeout(Stream stream, Throwable x)
+        {
+        }
+
+        /**
+         * <p>Callback method invoked when the stream exceeds its idle timeout.</p>
+         *
+         * @param stream the stream
+         * @param x      the timeout failure
+         * @see #getIdleTimeout()
+         * @return true to reset the stream, false to ignore the idle timeout
+         */
+        public default boolean onIdleTimeout(Stream stream, Throwable x)
+        {
+            onTimeout(stream, x);
+            return true;
+        }
 
         /**
          * <p>Empty implementation of {@link Listener}</p>
@@ -211,6 +229,13 @@ public interface Stream
             @Override
             public void onTimeout(Stream stream, Throwable x)
             {
+            }
+
+            @Override
+            public boolean onIdleTimeout(Stream stream, Throwable x)
+            {
+                onTimeout(stream, x);
+                return true;
             }
         }
     }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/GoAwayFrame.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/GoAwayFrame.java
@@ -18,10 +18,9 @@
 
 package org.eclipse.jetty.http2.frames;
 
-import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jetty.http2.ErrorCode;
-import org.eclipse.jetty.util.BufferUtil;
 
 public class GoAwayFrame extends Frame
 {
@@ -54,16 +53,15 @@ public class GoAwayFrame extends Frame
 
     public String tryConvertPayload()
     {
-        if (payload == null)
+        if (payload == null || payload.length == 0)
             return "";
-        ByteBuffer buffer = BufferUtil.toBuffer(payload);
         try
         {
-            return BufferUtil.toUTF8String(buffer);
+            return new String(payload, StandardCharsets.UTF_8);
         }
         catch (Throwable x)
         {
-            return BufferUtil.toDetailString(buffer);
+            return "";
         }
     }
 

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
@@ -132,9 +132,10 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
     }
 
     @Override
-    public void onTimeout(Stream stream, Throwable failure)
+    public boolean onIdleTimeout(Stream stream, Throwable x)
     {
-        responseFailure(failure);
+        responseFailure(x);
+        return true;
     }
 
     private class ContentNotifier extends IteratingCallback

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnection.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnection.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.ISession;
 import org.eclipse.jetty.http2.IStream;
+import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.DataFrame;
 import org.eclipse.jetty.http2.frames.Frame;
@@ -124,9 +125,26 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         if (LOG.isDebugEnabled())
             LOG.debug("Processing {} on {}", frame, stream);
         HttpChannelOverHTTP2 channel = (HttpChannelOverHTTP2)stream.getAttribute(IStream.CHANNEL_ATTRIBUTE);
-        Runnable task = channel.requestContent(frame, callback);
+        Runnable task = channel.onRequestContent(frame, callback);
         if (task != null)
             offerTask(task, false);
+    }
+
+    public void onStreamFailure(IStream stream, Throwable failure)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Processing failure on {}: {}", stream, failure);
+        HttpChannelOverHTTP2 channel = (HttpChannelOverHTTP2)stream.getAttribute(IStream.CHANNEL_ATTRIBUTE);
+        channel.onFailure(failure);
+    }
+
+    public void onSessionFailure(Throwable failure)
+    {
+        ISession session = getSession();
+        if (LOG.isDebugEnabled())
+            LOG.debug("Processing failure on {}: {}", session, failure);
+        for (Stream stream : session.getStreams())
+            onStreamFailure((IStream)stream, failure);
     }
 
     public void push(Connector connector, IStream stream, MetaData.Request request)

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -115,12 +115,11 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         public boolean onIdleTimeout(Session session)
         {
             boolean close = super.onIdleTimeout(session);
-            if (close)
-            {
-                long idleTimeout = getConnection().getEndPoint().getIdleTimeout();
-                getConnection().onSessionFailure(new TimeoutException("Session idle timeout " + idleTimeout + " ms"));
-            }
-            return close;
+            if (!close)
+                return false;
+
+            long idleTimeout = getConnection().getEndPoint().getIdleTimeout();
+            return getConnection().onSessionTimeout(new TimeoutException("Session idle timeout " + idleTimeout + " ms"));
         }
 
         @Override
@@ -166,9 +165,9 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         }
 
         @Override
-        public void onTimeout(Stream stream, Throwable failure)
+        public boolean onIdleTimeout(Stream stream, Throwable x)
         {
-            getConnection().onStreamFailure((IStream)stream, failure);
+            return getConnection().onStreamTimeout((IStream)stream, x);
         }
 
         private void close(Stream stream, String reason)

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -18,8 +18,10 @@
 
 package org.eclipse.jetty.http2.server;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Cipher;
@@ -28,6 +30,7 @@ import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
@@ -72,7 +75,7 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         return acceptable;
     }
 
-    private class HTTPServerSessionListener extends ServerSessionListener.Adapter implements Stream.Listener
+    protected class HTTPServerSessionListener extends ServerSessionListener.Adapter implements Stream.Listener
     {
         private final Connector connector;
         private final EndPoint endPoint;
@@ -83,7 +86,7 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
             this.endPoint = endPoint;
         }
 
-        private HTTP2ServerConnection getConnection()
+        protected HTTP2ServerConnection getConnection()
         {
             return (HTTP2ServerConnection)endPoint.getConnection();
         }
@@ -105,7 +108,31 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
         {
             getConnection().onNewStream(connector, (IStream)stream, frame);
-            return frame.isEndStream() ? null : this;
+            return this;
+        }
+
+        @Override
+        public boolean onIdleTimeout(Session session)
+        {
+            boolean close = super.onIdleTimeout(session);
+            if (close)
+            {
+                long idleTimeout = getConnection().getEndPoint().getIdleTimeout();
+                getConnection().onSessionFailure(new TimeoutException("Session idle timeout " + idleTimeout + " ms"));
+            }
+            return close;
+        }
+
+        @Override
+        public void onClose(Session session, GoAwayFrame frame)
+        {
+            ErrorCode error = ErrorCode.from(frame.getError());
+            if (error == null)
+                error = ErrorCode.STREAM_CLOSED_ERROR;
+            String reason = frame.tryConvertPayload();
+            if (reason != null && !reason.isEmpty())
+                reason = " (" + reason + ")";
+            getConnection().onSessionFailure(new IOException("HTTP/2 " + error + reason));
         }
 
         @Override
@@ -132,20 +159,21 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         @Override
         public void onReset(Stream stream, ResetFrame frame)
         {
-            // TODO:
+            ErrorCode error = ErrorCode.from(frame.getError());
+            if (error == null)
+                error = ErrorCode.CANCEL_STREAM_ERROR;
+            getConnection().onStreamFailure((IStream)stream, new IOException("HTTP/2 " + error));
         }
 
         @Override
-        public void onTimeout(Stream stream, Throwable x)
+        public void onTimeout(Stream stream, Throwable failure)
         {
-            // TODO
+            getConnection().onStreamFailure((IStream)stream, failure);
         }
 
         private void close(Stream stream, String reason)
         {
-            final Session session = stream.getSession();
-            session.close(ErrorCode.PROTOCOL_ERROR.code, reason, Callback.NOOP);
+            stream.getSession().close(ErrorCode.PROTOCOL_ERROR.code, reason, Callback.NOOP);
         }
     }
-
 }

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
@@ -189,7 +189,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         }
     }
 
-    public Runnable requestContent(DataFrame frame, final Callback callback)
+    public Runnable onRequestContent(DataFrame frame, final Callback callback)
     {
         Stream stream = getStream();
         if (stream.isReset())
@@ -256,6 +256,12 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         _delayedUntilContent = false;
 
         return handle || delayed ? this : null;
+    }
+
+    public void onFailure(Throwable failure)
+    {
+        onEarlyEOF();
+        getState().asyncError(failure);
     }
 
     protected void consumeInput()

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
@@ -53,6 +53,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
 
     private boolean _expect100Continue;
     private boolean _delayedUntilContent;
+    private boolean _handled;
 
     public HttpChannelOverHTTP2(Connector connector, HttpConfiguration configuration, EndPoint endPoint, HttpTransportOverHTTP2 transport)
     {
@@ -105,6 +106,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
 
             _delayedUntilContent = getHttpConfiguration().isDelayDispatchUntilContent() &&
                     !endStream && !_expect100Continue;
+            _handled = !_delayedUntilContent;
 
             if (LOG.isDebugEnabled())
             {
@@ -172,6 +174,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
     {
         _expect100Continue = false;
         _delayedUntilContent = false;
+        _handled = false;
         super.recycle();
         getHttpTransport().recycle();
     }
@@ -254,8 +257,14 @@ public class HttpChannelOverHTTP2 extends HttpChannel
 
         boolean delayed = _delayedUntilContent;
         _delayedUntilContent = false;
-
+        if (delayed)
+            _handled = true;
         return handle || delayed ? this : null;
+    }
+
+    public boolean isRequestHandled()
+    {
+        return _handled;
     }
 
     public void onFailure(Throwable failure)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
@@ -310,6 +310,45 @@ public class HttpChannelState
         }
     }
 
+    public void asyncError(Throwable failure)
+    {
+        AsyncContextEvent event = null;
+        try (Locker.Lock lock= _locker.lock())
+        {
+            switch (_state)
+            {
+                case IDLE:
+                case DISPATCHED:
+                case COMPLETING:
+                case COMPLETED:
+                case UPGRADED:
+                case ASYNC_IO:
+                case ASYNC_WOKEN:
+                {
+                    break;
+                }
+                case ASYNC_WAIT:
+                {
+                    _event.addThrowable(failure);
+                    _state=State.ASYNC_WOKEN;
+                    _async=Async.ERRORING;
+                    event=_event;
+                    break;
+                }
+                default:
+                {
+                    throw new IllegalStateException(getStatusStringLocked());
+                }
+            }
+        }
+
+        if (event != null)
+        {
+            cancelTimeout(event);
+            runInContext(event, _channel);
+        }
+    }
+
     /**
      * Signal that the HttpConnection has finished handling the request.
      * For blocking connectors, this call may block if the request has


### PR DESCRIPTION
Introduced new method HttpChannelState.asyncError() to be called in
case of asynchronous errors, i.e. those errors that do not happen in
the HttpChannel.handle() loop.

Implemented HTTP/2 callbacks to call HttpChannelState.asyncError()
and plug in the existing error handling mechanism.