### PR TITLE
Issue #2081 No idle timeout exception when dispatch is delayed

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTimeoutTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTimeoutTest.java
@@ -263,10 +263,10 @@ public class HttpClientTimeoutTest extends AbstractHttpClientServerTest
                         return new SslConnection(byteBufferPool, executor, endPoint, engine)
                         {
                             @Override
-                            protected boolean onReadTimeout()
+                            protected boolean onReadTimeout(Throwable timeout)
                             {
                                 sslIdle.set(true);
-                                return super.onReadTimeout();
+                                return super.onReadTimeout(timeout);
                             }
                         };
                     }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ssl/SslBytesServerTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ssl/SslBytesServerTest.java
@@ -126,12 +126,12 @@ public class SslBytesServerTest extends SslBytesTest
                     }
 
                     @Override
-                    protected boolean onReadTimeout()
+                    protected boolean onReadTimeout(Throwable timeout)
                     {
                         final Runnable idleHook = SslBytesServerTest.this.idleHook;
                         if (idleHook != null)
                             idleHook.run();
-                        return super.onReadTimeout();
+                        return super.onReadTimeout(timeout);
                     }
                 }, connector, endPoint);
             }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -183,7 +183,8 @@ public abstract class AbstractConnection implements Connection
 
     /**
      * <p>Callback method invoked when the endpoint failed to be ready to be read after a timeout</p>
-     * @param timeout TODO
+     *
+     * @param timeout the cause of the read timeout
      * @return true to signal that the endpoint must be closed, false to keep the endpoint open
      */
     protected boolean onReadTimeout(Throwable timeout)

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -167,7 +167,7 @@ public abstract class AbstractConnection implements Connection
         {
             boolean close = true;
             if (cause instanceof TimeoutException)
-                close = onReadTimeout();
+                close = onReadTimeout(cause);
             if (close)
             {
                 if (_endPoint.isOutputShutdown())
@@ -183,9 +183,10 @@ public abstract class AbstractConnection implements Connection
 
     /**
      * <p>Callback method invoked when the endpoint failed to be ready to be read after a timeout</p>
+     * @param timeout TODO
      * @return true to signal that the endpoint must be closed, false to keep the endpoint open
      */
-    protected boolean onReadTimeout()
+    protected boolean onReadTimeout(Throwable timeout)
     {
         return true;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -399,6 +399,17 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
         return !_delayedForContent;
     }
 
+    boolean onIdleTimeout(Throwable timeout)
+    {
+        if (_delayedForContent)
+        {
+            _delayedForContent = false;
+            getRequest().getHttpInput().onIdleTimeout(timeout);
+            execute(this);
+            return false;
+        }
+        return true;
+    }
 
     /**
      * <p>Attempts to perform a HTTP/1.1 upgrade.</p>
@@ -518,17 +529,5 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
             if (LOG.isDebugEnabled())
                 LOG.debug(violation);
         }
-    }
-
-    public boolean onConnectionReadTimeout(Throwable timeout)
-    {
-        if (_delayedForContent)
-        {
-            _delayedForContent = false;
-            getRequest().getHttpInput().failed(timeout);
-            execute(this);
-            return false;
-        }
-        return true;
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -519,4 +519,16 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
                 LOG.debug(violation);
         }
     }
+
+    public boolean onConnectionReadTimeout(Throwable timeout)
+    {
+        if (_delayedForContent)
+        {
+            _delayedForContent = false;
+            getRequest().getHttpInput().failed(timeout);
+            execute(this);
+            return false;
+        }
+        return true;
+    }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -287,12 +287,6 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
         }
     }
     
-    @Override
-    protected boolean onReadTimeout(Throwable timeout)
-    {
-        return _channel.onConnectionReadTimeout(timeout);
-    }
-
     /* ------------------------------------------------------------ */
     /** Fill and parse data looking for content
      * @return true if an {@link RequestHandler} method was called and it returned true;
@@ -490,6 +484,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
             else if (getEndPoint().isOpen())
                 fillInterested();
         }
+    }
+
+    @Override
+    protected boolean onReadTimeout(Throwable timeout)
+    {
+        return _channel.onIdleTimeout(timeout);
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -286,6 +286,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
                 LOG.debug("{} onFillable exit {} {}", this, _channel.getState(),BufferUtil.toDetailString(_requestBuffer));
         }
     }
+    
+    @Override
+    protected boolean onReadTimeout(Throwable timeout)
+    {
+        return _channel.onConnectionReadTimeout(timeout);
+    }
 
     /* ------------------------------------------------------------ */
     /** Fill and parse data looking for content

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -782,7 +782,8 @@ public class HttpInput extends ServletInputStream implements Runnable
     {
         synchronized (_inputQ)
         {
-            if (_waitingForContent && !isError())
+            boolean neverDispatched = getHttpChannelState().isIdle();
+            if ((_waitingForContent || neverDispatched) && !isError())
             {
                 x.addSuppressed(new Throwable("HttpInput idle timeout"));
                 _state = new ErrorState(x);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
@@ -601,7 +601,8 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
         long start = System.currentTimeMillis();
         try
         {
-            IO.toString(is);
+            String response = IO.toString(is);
+            Assert.assertThat(response,Matchers.is(""));
             Assert.assertEquals(-1, is.read());
         }
         catch(SSLException e)
@@ -629,12 +630,13 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
         long start = System.currentTimeMillis();
         try
         {
-            IO.toString(is);
+            String response = IO.toString(is);
+            Assert.assertThat(response,Matchers.is(""));
             Assert.assertEquals(-1, is.read());
         }
         catch(SSLException e)
         {
-            // e.printStackTrace();
+            e.printStackTrace();
         }
         catch(Exception e)
         {
@@ -644,6 +646,88 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
 
     }
 
+    @Test(timeout=60000)
+    public void testMaxIdleDelayedDispatch() throws Exception
+    {
+        configureServer(new EchoHandler());
+        Socket client=newSocket(_serverURI.getHost(),_serverURI.getPort());
+        client.setSoTimeout(10000);
+        InputStream is=client.getInputStream();
+        Assert.assertFalse(client.isClosed());
+
+        OutputStream os=client.getOutputStream();
+        os.write((
+            "GET / HTTP/1.1\r\n"+
+            "host: "+_serverURI.getHost()+":"+_serverURI.getPort()+"\r\n"+
+            "connection: keep-alive\r\n"+
+            "Content-Length: 20\r\n"+
+            "Content-Type: text/plain\r\n"+
+            "Connection: close\r\n"+
+            "\r\n").getBytes("utf-8"));
+        os.flush();
+
+        long start = System.currentTimeMillis();
+        try
+        {
+            String response = IO.toString(is);
+            Assert.assertThat(response,Matchers.containsString("500"));
+            Assert.assertEquals(-1, is.read());
+        }
+        catch(SSLException e)
+        {
+            e.printStackTrace();
+        }
+        catch(Exception e)
+        {
+            e.printStackTrace();
+        }
+        int duration = (int)(System.currentTimeMillis() - start);
+        Assert.assertThat(duration,Matchers.greaterThanOrEqualTo(MAX_IDLE_TIME));
+        Assert.assertThat(duration,Matchers.lessThan(maximumTestRuntime));
+    }
+    
+    @Test(timeout=60000)
+    public void testMaxIdleDispatch() throws Exception
+    {
+        configureServer(new EchoHandler());
+        Socket client=newSocket(_serverURI.getHost(),_serverURI.getPort());
+        client.setSoTimeout(10000);
+        InputStream is=client.getInputStream();
+        Assert.assertFalse(client.isClosed());
+
+        OutputStream os=client.getOutputStream();
+        os.write((
+            "GET / HTTP/1.1\r\n"+
+            "host: "+_serverURI.getHost()+":"+_serverURI.getPort()+"\r\n"+
+            "connection: keep-alive\r\n"+
+            "Content-Length: 20\r\n"+
+            "Content-Type: text/plain\r\n"+
+            "Connection: close\r\n"+
+            "\r\n"+
+            "1234567890").getBytes("utf-8"));
+        os.flush();
+
+        long start = System.currentTimeMillis();
+        try
+        {
+            String response = IO.toString(is);
+            Assert.assertThat(response,Matchers.containsString("500"));
+            Assert.assertEquals(-1, is.read());
+        }
+        catch(SSLException e)
+        {
+            e.printStackTrace();
+        }
+        catch(Exception e)
+        {
+            e.printStackTrace();
+        }
+        int duration = (int)(System.currentTimeMillis() - start);
+        Assert.assertThat(duration,Matchers.greaterThanOrEqualTo(MAX_IDLE_TIME));
+        Assert.assertThat(duration,Matchers.lessThan(maximumTestRuntime));
+    }
+    
+    
     @Test(timeout=60000)
     public void testMaxIdleWithSlowRequest() throws Exception
     {

--- a/jetty-websocket/websocket-client/src/test/java/org/eclipse/jetty/websocket/client/ClientCloseTest.java
+++ b/jetty-websocket/websocket-client/src/test/java/org/eclipse/jetty/websocket/client/ClientCloseTest.java
@@ -18,14 +18,6 @@
 
 package org.eclipse.jetty.websocket.client;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.SocketTimeoutException;
@@ -77,6 +69,14 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 public class ClientCloseTest
 {
@@ -147,7 +147,7 @@ public class ClientCloseTest
         @Override
         public void onWebSocketError(Throwable cause)
         {
-            LOG.warn("onWebSocketError",cause);
+            LOG.debug("onWebSocketError",cause);
             assertThat("Unique Error Event", error.compareAndSet(null, cause), is(true));
             errorLatch.countDown();
         }
@@ -526,8 +526,7 @@ public class ClientCloseTest
 
         // client idle timeout triggers close event on client ws-endpoint
         assertThat("OnError Latch", clientSocket.errorLatch.await(2, TimeUnit.SECONDS), is(true));
-        assertThat("OnError", clientSocket.error.get(), instanceOf(SocketTimeoutException.class));
-        assertThat("OnError", clientSocket.error.get().getMessage(), containsString("Timeout on Read"));
+        assertThat("OnError", clientSocket.error.get(), instanceOf(TimeoutException.class));
     }
 
     @Test(timeout = 5000L)

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -452,7 +452,7 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
      * Event for no activity on connection (read or write)
      */
     @Override
-    protected boolean onReadTimeout()
+    protected boolean onReadTimeout(Throwable timeout)
     {
         IOState state = getIOState();
         ConnectionState cstate = state.getConnectionState();

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.websocket.common.io;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -448,9 +447,6 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
         this.ioState.onOpened();
     }
 
-    /**
-     * Event for no activity on connection (read or write)
-     */
     @Override
     protected boolean onReadTimeout(Throwable timeout)
     {
@@ -470,7 +466,7 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
 
         try
         {
-            notifyError(new SocketTimeoutException("Timeout on Read"));
+            notifyError(timeout);
         }
         finally
         {


### PR DESCRIPTION
This is a fix for HTTP/1 for #2081 
Delegate the readtimeout handling to HttpChannel so that a delayed dispatch can be ended.

A test harness is needed and we also need to consider if HTTP/2 & FCGI need similar fixes....

Signed-off-by: Greg Wilkins <gregw@webtide.com>