### PR TITLE
Issue #2010 Support FIPs Key Managers

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -1122,7 +1122,7 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
                     }
                 }
 
-                if (!_certHosts.isEmpty() || !_certWilds.isEmpty())
+                if (!_certWilds.isEmpty() || _certHosts.size()>1)
                 {
                     for (int idx = 0; idx < managers.length; idx++)
                     {


### PR DESCRIPTION
Issue #2010 Support FIPs Key Managers, by only wrapping the default Key Manager if we have wildcard CN's or more than 1 non wild CN.  FIPs users will need to install a
keystore than has no multiple certificates than can only be resolved by SNI. They will also need to have no certificate aliases.

Signed-off-by: Greg Wilkins <gregw@webtide.com>