### PR TITLE
Issue #2046 - Graceful stop of connections

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/LivelockTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/LivelockTest.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.SocketAddressResolver;
-import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.After;
 import org.junit.Assert;

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/LivelockTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/LivelockTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.client;
 
+import java.nio.channels.Selector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,10 +90,10 @@ public class LivelockTest
         AtomicBoolean busy = new AtomicBoolean(true);
 
         ManagedSelector clientSelector = client.getContainedBeans(ManagedSelector.class).stream().findAny().get();
-        Runnable clientLivelock = new Invocable.NonBlocking()
+        ManagedSelector.SelectorUpdate clientLivelock = new ManagedSelector.SelectorUpdate()
         {
             @Override 
-            public void run()
+            public void update(Selector selector)
             {
                 sleep(10);
                 if (busy.get())
@@ -102,10 +103,10 @@ public class LivelockTest
         clientSelector.submit(clientLivelock);
         
         ManagedSelector serverSelector = connector.getContainedBeans(ManagedSelector.class).stream().findAny().get();
-        Runnable serverLivelock = new Invocable.NonBlocking()
+        ManagedSelector.SelectorUpdate serverLivelock = new ManagedSelector.SelectorUpdate()
         {
             @Override 
-            public void run()
+            public void update(Selector selector)
             {
                 sleep(10);
                 if (busy.get())

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/SelectorManagerTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/SelectorManagerTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.jetty.io.ManagedSelector.SelectorUpdate;
+import org.eclipse.jetty.io.ManagedSelector.Connect;
 import org.eclipse.jetty.toolchain.test.annotation.Slow;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
@@ -295,8 +295,21 @@ public class GracefulStopTest
                     {
                         try
                         {
-                            Thread.sleep(closeWait);
-                            super.close();
+                            new Thread(()->
+                            {
+                                try
+                                {
+                                    Thread.sleep(closeWait);
+                                }
+                                catch (InterruptedException e)
+                                {
+                                }
+                                finally
+                                {
+                                    super.close();
+                                }
+
+                            }).start();
                         }
                         catch(Exception e)
                         {
@@ -341,7 +354,6 @@ public class GracefulStopTest
             if (line.length()==0)
                 break;
         }
-        
 
         long start = System.nanoTime();
         try
@@ -403,7 +415,7 @@ public class GracefulStopTest
     @Test
     public void testSlowCloseGraceful() throws Exception
     {
-        testSlowClose(5000,1000,greaterThan(750L));
+        testSlowClose(5000,1000,Matchers.allOf(greaterThan(750L),lessThan(4999L)));
     }
     
     

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
@@ -25,12 +25,15 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.ConnectException;
 import java.net.Socket;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -41,12 +44,18 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.toolchain.test.AdvancedRunner;
 import org.eclipse.jetty.toolchain.test.OS;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -265,6 +274,155 @@ public class GracefulStopTest
         }
     }
 
+    
+    public void testSlowClose(long stopTimeout, long closeWait, Matcher<Long> stopTimeMatcher) throws Exception
+    {
+        Server server= new Server();
+        server.setStopTimeout(stopTimeout);
+
+        CountDownLatch closed = new CountDownLatch(1);
+        ServerConnector connector = new ServerConnector(server, 2, 2, new HttpConnectionFactory() 
+        {
+
+            @Override
+            public Connection newConnection(Connector connector, EndPoint endPoint)
+            {
+                // Slow closing connection
+                HttpConnection conn = new HttpConnection(getHttpConfiguration(), connector, endPoint, getHttpCompliance(), isRecordHttpComplianceViolations())
+                {
+                    @Override
+                    public void close()
+                    {
+                        try
+                        {
+                            Thread.sleep(closeWait);
+                            super.close();
+                        }
+                        catch(Exception e)
+                        {
+                            // e.printStackTrace();
+                        }
+                        finally
+                        {
+                            closed.countDown();
+                        }
+                    }
+                };
+                return configure(conn, connector, endPoint);
+            }
+            
+        });
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        NoopHandler handler = new NoopHandler();
+        server.setHandler(handler);
+
+        server.start();
+        final int port=connector.getLocalPort();
+        Socket client = new Socket("127.0.0.1", port);
+        client.setSoTimeout(10000);
+        client.getOutputStream().write((
+                "GET / HTTP/1.1\r\n"+
+                "Host: localhost:"+port+"\r\n" +
+                "Content-Type: plain/text\r\n" +
+                "\r\n"
+                ).getBytes());
+        client.getOutputStream().flush();
+        handler.latch.await();
+
+        // look for a response
+        BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream() ,StandardCharsets.ISO_8859_1));
+        while(true)
+        {
+            String line = in.readLine();
+            if (line==null)
+                Assert.fail();
+            if (line.length()==0)
+                break;
+        }
+        
+
+        long start = System.nanoTime();
+        try
+        {
+            server.stop();
+            Assert.assertTrue(stopTimeout==0 || stopTimeout>closeWait);  
+        }
+        catch(Exception e)
+        {
+            Assert.assertTrue(stopTimeout>0 && stopTimeout<closeWait);                
+        }
+        long stop = System.nanoTime();
+        
+        // Check stop time was correct
+        assertThat(TimeUnit.NANOSECONDS.toMillis(stop-start),stopTimeMatcher);
+
+        // Connection closed
+        while(true)
+        {
+            int r = client.getInputStream().read();
+            if (r==-1)
+                break;
+        }
+
+        // onClose Thread interrupted or completed
+        if (stopTimeout>0)
+            Assert.assertTrue(closed.await(1000,TimeUnit.MILLISECONDS));
+        
+        if (!client.isClosed())
+            client.close();
+    }
+
+    /**
+     * Test of non graceful stop when a connection close is slow
+     * @throws Exception on test failure
+     */
+    @Test
+    public void testSlowCloseNotGraceful() throws Exception
+    {        
+        Log.getLogger(QueuedThreadPool.class).info("Expect some threads can't be stopped");
+        testSlowClose(0,5000,lessThan(750L));
+    }
+
+    /**
+     * Test of graceful stop when close is slower than timeout
+     * @throws Exception on test failure
+     */
+    @Test
+    public void testSlowCloseTinyGraceful() throws Exception
+    {
+        Log.getLogger(QueuedThreadPool.class).info("Expect some threads can't be stopped");
+        testSlowClose(1,5000,lessThan(1500L));
+    }
+
+    /**
+     * Test of graceful stop when close is faster than timeout;
+     * @throws Exception on test failure
+     */
+    @Test
+    public void testSlowCloseGraceful() throws Exception
+    {
+        testSlowClose(5000,1000,greaterThan(750L));
+    }
+    
+    
+    static class NoopHandler extends AbstractHandler 
+    {           
+        final CountDownLatch latch = new CountDownLatch(1);
+        
+        NoopHandler()
+        {
+        }
+        
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+                        throws IOException, ServletException 
+        {
+            baseRequest.setHandled(true);
+            latch.countDown();
+        }
+    }
 
     static class TestHandler extends AbstractHandler 
     {		


### PR DESCRIPTION
This is a second attempt at fixing #2046 

Commit 337eb97 cleaned up the whole selector action (now update) mechanism that had gotten a little too complex.

Commit 85e3647 updated the abstract lifecycle to prevent exceptions terminating a doStop or destroy loop.

Commit 56b0a54 addresses #2046 by:
 - SelectorManager now tries to stop it's ManagedSelectors in parallel to avoid multiplying graceful stop timeout. This is still flawed, but is better than we had before.
 - ManagedSelector.doStop will now always wait at least 1s to try to stop the selector, even if not graceful.  If the timeout expires, then it aborts any stopping in progress and does a forced stop, which does not call any listeners etc.   I think this is a reasonable approach, but I don't like the arbitrary 1s wait.