### PR TITLE
Issue #2307 - On sendError() the response character encoding is null

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -621,6 +621,7 @@ public class Response implements HttpServletResponse
 
         _mimeType=null;
         _characterEncoding=null;
+        _encodingFrom = EncodingFrom.NOT_SET;
         _outputType = OutputType.NONE;
         setHeader(HttpHeader.EXPIRES,null);
         setHeader(HttpHeader.LAST_MODIFIED,null);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -619,10 +619,9 @@ public class Response implements HttpServletResponse
         }
 
 
-        _mimeType=null;
-        _characterEncoding=null;
-        _encodingFrom = EncodingFrom.NOT_SET;
         _outputType = OutputType.NONE;
+        setContentType(null);
+        setCharacterEncoding(null);
         setHeader(HttpHeader.EXPIRES,null);
         setHeader(HttpHeader.LAST_MODIFIED,null);
         setHeader(HttpHeader.CACHE_CONTROL,null);


### PR DESCRIPTION
+ Added testcase to replicate
+ Making character encoding from unset during sendError

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>