### PR TITLE
Fixes #1990 - Avoid creating unnecessary connections in HttpClient.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -293,10 +293,10 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         }
     }
 
-    public boolean process(final Connection connection)
+    public boolean process(Connection connection)
     {
         HttpClient client = getHttpClient();
-        final HttpExchange exchange = getHttpExchanges().poll();
+        HttpExchange exchange = getHttpExchanges().poll();
         if (LOG.isDebugEnabled())
             LOG.debug("Processing exchange {} on {} of {}", exchange, connection, this);
         if (exchange == null)
@@ -313,7 +313,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         }
         else
         {
-            final Request request = exchange.getRequest();
+            Request request = exchange.getRequest();
             Throwable cause = request.getAbortCause();
             if (cause != null)
             {
@@ -343,7 +343,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
                     request.abort(result.failure);
                 }
             }
-            return getHttpExchanges().peek() != null;
+            return false;
         }
     }
 


### PR DESCRIPTION
A connection was unnecessarily created when a new request was sent from
an onComplete() callback.

When sending from onComplete(), the current connection may have been
closed; the send would trigger the opening of a new connection;
returning from onComplete() would arrive to
HttpDestination.process(Connection) that would have peeked at the
exchanges queue, would have found one and returned true;
returning true would loop in HttpDestination.process(), which would
create an additional connection.

Returning false from HttpDestination.process(Connection) is fine
because if the connection was released, then
HttpDestination.release(Connection) would have called send() to send
queued requests; if the connection was removed, then
HttpDestination.close(Connection) would have called process() to send
queued requests.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>