### PR TITLE
Adding Log4j2 logging adapter

### DIFF
--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -81,6 +81,12 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
     <!--
       This dependency is used to test Slf4jLog.
       Due to the introduction of src/test/resource/jetty-logging.properties (and the Log.static{} block)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/Log4j2Log.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/Log4j2Log.java
@@ -1,0 +1,124 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util.log;
+
+import org.apache.logging.log4j.LogManager;
+
+/**
+ * Implementation of {@link Logger} based on {@link org.apache.logging.log4j.Logger}.
+ */
+public class Log4j2Log extends AbstractLogger
+{
+    private volatile boolean debugEnabled = false;
+
+    private final org.apache.logging.log4j.Logger log;
+
+    public Log4j2Log(String fullname)
+    {
+        log = LogManager.getLogger(fullname);
+    }
+
+    @Override
+    protected Logger newLogger(String fullname)
+    {
+        return new Log4j2Log(fullname);
+    }
+
+    @Override
+    public String getName()
+    {
+        return log.getName();
+    }
+
+    @Override
+    public void warn(String msg, Object... args)
+    {
+        log.warn(msg, args);
+    }
+
+    @Override
+    public void warn(Throwable thrown)
+    {
+        log.warn(thrown);
+    }
+
+    @Override
+    public void warn(String msg, Throwable thrown)
+    {
+        log.warn(msg, thrown);
+    }
+
+    @Override
+    public void info(String msg, Object... args)
+    {
+        log.info(msg, args);
+    }
+
+    @Override
+    public void info(Throwable thrown)
+    {
+        log.info(thrown);
+    }
+
+    @Override
+    public void info(String msg, Throwable thrown)
+    {
+        log.info(msg);
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return log.isDebugEnabled() || debugEnabled;
+    }
+
+    @Override
+    public void setDebugEnabled(boolean enabled)
+    {
+        debugEnabled = enabled;
+    }
+
+    @Override
+    public void debug(String msg, Object... args)
+    {
+        if (isDebugEnabled())
+            log.debug(msg, args);
+    }
+
+    @Override
+    public void debug(Throwable thrown)
+    {
+        if (isDebugEnabled())
+            log.debug(thrown);
+    }
+
+    @Override
+    public void debug(String msg, Throwable thrown)
+    {
+        if (isDebugEnabled())
+            log.debug(msg, thrown);
+    }
+
+    @Override
+    public void ignore(Throwable ignored)
+    {
+        if (isDebugEnabled())
+            log.debug("Ignoring: " + ignored.getMessage());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-support-version>1.4</build-support-version>
     <slf4j-version>1.6.6</slf4j-version>
+    <log4j2-version>2.9.0</log4j2-version>
     <jetty-test-policy-version>1.2</jetty-test-policy-version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <jsp.version>8.5.24.1</jsp.version>
@@ -977,6 +978,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2-version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
This patch introduces Log4j2Log logging adapter that could be used to log directly via log4j without a need of having slf4j on  classpath. Works similar to JavaUtilLog.

See: https://www.eclipse.org/jetty/documentation/9.4.x/configuring-logging.html
