### PR TITLE
Fixes #2311 - TimeoutException when server sends unexpected content.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -304,17 +304,19 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     @Override
     public boolean messageComplete()
     {
-        complete = true;
-
         HttpExchange exchange = getHttpExchange();
         if (exchange == null)
             return false;
+
+        int status = exchange.getResponse().getStatus();
+
+        if (status != HttpStatus.CONTINUE_100)
+            complete = true;
 
         boolean proceed = responseSuccess(exchange);
         if (!proceed)
             return true;
 
-        int status = exchange.getResponse().getStatus();
         if (status == HttpStatus.SWITCHING_PROTOCOLS_101)
             return true;
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -171,8 +171,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         {
             boolean handle = parser.parseNext(buffer);
             boolean complete = this.complete;
-            if (complete)
-                this.complete = false;
+            this.complete = false;
             if (LOG.isDebugEnabled())
                 LOG.debug("Parsed {}, remaining {} {}", handle, buffer.remaining(), parser);
             if (handle)

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1649,7 +1649,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
     }
 
     @Test
-    public void test204NoContentWithContent() throws Exception
+    public void test204WithContent() throws Exception
     {
         // This test only works with clear-text HTTP.
         Assume.assumeTrue(sslContextFactory == null);

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1648,6 +1648,70 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         Assert.assertEquals(200, response.getStatus());
     }
 
+    @Test
+    public void test204NoContentWithContent() throws Exception
+    {
+        // This test only works with clear-text HTTP.
+        Assume.assumeTrue(sslContextFactory == null);
+
+        try (ServerSocket server = new ServerSocket(0))
+        {
+            startClient();
+            client.setMaxConnectionsPerDestination(1);
+            int idleTimeout = 2000;
+            client.setIdleTimeout(idleTimeout);
+
+            Request request = client.newRequest("localhost", server.getLocalPort())
+                    .scheme(scheme)
+                    .timeout(5, TimeUnit.SECONDS);
+            FutureResponseListener listener = new FutureResponseListener(request);
+            request.send(listener);
+
+            try (Socket socket = server.accept())
+            {
+                socket.setSoTimeout(idleTimeout / 2);
+
+                InputStream input = socket.getInputStream();
+                consume(input, false);
+
+                // Send a bad response.
+                String httpResponse = "" +
+                        "HTTP/1.1 204 No Content\r\n" +
+                        "\r\n" +
+                        "No Content";
+                OutputStream output = socket.getOutputStream();
+                output.write(httpResponse.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+
+                ContentResponse response = listener.get(5, TimeUnit.SECONDS);
+                Assert.assertEquals(204, response.getStatus());
+
+                byte[] responseContent = response.getContent();
+                Assert.assertNotNull(responseContent);
+                Assert.assertEquals(0, responseContent.length);
+
+                // Send another request to verify we have handled the wrong response correctly.
+                request = client.newRequest("localhost", server.getLocalPort())
+                        .scheme(scheme)
+                        .timeout(5, TimeUnit.SECONDS);
+                listener = new FutureResponseListener(request);
+                request.send(listener);
+
+                consume(input, false);
+
+                httpResponse = "" +
+                        "HTTP/1.1 200 OK\r\n" +
+                        "Content-Length: 0\r\n" +
+                        "\r\n";
+                output.write(httpResponse.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+
+                response = listener.get(5, TimeUnit.SECONDS);
+                Assert.assertEquals(200, response.getStatus());
+            }
+        }
+    }
+
     private void assertCopyRequest(Request original)
     {
         Request copy = client.copyRequest((HttpRequest) original, original.getURI());


### PR DESCRIPTION
Now exiting the parse loop when the response is complete; if there
are bytes remaining in the buffer, then it's cleared out.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>