### PR TITLE
Jetty 9.4.x 2059 make osgi tests work jre9

### DIFF
--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -508,7 +508,7 @@
         <dependency>
           <groupId>org.conscrypt</groupId>
           <artifactId>conscrypt-openjdk-uber</artifactId>
-          <version>1.0.0.RC11</version>
+          <version>${conscrypt.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -478,7 +478,7 @@
     <profile>
       <id>jdk8</id>
       <activation>
-        <jdk>[1.8,9]</jdk>
+        <jdk>[1.8,9)</jdk>
       </activation>
       <dependencies>
         <dependency>
@@ -519,7 +519,7 @@
         <configuration>
           <skipTests>false</skipTests>
           <excludes>
-             <exclude>**/*JDK9*</exclude>
+             <exclude>**/TestJettyOSGiBootHTTP2JDK9*</exclude>
           </excludes>
           <!-- No point defining -Xbootclasspath as the actual OSGi VM is run as a forked process by pax-exam -->
           <!-- But we do pass the sys property of the alpn-boot jar so that it can be configured inside tests -->
@@ -532,9 +532,27 @@
     <profile>
       <id>jdk9</id>
       <activation>
-        <jdk>[1.9,)</jdk>
+        <jdk>[9,)</jdk>
       </activation>
       <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-alpn-conscrypt-server</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-alpn-conscrypt-client</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.conscrypt</groupId>
+          <artifactId>conscrypt-openjdk-uber</artifactId>
+          <version>1.0.0.RC11</version>
+          <scope>test</scope>
+        </dependency>
         <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-alpn-java-server</artifactId>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -478,7 +478,7 @@
     <profile>
       <id>jdk8</id>
       <activation>
-        <jdk>[1.8,1.9)</jdk>
+        <jdk>[1.8,9]</jdk>
       </activation>
       <dependencies>
         <dependency>
@@ -554,9 +554,9 @@
          <artifactId>maven-surefire-plugin</artifactId>
          <configuration>
            <skipTests>false</skipTests>
-           <includes>
-              <include>**/*JDK9</include>
-           </includes>
+           <excludes>
+             <exclude>**/TestJettyOSGiBootHTTP2</exclude>  
+           </excludes>
          </configuration>
        </plugin>
       </plugins>

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<!-- ============================================================= -->
+<!-- Configure a HTTP2 on the ssl connector.                       -->
+<!-- ============================================================= -->
+<Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
+  <Call name="addConnectionFactory">
+    <Arg>
+      <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
+        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
+        <Set name="maxConcurrentStreams"><Property name="jetty.http2.maxConcurrentStreams" deprecated="http2.maxConcurrentStreams" default="128"/></Set>
+        <Set name="initialStreamRecvWindow"><Property name="jetty.http2.initialStreamRecvWindow" default="524288"/></Set>
+        <Set name="initialSessionRecvWindow"><Property name="jetty.http2.initialSessionRecvWindow" default="1048576"/></Set>
+      </New>
+    </Arg>
+  </Call>
+
+  <Ref refid="sslContextFactory">
+    <Set name="CipherComparator">
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+    </Set>
+    <Set name="useCipherSuitesOrder">true</Set>
+  </Ref>
+
+</Configure>

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootHTTP2JDK9.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootHTTP2JDK9.java
@@ -1,0 +1,164 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.osgi.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import javax.inject.Inject;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.CoreOptions;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * Test HTTP2 using java9 alpn.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class TestJettyOSGiBootHTTP2JDK9
+{
+    private static final String LOG_LEVEL = "WARN";
+
+
+    @Inject
+    private BundleContext bundleContext;
+
+    @Configuration
+    public Option[] config()
+    {
+        ArrayList<Option> options = new ArrayList<>();
+        options.add(CoreOptions.junitBundles());
+        options.addAll(TestOSGiUtil.configureJettyHomeAndPort(true,"jetty-http2-jdk9.xml"));
+        options.add(CoreOptions.bootDelegationPackages("org.xml.sax", "org.xml.*", "org.w3c.*", "javax.xml.*", "javax.activation.*"));
+        options.add(CoreOptions.systemPackages("com.sun.org.apache.xalan.internal.res","com.sun.org.apache.xml.internal.utils",
+                                               "com.sun.org.apache.xml.internal.utils", "com.sun.org.apache.xpath.internal",
+                                               "com.sun.org.apache.xpath.internal.jaxp", "com.sun.org.apache.xpath.internal.objects"));
+        options.addAll(http2JettyDependencies());
+
+        options.addAll(TestOSGiUtil.coreJettyDependencies());
+        options.addAll(TestOSGiUtil.jspDependencies());
+        //deploy a test webapp
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("test-jetty-webapp").classifier("webbundle").versionAsInProject());
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
+        options.add(mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-client").versionAsInProject().start());
+        options.add(mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-http-client-transport").versionAsInProject().start());
+
+        options.add(systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value(LOG_LEVEL));
+        options.add(systemProperty("org.eclipse.jetty.LEVEL").value(LOG_LEVEL));
+        options.add(CoreOptions.cleanCaches(true));
+        return options.toArray(new Option[options.size()]);
+    }
+
+    public static List<Option> http2JettyDependencies()
+    {
+        List<Option> res = new ArrayList<>();
+        res.add(CoreOptions.systemProperty("jetty.alpn.protocols").value("h2,http/1.1"));
+ 
+        res.add(mavenBundle().groupId("org.eclipse.jetty.osgi").artifactId("jetty-osgi-alpn").versionAsInProject().noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-server").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-server").versionAsInProject().start());
+
+        res.add(mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-common").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-hpack").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-server").versionAsInProject().start());
+        return res;
+    }
+ 
+
+    @Ignore
+    public void assertAllBundlesActiveOrResolved() throws Exception
+    {
+        TestOSGiUtil.debugBundles(bundleContext);
+        TestOSGiUtil.assertAllBundlesActiveOrResolved(bundleContext);
+        Bundle javaAlpn = TestOSGiUtil.getBundle(bundleContext, "org.eclipse.jetty.alpn.java.server");
+        assertNotNull(javaAlpn);
+        ServiceReference<?>[] services = javaAlpn.getRegisteredServices();
+        assertNotNull(services);        
+        Bundle server = TestOSGiUtil.getBundle(bundleContext, "org.eclipse.jetty.alpn.server");
+        assertNotNull(server);
+    }
+
+    
+
+    @Test
+    public void testHTTP2() throws Exception
+    {
+        HttpClient httpClient = null;
+        HTTP2Client http2Client = null;
+        try 
+        {
+            //get the port chosen for https
+            String port = System.getProperty("boot.https.port");
+            assertNotNull(port);
+            
+            Path path = Paths.get("src",  "test", "config");
+            File keys = path.resolve("etc").resolve("keystore").toFile();
+            
+            //set up client to do http2
+            http2Client = new HTTP2Client();
+            SslContextFactory sslContextFactory = new SslContextFactory();
+            sslContextFactory.setKeyManagerPassword("OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4");
+            sslContextFactory.setTrustStorePath(keys.getAbsolutePath());
+            sslContextFactory.setKeyStorePath(keys.getAbsolutePath());
+            sslContextFactory.setTrustStorePassword("OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4");
+            httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), sslContextFactory);
+            Executor executor = new QueuedThreadPool();
+            httpClient.setExecutor(executor);
+            httpClient.start();
+
+            ContentResponse response = httpClient.GET("https://localhost:"+port+"/jsp/jstl.jsp");
+            assertEquals(200, response.getStatus());
+            assertTrue(response.getContentAsString().contains("JSTL Example"));
+
+        }
+        finally
+        {
+            if (httpClient != null) httpClient.stop();
+            if (http2Client != null) http2Client.stop();
+        }
+    }
+
+}

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootHTTP2JDK9.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootHTTP2JDK9.java
@@ -152,7 +152,6 @@ public class TestJettyOSGiBootHTTP2JDK9
             ContentResponse response = httpClient.GET("https://localhost:"+port+"/jsp/jstl.jsp");
             assertEquals(200, response.getStatus());
             assertTrue(response.getContentAsString().contains("JSTL Example"));
-
         }
         finally
         {
@@ -160,5 +159,4 @@ public class TestJettyOSGiBootHTTP2JDK9
             if (http2Client != null) http2Client.stop();
         }
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <slf4j-version>1.6.6</slf4j-version>
     <jetty-test-policy-version>1.2</jetty-test-policy-version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
-    <jsp.version>8.5.24.1</jsp.version>
+    <jsp.version>8.5.24.2</jsp.version>
     <!-- default values are unsupported, but required to be defined for reactor sanity reasons -->
     <alpn.version>undefined</alpn.version>
     <conscrypt.version>1.0.0.RC11</conscrypt.version>


### PR DESCRIPTION
Makes appropriate tests work in jdk9, plus adds a test for the alpn-java-server/client.