### PR TITLE
Issue #1732 Connection Limit

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -523,8 +523,7 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
                 if (_key==null)
                 {
                     _key = _channel.register(_selector, SelectionKey.OP_ACCEPT, this);
-                }
-                
+                }     
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("{} acceptor={}", this, _key);

--- a/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="addBean">
+    <Arg>
+      <New class="org.eclipse.jetty.server.ConnectionLimit">
+        <Arg type="int"><Property name="jetty.connection.limit" default="1000"/></Arg>
+	<Arg><Ref refid="Server"/></Arg>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-server/src/main/config/modules/connectionlimit.mod
+++ b/jetty-server/src/main/config/modules/connectionlimit.mod
@@ -1,0 +1,14 @@
+[description]
+Enable a server wide connection limit
+
+[tags]
+connector
+
+[depend]
+server
+
+[xml]
+etc/jetty-connectionlimit.xml
+
+[ini-template]
+jetty.connection.limit=1000

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
@@ -29,6 +29,15 @@ import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
+/**
+ * A Connection Listener that limits the number of Connections.
+ * <p>This listener applies a limit to the number of connections, which when 
+ * exceeded results in  a call to {@link AbstractConnector#setAccepting(boolean)} 
+ * to prevent further connections being received.  It can be applied to an
+ * entire server or to a specific connector.
+ * <p>
+ * @see Connection.Listener
+ */
 @ManagedObject
 public class ConnectionLimit extends AbstractLifeCycle implements Listener
 {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
@@ -1,0 +1,141 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.Connection.Listener;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+
+@ManagedObject
+public class ConnectionLimit extends AbstractLifeCycle implements Listener
+{
+    private static final Logger LOG = Log.getLogger(ConnectionLimit.class);
+    
+    private final Server _server;
+    private final List<AbstractConnector> _connectors = new ArrayList<>();
+    private int _connections;
+    private int _maxConnections;
+    private boolean _accepting = true;
+
+    public ConnectionLimit(int maxConnections, Server server)
+    {
+        _maxConnections = maxConnections;
+        _server = server;
+    }
+    
+    public ConnectionLimit(int maxConnections, Connector...connectors)
+    {
+        _maxConnections = maxConnections;
+        _server = null;
+        for (Connector c: connectors)
+        {
+            if (c instanceof AbstractConnector)
+                _connectors.add((AbstractConnector)c);
+            else
+                LOG.warn("Connector {} is not an AbstractConnection. Connections not limited",c);
+        }
+    }
+    
+    @ManagedAttribute("The maximum number of connections allowed")
+    public synchronized int getMaxConnections()
+    {
+        return _maxConnections;
+    }
+    
+    public synchronized void setMaxConnections(int max)
+    {
+        _maxConnections = max;
+    }
+
+    @ManagedAttribute("The current number of connections ")
+    public synchronized int getConnections()
+    {
+        return _connections;
+    }
+    
+    @Override
+    protected synchronized void doStart() throws Exception
+    {
+        if (_server!=null)
+        {
+            for (Connector c: _server.getConnectors())
+            {
+                if (c instanceof AbstractConnector)
+                    _connectors.add((AbstractConnector)c);
+                else
+                    LOG.warn("Connector {} is not an AbstractConnection. Connections not limited",c);
+            }
+        }
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("ConnectionLimit {} for {}",_maxConnections,_connectors);
+        
+        _connections = 0;
+        _accepting = true;
+        
+        for (AbstractConnector c : _connectors)
+            c.addBean(this);
+    }
+
+    @Override
+    protected synchronized void doStop() throws Exception
+    {
+        for (AbstractConnector c : _connectors)
+            c.removeBean(this);
+        _connections = 0;
+        if (_server!=null)
+            _connectors.clear();   
+    }
+    
+    @Override
+    public synchronized void onOpened(Connection connection)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("onOpen {} < {} {}",_connections, _maxConnections, connection);
+        if ( ++_connections >= _maxConnections && _accepting)
+        {
+            _accepting = false;
+            LOG.info("Connection Limit({}) reached for {}",_maxConnections,_connectors);
+            for (AbstractConnector c : _connectors)
+                c.setAccepting(false);
+        }
+    }
+
+    @Override
+    public synchronized void onClosed(Connection connection)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("onClosed {} < {} {}",_connections, _maxConnections, connection);
+        if ( --_connections < _maxConnections && !_accepting)
+        {
+            _accepting = true;
+            LOG.info("Connection Limit({}) cleared for {}",_maxConnections,_connectors);
+            for (AbstractConnector c : _connectors)
+                c.setAccepting(true);
+        }
+    }
+
+}


### PR DESCRIPTION
I had previously added the setAccepting(boolean) mechanism on the connectors.
This is a mechanism to trigger this by monitoring the total number of connections on the server.

I'm not 100% sure I like the approach, other options include:
- a limit per connector rather than server wide (this one can be used like that but not with current mod file)
- add a limit to the existing connector stats listener
- use the low resources monitor to poll the connector stats listener for the number of connections

Feedback wanted