### PR TITLE
Fix wrong artifact ID of maven plugin

### DIFF
--- a/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
@@ -1,5 +1,5 @@
 //  ========================================================================
-//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd. and others
 //  ========================================================================
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0
@@ -506,7 +506,7 @@ Here's how to set it:
 ...
     <plugin>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>maven-jetty-plugin</artifactId>
+      <artifactId>jetty-maven-plugin</artifactId>
       <version>{VERSION}</version>
       <configuration>
         <war>${project.basedir}/target/myfunkywebapp</war>


### PR DESCRIPTION
This change fixes a location in the documentation where the artifact ID
of the plugin was still `maven-jetty-plugin`, where it should be
`jetty-maven-plugin`.

Signed-off-by: Jens Reimann <jreimann@redhat.com>