### PR TITLE
Fix HttpClient#copyRequest

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -459,9 +459,10 @@ public class HttpClient extends ContainerLifeCycle
                     HttpHeader.PROXY_AUTHORIZATION == header)
                 continue;
 
+            String name = field.getName();
             String value = field.getValue();
-            if (!newRequest.getHeaders().contains(header, value))
-                newRequest.header(field.getName(), value);
+            if (!newRequest.getHeaders().contains(name, value))
+                newRequest.header(name, value);
         }
         return newRequest;
     }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1548,6 +1548,68 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         Assert.assertThat(new String(response.getContent(), StandardCharsets.ISO_8859_1),Matchers.startsWith("[::1]:"));
     }
 
+    @Test
+    public void testCopyRequest()
+            throws Exception
+    {
+        startClient();
+
+        assertCopyRequest(client.newRequest("http://example.com/some/url")
+                .method(HttpMethod.HEAD)
+                .version(HttpVersion.HTTP_2)
+                .content(new StringContentProvider("some string"))
+                .timeout(321, TimeUnit.SECONDS)
+                .idleTimeout(2221, TimeUnit.SECONDS)
+                .followRedirects(true)
+                .header(HttpHeader.CONTENT_TYPE, "application/json")
+                .header("X-Some-Custom-Header", "some-value"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .method(HttpMethod.POST)
+                .version(HttpVersion.HTTP_1_0)
+                .content(new StringContentProvider("some other string"))
+                .timeout(123231, TimeUnit.SECONDS)
+                .idleTimeout(232342, TimeUnit.SECONDS)
+                .followRedirects(false)
+                .header(HttpHeader.ACCEPT, "application/json")
+                .header("X-Some-Other-Custom-Header", "some-other-value"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .header(HttpHeader.ACCEPT, "application/json")
+                .header(HttpHeader.ACCEPT, "application/xml")
+                .header("x-same-name", "value1")
+                .header("x-same-name", "value2"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .header(HttpHeader.ACCEPT, "application/json")
+                .header(HttpHeader.CONTENT_TYPE, "application/json"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .header("X-Custom-Header-1", "value1")
+                .header("X-Custom-Header-2", "value2"));
+
+        assertCopyRequest(client.newRequest("https://example.com")
+                .header("X-Custom-Header-1", "value")
+                .header("X-Custom-Header-2", "value"));
+    }
+
+    private void assertCopyRequest(Request original)
+    {
+        Request copy = client.copyRequest((HttpRequest) original, original.getURI());
+        Assert.assertEquals(original.getURI(), copy.getURI());
+        Assert.assertEquals(original.getMethod(), copy.getMethod());
+        Assert.assertEquals(original.getVersion(), copy.getVersion());
+        Assert.assertEquals(original.getContent(), copy.getContent());
+        Assert.assertEquals(original.getIdleTimeout(), copy.getIdleTimeout());
+        Assert.assertEquals(original.getTimeout(), copy.getTimeout());
+        Assert.assertEquals(original.isFollowRedirects(), copy.isFollowRedirects());
+        Assert.assertEquals(original.getHeaders(), copy.getHeaders());
+    }
+
     private void consume(InputStream input, boolean eof) throws IOException
     {
         int crlfs = 0;


### PR DESCRIPTION
Make HttpClient#copyRequest to copy custom headers with the same values.

When original request contains some custom header, say `X-Custom`, than
HttpHeader object within a HttpField will be `null`. In such case
`newRequest.getHeaders().contains(field.getName(), value)` check returns
true when there are 2 and more custom headers with the same value. As a result
not all the custom headers are being copied to the new request.