### PR TITLE
Make the requirement on "osgi.serviceloader.processor" optional

### DIFF
--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -37,7 +37,7 @@
         <extensions>true</extensions>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
 <!--
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
 -->


### PR DESCRIPTION
This allows Eclipse to continue to make use of jetty-http
without requiring the presence of Apache Aries bundles.

This fixes a problem introduced by the resolution to #1290 
See also the discussion here:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=512807

Signed-off-by: Mat Booth <mat.booth@redhat.com>