### PR TITLE
Jetty 9.4.x #1918 scalable scheduler

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeoutTask.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeoutTask.java
@@ -1,0 +1,150 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.util.thread.Scheduler;
+
+/**
+ * An Abstract implementation of a Timeout Task.
+ * <p>
+ * This implementation is optimized assuming that the timeout will mostly
+ * be cancelled and then reused with a similar value.
+ */
+public abstract class CyclicTimeoutTask
+{
+    private final Scheduler _scheduler;
+    private final AtomicReference<Schedule> _scheduled = new AtomicReference<>();
+    private final AtomicLong _expireAtNanos = new AtomicLong(-1L);
+    private volatile Scheduler.Task _task;
+
+
+    /**
+     * @param scheduler A scheduler used to schedule checks for the idle timeout.
+     */
+    public CyclicTimeoutTask(Scheduler scheduler)
+    {
+        _scheduler = scheduler;
+    }
+
+    public Scheduler getScheduler()
+    {
+        return _scheduler;
+    }
+    
+    public void schedule(long delay, TimeUnit units)
+    {
+        long now = System.nanoTime();
+        long expireAtNanos = now + units.toNanos(delay);
+    
+        if (!_expireAtNanos.compareAndSet(-1,expireAtNanos))
+            throw new IllegalStateException("Timeout pending");
+    
+        Schedule schedule = _scheduled.get();
+        if (schedule==null || schedule._scheduledAt>expireAtNanos)
+            _scheduled.compareAndSet(schedule,new Schedule(now,expireAtNanos,schedule));
+    }
+    
+    public boolean reschedule(long delay, TimeUnit units)
+    {
+        long now = System.nanoTime();
+        long expireAtNanos = now + units.toNanos(delay);
+    
+        while(true)
+        {
+            long expireAt = _expireAtNanos.get();
+            if (expireAt==-1)
+                return false;
+
+            if (_expireAtNanos.compareAndSet(expireAt,expireAtNanos))
+            {
+                Schedule schedule = _scheduled.get();
+                if (schedule==null || schedule._scheduledAt>expireAtNanos)
+                    _scheduled.compareAndSet(schedule,new Schedule(now,expireAtNanos,schedule));
+                return true;
+            }
+        }
+    }
+    
+    
+    public boolean cancel()
+    {
+        return _expireAtNanos.getAndSet(-1)!=-1;
+    }
+    
+    protected abstract void onTimeoutExpired();
+
+    public void destroy()
+    {
+        cancel();
+        Scheduler.Task task = _task;
+        if (task!=null)
+            task.cancel();
+        Schedule schedule = _scheduled.getAndSet(null);
+        while (schedule!=null)
+        {
+            schedule._task.cancel();
+            schedule = schedule._next;
+        }
+    }
+    
+    private class Schedule implements Runnable
+    {
+        final long _scheduledAt;
+        final Scheduler.Task _task;
+        final Schedule _next;
+        
+        Schedule(long now, long scheduledAt, Schedule next)
+        {
+            _scheduledAt = scheduledAt;
+            _task = _scheduler.schedule(this,scheduledAt-now,TimeUnit.NANOSECONDS);
+            _next = next;
+        }
+        
+        @Override
+        public void run()
+        {
+            while(true)
+            {
+                long now = System.nanoTime();
+                long expireAt = _expireAtNanos.get();
+                if (expireAt==-1)
+                    return;
+
+                if (expireAt<now)
+                {
+                    if (!_expireAtNanos.compareAndSet(expireAt,-1))
+                        continue;
+                    _scheduled.compareAndSet(this,_next);
+                    onTimeoutExpired();
+                    return;
+                }
+                
+                Schedule next = _next;
+                if (next==null || next._scheduledAt>expireAt)
+                    next = new Schedule(now,expireAt,next);
+                _scheduled.compareAndSet(this,next);
+            }
+        }
+    }
+    
+}

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/CyclicTimeoutTaskTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/CyclicTimeoutTaskTest.java
@@ -1,0 +1,169 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.toolchain.test.AdvancedRunner;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AdvancedRunner.class)
+public class CyclicTimeoutTaskTest
+{
+    volatile boolean _open;
+    volatile boolean _expired;
+
+    ScheduledExecutorScheduler _timer = new ScheduledExecutorScheduler();
+    CyclicTimeoutTask _timeout;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        _expired=false;
+        _timer.start();
+        _timeout=new CyclicTimeoutTask(_timer)
+        {
+            @Override
+            protected void onTimeoutExpired()
+            {
+                _expired = true;
+            }
+        };
+        _timeout.schedule(1000,TimeUnit.MILLISECONDS);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        _timeout.destroy();
+        _timer.stop();
+    }
+
+    @Test
+    public void testReschedule() throws Exception
+    {
+        for (int i=0;i<20;i++)
+        {
+            Thread.sleep(100);
+            Assert.assertTrue(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        }
+        Assert.assertFalse(_expired);
+    }
+
+    @Test
+    public void testExpire() throws Exception
+    {
+        for (int i=0;i<5;i++)
+        {
+            Thread.sleep(100);
+            Assert.assertTrue(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        }
+        Thread.sleep(1500);
+        Assert.assertTrue(_expired);
+    }
+
+    @Test
+    public void testCancel() throws Exception
+    {
+        for (int i=0;i<5;i++)
+        {
+            Thread.sleep(100);
+            Assert.assertTrue(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        }
+        _timeout.cancel();
+        Thread.sleep(1500);
+        Assert.assertFalse(_expired);
+    }
+
+    @Test
+    public void testShorten() throws Exception
+    {
+        for (int i=0;i<5;i++)
+        {
+            Thread.sleep(100);
+            Assert.assertTrue(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        }
+        Assert.assertTrue(_timeout.reschedule(100,TimeUnit.MILLISECONDS));
+        Thread.sleep(400);
+        Assert.assertTrue(_expired);
+    }
+
+    @Test
+    public void testLengthen() throws Exception
+    {
+        for (int i=0;i<5;i++)
+        {
+            Thread.sleep(100);
+            Assert.assertTrue(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        }
+        Assert.assertTrue(_timeout.reschedule(10000,TimeUnit.MILLISECONDS));
+        Thread.sleep(1500);
+        Assert.assertFalse(_expired);
+    }
+
+    @Test
+    public void testMultiple() throws Exception
+    {
+        Thread.sleep(1500);
+        Assert.assertTrue(_expired);
+        Assert.assertFalse(_timeout.reschedule(1000,TimeUnit.MILLISECONDS));
+        _expired=false;
+        _timeout.schedule(500,TimeUnit.MILLISECONDS);
+        Thread.sleep(1000);
+        Assert.assertTrue(_expired);
+    }
+
+
+    @Test
+    @Ignore
+    public void testBusy() throws Exception
+    {
+        QueuedThreadPool pool = new QueuedThreadPool(200);
+        pool.start();
+        
+        long test_until = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(1500);
+
+        Assert.assertTrue(_timeout.reschedule(100,TimeUnit.MILLISECONDS));
+        while(System.nanoTime()<test_until)
+        {
+            CountDownLatch latch = new CountDownLatch(1);
+            pool.execute(()->
+            {
+                _timeout.reschedule(100,TimeUnit.MILLISECONDS);
+                latch.countDown();
+            });
+            latch.await();
+        }
+
+        Assert.assertFalse(_expired);
+        pool.stop();
+    }
+
+
+
+}


### PR DESCRIPTION
A proposed solution for improving HttpClient scheduling.

This has a `CyclicTimeoutTask` class that implements the IdleTimeout mechanism in a style similar to a regular scheduler.

The HttpClient has been modified to use the CyclicTimeoutTask:
- The HttpRequest class now takes a timestamp when the request is sent, so that all timeouts can be relative to this time.
- The HttpDestination does a regular sweep (using a CyclicTimeoutTask) of all queued exchanges looking for expired timeouts
- The HttpConnection class has its own CyclicTimeoutTask which is applied to the current exchange.

