### PR TITLE
ByteBufferContentProvider should return slice of the original ByteBuffer

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/ByteBufferContentProvider.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/ByteBufferContentProvider.java
@@ -76,9 +76,8 @@ public class ByteBufferContentProvider extends AbstractTypedContentProvider
                 try
                 {
                     ByteBuffer buffer = buffers[index];
-                    buffers[index] = buffer.slice();
                     ++index;
-                    return buffer;
+                    return buffer.slice();
                 }
                 catch (ArrayIndexOutOfBoundsException x)
                 {


### PR DESCRIPTION
Signed-off-by: Chris Redinger <redinger@gmail.com>

The package docs on ByteBufferContentProvider state "each invocation of the iterator() method returns a slice of the original ByteBuffer."

But, the implementation updates the original ByteBuffer list with the newly created slice, and instead returns the original ByteBuffer.
