### PR TITLE
Issue #1797 - JEP 238 - Multi-Release JAR files break bytecode scanning.

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -916,18 +916,20 @@ public class AnnotationParser
                 LOG.debug("Scanning jar {}", jarResource);
 
             MultiException me = new MultiException();
-            MultiReleaseJarFile jarFile = new MultiReleaseJarFile(jarResource.getFile(),_javaPlatform,false);
-            jarFile.stream().forEach(e->
+            try (MultiReleaseJarFile jarFile = new MultiReleaseJarFile(jarResource.getFile(),_javaPlatform,false))
             {
-                try
+                jarFile.stream().forEach(e->
                 {
-                    parseJarEntry(handlers, jarResource, e, resolver);
-                }
-                catch (Exception ex)
-                {
-                    me.add(new RuntimeException("Error scanning entry " + e.getName() + " from jar " + jarResource, ex));
-                }
-            });
+                    try
+                    {
+                        parseJarEntry(handlers, jarResource, e, resolver);
+                    }
+                    catch (Exception ex)
+                    {
+                        me.add(new RuntimeException("Error scanning entry " + e.getName() + " from jar " + jarResource, ex));
+                    }
+                });
+            }
             me.ifExceptionThrow();
         }
     }


### PR DESCRIPTION
Made MultiReleaseJarFile closeable and using try-with-resources in
AnnotationParser to avoid leaking file descriptors.

Made few code simplifications.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>