### PR TITLE
Disabled errorprone OperatorPrecedence warnings #2206

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1066,6 +1066,7 @@
                 <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 <compilerArgs>
                   <arg>-XepAllErrorsAsWarnings</arg>
+                  <arg>-Xep:OperatorPrecedence:OFF</arg>
                 </compilerArgs>
               </configuration>
               <dependencies>


### PR DESCRIPTION
brackets can be used optionally for clarity but aren't manditory #2206

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>