### PR TITLE
CrossOriginFilter: performance: allowedMethods

### DIFF
--- a/benchmarks/README.txt
+++ b/benchmarks/README.txt
@@ -1,0 +1,3 @@
+
+This directory holds microbenchmarks for various functionality.
+

--- a/benchmarks/servlets/pom.xml
+++ b/benchmarks/servlets/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>jetty-project</artifactId>
+    <groupId>org.eclipse.jetty</groupId>
+    <version>9.4.8-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>benchmark-servlets</artifactId>
+  <name>Jetty :: Development Benchmarks</name>
+
+  <properties>
+     <!-- no bom :( -->
+     <jmh.version>1.19</jmh.version>
+     <bundle-symbolic-name>${project.groupId}.benchmark-servlets</bundle-symbolic-name>
+  </properties>
+  <description>Provides micro benchmarks</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <onlyAnalyze>org.eclipse.jetty.servlets.*</onlyAnalyze>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/benchmarks/servlets/pom.xml
+++ b/benchmarks/servlets/pom.xml
@@ -70,6 +70,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/benchmarks/servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilterBenchmark.java
+++ b/benchmarks/servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilterBenchmark.java
@@ -1,0 +1,115 @@
+//  ========================================================================
+//  Copyright (c) 2017 Juan F. Codagnone
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+package org.eclipse.jetty.servlets;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode({ Mode.Throughput })
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class CrossOriginFilterBenchmark 
+{
+    // cases to use for the benchmark
+    @SuppressWarnings("unchecked")
+    private static final List<String> [] cases = new List[] 
+    {
+        // one method
+/* 0 */ Arrays.asList("GET"),
+        // two methods
+/* 1 */ Arrays.asList("GET", "POST"),
+        // three methods, this is the default
+/* 2 */ Arrays.asList("GET", "POST", "HEAD"),
+        // this is another configuracion pausible 
+/* 3 */ Arrays.asList("GET", "POST", "HEAD", "PUT","DELETE"),
+        // this is an insame configuration, every registered methods, 2017-04-14 version of
+        // https://www.iana.org/assignments/http-methods/http-methods.xhtml 
+/* 4 */ Arrays.asList("ACL", "BASELINE-CONTROL", "BIND", 
+        "CHECKIN", "CHECKOUT", "CONNECT", "COPY", "DELETE", "GET", "HEAD", "LABEL", "LINK", "LOCK", 
+        "MERGE", "MKACTIVITY", "MKCALENDAR", "MKCOL", "MKREDIRECTREF", "MKWORKSPACE", "MOVE", "OPTIONS", 
+        "ORDERPATCH", "PATCH", "POST", "PRI", "PROPFIND", "PROPPATCH", "PUT", "REBIND", "REPORT", "SEARCH", 
+        "TRACE", "UNBIND", "UNCHECKOUT", "UNLINK", "UNLOCK", "UPDATE", "UPDATEREDIRECTREF", "VERSION-CONTROL"),
+    };
+    
+    // pattern version of the cases
+    private static final Pattern[]   PATTERNS = Stream.of(cases)
+                                                     .map(CrossOriginFilter::patternize)
+                                                     .toArray(Pattern[]::new);
+    
+    // method to use for the HIT benchmark: the last one that the user wrote
+    private static final String[]  HIT_METHOD = Stream.of(cases).map( l -> l.get(l.size() -1))
+                                                     .toArray(String[]::new);
+    
+    // method to use in MISS benchmark
+    private static final String MISS_METHOD   = "FOO";
+    
+    @Param({"0", "1", "2", "3", "4"})
+    public int arg;
+
+
+    @Benchmark
+    public boolean pattern_hit()  
+    {
+        return CrossOriginFilter.isMethodAllowed(PATTERNS[arg], HIT_METHOD[arg]);
+    }
+    
+    @Benchmark
+    public boolean pattern_miss()  
+    {
+        return CrossOriginFilter.isMethodAllowed(PATTERNS[arg], MISS_METHOD);
+    }
+    
+    @Benchmark
+    public boolean contains_hit()  
+    {
+        return cases[arg].contains(HIT_METHOD[arg]);
+    }
+    
+    public boolean contains_hits()  
+    {
+        return cases[arg].contains(HIT_METHOD[arg]);
+    }
+    
+    @Benchmark
+    public boolean contains_miss()  
+    {
+        return cases[arg].contains(MISS_METHOD); 
+    }
+    
+    public static void main(String[] args) throws RunnerException 
+    {
+        final Options opt = new OptionsBuilder()
+                          .include(CrossOriginFilterBenchmark.class.getSimpleName())
+                          .forks(1)
+                          .build();
+        new Runner(opt).run();
+    }
+}

--- a/benchmarks/servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilterBenchmark.java
+++ b/benchmarks/servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilterBenchmark.java
@@ -16,7 +16,10 @@
 package org.eclipse.jetty.servlets;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -74,7 +77,17 @@ public class CrossOriginFilterBenchmark
     @Param({"0", "1", "2", "3", "4"})
     public int arg;
 
+    @SuppressWarnings("unchecked")
+    private static final Collection<String>[] TREE_SETS = Stream.of(cases)
+                                                     .map(TreeSet::new)
+                                                     .toArray(Collection[]::new);
 
+    @SuppressWarnings("unchecked")
+    private static final Collection<String>[] HASHSET_SETS = Stream.of(cases)
+                                                     .map(HashSet::new)
+                                                     .toArray(Collection[]::new);
+
+    
     @Benchmark
     public boolean pattern_hit()  
     {
@@ -102,6 +115,30 @@ public class CrossOriginFilterBenchmark
     public boolean contains_miss()  
     {
         return cases[arg].contains(MISS_METHOD); 
+    }
+    
+    @Benchmark
+    public boolean treeset_contains_hits()  
+    {
+        return TREE_SETS[arg].contains(HIT_METHOD[arg]);
+    }
+    
+    @Benchmark
+    public boolean treeset_contains_miss()  
+    {
+        return TREE_SETS[arg].contains(MISS_METHOD); 
+    }
+    
+    @Benchmark
+    public boolean hashset_contains_hits()  
+    {
+        return HASHSET_SETS[arg].contains(HIT_METHOD[arg]);
+    }
+    
+    @Benchmark
+    public boolean hashset_contains_miss()  
+    {
+        return HASHSET_SETS[arg].contains(MISS_METHOD); 
     }
     
     public static void main(String[] args) throws RunnerException 

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -514,7 +514,7 @@ public class CrossOriginFilter implements Filter
     /** 
      * creates a pattern to match any of a list of  string
      * If the input list is ["foo, "bar"] it will generate
-     * a Pattern for the regex "(\\Efoo\\E|\\Ebar\\E) 
+     * a Pattern for the regex "(\\Qfoo\\E|\\Qbar\\E) 
      */
     static Pattern patternize(final List<String> strings) 
     {

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -521,8 +521,8 @@ public class CrossOriginFilter implements Filter
         final StringBuilder builder = new StringBuilder();
         for (int i = 0; i < strings.size(); ++i)
         {
-            final String string = strings.get(i);
-            if (string.trim().isEmpty()) break;
+            final String string = strings.get(i).trim();
+            if (string.isEmpty()) break;
             
             if (builder.length() == 0) 
                 builder.append('(');

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -519,9 +519,9 @@ public class CrossOriginFilter implements Filter
     static Pattern patternize(final List<String> strings) 
     {
         final StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < strings.size(); ++i)
+        for (String string : strings)
         {
-            final String string = strings.get(i).trim();
+            string = string.trim();
             if (string.isEmpty()) break;
             
             if (builder.length() == 0) 

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CrossOriginFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CrossOriginFilterTest.java
@@ -19,9 +19,11 @@
 package org.eclipse.jetty.servlets;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
@@ -565,6 +567,25 @@ public class CrossOriginFilterTest
         Assert.assertFalse(latch.await(1, TimeUnit.SECONDS));
     }
 
+    
+    @Test
+    public void testPatternize()
+    {
+        Pattern p = CrossOriginFilter.patternize(Arrays.asList("GET", "POST", "   "));
+        Assert.assertTrue (CrossOriginFilter.isMethodAllowed(p, "GET"));
+        Assert.assertTrue (CrossOriginFilter.isMethodAllowed(p, "POST"));
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, "PUT"));
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, "GETA"));
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, "AGET"));
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, ""));
+        
+        
+        p = CrossOriginFilter.patternize(Arrays.asList("  ", "   "));
+        Assert.assertNull(p);
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, "AGET"));
+        Assert.assertFalse(CrossOriginFilter.isMethodAllowed(p, ""));
+    }
+    
     public static class ResourceServlet extends HttpServlet
     {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Avoid recreating for each request the value of the header
Access-Control-Allow-Method.

Cheaper matching: Previously an array list was iterated to try to match the
method. Now a single Pattern is used.

Related to: #1053 (Review CrossOriginFilter)
Might conflict with: #1952 (CrossOriginFilter performace: reuse matcher)
