### PR TITLE
Resolved errorprone ReferenceEquality warnings #2206

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
@@ -82,6 +82,18 @@ public class HttpContent implements Callback, Closeable
     }
 
     /**
+     * 
+     * @param buffer
+     * @return whether the input buffer has been closed
+     */
+    private static boolean isBufferClosed(ByteBuffer buffer)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean bufferClosed = (buffer == CLOSE);
+        return bufferClosed;
+    }
+    
+    /**
      * @return whether there is any content at all
      */
     public boolean hasContent()
@@ -177,6 +189,7 @@ public class HttpContent implements Callback, Closeable
     /**
      * @return whether the cursor has been advanced past the {@link #isLast() last} position.
      */
+    @SuppressWarnings("ReferenceEquality")
     public boolean isConsumed()
     {
         return buffer == AFTER;
@@ -187,7 +200,7 @@ public class HttpContent implements Callback, Closeable
     {
         if (isConsumed())
             return;
-        if (buffer == CLOSE)
+        if (isBufferClosed(buffer))
             return;
         if (iterator instanceof Callback)
             ((Callback)iterator).succeeded();
@@ -198,7 +211,7 @@ public class HttpContent implements Callback, Closeable
     {
         if (isConsumed())
             return;
-        if (buffer == CLOSE)
+        if (isBufferClosed(buffer))
             return;
         if (iterator instanceof Callback)
             ((Callback)iterator).failed(x);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
@@ -82,15 +82,14 @@ public class HttpContent implements Callback, Closeable
     }
 
     /**
-     * 
      * @param buffer
-     * @return whether the input buffer has been closed
+     * @return true if the buffer is the sentinel instance {@link CLOSE}
      */
-    private static boolean isBufferClosed(ByteBuffer buffer)
+    private static boolean isTheCloseBuffer(ByteBuffer buffer)
     {
         @SuppressWarnings("ReferenceEquality")
-        boolean bufferClosed = (buffer == CLOSE);
-        return bufferClosed;
+        boolean isTheCloseBuffer = (buffer == CLOSE);
+        return isTheCloseBuffer;
     }
     
     /**
@@ -200,7 +199,7 @@ public class HttpContent implements Callback, Closeable
     {
         if (isConsumed())
             return;
-        if (isBufferClosed(buffer))
+        if (isTheCloseBuffer(buffer))
             return;
         if (iterator instanceof Callback)
             ((Callback)iterator).succeeded();
@@ -211,7 +210,7 @@ public class HttpContent implements Callback, Closeable
     {
         if (isConsumed())
             return;
-        if (isBufferClosed(buffer))
+        if (isTheCloseBuffer(buffer))
             return;
         if (iterator instanceof Callback)
             ((Callback)iterator).failed(x);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -204,7 +204,10 @@ public class HttpRequest implements Request
     {
         if (uri == null)
             uri = buildURI(true);
-        return uri == NULL_URI ? null : uri;
+        
+        @SuppressWarnings("ReferenceEquality")
+        boolean isNullURI = (uri == NULL_URI);
+        return isNullURI ? null : uri;
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
@@ -321,10 +321,10 @@ public class HttpSenderOverHTTP extends HttpSender
         private void release()
         {
             ByteBufferPool bufferPool = httpClient.getByteBufferPool();
-            if (headerBuffer != BufferUtil.EMPTY_BUFFER)
+            if (!BufferUtil.isTheEmptyBuffer(headerBuffer))
                 bufferPool.release(headerBuffer);
             headerBuffer = null;
-            if (chunkBuffer != BufferUtil.EMPTY_BUFFER)
+            if (!BufferUtil.isTheEmptyBuffer(chunkBuffer))
                 bufferPool.release(chunkBuffer);
             chunkBuffer = null;
             contentBuffer = null;

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -589,6 +589,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
                 public ByteBuffer current;
 
                 @Override
+                @SuppressWarnings("ReferenceEquality")
                 public boolean hasNext()
                 {
                     if (current == null)

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -311,10 +312,12 @@ public class DeploymentManager extends ContainerLifeCycle
      */
     public Collection<App> getApps(Node node)
     {
+        Objects.requireNonNull(node);
+        
         List<App> ret = new ArrayList<>();
         for (AppEntry entry : _apps)
         {
-            if (entry.lifecyleNode == node)
+            if (node.equals(entry.lifecyleNode))
             {
                 ret.add(entry.app);
             }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Edge.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Edge.java
@@ -74,23 +74,9 @@ public final class Edge
         return _from;
     }
     
-    public boolean isFromNode(Node node)
-    {
-        @SuppressWarnings("ReferenceEquality")
-        boolean isFromNode_ = (_from == node);
-        return isFromNode_;
-    }
-
     public Node getTo()
     {
         return _to;
-    }
-    
-    public boolean isToNode(Node node)
-    {
-        @SuppressWarnings("ReferenceEquality")
-        boolean isToNode_ = (_to == node);
-        return isToNode_;
     }
     
     @Override

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Edge.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Edge.java
@@ -28,7 +28,9 @@ public final class Edge
 
     public Edge(Node from, Node to)
     {
-        if (from==null || to==null || from==to)
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameObject = (from==to);
+        if (from==null || to==null || sameObject)
             throw new IllegalArgumentException("from "+from+" to "+to);
         _from = from;
         _to = to;
@@ -71,10 +73,24 @@ public final class Edge
     {
         return _from;
     }
+    
+    public boolean isFromNode(Node node)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean isFromNode_ = (_from == node);
+        return isFromNode_;
+    }
 
     public Node getTo()
     {
         return _to;
+    }
+    
+    public boolean isToNode(Node node)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean isToNode_ = (_to == node);
+        return isToNode_;
     }
     
     @Override

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Graph.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Graph.java
@@ -40,7 +40,7 @@ public class Graph
             addNode(toNode=edge.getTo());
         
         // replace edge with normalized edge
-        if (!edge.isFromNode(fromNode) || !edge.isToNode(toNode))
+        if (!edge.getFrom().equals(fromNode) || !edge.getTo().equals(toNode))
             edge=new Edge(fromNode,toNode);
         
         this._edges.add(edge);
@@ -129,7 +129,7 @@ public class Graph
 
         for (Edge edge : this._edges)
         {
-            if (edge.isFromNode(node) || edge.isToNode(node))
+            if (edge.getFrom().equals(node) || edge.getTo().equals(node))
             {
                 fromedges.add(edge);
             }
@@ -151,7 +151,7 @@ public class Graph
 
         for (Edge edge : this._edges)
         {
-            if (edge.isFromNode(from))
+            if (edge.getFrom().equals(from))
             {
                 fromedges.add(edge);
             }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Graph.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/graph/Graph.java
@@ -40,7 +40,7 @@ public class Graph
             addNode(toNode=edge.getTo());
         
         // replace edge with normalized edge
-        if (edge.getFrom()!=fromNode || edge.getTo()!=toNode)
+        if (!edge.isFromNode(fromNode) || !edge.isToNode(toNode))
             edge=new Edge(fromNode,toNode);
         
         this._edges.add(edge);
@@ -129,7 +129,7 @@ public class Graph
 
         for (Edge edge : this._edges)
         {
-            if ((edge.getFrom() == node) || (edge.getTo() == node))
+            if (edge.isFromNode(node) || edge.isToNode(node))
             {
                 fromedges.add(edge);
             }
@@ -151,7 +151,7 @@ public class Graph
 
         for (Edge edge : this._edges)
         {
-            if (edge.getFrom() == from)
+            if (edge.isFromNode(from))
             {
                 fromedges.add(edge);
             }
@@ -192,7 +192,9 @@ public class Graph
      */
     public Path getPath(Node from, Node to)
     {
-        if (from == to)
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameObject = (from==to);
+        if (sameObject)
         {
             return new Path();
         }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/jmx/DeploymentManagerMBean.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/jmx/DeploymentManagerMBean.java
@@ -74,7 +74,7 @@ public class DeploymentManagerMBean extends ObjectMBean
         List<String> ret = new ArrayList<>();
         for (DeploymentManager.AppEntry entry : _manager.getAppEntries())
         {
-            if (entry.getLifecyleNode() == node)
+            if (node.equals(entry.getLifecyleNode()))
             {
                 ret.add(toRef(entry.getApp()));
             }

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
@@ -127,7 +127,9 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements Connec
 
     private void releaseBuffer(ByteBuffer buffer)
     {
-        assert this.buffer == buffer;
+        @SuppressWarnings("ReferenceEquality")
+        boolean isCurrentBuffer = (this.buffer == buffer);
+        assert(isCurrentBuffer);
         HttpClient client = destination.getHttpClient();
         ByteBufferPool bufferPool = client.getByteBufferPool();
         bufferPool.release(buffer);

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -417,7 +417,9 @@ public class GZIPContentDecoder implements Destroyable
      */
     public void release(ByteBuffer buffer)
     {
-        if (_pool!=null && buffer!=BufferUtil.EMPTY_BUFFER)
+        @SuppressWarnings("ReferenceEquality")
+        boolean isBufferEmpty = (buffer!=BufferUtil.EMPTY_BUFFER);
+        if (_pool!=null && isBufferEmpty)
             _pool.release(buffer);
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -418,8 +418,8 @@ public class GZIPContentDecoder implements Destroyable
     public void release(ByteBuffer buffer)
     {
         @SuppressWarnings("ReferenceEquality")
-        boolean isBufferEmpty = (buffer!=BufferUtil.EMPTY_BUFFER);
-        if (_pool!=null && isBufferEmpty)
+        boolean isTheEmptyBuffer = (buffer!=BufferUtil.EMPTY_BUFFER);
+        if (_pool!=null && isTheEmptyBuffer)
             _pool.release(buffer);
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -418,8 +418,8 @@ public class GZIPContentDecoder implements Destroyable
     public void release(ByteBuffer buffer)
     {
         @SuppressWarnings("ReferenceEquality")
-        boolean isTheEmptyBuffer = (buffer!=BufferUtil.EMPTY_BUFFER);
-        if (_pool!=null && isTheEmptyBuffer)
+        boolean isTheEmptyBuffer = (buffer==BufferUtil.EMPTY_BUFFER);
+        if (_pool!=null && !isTheEmptyBuffer)
             _pool.release(buffer);
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
@@ -276,9 +276,12 @@ public class HttpField
 
     public boolean isSameName(HttpField field)
     {
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameObject = (field==this);
+
         if (field==null)
             return false;
-        if (field==this)
+        if (sameObject)
             return true;
         if (_header!=null && _header==field.getHeader())
             return true;

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -2025,6 +2025,7 @@ public class HttpParserTest
         Assert.assertEquals(null, _bad);
     }
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testCachedField() throws Exception
     {
         ByteBuffer buffer = BufferUtil.toBuffer(

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackContextTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackContextTest.java
@@ -131,6 +131,7 @@ public class HpackContextTest
         assertNull(ctx.get("name"));
     }
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testGetAddStatic()
     {
         HpackContext ctx = new HpackContext(4096);

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
@@ -202,7 +202,7 @@ public class ByteArrayEndPoint extends AbstractEndPoint
                 throw new ClosedChannelException();
 
             ByteBuffer in = _inQ.peek();
-            if (BufferUtil.hasContent(in) || in==EOF)
+            if (BufferUtil.hasContent(in) || isEOF(in))
                 execute(_runFillable);
         }
     }
@@ -224,7 +224,7 @@ public class ByteArrayEndPoint extends AbstractEndPoint
         boolean fillable=false;
         try(Locker.Lock lock = _locker.lock())
         {
-            if (_inQ.peek()==EOF)
+            if (isEOF(_inQ.peek()))
                 throw new RuntimeIOException(new EOFException());
             boolean was_empty=_inQ.isEmpty();
             if (in==null)
@@ -248,7 +248,7 @@ public class ByteArrayEndPoint extends AbstractEndPoint
         boolean fillable=false;
         try(Locker.Lock lock = _locker.lock())
         {
-            if (_inQ.peek()==EOF)
+            if (isEOF(_inQ.peek()))
                 throw new RuntimeIOException(new EOFException());
             boolean was_empty=_inQ.isEmpty();
             if (in==null)
@@ -415,7 +415,7 @@ public class ByteArrayEndPoint extends AbstractEndPoint
                     break;
 
                 ByteBuffer in= _inQ.peek();
-                if (in==EOF)
+                if (isEOF(in))
                 {
                     filled=-1;
                     break;
@@ -549,4 +549,16 @@ public class ByteArrayEndPoint extends AbstractEndPoint
         return String.format("%s[q=%d,q[0]=%s,o=%s]",super.toString(),q,b,o);
     }
 
+    /* ------------------------------------------------------------ */
+    /**
+     * Compares a ByteBuffer Object to EOF by Reference
+     * @param buffer the input ByteBuffer to be compared to EOF
+     * @return Whether the reference buffer is equal to that of EOF
+     */
+    private static boolean isEOF(ByteBuffer buffer)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean is_EOF = (buffer==EOF);
+        return is_EOF;
+    }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -626,8 +626,12 @@ public class SslConnection extends AbstractConnection
 
                         // We also need an app buffer, but can use the passed buffer if it is big enough
                         ByteBuffer app_in;
+                        boolean used_passed_buffer = false;
                         if (BufferUtil.space(buffer) > _sslEngine.getSession().getApplicationBufferSize())
+                        {
                             app_in = buffer;
+                            used_passed_buffer = true;
+                        }
                         else if (_decryptedInput == null)
                             app_in = _decryptedInput = _bufferPool.acquire(_sslEngine.getSession().getApplicationBufferSize(), _decryptedDirectBuffers);
                         else
@@ -729,7 +733,7 @@ public class SslConnection extends AbstractConnection
                                         // another call to fill() or flush().
                                         if (unwrapResult.bytesProduced() > 0)
                                         {
-                                            if (app_in == buffer)
+                                            if (used_passed_buffer)
                                                 return unwrapResult.bytesProduced();
                                             return BufferUtil.append(buffer,_decryptedInput);
                                         }

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import org.eclipse.jetty.io.ByteBufferPool.Bucket;
 import org.junit.Test;
 
+@SuppressWarnings("ReferenceEquality")
 public class ArrayByteBufferPoolTest
 {
     @Test
@@ -113,6 +114,7 @@ public class ArrayByteBufferPoolTest
     }
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testAcquireReleaseAcquire() throws Exception
     {
         ArrayByteBufferPool bufferPool = new ArrayByteBufferPool(10,100,1000);

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ValidUrlRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ValidUrlRule.java
@@ -115,7 +115,7 @@ public class ValidUrlRule extends Rule
         
         LOG.debug("{} {} {} {}", Character.charCount(codepoint), codepoint, block, Character.isISOControl(codepoint));
         
-        return (!Character.isISOControl(codepoint)) && block != null && block != Character.UnicodeBlock.SPECIALS;       
+        return (!Character.isISOControl(codepoint)) && block != null && !Character.UnicodeBlock.SPECIALS.equals(block);       
     }
 
     public String toString()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -427,7 +427,10 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
         if (LOG.isDebugEnabled())
             LOG.debug("upgrade {} {}", this, _upgrade);
 
-        if (_upgrade != PREAMBLE_UPGRADE_H2C && (_connection == null || !_connection.contains("upgrade")))
+        @SuppressWarnings("ReferenceEquality")
+        boolean isUpgraded_H2C = (_upgrade == PREAMBLE_UPGRADE_H2C);
+
+        if (!isUpgraded_H2C && (_connection == null || !_connection.contains("upgrade")))
             throw new BadMessageException(HttpStatus.BAD_REQUEST_400);
 
         // Find the upgrade factory
@@ -464,7 +467,7 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
         // Send 101 if needed
         try
         {
-            if (_upgrade != PREAMBLE_UPGRADE_H2C)
+            if (!isUpgraded_H2C)
                 sendResponse(new MetaData.Response(HttpVersion.HTTP_1_1, HttpStatus.SWITCHING_PROTOCOLS_101, response101, 0), null, true);
         }
         catch (IOException e)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -145,6 +145,18 @@ public class Request implements HttpServletRequest
 
     /* ------------------------------------------------------------ */
     /**
+     * Compare inputParameters to NO_PARAMS by Reference
+     * @param inputParameters The parameters to compare to NO_PARAMS
+     * @return True if the inputParameters reference is equal to NO_PARAMS otherwise False
+     */
+    private static boolean isNoParams(MultiMap<String> inputParameters) {
+        @SuppressWarnings("ReferenceEquality")
+        boolean is_no_params = (inputParameters==NO_PARAMS);
+        return is_no_params;
+    }
+
+    /* ------------------------------------------------------------ */
+    /**
      * Obtain the base {@link Request} instance of a {@link ServletRequest}, by
      * coercion, unwrapping or special attribute.
      * @param request The request
@@ -397,9 +409,9 @@ public class Request implements HttpServletRequest
         }
 
         // Do parameters need to be combined?
-        if (_queryParameters==NO_PARAMS || _queryParameters.size()==0)
+        if (isNoParams(_queryParameters) || _queryParameters.size()==0)
             _parameters=_contentParameters;
-        else if (_contentParameters==NO_PARAMS || _contentParameters.size()==0)
+        else if (isNoParams(_contentParameters) || _contentParameters.size()==0)
             _parameters=_queryParameters;
         else
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
@@ -456,11 +456,29 @@ public class ResponseWriter extends PrintWriter
     { 
         try 
         {
+            
+            if(l==null) 
+                l = _locale;
+            
             synchronized (lock) 
             {
                 isOpen();
-                if ((_formatter == null) || (_formatter.locale() != l))
+
+                if(_formatter == null)
+                {
                     _formatter = new Formatter(this, l);
+                } 
+                else if(_formatter.locale() != null) 
+                {
+                    if(!_formatter.locale().equals(l))
+                        _formatter = new Formatter(this, l);
+                } 
+                else 
+                {
+                    if(l != null)
+                        _formatter = new Formatter(this, l);
+                }
+                
                 _formatter.format(l, format, args);
             }
         } 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
@@ -470,11 +470,6 @@ public class ResponseWriter extends PrintWriter
                 {
                     _formatter = new Formatter(this, locale);
                 } 
-                else if(_formatter.locale()==null)
-                {
-                    if(locale != null)
-                        _formatter = new Formatter(this, locale);
-                }
                 else if (!_formatter.locale().equals(locale))
                 {
                     _formatter = new Formatter(this, locale);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java
@@ -452,13 +452,15 @@ public class ResponseWriter extends PrintWriter
     }
 
     @Override
-    public PrintWriter format(Locale l, String format, Object... args)
+    public PrintWriter format(Locale locale, String format, Object... args)
     { 
         try 
         {
             
-            if(l==null) 
-                l = _locale;
+            /* If the passed locale is null then 
+            use any locale set on the response as the default. */
+            if(locale == null) 
+                locale = _locale;
             
             synchronized (lock) 
             {
@@ -466,20 +468,19 @@ public class ResponseWriter extends PrintWriter
 
                 if(_formatter == null)
                 {
-                    _formatter = new Formatter(this, l);
+                    _formatter = new Formatter(this, locale);
                 } 
-                else if(_formatter.locale() != null) 
+                else if(_formatter.locale()==null)
                 {
-                    if(!_formatter.locale().equals(l))
-                        _formatter = new Formatter(this, l);
-                } 
-                else 
+                    if(locale != null)
+                        _formatter = new Formatter(this, locale);
+                }
+                else if (!_formatter.locale().equals(locale))
                 {
-                    if(l != null)
-                        _formatter = new Formatter(this, l);
+                    _formatter = new Formatter(this, locale);
                 }
                 
-                _formatter.format(l, format, args);
+                _formatter.format(locale, format, args);
             }
         } 
         catch (InterruptedIOException ex)

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -514,7 +514,9 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             if ((_welcomeServlets || _welcomeExactServlets) && welcome_servlet==null)
             {
                 MappedResource<ServletHolder> entry=_servletHandler.getMappedServlet(welcome_in_context);
-                if (entry!=null && entry.getResource()!=_defaultHolder &&
+                @SuppressWarnings("ReferenceEquality")
+                boolean isDefaultHolder = (entry.getResource()!=_defaultHolder);
+                if (entry!=null && isDefaultHolder &&
                         (_welcomeServlets || (_welcomeExactServlets && entry.getPathSpec().getDeclaration().equals(welcome_in_context))))
                     welcome_servlet=welcome_in_context;
 

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -1513,7 +1513,9 @@ public class ServletHandler extends ScopedHandler
         boolean found = false;
         for (ServletHolder s:_servlets)
         {
-            if (s == holder)
+            @SuppressWarnings("ReferenceEquality")
+            boolean foundServletHolder = (s == holder);
+            if (foundServletHolder)
                 found = true;
         }
         return found;

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -381,7 +381,7 @@ public class DoSFilter implements Filter
                 // or if we were woken up we insist or we fail.
                 Boolean throttled = (Boolean)request.getAttribute(__THROTTLED);
                 long throttleMs = getThrottleMs();
-                if (Boolean.FALSE.equals(throttled) && throttleMs > 0)
+                if (!Boolean.TRUE.equals(throttled) && throttleMs > 0)
                 {
                     int priority = getPriority(request, tracker);
                     request.setAttribute(__THROTTLED, Boolean.TRUE);

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -381,7 +381,7 @@ public class DoSFilter implements Filter
                 // or if we were woken up we insist or we fail.
                 Boolean throttled = (Boolean)request.getAttribute(__THROTTLED);
                 long throttleMs = getThrottleMs();
-                if (throttled != Boolean.TRUE && throttleMs > 0)
+                if (Boolean.FALSE.equals(throttled) && throttleMs > 0)
                 {
                     int priority = getPriority(request, tracker);
                     request.setAttribute(__THROTTLED, Boolean.TRUE);
@@ -399,7 +399,7 @@ public class DoSFilter implements Filter
                 }
 
                 Boolean resumed = (Boolean)request.getAttribute(_resumed);
-                if (resumed == Boolean.TRUE)
+                if (Boolean.TRUE.equals(resumed))
                 {
                     // We were resumed, we wait for the next pass.
                     _passes.acquire();
@@ -444,7 +444,7 @@ public class DoSFilter implements Filter
                         {
                             ServletRequest candidate = asyncContext.getRequest();
                             Boolean suspended = (Boolean)candidate.getAttribute(_suspended);
-                            if (suspended == Boolean.TRUE)
+                            if (Boolean.TRUE.equals(suspended))
                             {
                                 if (LOG.isDebugEnabled())
                                     LOG.debug("Resuming {}", request);

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/QoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/QoSFilter.java
@@ -171,7 +171,7 @@ public class QoSFilter implements Filter
                 {
                     request.setAttribute(_suspended, Boolean.FALSE);
                     Boolean resumed = (Boolean)request.getAttribute(_resumed);
-                    if (resumed == Boolean.TRUE)
+                    if (Boolean.TRUE.equals(resumed))
                     {
                         _passes.acquire();
                         accepted = true;
@@ -222,7 +222,7 @@ public class QoSFilter implements Filter
                     {
                         ServletRequest candidate = asyncContext.getRequest();
                         Boolean suspended = (Boolean)candidate.getAttribute(_suspended);
-                        if (suspended == Boolean.TRUE)
+                        if (Boolean.TRUE.equals(suspended))
                         {
                             candidate.setAttribute(_resumed, Boolean.TRUE);
                             asyncContext.dispatch();

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -305,7 +305,7 @@ public class Modules implements Iterable<Module>
             {
                 for (Module p:providers)
                 { 
-                    if (p!=module && p.isEnabled())
+                    if (!p.equals(module) && p.isEnabled())
                     {
                         // If the already enabled module is transitive and this enable is not
                         if (p.isTransitive() && !transitive)
@@ -364,8 +364,8 @@ public class Modules implements Iterable<Module>
             }
             
             // If a provider is already enabled, then add a transitive enable
-            if (providers.stream().filter(Module::isEnabled).count()!=0)
-                providers.stream().filter(m->m.isEnabled()&&m!=module).forEach(m->enable(newlyEnabled,m,"transitive provider of "+dependsOn+" for "+module.getName(),true));
+            if (providers.stream().filter(Module::isEnabled).count()>0)
+                providers.stream().filter(m->m.isEnabled()&&!m.equals(module)).forEach(m->enable(newlyEnabled,m,"transitive provider of "+dependsOn+" for "+module.getName(),true));
             else
             {
                 // Is there an obvious default?

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -238,6 +238,17 @@ public class BufferUtil
         }
     }
 
+    /**
+     * @param buf the buffer to check
+     * @return true if buf is equal to EMPTY_BUFFER
+     */
+    public static boolean isTheEmptyBuffer(ByteBuffer buf)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean isTheEmptyBuffer_ = (buf == EMPTY_BUFFER);
+        return isTheEmptyBuffer_;
+    }
+    
     /* ------------------------------------------------------------ */
     /** Check for an empty or null buffer.
      * @param buf the buffer to check

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -254,8 +254,8 @@ public class Fields implements Iterable<Fields.Field>
         public boolean equals(Field that, boolean caseSensitive)
         {
             @SuppressWarnings("ReferenceEquality")
-            boolean isCurrentObject = (this == that);
-            if (isCurrentObject)
+            boolean isThisInstance = (this == that);
+            if (isThisInstance)
                 return true;
             if (that == null)
                 return false;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -253,7 +253,9 @@ public class Fields implements Iterable<Fields.Field>
 
         public boolean equals(Field that, boolean caseSensitive)
         {
-            if (this == that)
+            @SuppressWarnings("ReferenceEquality")
+            boolean isCurrentObject = (this == that);
+            if (isCurrentObject)
                 return true;
             if (that == null)
                 return false;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -251,11 +251,10 @@ public class Fields implements Iterable<Fields.Field>
             this.values = Collections.unmodifiableList(list);
         }
 
+        @SuppressWarnings("ReferenceEquality")
         public boolean equals(Field that, boolean caseSensitive)
         {
-            @SuppressWarnings("ReferenceEquality")
-            boolean isThisInstance = (this == that);
-            if (isThisInstance)
+            if (this == that)
                 return true;
             if (that == null)
                 return false;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -221,7 +221,7 @@ public class UrlEncoded extends MultiMap<String> implements Cloneable
         if (charset==null)
             charset=ENCODING;
 
-        if (charset==StandardCharsets.UTF_8)
+        if (StandardCharsets.UTF_8.equals(charset))
         {
             decodeUtf8To(content,0,content.length(),map);
             return;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/StdErrLog.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/StdErrLog.java
@@ -211,7 +211,9 @@ public class StdErrLog extends AbstractLogger
      */
     public StdErrLog(String name, Properties props)
     {
-        if (props!=null && props!=Log.__props)
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameObject = (props!=Log.__props);
+        if (props!=null && sameObject)
             Log.__props.putAll(props);
         _name = name == null?"":name;
         _abbrevname = condensePackageString(this._name);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -416,7 +416,9 @@ public class FileResource extends Resource
             return false;
 
         FileResource f=(FileResource)o;
-        return f._file == _file || (null != _file && _file.equals(f._file));
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameFile = f._file==_file;
+        return sameFile || (null != _file && _file.equals(f._file));
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -407,6 +407,7 @@ public class FileResource extends Resource
      * @return <code>true</code> of the object <code>o</code> is a {@link FileResource} pointing to the same file as this resource. 
      */
     @Override
+    @SuppressWarnings("ReferenceEquality")
     public boolean equals( Object o)
     {
         if (this == o)
@@ -416,9 +417,7 @@ public class FileResource extends Resource
             return false;
 
         FileResource f=(FileResource)o;
-        @SuppressWarnings("ReferenceEquality")
-        boolean sameFile = f._file==_file;
-        return sameFile || (null != _file && _file.equals(f._file));
+        return f._file==_file || (null != _file && _file.equals(f._file));
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
@@ -95,7 +95,9 @@ public abstract class Credential implements Serializable
      */
     protected static boolean stringEquals(String known, String unknown)
     {
-        if (known == unknown)
+        @SuppressWarnings("ReferenceEquality")
+        boolean sameObject = (known == unknown);
+        if (sameObject)
             return true;
         if (known == null || unknown == null)
             return false;

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
@@ -297,6 +297,7 @@ public class BufferUtilTest
 
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testEnsureCapacity() throws Exception
     {
         ByteBuffer b = BufferUtil.toBuffer("Goodbye Cruel World");

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/DateCacheTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/DateCacheTest.java
@@ -40,6 +40,7 @@ public class DateCacheTest
     /* ------------------------------------------------------------ */
     @Test
     @Slow
+    @SuppressWarnings("ReferenceEquality")
     public void testDateCache() throws Exception
     {
         //@WAS: Test t = new Test("org.eclipse.jetty.util.DateCache");

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 public class StringUtilTest
 {
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testAsciiToLowerCase()
     {
         String lc="\u0690bc def 1\u06903";
@@ -88,6 +89,7 @@ public class StringUtilTest
     }
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testReplace()
     {
         String s="\u0690bc \u0690bc \u0690bc";
@@ -100,6 +102,7 @@ public class StringUtilTest
     }
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testUnquote()
     {
         String uq =" not quoted ";
@@ -112,9 +115,10 @@ public class StringUtilTest
 
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testNonNull()
     {
-        String nn="";
+        String nn="non empty string";
         assertTrue(nn==StringUtil.nonNull(nn));
         assertEquals("",StringUtil.nonNull(null));
     }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/TopologicalSortTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/TopologicalSortTest.java
@@ -193,6 +193,7 @@ public class TopologicalSortTest
         }
     }
     
+    @SuppressWarnings("ReferenceEquality")
     private int indexOf(String[] list,String s)
     {
         for (int i=0;i<list.length;i++)

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/ClasspathPattern.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/ClasspathPattern.java
@@ -696,9 +696,9 @@ public class ClasspathPattern extends AbstractSet<String>
                 LOG.debug("match {} from {} byName={} byLocation={} in {}",clazz,location,byName,byLocation,this);
             
             // Combine the tri-state match of both IncludeExclude Sets
-            boolean included = byName==Boolean.TRUE || byLocation==Boolean.TRUE
+            boolean included = Boolean.TRUE.equals(byName) || Boolean.TRUE.equals(byLocation)
                 || (byName==null && !_patterns.hasIncludes() && byLocation==null && !_locations.hasIncludes());
-            boolean excluded = byName==Boolean.FALSE || byLocation==Boolean.FALSE;
+            boolean excluded = Boolean.FALSE.equals(byName) || Boolean.FALSE.equals(byLocation);
             return included && !excluded;
         }
         catch (Exception e)
@@ -737,9 +737,9 @@ public class ClasspathPattern extends AbstractSet<String>
         }
 
         // Combine the tri-state match of both IncludeExclude Sets
-        boolean included = byName==Boolean.TRUE || byLocation==Boolean.TRUE
+        boolean included = Boolean.TRUE.equals(byName) || Boolean.TRUE.equals(byLocation)
             || (byName==null && !_patterns.hasIncludes() && byLocation==null && !_locations.hasIncludes());
-        boolean excluded = byName==Boolean.FALSE || byLocation==Boolean.FALSE;
+        boolean excluded = Boolean.FALSE.equals(byName) || Boolean.FALSE.equals(byLocation);
         return included && !excluded;
     }
     

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
@@ -45,6 +45,13 @@ public class MessageInputStream extends InputStream implements MessageAppender
     private final long timeoutMs;
     private ByteBuffer activeBuffer = null;
 
+    private static boolean isBufferEOF(ByteBuffer buf)
+    {
+        @SuppressWarnings("ReferenceEquality")
+        boolean isBufferEOF_ = (buf==EOF);
+        return isBufferEOF_;
+    }
+    
     public MessageInputStream()
     {
         this(-1);
@@ -166,7 +173,7 @@ public class MessageInputStream extends InputStream implements MessageAppender
                     }
                 }
 
-                if (activeBuffer == EOF)
+                if (isBufferEOF(activeBuffer))
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("Reached EOF");

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
@@ -45,11 +45,11 @@ public class MessageInputStream extends InputStream implements MessageAppender
     private final long timeoutMs;
     private ByteBuffer activeBuffer = null;
 
-    private static boolean isBufferEOF(ByteBuffer buf)
+    private static boolean isTheEofBuffer(ByteBuffer buf)
     {
         @SuppressWarnings("ReferenceEquality")
-        boolean isBufferEOF_ = (buf==EOF);
-        return isBufferEOF_;
+        boolean isTheEofBuffer = (buf==EOF);
+        return isTheEofBuffer;
     }
     
     public MessageInputStream()
@@ -173,7 +173,7 @@ public class MessageInputStream extends InputStream implements MessageAppender
                     }
                 }
 
-                if (isBufferEOF(activeBuffer))
+                if (isTheEofBuffer(activeBuffer))
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("Reached EOF");

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractSessionInvalidateCreateScavengeTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractSessionInvalidateCreateScavengeTest.java
@@ -85,6 +85,7 @@ public abstract class AbstractSessionInvalidateCreateScavengeTest extends Abstra
     }
 
     @Test
+    @SuppressWarnings("ReferenceEquality")
     public void testSessionScavenge() throws Exception
     {
         String contextPath = "/";


### PR DESCRIPTION
Objects which inherit or implement an `equals()` method should not be compared with == or !=
When the comparison of references is intentional `@SuppressWarnings("ReferenceEquality")` can be used

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>