### PR TITLE
Fix for MongoSessionIdManager's scavenging of immortal sessions

### DIFF
--- a/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionIdManager.java
+++ b/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionIdManager.java
@@ -268,8 +268,7 @@ public class MongoSessionIdManager extends AbstractSessionIdManager
         
         BasicDBObject query = new BasicDBObject();     
         query.put(MongoSessionManager.__ID,new BasicDBObject("$in", ids ));
-        query.put(MongoSessionManager.__EXPIRY, new BasicDBObject("$gt", 0));
-        query.put(MongoSessionManager.__EXPIRY, new BasicDBObject("$lt", atTime));   
+        query.put(MongoSessionManager.__EXPIRY, new BasicDBObject("$gt", 0).append("$lt", atTime));   
             
         DBCursor checkSessions = _sessions.find(query, new BasicDBObject(MongoSessionManager.__ID, 1));
                         


### PR DESCRIPTION
MongoSessionIdManager scavenged immortal sessions (expiry <= 0) by accident. The third query condition (expiry $lt) overwrote the second (expiry $gt). BasicDBObject is a Map.

Query was:
`.find({ _id: { $in: ... }, expiry: { $lt: atTime } })`

After pull request:
`.find({ _id: { $in: ... }, expiry: { $gt: 0, $lt: atTime } })`