### PR TITLE
Added --pregenerate-quickstart-xml command to start.jar

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/startup/start-jar.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/startup/start-jar.adoc
@@ -96,6 +96,8 @@ This allows the generated properties file to be saved and reused.
 Without this option, a temporary file is used.
 --commands=<filename>::
 Instructs `start.jar` to use each line of the specified file as arguments on the command line.
+--pregenerate-quickstart-xml=<war>|<wardir>::
+Expands war and generates quickstart-web.xml. See <<quickstart-webapp,Quickstart>> doc.
 
 ===== Debugg and Start Logging
 

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -189,10 +189,9 @@ public class Main
         return "";
     }
 
-    public void invokeMain(ClassLoader classloader, StartArgs args) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, ClassNotFoundException, IOException
+    public void invokeMain(ClassLoader classloader, String mainclass, CommandLineBuilder cmd) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, ClassNotFoundException, IOException
     {
         Class<?> invoked_class = null;
-        String mainclass = args.getMainClassname();
 
         try
         {
@@ -208,7 +207,6 @@ public class Main
 
         StartLog.debug("%s - %s",invoked_class,invoked_class.getPackage().getImplementationVersion());
 
-        CommandLineBuilder cmd = args.getMainArgs(false);
         String argArray[] = cmd.getArgs().toArray(new String[0]);
         StartLog.debug("Command Line Args: %s",cmd.toString());
 
@@ -503,7 +501,14 @@ public class Main
         // Invoke the Main Class
         try
         {
-            invokeMain(cl, args);
+            if (args.isPregenerateQuickstart())
+            {
+                invokeMain(cl, args.getPreconfigureQuickstartClassname(), args.getPreconfigureQuickstartArgs());
+            }
+            else
+            {
+                invokeMain(cl, args.getMainClassname(), args.getMainArgs(false));
+            }
         }
         catch (Throwable e)
         {

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -110,6 +110,7 @@ public class StartArgs
     }
 
     private static final String SERVER_MAIN = "org.eclipse.jetty.xml.XmlConfiguration";
+    private static final String PRECONFIGURE_QUICKSTART_MAIN = "org.eclipse.jetty.quickstart.PreconfigureQuickStartWar";
 
     private final BaseHome baseHome;
 
@@ -178,6 +179,8 @@ public class StartArgs
     private boolean dryRun = false;
     private boolean createStartd = false;
     private boolean updateIni = false;
+    private boolean pregenerateQuickstart = false;
+    private String warFileDir;
 
     private boolean exec = false;
     private String exec_properties;
@@ -655,6 +658,19 @@ public class StartArgs
         return System.getProperty("main.class",mainclass);
     }
 
+    public CommandLineBuilder getPreconfigureQuickstartArgs()
+    {
+        CommandLineBuilder cmd = new CommandLineBuilder();
+        cmd.addRawArg(getPreconfigureQuickstartClassname());
+        cmd.addRawArg(warFileDir);
+        return cmd;
+    }
+
+    public String getPreconfigureQuickstartClassname()
+    {
+        return System.getProperty("main.class", PRECONFIGURE_QUICKSTART_MAIN);
+    }
+
     public String getMavenLocalRepoDir()
     {
         String localRepo = getProperties().getString("maven.local.repo");
@@ -827,6 +843,11 @@ public class StartArgs
     public boolean isUpdateIni()
     {
         return updateIni;
+    }
+
+    public boolean isPregenerateQuickstart()
+    {
+        return pregenerateQuickstart;
     }
 
     public void parse(ConfigSources sources)
@@ -1085,6 +1106,13 @@ public class StartArgs
         {
             this.moduleGraphFilename = Props.getValue(arg);
             run = false;
+            return;
+        }
+
+        if (arg.startsWith("--pregenerate-quickstart-xml="))
+        {
+            pregenerateQuickstart = true;
+            warFileDir = Props.getValue(arg);
             return;
         }
 

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -662,7 +662,7 @@ public class StartArgs
     {
         CommandLineBuilder cmd = new CommandLineBuilder();
         cmd.addRawArg(getPreconfigureQuickstartClassname());
-        cmd.addRawArg(warFileDir);
+        cmd.addArg(warFileDir);
         return cmd;
     }
 

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -45,6 +45,10 @@ Command Line Options:
                    Use each line of the file as arguments on the command
                    line.
 
+  --pregenerate-quickstart-xml=<war>|<wardir>
+                   Expands war and generates quickstart-web.xml.
+                   http://www.eclipse.org/jetty/documentation/
+
 Debug and Start Logging:
 ------------------------
 

--- a/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.start;
 
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -208,5 +209,21 @@ public class MainTest
         assertThat("jetty.base",baseHome.getBase(),is(homePath.toString()));
 
         ConfigurationAssert.assertConfiguration(baseHome,args,"assert-home-with-spaces.txt");
+    }
+
+    @Test
+    public void testPregenerateQuickstartIsLikeRun() throws Exception
+    {
+        List<String> cmdLineArgs = new ArrayList<>();
+        Path warDir = MavenTestingUtils.getTargetTestingPath().resolve("path with spaces");
+        cmdLineArgs.add("--pregenerate-quickstart-xml=" + warDir);
+
+        Main main = new Main();
+        StartArgs args = main.processCommandLine(cmdLineArgs.toArray(new String[cmdLineArgs.size()]));
+
+        assertThat(args.isRun(), is(true));
+        assertThat(args.isPregenerateQuickstart(), is(true));
+
+        assertThat(args.getPreconfigureQuickstartArgs().toString(), endsWith(CommandLineBuilder.quote(warDir.toString())));
     }
 }


### PR DESCRIPTION
This adds a new command, `--pregenerate-quickstart-xml`, to start.jar

You can see it in action at https://github.com/ffissore/jetty-quickstart-poc

Once cloned the repo, run `pack.sh` to 1) generate an hello world webapp, 2) put the war into a docker image, 3) generate quickstart-web.xml at docker build time, 4) run the app

New command is a [RUN step in Dockerfile](https://github.com/ffissore/jetty-quickstart-poc/blob/master/Dockerfile#L10)

I've pushed a [custom jetty docker image](https://hub.docker.com/r/ffissore/jetty-quickstart) on docker hub for POC purposes

I still see an empty list in param `org.eclipse.jetty.tlds`. Any hints are welcome

While this feature is meant to ease adoption of quickstart, it may also influence the way #1542 is implemented