### PR TITLE
Resolved default charset warning in jetty-util for #2206

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/B64Code.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/B64Code.java
@@ -261,6 +261,7 @@ public class B64Code
      * @throws IllegalArgumentException if the input is not a valid
      *         B64 encoding.
      */
+	@SuppressWarnings("DefaultCharset")
     public static String decode(String encoded,String charEncoding)
     {
         byte[] decoded=decode(encoded);
@@ -279,6 +280,7 @@ public class B64Code
      * @throws IllegalArgumentException if the input is not a valid
      *         B64 encoding.
      */
+	@SuppressWarnings("DefaultCharset")
     public static String decode(String encoded, Charset charEncoding)
     {
         byte[] decoded=decode(encoded);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/B64Code.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/B64Code.java
@@ -255,13 +255,14 @@ public class B64Code
      * <p>Unlike {@link #decode(char[])}, extra whitespace is ignored.
      * @param encoded String to decode.
      * @param charEncoding String representing the character encoding
-     *        used to map the decoded bytes into a String.
+     *        used to map the decoded bytes into a String. If null
+     *        the platforms default charset is used.
      * @return String decoded byte array.
      * @throws UnsupportedCharsetException if the encoding is not supported
      * @throws IllegalArgumentException if the input is not a valid
      *         B64 encoding.
      */
-	@SuppressWarnings("DefaultCharset")
+    @SuppressWarnings("DefaultCharset")
     public static String decode(String encoded,String charEncoding)
     {
         byte[] decoded=decode(encoded);
@@ -275,12 +276,13 @@ public class B64Code
      * <p>Unlike {@link #decode(char[])}, extra whitespace is ignored.
      * @param encoded String to decode.
      * @param charEncoding Character encoding
-     *        used to map the decoded bytes into a String.
+     *        used to map the decoded bytes into a String. If null
+     *        the platforms default charset is used.
      * @return String decoded byte array.
      * @throws IllegalArgumentException if the input is not a valid
      *         B64 encoding.
      */
-	@SuppressWarnings("DefaultCharset")
+    @SuppressWarnings("DefaultCharset")
     public static String decode(String encoded, Charset charEncoding)
     {
         byte[] decoded=decode(encoded);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/UnixCrypt.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/UnixCrypt.java
@@ -23,6 +23,7 @@
 
 package org.eclipse.jetty.util.security;
 
+import java.nio.charset.StandardCharsets;
 
 /* ------------------------------------------------------------ */
 /**
@@ -444,7 +445,7 @@ public class UnixCrypt
             rsltblock >>= 6;
         }
 
-        return new String(cryptresult, 0, 13);
+        return new String(cryptresult, 0, 13, StandardCharsets.US_ASCII);
     }
 
     public static void main(String[] arg)


### PR DESCRIPTION
Ignored warning in B64Code
US-ASCII in UnixCrypt
#2206

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>