### PR TITLE
Speed up multi part parsing #1027

### DIFF
--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/MultipartFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/MultipartFilterTest.java
@@ -471,7 +471,7 @@ public class MultipartFilterTest
         "Content-Transfer-Encoding: base64\r\n"+
         "Content-Type: application/octet-stream\r\n\r\n"+
         "SG93IG5vdyBicm93biBjb3cuCg=="+
-        "\r\n--" + boundary + "--";
+        "\r\n--" + boundary + "--\r\n\r\n";
 
         request.setContent(content);
 

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/MultipartFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/MultipartFilterTest.java
@@ -471,7 +471,7 @@ public class MultipartFilterTest
         "Content-Transfer-Encoding: base64\r\n"+
         "Content-Type: application/octet-stream\r\n\r\n"+
         "SG93IG5vdyBicm93biBjb3cuCg=="+
-        "\r\n--" + boundary + "--\r\n\r\n";
+        "\r\n--" + boundary + "--";
 
         request.setContent(content);
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -906,6 +906,8 @@ public class MultiPartInputStreamParser
                             if(lastChar == -1 || lastChar == '-') 
                             {
                                 lastPart = true;
+                            } else {
+                                throw new IOException("Incomplete parts, final boundary must end with --"); 
                             }
                         } else if (c2ndLastChar == '\r') 
                         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -693,16 +693,20 @@ public class MultiPartInputStreamParser
                         }
                         
                         @Override
-                        public int read(byte b[]) throws IOException {
+                        public int read(byte b[]) throws IOException 
+                        {
                             return read(b, 0, b.length);
                         }
                         
                         @Override
-                        public int read(byte b[], int off, int len) throws IOException {
+                        public int read(byte b[], int off, int len) throws IOException 
+                        {
                             int i = 0;
-                            for(i = 0; i < len; i++) {
+                            for(i = 0; i < len; i++) 
+                            {
                                 int c = this.read();
-                                if(c == -1) {
+                                if(c == -1) 
+                                {
                                     return i;
                                 }
                                 b[off + i] = (byte) c;
@@ -711,23 +715,27 @@ public class MultiPartInputStreamParser
                         }
                         
                         @Override
-                        public void mark(int readlimit) {
+                        public void mark(int readlimit) 
+                        {
                             this.in.mark(readlimit);
                         }
 
                         @Override
-                        public void reset() throws IOException {
+                        public void reset() throws IOException 
+                        {
                             this.in.reset();
                         }
 
                         @Override
-                        public boolean markSupported() {
+                        public boolean markSupported() 
+                        {
                             return this.in.markSupported();
                         }
                         
                         
                         @Override
-                        public long skip(long n) throws IOException {
+                        public long skip(long n) throws IOException 
+                        {
                             for(long i = 0; i < n; i++) {
                                 if(this.read() == -1) return i;
                             }
@@ -758,7 +766,8 @@ public class MultiPartInputStreamParser
                     byte[] bufin = new byte[CHUNK_READ_SIZE];
                     int offsetIntoBufin = -1;
                     int bufInSize;
-                    while(true) {
+                    while(true) 
+                    {
                         //If mark is not supported the stream must ensure that we will
                         //never read too much, i.e. not more than the boundary (excluding the trailing new line
                         // or double dash).
@@ -773,12 +782,14 @@ public class MultiPartInputStreamParser
                             chr = bufin[offsetIntoBufin];
 
                             //We allow boundaries to start with either CR or LF
-                            if(chr == '\r' || chr == '\n') {
+                            if(chr == '\r' || chr == '\n') 
+                            {
                                 
                                 if(bi != 0) {
                                     //We where already processing what looked like a boundary, write out
                                     //anything we missed.
-                                    if (offsetIntoBufin < bi) {
+                                    if (offsetIntoBufin < bi) 
+                                    {
                                         //write all of the boundary up to the point the boundary is in this array.
                                         part.write(boundaryWithNewLinePrefix,0,bi - offsetIntoBufin);
                                         lastCharWritten = boundaryWithNewLinePrefix[bi - offsetIntoBufin-1];
@@ -791,18 +802,22 @@ public class MultiPartInputStreamParser
                                 //Remember what this boundary started with.
                                 boundaryWithNewLinePrefix[bi] = (byte) chr;
                                 bi++;
-                            } else if(boundaryWithNewLinePrefix[bi] == chr) {
+                            } else if(boundaryWithNewLinePrefix[bi] == chr) 
+                            {
                                 bi++;
-                                if(bi == boundaryWithNewLinePrefix.length) {
+                                if(bi == boundaryWithNewLinePrefix.length) 
+                                {
                                     //boundary found
                                     //As we leave the loop early we need to increase offsetIntoBuffin
                                     //to ensure where we are up to into the buffer is consistent.
                                     offsetIntoBufin++;
                                     break;
                                 }
-                            } else {
+                            } else 
+                            {
                                 if(bi != 0) {
-                                    if (offsetIntoBufin < bi) {
+                                    if (offsetIntoBufin < bi) 
+                                    {
                                         //write all of the boundary up to the point the boundary is in this array.
                                         part.write(boundaryWithNewLinePrefix,0,bi - offsetIntoBufin);
                                         lastCharWritten = boundaryWithNewLinePrefix[bi - offsetIntoBufin-1];
@@ -823,7 +838,8 @@ public class MultiPartInputStreamParser
                             toWrite = offsetIntoBufin - bi;
                         }
 
-                        if (toWrite > 0) {
+                        if (toWrite > 0) 
+                        {
                             total += toWrite;
                             if (total > maxRequestSize)
                                 throw new IllegalStateException("Request exceeds maxRequestSize ("+_config.getMaxRequestSize()+")");
@@ -831,7 +847,8 @@ public class MultiPartInputStreamParser
                             part.write(bufin, 0, toWrite);
                         }
 
-                        if(bi == boundaryWithNewLinePrefix.length) {                        
+                        if(bi == boundaryWithNewLinePrefix.length) 
+                        {                        
                             //boundary found
                             break;
                         }
@@ -839,24 +856,29 @@ public class MultiPartInputStreamParser
                     if(partInput.markSupported()) {
                         partInput.reset();
                         long actuallySkipped = partInput.skip(offsetIntoBufin);
-                        for(; actuallySkipped<offsetIntoBufin; actuallySkipped++) {
+                        for(; actuallySkipped<offsetIntoBufin; actuallySkipped++) 
+                        {
                             partInput.read();
                         }
                     }
 
-                    if(bi != boundaryWithNewLinePrefix.length) {
+                    if(bi != boundaryWithNewLinePrefix.length) 
+                    {
                         throw new IllegalArgumentException("Missing trailing boundary");
                     }
 
                     //backup if the boundary was preceeded with \r\n, as we wrote out the \r
-                    if(boundaryWithNewLinePrefix[0] == '\n' && lastCharWritten == '\r') {
+                    if(boundaryWithNewLinePrefix[0] == '\n' && lastCharWritten == '\r') 
+                    {
                         //It ended with \r\n remove the extra written out \r
-                        if(part._bout == part._out) {
+                        if(part._bout == part._out) 
+                        {
                             //We are not writing to a file.
                             int lastchar = part._bout.getCount() - 1;
                             part._bout.setCount(lastchar);
                             part._size--;
-                        } else {
+                        } else 
+                        {
                             //we are writing to a file, we will trim the last char file.
                             trimLastChar = true;
                         }
@@ -864,38 +886,48 @@ public class MultiPartInputStreamParser
 
                     
                     //Is this the end?
-                    if( chr == -1) { 
+                    if( chr == -1) 
+                    { 
                         lastPart = true;
                     } else {
                         int c2ndLastChar = partInput.read();
-                        if(c2ndLastChar == -1) {
+                        if(c2ndLastChar == -1) 
+                        {
                             lastPart = true;
-                        } else if(c2ndLastChar == '-') {
+                        } else if(c2ndLastChar == '-') 
+                        {
                             int lastChar = partInput.read();
-                            if(lastChar == -1 || lastChar == '-') {
+                            if(lastChar == -1 || lastChar == '-') 
+                            {
                                 lastPart = true;
                             }
-                        } else if (c2ndLastChar == '\r') {
+                        } else if (c2ndLastChar == '\r') 
+                        {
                             //This ends well enough but we need to check the next char.
                             //we need to be careful what we do here this might be the end it or we may find we have
                             //more to deal with
-                            if(partInput.markSupported()) {
+                            if(partInput.markSupported()) 
+                            {
                                 partInput.mark(1);
                             }
                             int lastchar = partInput.read();
                             if(lastchar == '\n') {
                                 
-                            } else if (lastchar == -1) {
+                            } else if (lastchar == -1) 
+                            {
                                 lastPart = true;
                             } else {
-                                if(partInput.markSupported()) {
+                                if(partInput.markSupported()) 
+                                {
                                     partInput.reset();
-                                } else {
+                                } else 
+                                {
                                     throw new RuntimeException("The stream must support marking or "
                                         + "ensure the boundary is not terminated with \\r.");
                                 }
                             }
-                        } else if (c2ndLastChar == '\n') {
+                        } else if (c2ndLastChar == '\n') 
+                        {
                             //ok as well
                         } else {
                             throw new IllegalArgumentException("Boundary must be followed by a new line.");
@@ -907,7 +939,8 @@ public class MultiPartInputStreamParser
                 {
                     part.close();
                     //In the case of a file we may need to trim the last char.
-                    if(trimLastChar && part._file != null && part._file.exists()) {
+                    if(trimLastChar && part._file != null && part._file.exists()) 
+                    {
                         File f = part._file;
                         FileChannel outChan = new FileOutputStream(f, true).getChannel();
                         outChan.truncate(f.length() - 1);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -760,7 +760,7 @@ public class MultiPartInputStreamParser
                     int bufInSize;
                     while(true) {
                         //If mark is not supported the stream must ensure that we will
-                        //never read to much, i.e. not more than the boundary (excluding the trailing new line
+                        //never read too much, i.e. not more than the boundary (excluding the trailing new line
                         // or double dash).
                         if(partInput.markSupported()) {
                             partInput.mark(bufin.length);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -1117,10 +1117,12 @@ public class MultiPartInputStreamParser
         public int read(byte b[], int off, int len) throws IOException 
         {
             int i = 0;
-            if(!fillBuffer()) {
+            if(!fillBuffer()) 
+            {
                 return -1;
             }
-            for(i = 0; i < len && _pos < _buffer.length ; i++) {
+            for(i = 0; i < len && _pos < _buffer.length ; i++) 
+            {
                 b[off + i] = _buffer[_pos];
                 _pos++;
             }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -1037,7 +1037,8 @@ public class MultiPartInputStreamParser
         int _pos;
         String returnNext = null;
 
-        public long skip(long n) throws IOException {
+        public long skip(long n) throws IOException 
+        {
             return _in.skip(n);
         }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -736,7 +736,8 @@ public class MultiPartInputStreamParser
                         @Override
                         public long skip(long n) throws IOException 
                         {
-                            for(long i = 0; i < n; i++) {
+                            for(long i = 0; i < n; i++) 
+                            {
                                 if(this.read() == -1) return i;
                             }
                             return n;
@@ -771,13 +772,15 @@ public class MultiPartInputStreamParser
                         //If mark is not supported the stream must ensure that we will
                         //never read too much, i.e. not more than the boundary (excluding the trailing new line
                         // or double dash).
-                        if(partInput.markSupported()) {
+                        if(partInput.markSupported()) 
+                        {
                             partInput.mark(bufin.length);
                         }
                         //read a chunk
                         bufInSize = partInput.read(bufin);
                         if(bufInSize == -1) break;
-                        for(offsetIntoBufin = 0; offsetIntoBufin < bufInSize;offsetIntoBufin++) {
+                        for(offsetIntoBufin = 0; offsetIntoBufin < bufInSize;offsetIntoBufin++) 
+                        {
 
                             chr = bufin[offsetIntoBufin];
 
@@ -831,7 +834,8 @@ public class MultiPartInputStreamParser
                         }
                         //write up to boundary limit
                         int toWrite = offsetIntoBufin;
-                        if(bi > 0) {
+                        if(bi > 0) 
+                        {
                             //if we are looking at a boundary only write up to just before we think the
                             //boundary starts, again this will not include the prevchar which we may write out
                             //later on.
@@ -853,7 +857,8 @@ public class MultiPartInputStreamParser
                             break;
                         }
                     }
-                    if(partInput.markSupported()) {
+                    if(partInput.markSupported()) 
+                    {
                         partInput.reset();
                         long actuallySkipped = partInput.skip(offsetIntoBufin);
                         for(; actuallySkipped<offsetIntoBufin; actuallySkipped++) 
@@ -889,7 +894,8 @@ public class MultiPartInputStreamParser
                     if( chr == -1) 
                     { 
                         lastPart = true;
-                    } else {
+                    } else 
+                    {
                         int c2ndLastChar = partInput.read();
                         if(c2ndLastChar == -1) 
                         {
@@ -929,7 +935,8 @@ public class MultiPartInputStreamParser
                         } else if (c2ndLastChar == '\n') 
                         {
                             //ok as well
-                        } else {
+                        } else 
+                        {
                             throw new IllegalArgumentException("Boundary must be followed by a new line.");
                         }
 
@@ -1034,11 +1041,13 @@ public class MultiPartInputStreamParser
             return _in.skip(n);
         }
 
-        public boolean markSupported() {
+        public boolean markSupported() 
+        {
             return false;
         }
 
-        public void close() throws IOException {
+        public void close() throws IOException 
+        {
             _in.close();
         }
 
@@ -1047,7 +1056,8 @@ public class MultiPartInputStreamParser
             _in = rlis;
         }
         
-        private boolean fillBuffer() throws IOException {
+        private boolean fillBuffer() throws IOException 
+        {
             if (_buffer==null || _pos>= _buffer.length)
             {
                 
@@ -1060,9 +1070,11 @@ public class MultiPartInputStreamParser
                 _line = _in.readLine();
                 if (_line==null)
                     return false;  //nothing left
-                if (_line.startsWith("--")) {
+                if (_line.startsWith("--")) 
+                {
                     //Ensure the next call returns the parts after the boundary.
-                    if(_line.endsWith("--")) {
+                    if(_line.endsWith("--")) 
+                    {
                         returnNext = "--\r\n";
                     } else {
                         returnNext = "\r\n";
@@ -1087,19 +1099,22 @@ public class MultiPartInputStreamParser
         @Override
         public int read() throws IOException
         {
-            if(fillBuffer()) {
+            if(fillBuffer()) 
+            {
                 return _buffer[_pos++];
             } 
             return -1;
         }
         
         @Override
-        public int read(byte b[]) throws IOException {
+        public int read(byte b[]) throws IOException 
+        {
             return read(b, 0, b.length);
         }
         
         @Override
-        public int read(byte b[], int off, int len) throws IOException {
+        public int read(byte b[], int off, int len) throws IOException 
+        {
             int i = 0;
             if(!fillBuffer()) {
                 return -1;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -29,7 +29,6 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.SequenceInputStream;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -753,7 +753,7 @@ public class MultiPartInputStreamParser
 
                 try
                 {
-					//Read the config noew so we don't need to keep re-reading it.
+                    //Read the config noew so we don't need to keep re-reading it.
                     long maxRequestSize = Long.MAX_VALUE;
                     if (_config.getMaxRequestSize() > 0) maxRequestSize = _config.getMaxRequestSize();
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/MultiPartInputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/MultiPartInputStreamTest.java
@@ -659,6 +659,17 @@ public class MultiPartInputStreamTest
         IO.copy(p2.getInputStream(), baos);
         assertThat(baos.toString("UTF-8"), is("Other"));
     }
+    
+    @Test
+    public void checkVaryingChunkSize() throws Exception {
+        for(int i = 1; i < 2048; i++) {
+            MultiPartInputStreamParser.CHUNK_READ_SIZE = 1;
+            System.err.println(i);
+            testCRandLFMixRequest();
+            testCROnlyRequest();
+            testLFOnlyRequest();
+        }
+    }
 
     @Test
     public void testCRandLFMixRequest()


### PR DESCRIPTION
(See issue https://github.com/eclipse/jetty.project/issues/1027)
In essence we speed up multipart requests by reducing the amount of branching done. This is done by reading chunks (byte arrays) of data at once rather than a single byte at a time. 

Although this does result in faster multi part parsing (1.3s to 0.3s for about 3k requests) it does lead to some sticky situations where we need to undo how much we have read. To do this I have used mark/reset however for base64 encoding this is not possible and instead careful work had to be done to ensure each read would return a very specific amount of data. Also in this implementation we can write one char to much which may result in a file being created to early (e.g. we are supposed to create a file at 50bytes but we create it at 49), as we write one extra char we have to do some special work to backup in the case we have written to a file we truncate the file otherwise we backup the count into the byte array output stream.
