### PR TITLE
Issue #2079 Update to Jasper 8.5.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <slf4j-version>1.6.6</slf4j-version>
     <jetty-test-policy-version>1.2</jetty-test-policy-version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
-    <jsp.version>8.5.23</jsp.version>
+    <jsp.version>8.5.24.1</jsp.version>
     <!-- default values are unsupported, but required to be defined for reactor sanity reasons -->
     <alpn.version>undefined</alpn.version>
     <conscrypt.version>1.0.0.RC11</conscrypt.version>


### PR DESCRIPTION
This updates to jasper 8.5.24.  Note that the 8.5.24.1 updated mortbay jsp jars will have an Automatic-Module-Name header in their manifests that resolves #2123 too.