### PR TITLE
Issue #1885 Fixed rounding error of negative maxInactiveInterval

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
@@ -575,7 +575,8 @@ public class Session implements SessionHandler.SessionIf
     {
         try (Lock lock = _lock.lock())
         {
-            return (int)(_sessionData.getMaxInactiveMs()/1000);
+            long maxInactiveMs = _sessionData.getMaxInactiveMs();
+            return (int)(maxInactiveMs < 0 ? -1 : maxInactiveMs/1000);
         }
     }
 


### PR DESCRIPTION
Session.getMaxInactiveInterval should return a negative number if the
the session is configured with a negative maxInactiveInterval. It was
being rounded up to 0 by mistake.

Signed-off-by: Dan Smith <upthewaterspout@apache.org>