### PR TITLE
Issue #2278 - making distribution pom not require tests

### DIFF
--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -398,29 +398,37 @@
   </build>
 
   <dependencies>
+    <!-- For users of jetty-distribution via maven, none of the following
+         dependencies should be mandatory to function.
+         These only exist to make the reactor sane during the build
+         of jetty-distribution itself -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-home</artifactId>
       <version>${project.version}</version>
       <type>pom</type>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>test-jetty-webapp</artifactId>
       <type>war</type>
       <version>${project.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>test-proxy-webapp</artifactId>
       <type>war</type>
       <version>${project.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.example-async-rest</groupId>
       <artifactId>example-async-rest-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -428,6 +436,7 @@
       <version>${project.version}</version>
       <classifier>html</classifier>
       <type>zip</type>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1766,6 +1766,9 @@
     <url>https://webtide.com</url>
   </organization>
 
+  <!-- SNAPSHOT Repository is only for temporary usage.
+       This configuration should not be checked in, as it
+       can result in bad success on CI.
   <repositories>
     <repository>
       <id>jetty-snapshots</id>
@@ -1776,6 +1779,7 @@
       </snapshots>
     </repository>
   </repositories>
+   -->
 
   <distributionManagement>
     <repository>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -119,6 +119,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.tests</groupId>
       <artifactId>test-webapp-rfc2616</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
- Speculative fix to ensure that the users of the jetty-distribution
  do not require the test artifacts to utilize the tarball / zip files
- Also disabled the snapshot repository as it causes false success

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>