### PR TITLE
Authorization header in Digest authentication should use the raw path and the raw query rather than the full URI

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
@@ -211,8 +211,8 @@ public class DigestAuthentication extends AbstractAuthentication
             String A1 = user + ":" + realm + ":" + password;
             String hashA1 = toHexString(digester.digest(A1.getBytes(StandardCharsets.ISO_8859_1)));
 
-            URI uri = request.getURI();
-            String A2 = request.getMethod() + ":" + uri;
+            String uri = (request.getQuery() == null) ? request.getPath() : String.format("%s?%s", request.getPath(), request.getQuery());
+            String A2 = String.format("%s:%s", request.getMethod(), uri);
             if ("auth-int".equals(qop))
                 A2 += ":" + toHexString(digester.digest(content));
             String hashA2 = toHexString(digester.digest(A2.getBytes(StandardCharsets.ISO_8859_1)));

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
@@ -211,8 +211,10 @@ public class DigestAuthentication extends AbstractAuthentication
             String A1 = user + ":" + realm + ":" + password;
             String hashA1 = toHexString(digester.digest(A1.getBytes(StandardCharsets.ISO_8859_1)));
 
-            String uri = (request.getQuery() == null) ? request.getPath() : String.format("%s?%s", request.getPath(), request.getQuery());
-            String A2 = String.format("%s:%s", request.getMethod(), uri);
+            String query = request.getQuery();
+            String path = request.getPath();
+            String uri = (query == null) ? path : path + "?" + query;
+            String A2 = request.getMethod() + ":" + uri;
             if ("auth-int".equals(qop))
                 A2 += ":" + toHexString(digester.digest(content));
             String hashA2 = toHexString(digester.digest(A2.getBytes(StandardCharsets.ISO_8859_1)));


### PR DESCRIPTION
This Pull Request replaces the now closed https://github.com/eclipse/jetty.project/pull/2159
See the discussion in https://github.com/eclipse/jetty.project/issues/2160 for further background..

I've been working with a number of different HTTP Client libraries to get them to connect successfully to a host using Digest Authentication (these include curl, Apache HTTP Client, okHTTP, ASync HTTP Client and Jersey Client) and I was having issues getting Jetty to work with Digest Authentication...

... As I looked into the issue, I discovered that the main difference between the libraries that worked and Jetty were in the use of the URI that was returned within the Authentication header; the common pattern that I would see in every instance that worked as expected (given a request for the root resource "/") was a header like this:

Authorization: Digest [items], uri="/"

Whereas I could see that Jetty had been returning this:

Authorization: Digest [items], uri="http://hostname:65534/"

This was causing authentication to fail (tested on my side against MarkLogic Server v9.0-4). Making two minor changes to DigestAuthentication.java to not output the entire URI but just the path (uri.getPath) caused the digested response to be calculated slightly differently - and considered correct and hence for user authentication to pass. This change has resolved the issue for me.

Sending this pull request for consideration for inclusion into a future release of Jetty.