### PR TITLE
Allow for configuring WebSocketClient JVM lifecycle

### DIFF
--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -704,15 +704,17 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
      * @see Runtime#addShutdownHook(Thread)
      * @see ShutdownThread
      */
-    public void setStopAtShutdown(boolean stop)
+    public synchronized void setStopAtShutdown(boolean stop)
     {
         if (stop)
         {
-            if (!stopAtShutdown && isStarted() && !ShutdownThread.isRegistered(this)) {
+            if (!stopAtShutdown && isStarted() && !ShutdownThread.isRegistered(this))
+            {
                 ShutdownThread.register(this);
             }
         }
-        else {
+        else
+        {
             ShutdownThread.deregister(this);
         }
 

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -709,19 +709,16 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
         if (stop)
         {
             if (!stopAtShutdown && isStarted() && !ShutdownThread.isRegistered(this))
-            {
                 ShutdownThread.register(this);
-            }
         }
         else
-        {
             ShutdownThread.deregister(this);
-        }
 
         stopAtShutdown = stop;
     }
 
-    public boolean isStopAtShutdown() {
+    public boolean isStopAtShutdown()
+    {
         return stopAtShutdown;
     }
 


### PR DESCRIPTION
WebSocketClient automatically registers itself with a ShutdownThread which ensures cleanup when the JVM terminates. However, this prevents an application from managing JVM shutdown with open websockets.

This adds a new method to WebSocketClient, `setStopAtShutdown(boolean)`, which defaults to true to preserve existing behavior. This imitates the setStopAtShutdown logic in the jetty server.