### PR TITLE
Fix parsing of cookies if last cookie is empty. Added test case

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
@@ -249,6 +249,12 @@ public class CookieCutter
                                 break;
 
                             case '=':
+                                if (i==last)
+                                {
+                                    name = hdr.substring(tokenstart, tokenend+1);
+                                    value = "";
+                                    break;
+                                }
                                 if (tokenstart>=0)
                                     name = hdr.substring(tokenstart, tokenend+1);
                                 tokenstart = -1;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1245,6 +1245,23 @@ public class RequestTest
         assertEquals("quoted=;value", cookies.get(1).getValue());
 
         cookies.clear();
+        response=_connector.getResponse(
+                "GET / HTTP/1.1\n"+
+                        "Host: whatever\n"+
+                        "Cookie: first=value; second=; last=\n" +
+                        "Connection: close\n"+
+                        "\n"
+        );
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertEquals(3,cookies.size());
+        assertEquals("first", cookies.get(0).getName());
+        assertEquals("value", cookies.get(0).getValue());
+        assertEquals("second", cookies.get(1).getName());
+        assertEquals("", cookies.get(1).getValue());
+        assertEquals("last", cookies.get(2).getName());
+        assertEquals("", cookies.get(2).getValue());
+
+        cookies.clear();
         LocalEndPoint endp = _connector.executeRequest(
                 "GET /other HTTP/1.1\n"+
                 "Host: whatever\n"+


### PR DESCRIPTION
When parsing cookies, if the last cookie has no value (ex. foo=) then it would not get added to the cookie array. All other empty value cookies get added to this array so the last one should be as well.