### PR TITLE
Fixes #2088 - Recycle HTTP/2 channels on the client.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -95,6 +95,11 @@ public abstract class HttpReceiver
         return channel.getHttpDestination();
     }
 
+    public boolean isFailed()
+    {
+        return responseState.get() == ResponseState.FAILURE;
+    }
+
     /**
      * Method to be invoked when the response status code is available.
      * <p>

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpSender.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpSender.java
@@ -86,6 +86,11 @@ public abstract class HttpSender implements AsyncContentProvider.Listener
         return channel.getHttpExchange();
     }
 
+    public boolean isFailed()
+    {
+        return requestState.get() == RequestState.FAILURE;
+    }
+
     @Override
     public void onContent()
     {

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
@@ -247,16 +247,19 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
                 return new HttpConnectionOverHTTP2(destination, session)
                 {
                     @Override
-                    protected HttpChannelOverHTTP2 newHttpChannel(boolean push)
+                    protected HttpChannelOverHTTP2 provideHttpChannel()
                     {
-                        return new HttpChannelOverHTTP2(getHttpDestination(), this, getSession(), push)
+                        return new HttpChannelOverHTTP2(getHttpDestination(), this, getSession())
                         {
                             @Override
                             public void setStream(Stream stream)
                             {
                                 super.setStream(stream);
-                                streamRef.set(stream);
-                                streamLatch.countDown();
+                                if (stream != null)
+                                {
+                                    streamRef.set(stream);
+                                    streamLatch.countDown();
+                                }
                             }
                         };
                     }

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpChannelAssociationTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpChannelAssociationTest.java
@@ -146,9 +146,9 @@ public class HttpChannelAssociationTest extends AbstractTest
                         return new HttpConnectionOverHTTP2(destination, session)
                         {
                             @Override
-                            protected HttpChannelOverHTTP2 newHttpChannel(boolean push)
+                            protected HttpChannelOverHTTP2 provideHttpChannel()
                             {
-                                return new HttpChannelOverHTTP2(getHttpDestination(), this, getSession(), push)
+                                return new HttpChannelOverHTTP2(getHttpDestination(), this, getSession())
                                 {
                                     @Override
                                     public boolean associate(HttpExchange exchange)


### PR DESCRIPTION
Removed the distinction between pushed and non-pushed channels; only
non-pushed channels are released and recycled if they're not failed.

Properly resetting HttpReceiverOverHTTP2.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>