### PR TITLE
Make the requirement on "osgi.serviceloader.registrar" optional

### DIFF
--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -37,7 +37,7 @@
         <extensions>true</extensions>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
 <!--
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
 -->


### PR DESCRIPTION
Follow-up to acf3608 that was submitted in PR #1365.

I did not initially recognise that this second capability should also be optional in order for Eclipse to continue to make use of jetty-http without requiring the presence of Apache Aries bundles.

Signed-off-by: Mat Booth <mat.booth@redhat.com>