### PR TITLE
fix some Maven artifact coordinates in the bom

### DIFF
--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -262,11 +262,14 @@
         <artifactId>jetty-memcached-sessions</artifactId>
         <version>9.4.7-SNAPSHOT</version>
       </dependency>
+      <!--
+      not anymore part of the build?
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-monitor</artifactId>
         <version>9.4.7-SNAPSHOT</version>
       </dependency>
+      -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-nosql</artifactId>
@@ -388,7 +391,7 @@
         <version>9.4.7-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
+        <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-servlet</artifactId>
         <version>9.4.7-SNAPSHOT</version>
       </dependency>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -169,12 +169,12 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
-        <artifactId>jetty-fcgi-client</artifactId>
+        <artifactId>fcgi-client</artifactId>
         <version>9.4.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
-        <artifactId>jetty-fcgi-server</artifactId>
+        <artifactId>fcgi-server</artifactId>
         <version>9.4.7-SNAPSHOT</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
jetty-monitor is not build anymore. Not sure if we need to keep it in the bom?