### PR TITLE
Idle/ConnectTimeout: print socket endpoints in exception message

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
@@ -142,8 +142,12 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements Connec
         long idleTimeout = getEndPoint().getIdleTimeout();
         boolean close = delegate.onIdleTimeout(idleTimeout);
         if (close)
-            close(new TimeoutException("Idle timeout " + idleTimeout + " ms"));
+            close(new TimeoutException("Idle timeout " + idleTimeout + " ms: " + describe(getEndPoint())));
         return false;
+    }
+
+    private String describe(EndPoint ep) {
+        return ep.getLocalAddress() + "<->" + ep.getRemoteAddress();
     }
 
     @Override

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
@@ -459,7 +459,12 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
                 getIdleFor(),
                 getIdleTimeout());
     }
-    
+
+    @Override
+    protected String describeIdleTimeout() {
+        return getRemoteAddress() + "<->" + getLocalAddress();
+    }
+
     public String toConnectionString()
     {
         Connection connection = getConnection();

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/IdleTimeout.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/IdleTimeout.java
@@ -163,7 +163,7 @@ public abstract class IdleTimeout
                         LOG.debug("{} idle timeout expired", this);
                     try
                     {
-                        onIdleExpired(new TimeoutException("Idle timeout expired: " + idleElapsed + "/" + idleTimeout + " ms"));
+                        onIdleExpired(new TimeoutException("Idle timeout expired: " + idleElapsed + "/" + idleTimeout + " ms " + describeIdleTimeout()));
                     }
                     finally
                     {
@@ -175,6 +175,10 @@ public abstract class IdleTimeout
             return idleLeft >= 0 ? idleLeft : 0;
         }
         return -1;
+    }
+
+    protected String describeIdleTimeout() {
+        return "[" + this + "]";
     }
 
     /**

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -737,7 +737,7 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Channel {} timed out while connecting, closing it", channel);
-                connect.failed(new SocketTimeoutException("Connect Timeout"));
+                connect.failed(new SocketTimeoutException("Connect Timeout: " + channel));
             }
         }
     }


### PR DESCRIPTION
It's helpful to have this information readily available when diagnosing e.g. asymmetric network routing issues

I want to have similar diagnostics on e.g. connection refused, but that
requires a JDK change.  It'd be possible to catch / rethrow with better
detail but that probably has nontrivial implications for performance and
stack traces.  If that approach could be acceptable, I can prepare another PR.

Example output:

```
java.net.SocketTimeoutException: Connect Timeout: java.nio.channels.SocketChannel[connection-pending remote=/172.19.255.1:80]
java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException: Idle timeout 1000 ms: /127.0.0.1:60721<->localhost/127.0.0.1:60720
```