### PR TITLE
MongoSessionDataStore: fix for scavenging of local immortal sessions

### DIFF
--- a/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -366,8 +366,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
         //these candidates will be for our node
         BasicDBObject query = new BasicDBObject();     
         query.append(__ID,new BasicDBObject("$in", candidates));
-        query.append(__EXPIRY, new BasicDBObject("$gt", 0));
-        query.append(__EXPIRY, new BasicDBObject("$lt", upperBound));   
+        query.append(__EXPIRY, new BasicDBObject("$gt", 0).append("$lt", upperBound));  
 
         DBCursor verifiedExpiredSessions = null;
         try  


### PR DESCRIPTION
This is the version 9.4.x equivalent of https://github.com/eclipse/jetty.project/pull/1080. 

MongoSessionDataStore scavenges immortal sessions (expiry <= 0) by accident. The third query condition (expiry $lt) overwrote the second one (expiry $gt). BasicDBObject is a Map.

Query was:
`.find({ _id: { $in: ... }, expiry: { $lt: atTime } })`

After pull request:
`.find({ _id: { $in: ... }, expiry: { $gt: 0, $lt: atTime } })`