### PR TITLE
Fix MongoSessionDataStore old session scavenging

### DIFF
--- a/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -409,7 +409,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
         BasicDBList list = new BasicDBList();
         list.add(gt);
         list.add(lt);
-        query.append("and", list);
+        query.append("$and", list);
 
         DBCursor oldExpiredSessions = null;
         try


### PR DESCRIPTION
Old session scavenging is currently not working because of the missing $ sign