### PR TITLE
== to equals

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -610,7 +610,7 @@ public class HttpURI
     /* ------------------------------------------------------------ */
     public void decodeQueryTo(MultiMap<String> parameters)
     {
-        if (_query==_fragment)
+        if (_query!=null && _query.equals(_fragment))
             return;
         UrlEncoded.decodeUtf8To(_query,parameters);
     }
@@ -624,7 +624,7 @@ public class HttpURI
     /* ------------------------------------------------------------ */
     public void decodeQueryTo(MultiMap<String> parameters, Charset encoding) throws UnsupportedEncodingException
     {
-        if (_query==_fragment)
+        if (_query!=null && _query.equals(_fragment))
             return;
 
         if (encoding==null || StandardCharsets.UTF_8.equals(encoding))


### PR DESCRIPTION
It seems that long time ago, _query and _frament were integers, now they are String...

Signed-off-by: guillaume.maillard@gmail.com