### PR TITLE
cd'ing to jetty base

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -472,6 +472,7 @@ case "$ACTION" in
         chown "$JETTY_USER" "$JETTY_PID"
         # FIXME: Broken solution: wordsplitting, pathname expansion, arbitrary command execution, etc.
         su - "$JETTY_USER" $SU_SHELL -c "
+          cd "JETTY_BASE"
           exec ${RUN_CMD[*]} start-log-file="$JETTY_START_LOG" > /dev/null &
           disown \$!
           echo \$! > '$JETTY_PID'"


### PR DESCRIPTION
when running jetty.sh with root user, the jetty base was miss calculated as the home of the jetty user.