### PR TITLE
Allow to externally provide 'daemon' parameter

### DIFF
--- a/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
@@ -487,7 +487,7 @@ Here's how to set it:
 ==== jetty:run-exploded
 
 The run-exploded goal first assembles your webapp into an exploded WAR file and then deploys it to Jetty.
-If you set a non-zero `scanInterval`, Jetty watches your `pom.xml,`WEB-INF/lib`, `WEB-INF/` and `WEB-INF/web.xml` for changes and redeploys when necessary.
+If you set a non-zero `scanInterval`, Jetty watches your `pom.xml`, `WEB-INF/lib`, `WEB-INF/` and `WEB-INF/web.xml` for changes and redeploys when necessary.
 
 [[configuring-exploded-war]]
 ===== Configuration
@@ -527,9 +527,10 @@ Unlike `run-war`, the phase in which this plugin executes is not bound to the "p
 war::
 The location of the WAR file. This defaults to `${project.build.directory}/${project.build.finalName}`, but you can override the default by setting this parameter.
 daemon::
-If true, this plugin will start Jetty but let the build continue.
+If true (the default), this plugin will start Jetty but let the build continue.
 This is useful if you want to start jetty as an execution binding in a particular phase and then stop it in another.
-Alternatively, you can set this parameter to false, in which case Jetty will block and you will need to use a ctrl-c to stop it.
+Alternatively, you can set this parameter to false, in which case Jetty will block and you will need to use a ctrl-c to stop it. The parameter can also be set
+using the property `jetty.daemon`.
 
 Here's the configuration:
 

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd. and others
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0
@@ -53,7 +53,7 @@ public class JettyDeployWar extends JettyRunWarMojo
      * cntrl-c to stop it.
      * 
      * 
-     * @parameter  default-value="true"
+     * @parameter property="jetty.daemon" default-value="true"
      */
     protected boolean daemon = true;
     

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd. and others
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
This change allows to provide the `daemon` parameter using a property
using `-Djetty.daemon` in addition.

Signed-off-by: Jens Reimann <jreimann@redhat.com>

---

It looks like the file was checked in with CRLF line endings. I tried to keep it that way.