### PR TITLE
Issue #1602 - Deployment Error should fail fast

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppLifeCycle.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/AppLifeCycle.java
@@ -74,6 +74,7 @@ public class AppLifeCycle extends Graph
     public static final String STARTED = "started";
     public static final String STOPPING = "stopping";
     public static final String UNDEPLOYING = "undeploying";
+    public static final String FAILED = "failed";
     
     
     private Map<String, List<Binding>> lifecyclebindings = new HashMap<String, List<Binding>>();
@@ -97,6 +98,9 @@ public class AppLifeCycle extends Graph
         // deployed -> undeployed
         addEdge(DEPLOYED,UNDEPLOYING);
         addEdge(UNDEPLOYING,UNDEPLOYED);
+
+        // failed (unconnected)
+        addNode(new Node(FAILED));
     }
 
     public void addBinding(AppLifeCycle.Binding binding)

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
@@ -507,6 +507,17 @@ public class DeploymentManager extends ContainerLifeCycle
         catch (Throwable t)
         {
             LOG.warn("Unable to reach node goal: " + nodeName,t);
+            // migrate to FAILED node
+            Node failed = _lifecycle.getNodeByName(AppLifeCycle.FAILED);
+            appentry.setLifeCycleNode(failed);
+            try
+            {
+                _lifecycle.runBindings(failed, appentry.app, this);
+            }
+            catch (Throwable ignore)
+            {
+                // The runBindings failed for 'failed' node, no point doing anything else here.
+            }
         }
     }
 

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
@@ -516,7 +516,8 @@ public class DeploymentManager extends ContainerLifeCycle
             }
             catch (Throwable ignore)
             {
-                // The runBindings failed for 'failed' node, no point doing anything else here.
+                // The runBindings failed for 'failed' node
+                LOG.ignore(ignore);
             }
         }
     }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/bindings/StandardStarter.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/bindings/StandardStarter.java
@@ -40,7 +40,7 @@ public class StandardStarter implements AppLifeCycle.Binding
 
         ContextHandler handler = app.getContextHandler();
 
-        if (contexts.isRunning() && !handler.isRunning())
+        if (contexts.isStarted() && handler.isStopped())
         {
             // start the handler manually
             handler.start();

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/bindings/StandardStarter.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/bindings/StandardStarter.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppLifeCycle;
 import org.eclipse.jetty.deploy.graph.Node;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 
 public class StandardStarter implements AppLifeCycle.Binding
 {
@@ -35,12 +36,17 @@ public class StandardStarter implements AppLifeCycle.Binding
     @Override
     public void processBinding(Node node, App app) throws Exception
     {
+        ContextHandlerCollection contexts = app.getDeploymentManager().getContexts();
+
         ContextHandler handler = app.getContextHandler();
-        
-        // start the handler
-        handler.start();
-        
-        // After starting let the context manage state
-        app.getDeploymentManager().getContexts().manage(handler);
+
+        if (contexts.isRunning() && !handler.isRunning())
+        {
+            // start the handler manually
+            handler.start();
+
+            // After starting let the context manage state
+            contexts.manage(handler);
+        }
     }
 }

--- a/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/EnvConfiguration.java
+++ b/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/EnvConfiguration.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.webapp.AbstractConfiguration;
-import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.xml.XmlConfiguration;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
@@ -62,7 +62,7 @@ public abstract class AbstractLifeCycle implements LifeCycle
         {
             try
             {
-                if (_state == __STARTED || _state == __STARTING || _state == __FAILED)
+                if (_state == __STARTED || _state == __STARTING)
                     return;
                 setStarting();
                 doStart();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
@@ -62,7 +62,7 @@ public abstract class AbstractLifeCycle implements LifeCycle
         {
             try
             {
-                if (_state == __STARTED || _state == __STARTING)
+                if (_state == __STARTED || _state == __STARTING || _state == __FAILED)
                     return;
                 setStarting();
                 doStart();
@@ -206,7 +206,7 @@ public abstract class AbstractLifeCycle implements LifeCycle
             listener.lifeCycleStopped(this);
     }
 
-    private void setFailed(Throwable th)
+    protected void setFailed(Throwable th)
     {
         _state = __FAILED;
         if (LOG.isDebugEnabled())

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
@@ -206,7 +206,7 @@ public abstract class AbstractLifeCycle implements LifeCycle
             listener.lifeCycleStopped(this);
     }
 
-    protected void setFailed(Throwable th)
+    private void setFailed(Throwable th)
     {
         _state = __FAILED;
         if (LOG.isDebugEnabled())

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -553,8 +553,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             // start up of the webapp context failed, make sure it is not started
             LOG.warn("Failed startup of context "+this, t);
             _unavailableException=t;
-            setAvailable(false); // webapp cannot be accessed
-            setFailed(t); // be a proper Jetty LifeCycle participant and notify listeners of failure
+            setAvailable(false); // webapp cannot be accessed (results in status code 503)
             if (isThrowUnavailableOnStartupException())
                 throw t;
         }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -554,6 +554,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             LOG.warn("Failed startup of context "+this, t);
             _unavailableException=t;
             setAvailable(false);
+            setFailed(t);
             if (isThrowUnavailableOnStartupException())
                 throw t;
         }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -553,8 +553,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             // start up of the webapp context failed, make sure it is not started
             LOG.warn("Failed startup of context "+this, t);
             _unavailableException=t;
-            setAvailable(false);
-            setFailed(t);
+            setAvailable(false); // webapp cannot be accessed
+            setFailed(t); // be a proper Jetty LifeCycle participant and notify listeners of failure
             if (isThrowUnavailableOnStartupException())
                 throw t;
         }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -548,14 +548,14 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             if (isLogUrlOnStart())
                 dumpUrl();
         }
-        catch (Exception e)
+        catch (Throwable t)
         {
-            //start up of the webapp context failed, make sure it is not started
-            LOG.warn("Failed startup of context "+this, e);
-            _unavailableException=e;
+            // start up of the webapp context failed, make sure it is not started
+            LOG.warn("Failed startup of context "+this, t);
+            _unavailableException=t;
             setAvailable(false);
             if (isThrowUnavailableOnStartupException())
-                throw e;
+                throw t;
         }
     }
 

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
@@ -1,0 +1,38 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ * A SCI that tosses an Error to intentionally to cause issues with the DeploymentManager
+ * @see <a href="https://github.com/eclipse/jetty.project/issues/1602">Issue #1602</a>
+ */
+public class DeploymentErrorInitializer implements ServletContainerInitializer
+{
+    @Override
+    public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException
+    {
+        throw new NoClassDefFoundError("Intentional.Failure");
+    }
+}

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorTest.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  Copyright (c) 1995-2017 Mort Bay Consulting Pty. Ltd.
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorTest.java
@@ -1,0 +1,120 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.deploy.App;
+import org.eclipse.jetty.deploy.AppLifeCycle;
+import org.eclipse.jetty.deploy.DeploymentManager;
+import org.eclipse.jetty.deploy.providers.WebAppProvider;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.webapp.Configuration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeploymentErrorTest
+{
+    private static Server server;
+    private static URI serverURI; // TODO: test that we can not access webapp.
+    private static DeploymentManager deploymentManager;
+
+    @BeforeClass
+    public static void setUpServer()
+    {
+        try
+        {
+            server = new Server();
+            ServerConnector connector = new ServerConnector(server);
+            connector.setPort(0);
+            server.addConnector(connector);
+
+            // Empty handler collections
+            ContextHandlerCollection contexts = new ContextHandlerCollection();
+            HandlerCollection handlers = new HandlerCollection();
+            handlers.setHandlers(new Handler[]
+                    { contexts, new DefaultHandler() });
+            server.setHandler(handlers);
+
+            // Deployment Manager
+            deploymentManager = new DeploymentManager();
+            deploymentManager.setContexts(contexts);
+            Path testClasses = MavenTestingUtils.getTargetPath("test-classes");
+            System.setProperty("maven.test.classes", testClasses.toAbsolutePath().toString());
+            Path docroots = MavenTestingUtils.getTestResourcePathDir("docroots");
+            System.setProperty("test.docroots", docroots.toAbsolutePath().toString());
+            WebAppProvider appProvider = new WebAppProvider();
+            appProvider.setMonitoredDirResource(new PathResource(docroots.resolve("deployerror")));
+            appProvider.setScanInterval(1);
+            deploymentManager.addAppProvider(appProvider);
+            server.addBean(deploymentManager);
+
+            // Setup Configurations
+            Configuration.ClassList classlist = Configuration.ClassList
+                    .setServerDefault(server);
+            classlist.addAfter(
+                    "org.eclipse.jetty.webapp.FragmentConfiguration",
+                    "org.eclipse.jetty.plus.webapp.EnvConfiguration",
+                    "org.eclipse.jetty.plus.webapp.PlusConfiguration");
+            classlist.addBefore(
+                    "org.eclipse.jetty.webapp.JettyWebXmlConfiguration",
+                    "org.eclipse.jetty.annotations.AnnotationConfiguration");
+
+            server.start();
+        }
+        catch (final Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @AfterClass
+    public static void tearDownServer() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void testErrorDeploy() throws Exception
+    {
+        assertThat("app not started", deploymentManager.getApps(AppLifeCycle.STARTED), empty());
+        TimeUnit.SECONDS.sleep(3);
+        List<App> apps = new ArrayList<>();
+        apps.addAll(deploymentManager.getApps());
+        assertThat("Apps tracked", apps.size(), is(1));
+        App app = apps.get(0);
+        assertThat("App.handler.isFailed", app.getContextHandler().isFailed(), is(true));
+    }
+}

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
@@ -3,7 +3,7 @@
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp-uaf</Set>
-  <Set name="war"><SystemProperty name="test.docroots"/>/deployerror/badapp/</Set>
+  <Set name="war"><SystemProperty name="test.docroots"/>/badapp/</Set>
   <Set name="extraClasspath"><SystemProperty name="maven.test.classes"/></Set>
   <Set name="throwUnavailableOnStartupException">false</Set> <!-- Intentionally set to false to test behavior -->
   <Call name="setAttribute">

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
-  <Set name="contextPath">/badapp</Set>
+  <Set name="contextPath">/badapp-uaf</Set>
   <Set name="war"><SystemProperty name="test.docroots"/>/deployerror/badapp/</Set>
   <Set name="extraClasspath"><SystemProperty name="maven.test.classes"/></Set>
-  <Set name="throwUnavailableOnStartupException">true</Set>
+  <Set name="throwUnavailableOnStartupException">false</Set> <!-- Intentionally set to false to test behavior -->
   <Call name="setAttribute">
     <Arg>org.eclipse.jetty.containerInitializerExclusionPattern</Arg>
     <Arg>org.jboss.*</Arg>

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">/badapp</Set>
+  <Set name="war"><SystemProperty name="test.docroots"/>/deployerror/badapp/</Set>
+  <Set name="extraClasspath"><SystemProperty name="maven.test.classes"/></Set>
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.containerInitializerExclusionPattern</Arg>
+    <Arg>org.jboss.*</Arg>
+  </Call>
+</Configure>

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
@@ -3,7 +3,7 @@
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>
-  <Set name="war"><SystemProperty name="test.docroots"/>/deployerror/badapp/</Set>
+  <Set name="war"><SystemProperty name="test.docroots"/>/badapp/</Set>
   <Set name="extraClasspath"><SystemProperty name="maven.test.classes"/></Set>
   <Set name="throwUnavailableOnStartupException">true</Set>
   <Call name="setAttribute">

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp/WEB-INF/classes/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp/WEB-INF/classes/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.eclipse.jetty.test.DeploymentErrorInitializer

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp/WEB-INF/web.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+  <display-name>Intentional Deployment Error WebApp</display-name>
+</web-app>


### PR DESCRIPTION
Fixes deployment errors that occur during WebAppContext.doStart() to respond on Throwable, not Exception.  Allowing for a fast fail of the deployment and not running subsequent configurations and or SCI's if one fails.