### PR TITLE
proxy: case insensitive compare of Expect: 100-continue header

### DIFF
--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
@@ -445,7 +445,7 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected boolean expects100Continue(HttpServletRequest request)
     {
-        return HttpHeaderValue.CONTINUE.asString().equals(request.getHeader(HttpHeader.EXPECT.asString()));
+        return HttpHeaderValue.CONTINUE.is(request.getHeader(HttpHeader.EXPECT.asString()));
     }
 
     protected void copyRequestHeaders(HttpServletRequest clientRequest, Request proxyRequest)


### PR DESCRIPTION
> Comparison of expectation values is case-insensitive for unquoted tokens (including the 100-continue token), and is case-sensitive for quoted-string expectation-extensions.