### PR TITLE
Fix logging issue in HttpChannel

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -566,7 +566,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             if (LOG.isDebugEnabled())
                 LOG.debug(_request.getRequestURI(), failure);
             else
-                LOG.warn("{} {}",_request.getRequestURI(), failure);
+                LOG.warn(_request.getRequestURI(), failure);
         }
         else
         {


### PR DESCRIPTION
The previous implementation might result in lines which are not properly interpolated:

    2018-01-18 09:57:47,967 WARN HttpChannel: /resource/46473 {}

This also makes the logging statements in the method consistent.