### PR TITLE
HTTP/2 :authority: declaration should omit default ports in jetty-client

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpSenderOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpSenderOverHTTP2.java
@@ -53,7 +53,7 @@ public class HttpSenderOverHTTP2 extends HttpSender
     {
         HttpRequest request = exchange.getRequest();
         String path = relativize(request.getPath());
-        HttpURI uri = new HttpURI(request.getScheme(), request.getHost(), request.getPort(), path, null, request.getQuery(), null);
+        HttpURI uri = HttpURI.createHttpURI(request.getScheme(), request.getHost(), request.getPort(), path, null, request.getQuery(), null);
         MetaData.Request metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_2, request.getHeaders());
         Supplier<HttpFields> trailers = request.getTrailers();
         metaData.setTrailerSupplier(trailers);


### PR DESCRIPTION
Sush as Host field in http/1.1 or example in RFC 7541 page 36.

For example, the site https://www.limango.de/ returns 500 in this case.

Change-Id: Iaf98b7960b8001d82bcd351dd997372298068ff0
Signed-off-by: Stéphane Martin <stephane.martin@neotys.com>