### PR TITLE
Fix determining mime type of `PathResource` based on the file name in Jetty 9.2.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -201,6 +201,14 @@ public class PathResource extends Resource
         return path.toAbsolutePath().toString();
     }
 
+	@Override
+	public String toString() {
+		// Note: The org.eclipse.jetty.server.ResourceCache.Content uses #toString() instead of
+		// #getName() for determining the file name for mime type resolution based on the file name 
+        // extension.
+		return _path.toString();
+	}
+
     @Override
     public ReadableByteChannel getReadableByteChannel() throws IOException
     {


### PR DESCRIPTION
The result of `toString()` is expected to be the path name of a Resource. This is used for determining the mime type based on the file name extension in `org.eclipse.jetty.server.ResourceCache.Content`. Without a custom `toString()` implementation, no mime type can be determined for a resource. This problem does no longer exist in current Jetty, since `PathResource` has vanished.