### PR TITLE
correct value of max streams per http2 connection

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/http2/configuring-http2.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/http2/configuring-http2.adoc
@@ -64,6 +64,6 @@ Currently there are very few HTTP/2 configuration properties and the default val
 [cols=",",options="header",]
 |=======================================================================
 |Property |Description
-|jetty.http2.maxConcurrentStreams |The maximum number of concurrently open streams allowed on a single HTTP/2 connection (default 1024). Larger values increase parallelism but cost a memory commitment.
+|jetty.http2.maxConcurrentStreams |The maximum number of concurrently open streams allowed on a single HTTP/2 connection (default 128). Larger values increase parallelism but cost a memory commitment.
 |jetty.http2.initialStreamRecvWindow |The initial receive flow control window size for a new stream (default 65535). Larger values may allow greater throughput but also risk head of line blocking if TCP/IP flow control is triggered.
 |=======================================================================


### PR DESCRIPTION
The http2 documentation and the code do not agree on the default maximum concurrent streams per connection. The documentation has been updated to reflect the code's default value of 128. See line 48:

![image](https://user-images.githubusercontent.com/9098/30786678-dd913c1e-a147-11e7-8876-c550d1bd2e8a.png)
