### PR TITLE
Feature/jdk 10 build

### DIFF
--- a/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
@@ -70,7 +70,8 @@ public class ModulesTest
         modules.registerAll();
 
         // Check versions
-        assertThat("java.version.platform", args.getProperties().getString("java.version.platform"),anyOf(equalTo("8"),equalTo("9")));
+        assertThat("java.version.platform", args.getProperties().getString("java.version.platform"), //
+                   anyOf(equalTo("8"),equalTo("9"),equalTo( "10" )));
 
         List<String> moduleNames = new ArrayList<>();
         for (Module mod : modules)

--- a/pom.xml
+++ b/pom.xml
@@ -1016,7 +1016,7 @@
               <artifactId>jacoco-maven-plugin</artifactId>
               <version>0.8.1-SNAPSHOT</version>
               <configuration>
-                <skip>false</skip>
+                <skip>true</skip>
               </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -437,13 +437,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.20.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-lang3</artifactId>
-              <version>3.7</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1021,13 +1014,42 @@
             <plugin>
               <groupId>org.jacoco</groupId>
               <artifactId>jacoco-maven-plugin</artifactId>
+              <version>0.8.1-SNAPSHOT</version>
               <configuration>
                 <skip>true</skip>
               </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <version>2.21.0-SNAPSHOT</version>
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>oss.snapshots</id>
+          <name>OSS Snapshots</name>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>apache.snapshots</id>
+          <url>https://repository.apache.org/content/repositories/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
     <profile>
       <id>jdk8</id>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.20.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-lang3</artifactId>
+              <version>3.7</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -616,7 +623,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.9</version>
+          <version>0.8.0</version>
         </plugin>
         <plugin>
           <groupId>com.agilejava.docbkx</groupId>
@@ -1002,6 +1009,25 @@
   </dependencyManagement>
 
   <profiles>
+    <profile>
+      <id>jdk10</id>
+      <activation>
+        <jdk>10</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
     <profile>
       <id>jdk8</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -1009,6 +1009,7 @@
   </dependencyManagement>
 
   <profiles>
+    <!-- disable until jacoco release > 0.8.0 released -->
     <profile>
       <id>jdk10</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -1016,7 +1016,7 @@
               <artifactId>jacoco-maven-plugin</artifactId>
               <version>0.8.1-SNAPSHOT</version>
               <configuration>
-                <skip>true</skip>
+                <skip>false</skip>
               </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1002,7 +1002,7 @@
   </dependencyManagement>
 
   <profiles>
-    <!-- disable until jacoco release > 0.8.0 released -->
+    <!-- use last snapshot of jacoco and failsafe for jdk10 -->
     <profile>
       <id>jdk10</id>
       <activation>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -42,7 +42,15 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>
@@ -88,6 +96,7 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <argLine>-Xbootclasspath/p:${project.build.directory}/alpn/alpn-boot-${alpn.version}.jar</argLine>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -101,6 +101,13 @@
             <configuration>
               <argLine>-Xbootclasspath/p:${project.build.directory}/alpn/alpn-boot-${alpn.version}.jar</argLine>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -44,13 +44,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <goals>
@@ -101,13 +94,6 @@
             <configuration>
               <argLine>-Xbootclasspath/p:${project.build.directory}/alpn/alpn-boot-${alpn.version}.jar</argLine>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
this pr add a jdk10 profile to use last failsafe maven plugin version snapshot and skip jacoco.
This at least fix the build with jdk10.