### PR TITLE
qtp constructor min-max validation

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -75,7 +75,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
 
     public QueuedThreadPool(@Name("maxThreads") int maxThreads)
     {
-        this(maxThreads, 8);
+        this(maxThreads, Math.min(8, maxThreads));
     }
 
     public QueuedThreadPool(@Name("maxThreads") int maxThreads,  @Name("minThreads") int minThreads)
@@ -100,6 +100,11 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
     
     public QueuedThreadPool(@Name("maxThreads") int maxThreads, @Name("minThreads") int minThreads, @Name("idleTimeout") int idleTimeout, @Name("reservedThreads") int reservedThreads, @Name("queue") BlockingQueue<Runnable> queue, @Name("threadGroup") ThreadGroup threadGroup)
     {
+        if (maxThreads < minThreads) {
+            throw new IllegalArgumentException("max threads ("+maxThreads+") less than min threads ("
+                    +minThreads+")");
+        }
+
         setMinThreads(minThreads);
         setMaxThreads(maxThreads);
         setIdleTimeout(idleTimeout);

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -302,4 +302,10 @@ public class QueuedThreadPoolTest
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorMinMaxThreadsValidation()
+    {
+        new QueuedThreadPool(4, 8);
+    }
 }


### PR DESCRIPTION
`QueuedThreadPool` constructor validation for min vs max threads to prevent silent configuration failures. Unlike setters, the constructors have both values in one method call so we can check for incorrect argument ordering (e.g. broken configuration management).

The test is much more involved than the implementation, using reflection to find relevant `QTP` constructors. If that's not ok, then I'm fine deleting the test since the new constructor logic is so straightforward. Let me know, and I'll update.