### PR TITLE
Deprecate ConcurrentHashSet

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
@@ -45,7 +45,6 @@ import javax.servlet.annotation.HandlesTypes;
 
 import org.eclipse.jetty.annotations.AnnotationParser.Handler;
 import org.eclipse.jetty.plus.annotation.ContainerInitializer;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.MultiException;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
@@ -381,7 +380,7 @@ public class AnnotationConfiguration extends AbstractConfiguration
     @Override
     public void postConfigure(WebAppContext context) throws Exception
     {
-        ConcurrentHashMap<String, ConcurrentHashSet<String>> classMap = (ClassInheritanceMap)context.getAttribute(CLASS_INHERITANCE_MAP);
+        Map<String, Set<String>> classMap = (ClassInheritanceMap)context.getAttribute(CLASS_INHERITANCE_MAP);
         List<ContainerInitializer> initializers = (List<ContainerInitializer>)context.getAttribute(CONTAINER_INITIALIZERS);
         
         context.removeAttribute(CLASS_INHERITANCE_MAP);
@@ -596,7 +595,7 @@ public class AnnotationConfiguration extends AbstractConfiguration
                     if (context.getAttribute(CLASS_INHERITANCE_MAP) == null)
                     {
                         //MultiMap<String> map = new MultiMap<>();
-                        ConcurrentHashMap<String, ConcurrentHashSet<String>> map = new ClassInheritanceMap();
+                        Map<String, Set<String>> map = new ClassInheritanceMap();
                         context.setAttribute(CLASS_INHERITANCE_MAP, map);
                         _classInheritanceHandler = new ClassInheritanceHandler(map);
                     }
@@ -1072,7 +1071,7 @@ public class AnnotationConfiguration extends AbstractConfiguration
         return (d!=null && d.getMetaDataComplete() == MetaDataComplete.True);
     }
 
-    public static class ClassInheritanceMap extends ConcurrentHashMap<String, ConcurrentHashSet<String>>
+    public static class ClassInheritanceMap extends ConcurrentHashMap<String, Set<String>>
     {
         
         @Override

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -28,10 +28,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.MultiException;
 import org.eclipse.jetty.util.log.Log;
@@ -68,7 +68,7 @@ public class AnnotationParser
 {
     private static final Logger LOG = Log.getLogger(AnnotationParser.class);
 
-    protected Set<String> _parsedClassNames = new ConcurrentHashSet<String>();
+    protected Set<String> _parsedClassNames = ConcurrentHashMap.newKeySet();
     
     protected static int ASM_OPCODE_VERSION = Opcodes.ASM5; //compatibility of api
    

--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ClassInheritanceHandler.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/ClassInheritanceHandler.java
@@ -18,11 +18,12 @@
 
 package org.eclipse.jetty.annotations;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
 import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -35,10 +36,10 @@ public class ClassInheritanceHandler extends AbstractHandler
 {
     private static final Logger LOG = Log.getLogger(ClassInheritanceHandler.class);
     
-    ConcurrentHashMap<String, ConcurrentHashSet<String>> _inheritanceMap;
+    Map<String, Set<String>> _inheritanceMap;
  
     
-    public ClassInheritanceHandler(ConcurrentHashMap<String, ConcurrentHashSet<String>> map)
+    public ClassInheritanceHandler(Map<String, Set<String>> map)
     {
         _inheritanceMap = map;
     }
@@ -69,13 +70,13 @@ public class ClassInheritanceHandler extends AbstractHandler
     {
       
         //As it is likely that the interfaceOrSuperClassName is already in the map, try getting it first
-        ConcurrentHashSet<String> implementingClasses = _inheritanceMap.get(interfaceOrSuperClassName);
+        Set<String> implementingClasses = _inheritanceMap.get(interfaceOrSuperClassName);
         //If it isn't in the map, then add it in, but test to make sure that someone else didn't get in 
         //first and add it
         if (implementingClasses == null)
         {
-            implementingClasses = new ConcurrentHashSet<String>();
-            ConcurrentHashSet<String> tmp = _inheritanceMap.putIfAbsent(interfaceOrSuperClassName, implementingClasses);
+            implementingClasses = ConcurrentHashMap.newKeySet();
+            Set<String> tmp = _inheritanceMap.putIfAbsent(interfaceOrSuperClassName, implementingClasses);
             if (tmp != null)
                 implementingClasses = tmp;
         }

--- a/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationInheritance.java
+++ b/jetty-annotations/src/test/java/org/eclipse/jetty/annotations/TestAnnotationInheritance.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.naming.Context;
@@ -35,7 +37,6 @@ import org.eclipse.jetty.annotations.AnnotationParser.AbstractHandler;
 import org.eclipse.jetty.annotations.AnnotationParser.ClassInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.FieldInfo;
 import org.eclipse.jetty.annotations.AnnotationParser.MethodInfo;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.junit.After;
 import org.junit.Test;
 
@@ -147,7 +148,7 @@ public class TestAnnotationInheritance
     @Test
     public void testTypeInheritanceHandling() throws Exception
     {
-       ConcurrentHashMap<String, ConcurrentHashSet<String>> map = new ConcurrentHashMap<String, ConcurrentHashSet<String>>();
+        Map<String, Set<String>> map = new ConcurrentHashMap<>();
         
         AnnotationParser parser = new AnnotationParser();
         ClassInheritanceHandler handler = new ClassInheritanceHandler(map);
@@ -171,7 +172,7 @@ public class TestAnnotationInheritance
         
         assertTrue (map.keySet().contains("org.eclipse.jetty.annotations.ClassA"));
         assertTrue (map.keySet().contains("org.eclipse.jetty.annotations.InterfaceD"));
-        ConcurrentHashSet<String> classes = map.get("org.eclipse.jetty.annotations.ClassA");
+        Set<String> classes = map.get("org.eclipse.jetty.annotations.ClassA");
         assertEquals(1, classes.size());
         assertEquals ("org.eclipse.jetty.annotations.ClassB", classes.iterator().next());
 

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.http2.client.http;
 
 import java.nio.channels.AsynchronousCloseException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,12 +34,11 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.thread.Sweeper;
 
 public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable
 {
-    private final Set<HttpChannel> channels = new ConcurrentHashSet<>();
+    private final Set<HttpChannel> channels = ConcurrentHashMap.newKeySet();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicInteger sweeps = new AtomicInteger();
     private final Session session;

--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/annotations/AnnotationParser.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/annotations/AnnotationParser.java
@@ -30,7 +30,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.osgi.boot.utils.BundleFileLocatorHelperFactory;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.resource.Resource;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
@@ -40,7 +39,7 @@ import org.osgi.framework.Constants;
  */
 public class AnnotationParser extends org.eclipse.jetty.annotations.AnnotationParser
 {
-    private Set<URI> _alreadyParsed = new ConcurrentHashSet<URI>();
+    private Set<URI> _alreadyParsed = ConcurrentHashMap.newKeySet();
     
     private ConcurrentHashMap<URI,Bundle> _uriToBundle = new ConcurrentHashMap<URI, Bundle>();
     private ConcurrentHashMap<Bundle,Resource> _bundleToResource = new ConcurrentHashMap<Bundle,Resource>();

--- a/jetty-plus/src/main/java/org/eclipse/jetty/plus/annotation/ContainerInitializer.java
+++ b/jetty-plus/src/main/java/org/eclipse/jetty/plus/annotation/ContainerInitializer.java
@@ -24,13 +24,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletContainerInitializer;
 
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.log.Log;
@@ -43,8 +43,8 @@ public class ContainerInitializer
     
     final protected ServletContainerInitializer _target;
     final protected Class<?>[] _interestedTypes;
-    final protected Set<String> _applicableTypeNames = new ConcurrentHashSet<String>();
-    final protected Set<String> _annotatedTypeNames = new ConcurrentHashSet<String>();
+    final protected Set<String> _applicableTypeNames = ConcurrentHashMap.newKeySet();
+    final protected Set<String> _annotatedTypeNames = ConcurrentHashMap.newKeySet();
 
 
     public ContainerInitializer (ServletContainerInitializer target, Class<?>[] classes)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -29,6 +29,7 @@ import java.util.EventListener;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.AsyncEvent;
@@ -54,7 +55,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SessionIdManager;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ScopedHandler;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -247,7 +247,7 @@ public class SessionHandler extends ScopedHandler
     protected boolean _usingURLs;
     protected boolean _usingCookies=true;
     
-    protected ConcurrentHashSet<String> _candidateSessionIdsForExpiry = new ConcurrentHashSet<String>();
+    protected Set<String> _candidateSessionIdsForExpiry = ConcurrentHashMap.newKeySet();
 
     protected Scheduler _scheduler;
     protected boolean _ownScheduler = false;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentHashSet.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentHashSet.java
@@ -25,6 +25,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * @deprecated Use Java 8 method {@code ConcurrentHashMap.newKeySet()} instead.
+ */
+@Deprecated
 public class ConcurrentHashSet<E> extends AbstractSet<E> implements Set<E>
 {
     private final Map<E, Boolean> _map = new ConcurrentHashMap<E, Boolean>();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -24,14 +24,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jetty.util.BlockingArrayQueue;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
@@ -53,7 +54,7 @@ public class QueuedThreadPool extends AbstractLifeCycle implements SizedThreadPo
     private final AtomicInteger _threadsStarted = new AtomicInteger();
     private final AtomicInteger _threadsIdle = new AtomicInteger();
     private final AtomicLong _lastShrink = new AtomicLong();
-    private final ConcurrentHashSet<Thread> _threads=new ConcurrentHashSet<>();
+    private final Set<Thread> _threads = ConcurrentHashMap.newKeySet();
     private final Object _joinLock = new Object();
     private final BlockingQueue<Runnable> _jobs;
     private final ThreadGroup _threadGroup;

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/CachingWebAppClassLoader.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/CachingWebAppClassLoader.java
@@ -20,9 +20,9 @@ package org.eclipse.jetty.webapp;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
 import org.eclipse.jetty.util.log.Log;
@@ -40,7 +40,7 @@ public class CachingWebAppClassLoader extends WebAppClassLoader
 {
     private static final Logger LOG = Log.getLogger(CachingWebAppClassLoader.class);
     
-    private final ConcurrentHashSet<String> _notFound = new ConcurrentHashSet<>();
+    private final Set<String> _notFound = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String,URL> _cache = new ConcurrentHashMap<>();
     
     public CachingWebAppClassLoader(ClassLoader parent, Context context) throws IOException


### PR DESCRIPTION
Hey,

since Java 8 there is `ConcurrentHashMap.newKeySet()` which effectively replaces Jetty's custom ConcurrentHashSet. The following PR replaces occurences of `new ConcurrentHashSet()` with the built-in one and deprecates ConcurrentHashSet.

Let me know what you think.

Cheers,
Christoph