### PR TITLE
Make PathResource UNC compatible again

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -73,7 +73,7 @@ public class PathResource extends Resource
 
         if(!URIUtil.equalsIgnoreEncodings(uri,path.toUri()))
         {
-            return new File(uri).toPath().toAbsolutePath();
+            return Paths.get(uri).toAbsolutePath();
         }
 
         if (!abs.isAbsolute())

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -1397,5 +1398,19 @@ public class FileSystemResourceTest
         }
     }
     
-    
+    @Test
+    public void testUncPath() throws Exception
+    {
+        assumeTrue("Only windows supports UNC paths", OS.IS_WINDOWS);
+        assumeFalse("FileResource does not support this test", _class.equals(FileResource.class));
+        
+        try (Resource base = newResource(URI.create("file://127.0.0.1/path")))
+        {
+            Resource resource = base.addPath("WEB-INF/");
+            assertThat("getURI()", resource.getURI().toASCIIString(), containsString("path/WEB-INF/"));
+            assertThat("isAlias()", resource.isAlias(), is(true));
+            assertThat("getAlias()", resource.getAlias(), notNullValue());
+            assertThat("getAlias()", resource.getAlias().toASCIIString(), containsString("path/WEB-INF"));
+        }
+    }
 }


### PR DESCRIPTION
Hello,

Since Jetty 9.3.9, or since fixing issue #556, `PathResource` no longer correctly works with UNC paths.

The added `checkAliasPath` uses the `new File(uri).toPath()` construction, with the uri resulting from a `Path#toUri`, throwing:

```
java.lang.IllegalArgumentException: URI has an authority component
	at java.io.File.<init>(File.java:423) ~[na:1.8.0_66]
	at org.eclipse.jetty.util.resource.PathResource.checkAliasPath(PathResource.java:76) ~[jetty-util-9.3.16.v20170120.jar:9.3.16.v20170120]
	at org.eclipse.jetty.util.resource.PathResource.<init>(PathResource.java:207) ~[jetty-util-9.3.16.v20170120.jar:9.3.16.v20170120]
	at org.eclipse.jetty.util.resource.PathResource.addPath(PathResource.java:294) ~[jetty-util-9.3.16.v20170120.jar:9.3.16.v20170120]
	at org.eclipse.jetty.util.resource.ResourceCollection.addPath(ResourceCollection.java:215) ~[jetty-util-9.3.16.v20170120.jar:9.3.16.v20170120]
	at org.eclipse.jetty.webapp.WebAppContext.getWebInf(WebAppContext.java:861) ~[jetty-webapp-9.3.16.v20170120.jar:9.3.16.v20170120]
```
I included a test that verifies the problem above (and which throws said exception if the fix in `PathResource` is unapplied)

--
Fabian