### PR TITLE
Issue #2349 - Review HTTP/2 max streams enforcement.

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/EmptyServerHandler.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/EmptyServerHandler.java
@@ -1,0 +1,42 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.http2.client.http;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class EmptyServerHandler extends AbstractHandler.ErrorDispatchHandler
+{
+    @Override
+    protected final void doNonErrorHandle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+        jettyRequest.setHandled(true);
+        service(target, jettyRequest, request, response);
+    }
+
+    protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+    }
+}


### PR DESCRIPTION
Changed the max concurrent streams enforcement to be based on halves.

We now allow 2*max_concurrent_streams+1 halves to cope with the
race condition where the server sent the last frame of a stream,
but before it notifies the callback a new (legit) request arrives
from the client.

The new logic is not perfect as in the worst case it allows more
streams than max_concurrent_streams, but has an upper bound and
the window of the worst case happening is very small, especially
for non-loopback networks.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>