### PR TITLE
Issue #2209 Require war packaging only for some jetty maven plugin goals

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
@@ -293,8 +293,9 @@ public abstract class AbstractJettyMojo extends AbstractMojo
     public abstract void restartWebApp(boolean reconfigureScanner) throws Exception;
 
     
-    public abstract void checkPomConfiguration() throws MojoExecutionException;    
+    public abstract void checkPomConfiguration() throws MojoExecutionException;
     
+    public abstract void checkPackagingConfiguration() throws MojoExecutionException;  
     
     public abstract void configureScanner () throws MojoExecutionException;
     
@@ -323,11 +324,15 @@ public abstract class AbstractJettyMojo extends AbstractMojo
         
         configurePluginClasspath();
         PluginLog.setLog(getLog());
-        checkPomConfiguration();
+        checkConfiguration();
         startJetty();
     }
     
-    
+    public void checkConfiguration() throws MojoExecutionException
+    {
+        checkPackagingConfiguration();
+        checkPomConfiguration();
+    }
     
     
     public void configurePluginClasspath() throws MojoExecutionException

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyDeployWar.java
@@ -67,6 +67,23 @@ public class JettyDeployWar extends JettyRunWarMojo
     
 
 
+  
+
+
+    /** 
+     * @see org.eclipse.jetty.maven.plugin.JettyRunWarMojo#checkPackagingConfiguration()
+     */
+    @Override
+    public void checkPackagingConfiguration() throws MojoExecutionException
+    {
+        return; //do not require this to be a war project
+    }
+
+
+
+
+
+
     @Override
     public void finishConfigurationBeforeStart() throws Exception
     {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -175,17 +175,25 @@ public class JettyRunMojo extends AbstractJettyMojo
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
-        if ( !"war".equals( project.getPackaging() ) || skip )
-        {
-            return;
-        }
         warPluginInfo = new WarPluginInfo(project);
         super.execute();
     }
     
     
+
     
-    
+    /** 
+     * @see org.eclipse.jetty.maven.plugin.AbstractJettyMojo#checkPackagingConfiguration()
+     */
+    @Override
+    public void checkPackagingConfiguration() throws MojoExecutionException
+    { 
+        if ( !"war".equals( project.getPackaging() ))
+            throw new MojoExecutionException("Not war packaging");
+    }
+
+
+
     /**
      * Verify the configuration given in the pom.
      * 

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarExplodedMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarExplodedMojo.java
@@ -79,6 +79,17 @@ public class JettyRunWarExplodedMojo extends AbstractJettyMojo
     }
 
     
+    /** 
+     * @see org.eclipse.jetty.maven.plugin.AbstractJettyMojo#checkPackagingConfiguration()
+     */
+    @Override
+    public void checkPackagingConfiguration() throws MojoExecutionException
+    { 
+        if ( !"war".equals( project.getPackaging() ))
+            throw new MojoExecutionException("Not war packaging");
+    }
+    
+    
     /**
      * 
      * @see AbstractJettyMojo#checkPomConfiguration()

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
@@ -61,10 +61,6 @@ public class JettyRunWarMojo extends AbstractJettyMojo
      */
     public void execute() throws MojoExecutionException, MojoFailureException
     {
-        if ( !"war".equals( project.getPackaging() ) || skip )
-        {
-            return;
-        }
         super.execute();  
     }
 
@@ -96,7 +92,18 @@ public class JettyRunWarMojo extends AbstractJettyMojo
        return;        
     }
 
+    
 
+    
+    /** 
+     * @see org.eclipse.jetty.maven.plugin.AbstractJettyMojo#checkPackagingConfiguration()
+     */
+    @Override
+    public void checkPackagingConfiguration() throws MojoExecutionException
+    { 
+        if ( !"war".equals( project.getPackaging() ))
+            throw new MojoExecutionException("Not war packaging");
+    }
 
     
     /**

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStartMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStartMojo.java
@@ -48,7 +48,15 @@ public class JettyStartMojo extends JettyRunMojo
         super.execute();
     }
     
-
+    /** 
+     * @see org.eclipse.jetty.maven.plugin.AbstractJettyMojo#checkPackagingConfiguration()
+     */
+    @Override
+    public void checkPackagingConfiguration() throws MojoExecutionException
+    {
+        return; //don't check that the project is a war
+    }
+    
     @Override
     public void finishConfigurationBeforeStart() throws Exception
     {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
@@ -62,9 +62,7 @@ public class JettyStopMojo extends AbstractMojo
      * @parameter
      */
     protected int stopWait;
-    
- 
-    
+
     
     
 


### PR DESCRIPTION
A change that came in with commit https://github.com/eclipse/jetty.project/commit/4b513c61e8ac7400826880d18729c71eca1b6ae8#diff-28ee2c02100a8cae9e1d1754ea32af10R64 meant that the deploy-war goal was now insisting that the project was of packaging type war, which was not the intention.

I've reviewed all of the goals, and implemented a check for packaging war only on these:
run
run-war
run-exploded
run-forked
run-distro
effective-web-xml

These other goals do not require packaging war:
start
stop
deploy-war