### PR TITLE
Fix NPE when stopping with no resesrved threads

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -212,9 +212,10 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements Executo
             return false;
 
         ReservedThread thread = _stack.pop();
-        if (thread==null && task!=STOP)
+        if (thread==null)
         {
-            startReservedThread();
+            if (task!=STOP)
+                startReservedThread();
             return false;
         }
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
@@ -18,28 +18,23 @@
 
 package org.eclipse.jetty.util.thread;
 
-import java.security.SecureRandom;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Random;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.StreamSupport;
 
-import org.eclipse.jetty.toolchain.test.annotation.Stress;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class ReservedThreadExecutorTest
 {


### PR DESCRIPTION
A NPE was observed from the ReservedThreadPool, that indicated a null thread was being used.  While I was unable to reproduce, it appears a race between stopping and using the last reserved thread.

Signed-off-by: Greg Wilkins <gregw@webtide.com>