### PR TITLE
Fix native memory leak in GzipHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -610,9 +610,13 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     @Override
     public void recycle(Deflater deflater)
     {
-        deflater.reset();
         if (_deflater.get()==null)
+        {
+            deflater.reset();
             _deflater.set(deflater);
+        }
+        else
+            deflater.end();
     }
 
     /* ------------------------------------------------------------ */


### PR DESCRIPTION
Looks like this leak shows itself only with asynchronous responses.

Some relevant info: http://www.devguli.com/blog/eng/java-deflater-and-outofmemoryerror/