### PR TITLE
add multiple jdks build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ for (def jdk in jdks) {
   node {
     // System Dependent Locations
     def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
-    def jdktool = tool name: $jdk, type: 'hudson.model.JDK'
+    def jdktool = tool name: "$jdk", type: 'hudson.model.JDK'
 
     // Environment
     List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,165 +1,173 @@
 #!groovy
 
-node {
-  // System Dependent Locations
-  def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
-  def jdktool = tool name: 'jdk8', type: 'hudson.model.JDK'
-
-  // Environment
-  List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]
-  mvnEnv.add("MAVEN_OPTS=-Xms256m -Xmx1024m -Djava.awt.headless=true")
-
-  try
-  {
-    stage('Checkout') {
-      checkout scm
-    }
-  } catch (Exception e) {
-    notifyBuild("Checkout Failure")
-    throw e
-  }
-
-  try
-  {
-    stage('Compile') {
-      withEnv(mvnEnv) {
-        timeout(time: 15, unit: 'MINUTES') {
-          sh "mvn -B clean install -Dtest=None"
-        }
-      }
-    }
-  } catch(Exception e) {
-    notifyBuild("Compile Failure")
-    throw e
-  }
-
-  try
-  {
-    stage('Javadoc') {
-      withEnv(mvnEnv) {
-        timeout(time: 20, unit: 'MINUTES') {
-          sh "mvn -B javadoc:javadoc"
-        }
-      }
-    }
-  } catch(Exception e) {
-    notifyBuild("Javadoc Failure")
-    throw e
-  }
-
-  try
-  {
-    stage('Test') {
-      withEnv(mvnEnv) {
-        timeout(time: 90, unit: 'MINUTES') {
-          // Run test phase / ignore test failures
-          sh "mvn -B install -Dmaven.test.failure.ignore=true -Prun-its"
-          // Report failures in the jenkins UI
-          step([$class: 'JUnitResultArchiver', 
-              testResults: '**/target/surefire-reports/TEST-*.xml'])
-          // Collect up the jacoco execution results
-          def jacocoExcludes = 
-              // build tools
-              "**/org/eclipse/jetty/ant/**" +
-              ",**/org/eclipse/jetty/maven/**" +
-              ",**/org/eclipse/jetty/jspc/**" +
-              // example code / documentation
-              ",**/org/eclipse/jetty/embedded/**" +
-              ",**/org/eclipse/jetty/asyncrest/**" +
-              ",**/org/eclipse/jetty/demo/**" +
-              // special environments / late integrations
-              ",**/org/eclipse/jetty/gcloud/**" +
-              ",**/org/eclipse/jetty/infinispan/**" +
-              ",**/org/eclipse/jetty/osgi/**" +
-              ",**/org/eclipse/jetty/spring/**" +
-              ",**/org/eclipse/jetty/http/spi/**" +
-              // test classes
-              ",**/org/eclipse/jetty/tests/**" +
-              ",**/org/eclipse/jetty/test/**";
-          step([$class: 'JacocoPublisher', 
-              inclusionPattern: '**/org/eclipse/jetty/**/*.class',
-              exclusionPattern: jacocoExcludes,
-              execPattern: '**/target/jacoco.exec', 
-              classPattern: '**/target/classes', 
-              sourcePattern: '**/src/main/java'])
-          // Report on Maven and Javadoc warnings
-          step([$class: 'WarningsPublisher', 
-              consoleParsers: [
-                  [parserName: 'Maven'],
-                  [parserName: 'JavaDoc'],
-                  [parserName: 'JavaC']
-              ]])
-        }
-        if(isUnstable())
-        {
-          notifyBuild("Unstable / Test Errors")
-        }
-      }
-    }
-  } catch(Exception e) {
-    notifyBuild("Test Failure")
-    throw e
-  }
-
-  try
-  {
-    stage 'Compact3'
-
-    dir("aggregates/jetty-all-compact3") {
-      withEnv(mvnEnv) {
-        sh "mvn -B -Pcompact3 clean install"
-      }
-    }
-  } catch(Exception e) {
-    notifyBuild("Compact3 Failure")
-    throw e
-  }
-}
-
-// True if this build is part of the "active" branches
-// for Jetty.
-def isActiveBranch()
+def jdks = ["jdk8", "jdk9"]
+for (def jdk in jdks)
 {
-  def branchName = "${env.BRANCH_NAME}"
-  return ( branchName == "master" ||
-           branchName.startsWith("jetty-") );
-}
 
-// Test if the Jenkins Pipeline or Step has marked the
-// current build as unstable
-def isUnstable()
-{
-  return currentBuild.result == "UNSTABLE"
-}
+  node {
+    // System Dependent Locations
+    def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
+    def jdktool = tool name: '${jdk}', type: 'hudson.model.JDK'
 
-// Send a notification about the build status
-def notifyBuild(String buildStatus)
-{
-  if ( !isActiveBranch() )
-  {
-    // don't send notifications on transient branches
-    return
+    // Environment
+    List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]
+    mvnEnv.add( "MAVEN_OPTS=-Xms256m -Xmx1024m -Djava.awt.headless=true" )
+
+    try
+    {
+      stage( 'Checkout' ) {
+        checkout scm
+      }
+    } catch ( Exception e ) {
+      notifyBuild( "Checkout Failure" )
+      throw e
+    }
+
+    try
+    {
+      stage( 'Compile' ) {
+        withEnv( mvnEnv ) {
+          timeout( time: 15, unit: 'MINUTES' ) {
+            sh "mvn -B clean install -Dtest=None"
+          }
+        }
+      }
+    }
+    catch ( Exception e )
+    {
+      notifyBuild( "Compile Failure" )
+      throw e
+    }
+
+    try
+    {
+      stage( 'Javadoc' ) {
+        withEnv( mvnEnv ) {
+          timeout( time: 20, unit: 'MINUTES' ) {
+            sh "mvn -B javadoc:javadoc"
+          }
+        }
+      }
+    }
+    catch ( Exception e )
+    {
+      notifyBuild( "Javadoc Failure" )
+      throw e
+    }
+
+    try
+    {
+      stage( 'Test' ) {
+        withEnv( mvnEnv ) {
+          timeout( time: 90, unit: 'MINUTES' ) {
+            // Run test phase / ignore test failures
+            sh "mvn -B install -Dmaven.test.failure.ignore=true -Prun-its"
+            // Report failures in the jenkins UI
+            step( [$class     : 'JUnitResultArchiver',
+                   testResults: '**/target/surefire-reports/TEST-*.xml'] )
+            // Collect up the jacoco execution results
+            def jacocoExcludes =
+                    // build tools
+                "**/org/eclipse/jetty/ant/**" +
+                ",**/org/eclipse/jetty/maven/**" +
+                ",**/org/eclipse/jetty/jspc/**" +
+                // example code / documentation
+                ",**/org/eclipse/jetty/embedded/**" +
+                ",**/org/eclipse/jetty/asyncrest/**" +
+                ",**/org/eclipse/jetty/demo/**" +
+                // special environments / late integrations
+                ",**/org/eclipse/jetty/gcloud/**" +
+                ",**/org/eclipse/jetty/infinispan/**" +
+                ",**/org/eclipse/jetty/osgi/**" +
+                ",**/org/eclipse/jetty/spring/**" +
+                ",**/org/eclipse/jetty/http/spi/**" +
+                // test classes
+                ",**/org/eclipse/jetty/tests/**" +
+                ",**/org/eclipse/jetty/test/**";
+            step([$clas          s: 'JacocoPublisher',
+                  inclusionPattern: '**/org/eclipse/jetty/**/*.class',
+                  exclusionPattern: jacocoExcludes,
+                  execPatter     n: '**/target/jacoco.exec',
+                  classPatter    n: '**/target/classes',
+                  sourcePatter   n: '**/src/main/java'])
+            // Report on Maven and Javadoc warnings
+            step([$clas        s: 'WarningsPublisher',
+                  consoleParsers: [
+                    [parserName: 'Maven'],
+                    [parserName: 'JavaDoc'],
+                    [parserName: 'JavaC']
+                ]])
+          }
+          i f (isUnstable())
+          {
+            notifyBuild( "Unstable / Test Errors ")
+          }
+        }
+      }
+    } catc h (Exception e)
+    {
+      notifyBuild( "Test Failure" )
+      throw e
+    }
+
+    try
+    {
+      stage 'Compact3'
+
+      dir( "aggregates/jetty-all-compact3" ) {
+        withEnv( mvnEnv ) {
+          sh "mvn -B -Pcompact3 clean install"
+        }
+      }
+    }
+    catch ( Exception e )
+    {
+      notifyBuild( "Compact3 Failure" )
+      throw e
+    }
   }
 
-  // default the value
-  buildStatus = buildStatus ?: "UNKNOWN"
+  // True if this build is part of the "active" branches
+  // for Jetty.
+  def isActiveBranch()
+  {
+    def branchName = "${env.BRANCH_NAME}"
+    return ( branchName == "master" || branchName.startsWith( "jetty-" ) );
+  }
 
-  def email = "${env.EMAILADDRESS}"
-  def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus}"
-  def detail = """<h4>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a> [#${env.BUILD_NUMBER}]</h4>
-  <p><b>${buildStatus}</b></p>
-  <table>
-    <tr><td>Build</td><td><a href='${env.BUILD_URL}'>${env.BUILD_URL}</a></td><tr>
-    <tr><td>Console</td><td><a href='${env.BUILD_URL}console'>${env.BUILD_URL}console</a></td><tr>
-    <tr><td>Test Report</td><td><a href='${env.BUILD_URL}testReport/'>${env.BUILD_URL}testReport/</a></td><tr>
-  </table>
-  """
+  // Test if the Jenkins Pipeline or Step has marked the
+  // current build as unstable
+  def isUnstable()
+  {
+    return currentBuild.result == "UNSTABLE"
+  }
 
-  emailext (
-    to: email,
-    subject: summary,
-    body: detail
-  )
+  // Send a notification about the build status
+  def notifyBuild( String buildStatus )
+  {
+    if ( !isActiveBranch() )
+    {
+      // don't send notifications on transient branches
+      return
+    }
+
+    // default the value
+    buildStatus = buildStatus ?: "UNKNOWN"
+
+    def email = "${env.EMAILADDRESS}"
+    def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus}"
+    def detail = """<h4>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a> [#${env.BUILD_NUMBER}]</h4>
+    <p><b>${buildStatus}</b></p>
+    <table>
+      <tr><td>Build</td><td><a href='${env.BUILD_URL}'>${env.BUILD_URL}</a></td><tr>
+      <tr><td>Console</td><td><a href='${env.BUILD_URL}console'>${env.BUILD_URL}console</a></td><tr>
+      <tr><td>Test Report</td><td><a href='${env.BUILD_URL}testReport/'>${env.BUILD_URL}testReport/</a></td><tr>
+    </table>
+    """
+
+    emailext( to: email,
+              subject: summary,
+              body: detail )
+  }
 }
-
 // vim: et:ts=2:sw=2:ft=groovy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
-
 #!groovy
+
 def jdks = ["jdk8", "jdk9"]
+
 for (def jdk in jdks) {
 
   node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,8 +68,7 @@ def getFullBuild(jdk, os) {
               // Run test phase / ignore test failures
               sh "mvn -V -B install -Dmaven.test.failure.ignore=true -Prun-its"
               // Report failures in the jenkins UI
-              step([$class: 'JUnitResultArchiver',
-                    testResults: '**/target/surefire-reports/TEST-*.xml'])
+              junit testResults:'**/target/surefire-reports/TEST-*.xml'
               // Collect up the jacoco execution results
               def jacocoExcludes =
                       // build tools

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ def isActiveBranch()
 {
   def branchName = "${env.BRANCH_NAME}"
   return ( branchName == "master" ||
-          branchName.startsWith("jetty-") );
+          ( branchName.startsWith("jetty-") && branchName.endsWith(".x") ) );
 }
 
 // Test if the Jenkins Pipeline or Step has marked the

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ for (def jdk in jdks) {
   node {
     // System Dependent Locations
     def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
-    def jdktool = tool name: '${jdk}', type: 'hudson.model.JDK'
+    def jdktool = tool name: '$jdk', type: 'hudson.model.JDK'
 
     // Environment
     List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ parallel builds
 
 def getFullBuild(jdk, os) {
   return {
-    node {
+    node(os) {
       // System Dependent Locations
       def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
       def jdktool = tool name: "$jdk", type: 'hudson.model.JDK'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ def jdks = ["jdk8", "jdk9"]
 def builds = [:]
 for (def jdk in jdks) {
   builds[jdk] = getFullBuild( jdk )
-  parallel builds
 }
+parallel builds
 
 def getFullBuild(jdk) {
   return {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,17 @@
 #!groovy
 
 def jdks = ["jdk8", "jdk9"]
+def oss = ["linux"] //windows?
 def builds = [:]
-for (def jdk in jdks) {
-  builds[jdk] = getFullBuild( jdk )
+for (def os in oss) {
+  for (def jdk in jdks) {
+    builds[os+"_"+jdk] = getFullBuild( jdk, os )
+  }
 }
+
 parallel builds
 
-def getFullBuild(jdk) {
+def getFullBuild(jdk, os) {
   return {
     node {
       // System Dependent Locations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,11 +112,12 @@ def getFullBuild(jdk) {
 
       try
       {
-        stage 'Compact3'
+        stage ('Compact3') {
 
-        dir("aggregates/jetty-all-compact3") {
-          withEnv(mvnEnv) {
-            sh "mvn -V -B -Pcompact3 clean install"
+          dir("aggregates/jetty-all-compact3") {
+            withEnv(mvnEnv) {
+              sh "mvn -V -B -Pcompact3 clean install"
+            }
           }
         }
       } catch(Exception e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Checkout-'+os+'-'+jdk) {
+        stage('Checkout') {
           checkout scm
         }
       } catch (Exception e) {
@@ -34,7 +34,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Compile-'+os+'-'+jdk) {
+        stage('Compile') {
           withEnv(mvnEnv) {
             timeout(time: 15, unit: 'MINUTES') {
               sh "mvn -V -B clean install -Dtest=None"
@@ -48,7 +48,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Javadoc-'+os+'-'+jdk) {
+        stage('Javadoc') {
           withEnv(mvnEnv) {
             timeout(time: 20, unit: 'MINUTES') {
               sh "mvn -V -B javadoc:javadoc"
@@ -62,7 +62,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Test-'+os+'-'+jdk) {
+        stage('Test') {
           withEnv(mvnEnv) {
             timeout(time: 90, unit: 'MINUTES') {
               // Run test phase / ignore test failures
@@ -115,7 +115,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage ('Compact3-'+os+'-'+jdk) {
+        stage ('Compact3') {
 
           dir("aggregates/jetty-all-compact3") {
             withEnv(mvnEnv) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ for (def jdk in jdks) {
         checkout scm
       }
     } catch (Exception e) {
-      notifyBuild("Checkout Failure")
+      notifyBuild("Checkout Failure", jdk)
       throw e
     }
 
@@ -33,7 +33,7 @@ for (def jdk in jdks) {
         }
       }
     } catch(Exception e) {
-      notifyBuild("Compile Failure")
+      notifyBuild("Compile Failure", jdk)
       throw e
     }
 
@@ -47,7 +47,7 @@ for (def jdk in jdks) {
         }
       }
     } catch(Exception e) {
-      notifyBuild("Javadoc Failure")
+      notifyBuild("Javadoc Failure", jdk)
       throw e
     }
 
@@ -96,12 +96,12 @@ for (def jdk in jdks) {
           }
           if(isUnstable())
           {
-            notifyBuild("Unstable / Test Errors")
+            notifyBuild("Unstable / Test Errors", jdk)
           }
         }
       }
     } catch(Exception e) {
-      notifyBuild("Test Failure")
+      notifyBuild("Test Failure", jdk)
       throw e
     }
 
@@ -115,7 +115,7 @@ for (def jdk in jdks) {
         }
       }
     } catch(Exception e) {
-      notifyBuild("Compact3 Failure")
+      notifyBuild("Compact3 Failure", jdk)
       throw e
     }
   }
@@ -140,7 +140,7 @@ def isUnstable()
 }
 
 // Send a notification about the build status
-def notifyBuild(String buildStatus)
+def notifyBuild(String buildStatus, String jdk)
 {
   if ( !isActiveBranch() )
   {
@@ -152,7 +152,7 @@ def notifyBuild(String buildStatus)
   buildStatus = buildStatus ?: "UNKNOWN"
 
   def email = "${env.EMAILADDRESS}"
-  def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus}"
+  def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus} with jdk ${jdk}"
   def detail = """<h4>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a> [#${env.BUILD_NUMBER}]</h4>
     <p><b>${buildStatus}</b></p>
     <table>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ for (def jdk in jdks) {
       stage('Compile') {
         withEnv(mvnEnv) {
           timeout(time: 15, unit: 'MINUTES') {
-            sh "mvn -B clean install -Dtest=None"
+            sh "mvn -V -B clean install -Dtest=None"
           }
         }
       }
@@ -42,7 +42,7 @@ for (def jdk in jdks) {
       stage('Javadoc') {
         withEnv(mvnEnv) {
           timeout(time: 20, unit: 'MINUTES') {
-            sh "mvn -B javadoc:javadoc"
+            sh "mvn -V -B javadoc:javadoc"
           }
         }
       }
@@ -57,7 +57,7 @@ for (def jdk in jdks) {
         withEnv(mvnEnv) {
           timeout(time: 90, unit: 'MINUTES') {
             // Run test phase / ignore test failures
-            sh "mvn -B install -Dmaven.test.failure.ignore=true -Prun-its"
+            sh "mvn -V -B install -Dmaven.test.failure.ignore=true -Prun-its"
             // Report failures in the jenkins UI
             step([$class: 'JUnitResultArchiver',
                   testResults: '**/target/surefire-reports/TEST-*.xml'])
@@ -111,7 +111,7 @@ for (def jdk in jdks) {
 
       dir("aggregates/jetty-all-compact3") {
         withEnv(mvnEnv) {
-          sh "mvn -B -Pcompact3 clean install"
+          sh "mvn -V -B -Pcompact3 clean install"
         }
       }
     } catch(Exception e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,37 +120,40 @@ for (def jdk in jdks) {
     }
   }
 
-  // True if this build is part of the "active" branches
-  // for Jetty.
-  def isActiveBranch()
+}
+
+
+// True if this build is part of the "active" branches
+// for Jetty.
+def isActiveBranch()
+{
+  def branchName = "${env.BRANCH_NAME}"
+  return ( branchName == "master" ||
+          branchName.startsWith("jetty-") );
+}
+
+// Test if the Jenkins Pipeline or Step has marked the
+// current build as unstable
+def isUnstable()
+{
+  return currentBuild.result == "UNSTABLE"
+}
+
+// Send a notification about the build status
+def notifyBuild(String buildStatus)
+{
+  if ( !isActiveBranch() )
   {
-    def branchName = "${env.BRANCH_NAME}"
-    return ( branchName == "master" ||
-            branchName.startsWith("jetty-") );
+    // don't send notifications on transient branches
+    return
   }
 
-  // Test if the Jenkins Pipeline or Step has marked the
-  // current build as unstable
-  def isUnstable()
-  {
-    return currentBuild.result == "UNSTABLE"
-  }
+  // default the value
+  buildStatus = buildStatus ?: "UNKNOWN"
 
-  // Send a notification about the build status
-  def notifyBuild(String buildStatus)
-  {
-    if ( !isActiveBranch() )
-    {
-      // don't send notifications on transient branches
-      return
-    }
-
-    // default the value
-    buildStatus = buildStatus ?: "UNKNOWN"
-
-    def email = "${env.EMAILADDRESS}"
-    def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus}"
-    def detail = """<h4>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a> [#${env.BUILD_NUMBER}]</h4>
+  def email = "${env.EMAILADDRESS}"
+  def summary = "${env.JOB_NAME}#${env.BUILD_NUMBER} - ${buildStatus}"
+  def detail = """<h4>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a> [#${env.BUILD_NUMBER}]</h4>
     <p><b>${buildStatus}</b></p>
     <table>
       <tr><td>Build</td><td><a href='${env.BUILD_URL}'>${env.BUILD_URL}</a></td><tr>
@@ -159,11 +162,11 @@ for (def jdk in jdks) {
     </table>
     """
 
-    emailext (
-            to: email,
-            subject: summary,
-            body: detail
-    )
-  }
+  emailext (
+          to: email,
+          subject: summary,
+          body: detail
+  )
 }
+
 // vim: et:ts=2:sw=2:ft=groovy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Checkout') {
+        stage('Checkout-'+os+'-'+jdk) {
           checkout scm
         }
       } catch (Exception e) {
@@ -34,7 +34,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Compile') {
+        stage('Compile-'+os+'-'+jdk) {
           withEnv(mvnEnv) {
             timeout(time: 15, unit: 'MINUTES') {
               sh "mvn -V -B clean install -Dtest=None"
@@ -48,7 +48,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Javadoc') {
+        stage('Javadoc-'+os+'-'+jdk) {
           withEnv(mvnEnv) {
             timeout(time: 20, unit: 'MINUTES') {
               sh "mvn -V -B javadoc:javadoc"
@@ -62,7 +62,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage('Test') {
+        stage('Test-'+os+'-'+jdk) {
           withEnv(mvnEnv) {
             timeout(time: 90, unit: 'MINUTES') {
               // Run test phase / ignore test failures
@@ -116,7 +116,7 @@ def getFullBuild(jdk, os) {
 
       try
       {
-        stage ('Compact3') {
+        stage ('Compact3-'+os+'-'+jdk) {
 
           dir("aggregates/jetty-all-compact3") {
             withEnv(mvnEnv) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ for (def jdk in jdks) {
   node {
     // System Dependent Locations
     def mvntool = tool name: 'maven3', type: 'hudson.tasks.Maven$MavenInstallation'
-    def jdktool = tool name: '$jdk', type: 'hudson.model.JDK'
+    def jdktool = tool name: $jdk, type: 'hudson.model.JDK'
 
     // Environment
     List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]


### PR DESCRIPTION
Signed-off-by: olivier lamy <olamy@webtide.com>
ATM we only build with jdk8 and have a separate build for jdk9 so it means pr are not build with jdk9 (so we usually verify pr or branches with jdk9 after merge)
This pr will simply build the project with jdk9 as well (in parallel)