### PR TITLE
Cherry-pick 'direct buffer configuration' to 9.2

### DIFF
--- a/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpTransportOverFCGI.java
+++ b/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpTransportOverFCGI.java
@@ -47,6 +47,11 @@ public class HttpTransportOverFCGI implements HttpTransport
         this.request = request;
     }
 
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return false;
+    }
+
     @Override
     public void send(HttpGenerator.ResponseInfo info, ByteBuffer content, boolean lastContent, Callback callback)
     {

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
@@ -93,6 +93,12 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
     }
 
     @Override
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return false;
+    }
+
+    @Override
     public void onOpen()
     {
         if (LOG.isDebugEnabled())

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ChannelEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ChannelEndPoint.java
@@ -54,6 +54,12 @@ public class ChannelEndPoint extends AbstractEndPoint
     }
 
     @Override
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return true;
+    }
+    
+    @Override
     public boolean isOpen()
     {
         return _channel.isOpen();

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
@@ -247,4 +247,11 @@ public interface EndPoint extends Closeable
      * @param newConnection The connection to upgrade to
      */
     public void upgrade(Connection newConnection);
+
+    /** Is the endpoint optimized for DirectBuffer usage
+     * @return True if direct buffers can be used optimally.
+     */
+    boolean isOptimizedForDirectBuffers();
+
+    
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -88,7 +88,7 @@ public class SslConnection extends AbstractConnection
     private ByteBuffer _decryptedInput;
     private ByteBuffer _encryptedInput;
     private ByteBuffer _encryptedOutput;
-    private final boolean _encryptedDirectBuffers = false;
+    private final boolean _encryptedDirectBuffers = true;
     private final boolean _decryptedDirectBuffers = false;
     private final Runnable _runCompletWrite = new Runnable()
     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -180,6 +180,11 @@ public class HttpChannel<T> implements HttpParser.RequestHandler<T>, Runnable, H
         return _configuration;
     }
 
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return getHttpTransport().isOptimizedForDirectBuffers();
+    }
+
     public Server getServer()
     {
         return _connector.getServer();
@@ -793,7 +798,7 @@ public class HttpChannel<T> implements HttpParser.RequestHandler<T>, Runnable, H
      * @param complete whether the content is complete for the response
      * @param callback Callback when complete or failed
      */
-    protected void write(ByteBuffer content, boolean complete, Callback callback)
+    public void write(ByteBuffer content, boolean complete, Callback callback)
     {
         sendResponse(null,content,complete,callback);
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -153,6 +153,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     }
 
     @Override
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return getEndPoint().isOptimizedForDirectBuffers();
+    }
+
+    @Override
     public int getMessagesIn()
     {
         return getHttpChannel().getRequests();

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpTransport.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpTransport.java
@@ -23,6 +23,10 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.HttpGenerator;
 import org.eclipse.jetty.util.Callback;
 
+
+/* ------------------------------------------------------------ */
+/** Abstraction of the outbound HTTP transport.
+ */
 public interface HttpTransport
 {    
     void send(HttpGenerator.ResponseInfo info, ByteBuffer content, boolean lastContent, Callback callback);
@@ -37,4 +41,10 @@ public interface HttpTransport
      * Abort to should terminate the transport in a way that can indicate abnormal response to the client. 
      */
     void abort();
+
+    /* ------------------------------------------------------------ */
+    /** Is the underlying transport optimized for DirectBuffer usage
+     * @return True if direct buffers can be used optimally.
+     */
+    boolean isOptimizedForDirectBuffers();
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -106,6 +106,11 @@ public class ResponseTest
                 
             }
 
+            @Override
+            public boolean isOptimizedForDirectBuffers()
+            {
+                return false;
+            }
         }, input);
     }
 

--- a/jetty-spdy/spdy-http-server/src/main/java/org/eclipse/jetty/spdy/server/http/HttpTransportOverSPDY.java
+++ b/jetty-spdy/spdy-http-server/src/main/java/org/eclipse/jetty/spdy/server/http/HttpTransportOverSPDY.java
@@ -79,6 +79,12 @@ public class HttpTransportOverSPDY implements HttpTransport
         this.version = session.getVersion();
     }
 
+    @Override
+    public boolean isOptimizedForDirectBuffers()
+    {
+        return false;
+    }
+
     protected Stream getStream()
     {
         return stream;


### PR DESCRIPTION
A fix for #2135 (issues with crypto on Android 8.1) is enabling direct buffer support. The problem is that commit references a lot of other changes that aren't in 9.2, so there were a number of conflicts. I resolved them as best I could without introducing too many new-to-9.2 changes.

With my local environment and Travis CI's service, I was never able to get the tests completely passing - before or after my change to the 9.2.x branch. This change works fine for me on Android 5.0, 6.0, 8.0 and 8.1 via our CometD client integration. I don't run a Jetty server and this commit touches the server code, so I'm unable to manually test that besides your existing tests.

Let me know if there's anything else I can do to validate this for you. I don't want to inadvertently break anything!