### PR TITLE
Make the requirement on "osgi.serviceloader.processor" optional

### DIFF
--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -50,7 +50,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
+            <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -27,7 +27,7 @@
         <extensions>true</extensions>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.xml.ConfigurationProcessorFactory)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.xml.ConfigurationProcessorFactory)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
               </instructions>
             </configuration>
       </plugin>


### PR DESCRIPTION
This allows Eclipse to continue to make use of jetty-* bundles
without requiring the presence of Apache Aries.

This fixes a problem introduced by the resolution to #2164 and
the same solution is used as in 10cdf16

See also the discussion at Eclipse:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=532294

Signed-off-by: Mat Booth <mat.booth@redhat.com>