### PR TITLE
Added missing space to remove bash warning from JETTY_START_TIMEOUT

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -385,7 +385,7 @@ fi
 #####################################################
 # Set STARTED timeout
 #####################################################
-if [ -z "$JETTY_START_TIMEOUT"]
+if [ -z "$JETTY_START_TIMEOUT" ]
 then
   JETTY_START_TIMEOUT=60
 fi


### PR DESCRIPTION
A coworker pointed out there was a warning that I overlooked.

Signed-off-by: Zachary Duquette <zachary.duquette@eidosmontreal.com>