### PR TITLE
Fixes #2020 - Introduce a name for `HttpClient` instances.

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -99,6 +99,12 @@
       <artifactId>jetty-io</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-jmx</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -146,6 +146,7 @@ public class HttpClient extends ContainerLifeCycle
     private HttpField encodingField;
     private boolean removeIdleDestinations = false;
     private boolean connectBlocking = false;
+    private String name = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
     /**
      * Creates a {@link HttpClient} instance that can perform requests to non-TLS destinations only
@@ -195,8 +196,6 @@ public class HttpClient extends ContainerLifeCycle
     {
         if (sslContextFactory != null)
             addBean(sslContextFactory);
-
-        String name = HttpClient.class.getSimpleName() + "@" + hashCode();
 
         if (executor == null)
         {
@@ -637,6 +636,17 @@ public class HttpClient extends ContainerLifeCycle
     public void setByteBufferPool(ByteBufferPool byteBufferPool)
     {
         this.byteBufferPool = byteBufferPool;
+    }
+
+    @ManagedAttribute("The name of this HttpClient")
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
     }
 
     /**

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -638,12 +638,22 @@ public class HttpClient extends ContainerLifeCycle
         this.byteBufferPool = byteBufferPool;
     }
 
+    /**
+     * @return the name of this HttpClient
+     */
     @ManagedAttribute("The name of this HttpClient")
     public String getName()
     {
         return name;
     }
 
+    /**
+     * <p>Sets the name of this HttpClient.</p>
+     * <p>The name is also used to generate the JMX ObjectName of this HttpClient
+     * and must be set before the registration of the HttpClient MBean in the MBeanServer.</p>
+     *
+     * @param name the name of this HttpClient
+     */
     public void setName(String name)
     {
         this.name = name;

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/jmx/HttpClientMBean.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/jmx/HttpClientMBean.java
@@ -1,0 +1,40 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.client.jmx;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.jmx.ObjectMBean;
+
+public class HttpClientMBean extends ObjectMBean
+{
+    public HttpClientMBean(Object managedObject)
+    {
+        super(managedObject);
+    }
+
+    @Override
+    public String getObjectContextBasis()
+    {
+        // Returning the HttpClient name as the "context" property
+        // because it is inherited by the ObjectNames of the components
+        // of HttpClient such as the transport, the threadpool, etc.
+        HttpClient httpClient = (HttpClient)getManagedObject();
+        return httpClient.getName();
+    }
+}

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/jmx/HttpClientJMXTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/jmx/HttpClientJMXTest.java
@@ -1,0 +1,51 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.client.jmx;
+
+import java.lang.management.ManagementFactory;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.jmx.MBeanContainer;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpClientJMXTest
+{
+    @Test
+    public void testHttpClientName() throws Exception
+    {
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+        MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);
+        HttpClient httpClient = new HttpClient();
+        httpClient.addBean(mbeanContainer);
+        httpClient.start();
+
+        String domain = HttpClient.class.getPackage().getName();
+        ObjectName pattern = new ObjectName(domain + ":type=" + HttpClient.class.getSimpleName().toLowerCase(Locale.ENGLISH) + ",*");
+        Set<ObjectName> objectNames = mbeanServer.queryNames(pattern, null);
+        Assert.assertEquals(1, objectNames.size());
+        ObjectName objectName = objectNames.iterator().next();
+        Assert.assertEquals(httpClient.getName(), objectName.getKeyProperty("context"));
+    }
+}


### PR DESCRIPTION
Added HttpClientMBean, and overridden getObjectContextBasis() so that
the HttpClient name is inherited by children components such as the
HttpClientTransport, the ThreadPool, etc.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>