### PR TITLE
Fixing system locale dependent test

### DIFF
--- a/jetty-websocket/javax-websocket-server-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/server/ConfiguratorTest.java
+++ b/jetty-websocket/javax-websocket-server-impl/src/test/java/org/eclipse/jetty/websocket/jsr356/server/ConfiguratorTest.java
@@ -32,6 +32,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -350,7 +351,7 @@ public class ConfiguratorTest
 
         private SimpleDateFormat newDateFormat()
         {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd G 'at' HH:mm:ss Z");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd G 'at' HH:mm:ss Z", Locale.ENGLISH);
             dateFormat.setTimeZone(TZ);
             return dateFormat;
         }


### PR DESCRIPTION
Hi,

I've noticed that one test is failing on my machine because the implementation of the tests assumes the system locale to be set to "English". This is not the case on my machine and should not be the case for other developers either.