### PR TITLE
#2006 Use a NOOP to allow unhandle to cope with stolen read

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -318,7 +318,12 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                 {
                     case TERMINATED:
                     case WAIT:
+                        // break loop without calling unhandle
                         break loop;
+                        
+                    case NOOP:
+                        // do nothing other than call unhandle
+                        break;
 
                     case DISPATCH:
                     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
@@ -244,6 +244,8 @@ public class HttpChannelState
                         case IDLE:
                         case REGISTERED:
                             break;
+                        default:
+                            throw new IllegalStateException(getStatusStringLocked());
                     }
 
                     if (_asyncWritePossible)
@@ -273,6 +275,7 @@ public class HttpChannelState
                             _state=State.ASYNC_WAIT;
                             return Action.NOOP;
                         case NOT_ASYNC:
+                        default:
                             throw new IllegalStateException(getStatusStringLocked());
                     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
@@ -73,6 +73,7 @@ public class HttpChannelState
      */
     public enum Action
     {
+        NOOP,             // No action 
         DISPATCH,         // handle a normal request dispatch
         ASYNC_DISPATCH,   // handle an async request dispatch
         ERROR_DISPATCH,   // handle a normal error
@@ -269,14 +270,12 @@ public class HttpChannelState
                         case STARTED:
                         case EXPIRING:
                         case ERRORING:
-                            return Action.WAIT;
+                            _state=State.ASYNC_WAIT;
+                            return Action.NOOP;
                         case NOT_ASYNC:
-                            break;
-                        default:
                             throw new IllegalStateException(getStatusStringLocked());
                     }
 
-                    return Action.WAIT;
 
                 case ASYNC_ERROR:
                     return Action.ASYNC_ERROR;
@@ -408,6 +407,7 @@ public class HttpChannelState
                 case DISPATCHED:
                 case ASYNC_IO:
                 case ASYNC_ERROR:
+                case ASYNC_WAIT:
                     break;
 
                 default:

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
@@ -127,7 +127,7 @@ public class AsyncServletIOTest
         
         _server.start();
         _port=_connector.getLocalPort();
-        
+
         _owp.set(0);
         _oda.set(0);
         _read.set(0);
@@ -824,8 +824,7 @@ public class AsyncServletIOTest
             
             // Stop any dispatches until we want them
             UnaryOperator<Runnable> old = _wQTP.wrapper.getAndSet(r->
-            { 
-                return ()->
+                ()->
                 {
                     try
                     {
@@ -836,8 +835,8 @@ public class AsyncServletIOTest
                     {
                         e.printStackTrace();
                     }
-                };
-            });
+                }
+            );
 
             // We are an unrelated thread, let's mess with the input stream
             ServletInputStream sin = _servletStolenAsyncRead.listener.in;
@@ -886,7 +885,6 @@ public class AsyncServletIOTest
                 if (line.length()==0)
                     break;
             }
-            
         }
 
         assertTrue(_servletStolenAsyncRead.completed.await(5, TimeUnit.SECONDS));     
@@ -903,7 +901,7 @@ public class AsyncServletIOTest
         @Override
         public void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException
         {
-            listener = new StealingListener(request,response);
+            listener = new StealingListener(request);
             ready.countDown();
         }
 
@@ -913,7 +911,7 @@ public class AsyncServletIOTest
             final ServletInputStream in;
             final AsyncContext asyncContext;
 
-            StealingListener(HttpServletRequest request,HttpServletResponse response) throws IOException
+            StealingListener(HttpServletRequest request) throws IOException
             {
                 asyncContext = request.startAsync();
                 asyncContext.setTimeout(10000L);
@@ -922,9 +920,8 @@ public class AsyncServletIOTest
                 in = request.getInputStream();
             }
 
-
             @Override
-            public void onDataAvailable() throws IOException
+            public void onDataAvailable()
             {
                 oda.countDown();
             }
@@ -943,35 +940,33 @@ public class AsyncServletIOTest
             }
 
             @Override
-            public void onComplete(final AsyncEvent event) throws IOException
+            public void onComplete(final AsyncEvent event)
             {
                 completed.countDown();
             }
 
             @Override
-            public void onTimeout(final AsyncEvent event) throws IOException
+            public void onTimeout(final AsyncEvent event)
             {
                 asyncContext.complete();
             }
 
             @Override
-            public void onError(final AsyncEvent event) throws IOException
+            public void onError(final AsyncEvent event)
             {
                 asyncContext.complete();
             }
 
             @Override
-            public void onStartAsync(AsyncEvent event) throws IOException
+            public void onStartAsync(AsyncEvent event)
             {
-
             }
         }
     }
     
-    
     private class WrappingQTP extends QueuedThreadPool
     {
-        AtomicReference<UnaryOperator<Runnable>> wrapper = new AtomicReference<UnaryOperator<Runnable>>(UnaryOperator.identity());
+        AtomicReference<UnaryOperator<Runnable>> wrapper = new AtomicReference<>(UnaryOperator.identity());
         
         @Override
         public void execute(Runnable job)


### PR DESCRIPTION
Fix for #2006 isReady fails to register read interest

The problem was during a window between when we entered `ASYNC_WOKEN` state, but before the woken thread arrived in `HttpChannel.handle`.  If during that window, another thread "stole" the data data by reading it, then there would be no data available once the thread arrived in handle.  It was correctly not calling `onDataAvailable`, but incorrectly not registering for read interest after doing nothing

Signed-off-by: Greg Wilkins <gregw@webtide.com>