### PR TITLE
Add systemd service file #1485

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.service
+++ b/jetty-home/src/main/resources/bin/jetty.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Jetty Web Application Server
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/opt/web/mybase/jetty.pid
+ExecStart=/etc/init.d/jetty start
+ExecStop=/etc/init.d/jetty stop
+ExecReload=/etc/init.d/jetty restart
+User=jetty
+Group=jetty
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request adds the systemd service file, it relies on the systemv init script.

Don't forget to run:
echo "JETTY_PID=/opt/web/mybase/jetty.pid" >> /etc/default/jetty

This documentation should be updated:
http://www.eclipse.org/jetty/documentation/current/startup-unix-service.html#_practical_setup_of_a_jetty_service