### PR TITLE
Refactor ServletHandler to add getMappedServlet method

### DIFF
--- a/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/TestQuickStart.java
+++ b/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/TestQuickStart.java
@@ -22,14 +22,11 @@ package org.eclipse.jetty.quickstart;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.nio.file.Path;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,7 +87,7 @@ public class TestQuickStart
         server.start();
         
         //verify that FooServlet is now mapped to / and not the DefaultServlet
-        ServletHolder sh = webapp.getServletHandler().getHolderEntry("/").getResource();
+        ServletHolder sh = webapp.getServletHandler().getMappedServlet("/").getResource();
         assertNotNull(sh);
         assertEquals("foo", sh.getName());
         server.stop();

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -513,7 +513,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
 
             if ((_welcomeServlets || _welcomeExactServlets) && welcome_servlet==null)
             {
-                MappedResource<ServletHolder> entry=_servletHandler.getHolderEntry(welcome_in_context);
+                MappedResource<ServletHolder> entry=_servletHandler.getMappedServlet(welcome_in_context);
                 if (entry!=null && entry.getResource()!=_defaultHolder &&
                         (_welcomeServlets || (_welcomeExactServlets && entry.getPathSpec().getDeclaration().equals(welcome_in_context))))
                     welcome_servlet=welcome_in_context;

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
@@ -32,7 +32,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.PathMap.MappedEntry;
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.server.Dispatcher;
 import org.eclipse.jetty.server.Handler;
@@ -66,6 +65,7 @@ import org.eclipse.jetty.util.log.Logger;
  * @version $Id: Invoker.java 4780 2009-03-17 15:36:08Z jesse $
  *
  */
+@SuppressWarnings("serial")
 public class Invoker extends HttpServlet
 {
     private static final Logger LOG = Log.getLogger(Invoker.class);
@@ -168,11 +168,11 @@ public class Invoker extends HttpServlet
             synchronized(_servletHandler)
             {
                 // find the entry for the invoker (me)
-                 _invokerEntry=_servletHandler.getHolderEntry(servlet_path);
+                 _invokerEntry=_servletHandler.getMappedServlet(servlet_path);
 
                 // Check for existing mapping (avoid threaded race).
                 String path=URIUtil.addPaths(servlet_path,servlet);
-                MappedResource<ServletHolder> entry = _servletHandler.getHolderEntry(path);
+                MappedResource<ServletHolder> entry = _servletHandler.getMappedServlet(path);
 
                 if (entry!=null && !entry.equals(_invokerEntry))
                 {

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -51,8 +50,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
-import org.eclipse.jetty.http.pathmap.PathSpec;
-import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.security.IdentityService;
@@ -361,14 +358,16 @@ public class ServletHandler extends ScopedHandler
     /**
      * ServletHolder matching path.
      *
-     * @param pathInContext Path within _context.
+     * @param target Path within _context or servlet name
      * @return PathMap Entries pathspec to ServletHolder
+     * @deprecated Use {@link #getMappedServlet(String)}
      */
-    public MappedResource<ServletHolder> getHolderEntry(String pathInContext)
+    @Deprecated
+    public MappedResource<ServletHolder> getHolderEntry(String target)
     {
-        if (_servletPathMap==null)
-            return null;
-        return _servletPathMap.getMatch(pathInContext);
+        if (target.startsWith("/"))
+            return getMappedServlet(target);
+        return null;
     }
 
     /* ------------------------------------------------------------ */
@@ -438,16 +437,14 @@ public class ServletHandler extends ScopedHandler
         ServletHolder servlet_holder=null;
         UserIdentity.Scope old_scope=null;
 
-        // find the servlet
-        if (target.startsWith("/"))
+        MappedResource<ServletHolder> mapping=getMappedServlet(target);
+        if (mapping!=null)
         {
-            // Look for the servlet by path
-            MappedResource<ServletHolder> entry=getHolderEntry(target);
-            if (entry!=null)
+            servlet_holder = mapping.getResource();
+            
+            if (mapping.getPathSpec()!=null)
             {
-                PathSpec pathSpec = entry.getPathSpec();
-                servlet_holder=entry.getResource();
-
+                PathSpec pathSpec = mapping.getPathSpec();
                 String servlet_path=pathSpec.getPathMatch(target);
                 String path_info=pathSpec.getPathInfo(target);
 
@@ -463,12 +460,7 @@ public class ServletHandler extends ScopedHandler
                 }
             }
         }
-        else
-        {
-            // look for a servlet by name!
-            servlet_holder= _servletNameMap.get(target);
-        }
-
+        
         if (LOG.isDebugEnabled())
             LOG.debug("servlet {}|{}|{} -> {}",baseRequest.getContextPath(),baseRequest.getServletPath(),baseRequest.getPathInfo(),servlet_holder);
 
@@ -549,7 +541,33 @@ public class ServletHandler extends ScopedHandler
                 baseRequest.setHandled(true);
         }
     }
+    
 
+    /* ------------------------------------------------------------ */
+    /**
+     * ServletHolder matching path.
+     *
+     * @param target Path within _context or servlet name
+     * @return MappedResource to the ServletHolder.  Named servlets have a null PathSpec
+     */
+    public MappedResource<ServletHolder> getMappedServlet(String target)
+    {
+        if (target.startsWith("/"))
+        {
+            if (_servletPathMap==null)
+                return null;
+            return _servletPathMap.getMatch(target);
+        }
+        
+        if (_servletNameMap==null)
+            return null;
+        ServletHolder holder = _servletNameMap.get(target);
+        if (holder==null)
+            return null;
+        return new MappedResource<>(null,holder);
+    }
+    
+    /* ------------------------------------------------------------ */
     protected FilterChain getFilterChain(Request baseRequest, String pathInContext, ServletHolder servletHolder)
     {
         String key=pathInContext==null?servletHolder.getName():pathInContext;
@@ -702,8 +720,6 @@ public class ServletHandler extends ScopedHandler
     {
         return _startWithUnavailable;
     }
-
-
 
     /* ------------------------------------------------------------ */
     /** Initialize filters and load-on-startup servlets.
@@ -1765,6 +1781,7 @@ public class ServletHandler extends ScopedHandler
     /* ------------------------------------------------------------ */
     /* ------------------------------------------------------------ */
     /* ------------------------------------------------------------ */
+    @SuppressWarnings("serial")
     public static class Default404Servlet extends HttpServlet
     {
         @Override

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletHandlerTest.java
@@ -267,7 +267,7 @@ public class ServletHandlerTest
 
         handler.updateMappings();
 
-        MappedResource<ServletHolder> entry=handler.getHolderEntry("/foo/*");
+        MappedResource<ServletHolder> entry=handler.getMappedServlet("/foo/*");
         assertNotNull(entry);
         assertEquals("s1", entry.getResource().getName());
     }
@@ -312,7 +312,7 @@ public class ServletHandlerTest
         handler.addServletMapping(sm2);
         handler.updateMappings();
         
-       MappedResource<ServletHolder> entry=handler.getHolderEntry("/foo/*");
+       MappedResource<ServletHolder> entry=handler.getMappedServlet("/foo/*");
        assertNotNull(entry);
        assertEquals("s2", entry.getResource().getName());
     }


### PR DESCRIPTION
@joakime We could refactor `ServletHandler` like this to better support your use-case of adding regex mapping support (specially as `PathSpec` already has a regex variant).  Can you evaluate if this works for your use-case.

Note that for servlet 4.0, we will need to carry the MappedResource<ServletHolder> entry with the request so that we will be able to generate the new https://github.com/javaee/javax.servlet/blob/master/src/main/java/javax/servlet/http/ServletMapping.java instance 