### PR TITLE
Issue #1958 Blocking timeout spurious wakeups

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -564,7 +564,15 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
 
     public void blockingReadFillInterested()
     {
-        getEndPoint().fillInterested(_blockingReadCallback);
+        // We try fillInterested here because of SSL and 
+        // spurious wakeups.  With  blocking reads, we read in a loop
+        // that tries to read/parse content and blocks waiting if there is
+        // none available.  The loop can be woken up by incoming encrypted 
+        // bytes, which due to SSL might not produce any decrypted bytes.
+        // Thus the loop needs to register fill interest again.  However if 
+        // the loop is woken up spuriously, then the register interest again
+        // can result in a pending read exception, unless we use tryFillInterested.
+        getEndPoint().tryFillInterested(_blockingReadCallback);
     }
 
     public void blockingReadFailure(Throwable e)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -538,8 +538,11 @@ public class HttpInput extends ServletInputStream implements Runnable
     {
         try
         {
-            _waitingForContent = true;
-            _channelState.getHttpChannel().onBlockWaitForContent();
+            if (!_waitingForContent)
+            {
+                _waitingForContent = true;
+                _channelState.getHttpChannel().onBlockWaitForContent();
+            }
 
             boolean loop = false;
             long timeout = 0;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -538,11 +538,8 @@ public class HttpInput extends ServletInputStream implements Runnable
     {
         try
         {
-            if (!_waitingForContent)
-            {
-                _waitingForContent = true;
-                _channelState.getHttpChannel().onBlockWaitForContent();
-            }
+            _waitingForContent = true;
+            _channelState.getHttpChannel().onBlockWaitForContent();
 
             boolean loop = false;
             long timeout = 0;


### PR DESCRIPTION
While testing #1961 for #1958,  it was noticed that blocking waits do not handle spurious wakeups.
This is a proposed change to handle spurious wakeups, but it is causing problems with
`org.eclipse.jetty.client.ssl.SslBytesServerTest.testRequestWithBigContentWithSplitBoundary()`.

Signed-off-by: Greg Wilkins <gregw@webtide.com>