### PR TITLE
Open Network Connectors before starting contexts.

### DIFF
--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -126,6 +126,6 @@
     <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
     <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
     <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
-    <Set name="openNetworkConnectors"><Property name="jetty.server.openNetworkConnectors" default="false"/></Set>
+    <Set name="verifiedStartSequence"><Property name="jetty.server.verifiedStartSequence" default="false"/></Set>
 
 </Configure>

--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -126,5 +126,6 @@
     <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
     <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
     <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+    <Set name="openNetworkConnectors"><Property name="jetty.server.openNetworkConnectors" default="false"/></Set>
 
 </Configure>

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -83,5 +83,5 @@ etc/jetty.xml
 ## Dump the state of the Jetty server, components, and webapps before shutdown
 # jetty.server.dumpBeforeStop=false
 
-## Open Network Connectors before starting contexts
-# jetty.server.openNetworkConnectors=false
+## Verified Start Sequence by checking ports and contexts are available before starting connectors
+# jetty.server.verifiedStartSequence=false

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -82,3 +82,6 @@ etc/jetty.xml
 
 ## Dump the state of the Jetty server, components, and webapps before shutdown
 # jetty.server.dumpBeforeStop=false
+
+## Open Network Connectors before starting contexts
+# jetty.server.openNetworkConnectors=false

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -148,12 +148,12 @@ public class Server extends HandlerWrapper implements Attributes
 
     /**
      * Set if the start sequence is to be verified by in the following stages:
-     * <nl>
+     * <ul>
      * <li>{@link NetworkConnector}s are opened with {@link NetworkConnector#open()} to check ports are
      * available and to reserve them.</li>
      * <li>Start the contained {@link Handler}s and beans.</li>
      * <li>Start the {@link Connector}s
-     * </nl>
+     * </ul>
      * If any failures are encountered at any of the stages, the start sequence is aborted without 
      * running the subsequent stage and reversing closing any open connectors.
      * @param verified If true the start sequence is verified by checking port availability prior

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/NotAcceptingTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/NotAcceptingTest.java
@@ -385,9 +385,9 @@ public class NotAcceptingTest
     }
     
     @Test
-    public void testOpenBeforeStart() throws Exception
+    public void testVerifiedStartSequence() throws Exception
     {
-        server.setOpenNetworkConnectors(true);
+        server.setVerifiedStartSequence(true);
         
         try(ServerSocket alreadyOpened = new ServerSocket(0))
         {
@@ -409,7 +409,6 @@ public class NotAcceptingTest
             ServerConnector connector1 = new ServerConnector(server);
             connector1.setPort(alreadyOpened.getLocalPort());
             server.addConnector(connector1);
-            
             
             // Add a handler to detect if handlers are started
             AtomicBoolean handlerStarted = new AtomicBoolean(false);


### PR DESCRIPTION
Add option to open network connectors to check port availability prior to starting contexts.

Prompted by question in #2049 

Signed-off-by: Greg Wilkins <gregw@webtide.com>