### PR TITLE
Issue #110 Avoid classloading for checking roles in jaas

### DIFF
--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -34,5 +34,10 @@
       <artifactId>jetty-security</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/JAASLoginService.java
+++ b/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/JAASLoginService.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.jaas;
 
 import java.io.IOException;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -42,14 +41,19 @@ import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.ArrayUtil;
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
-/* ---------------------------------------------------- */
+
 /** 
  * JAASLoginService
+ *
+ *
+ * Implementation of jetty's LoginService that works with JAAS for
+ * authorization and authentication.
  *
  */
 public class JAASLoginService extends AbstractLifeCycle implements LoginService
@@ -66,9 +70,8 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
     protected JAASUserPrincipal _defaultUser = new JAASUserPrincipal(null, null, null);
     protected IdentityService _identityService;
 
-    /* ---------------------------------------------------- */
+
     /**
-     * Constructor.
      *
      */
     public JAASLoginService()
@@ -76,9 +79,8 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
     }
 
 
-    /* ---------------------------------------------------- */
+
     /**
-     * Constructor.
      *
      * @param name the name of the realm
      */
@@ -90,7 +92,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
     }
 
 
-    /* ---------------------------------------------------- */
+
     /**
      * Get the name of the realm.
      *
@@ -103,7 +105,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
     }
 
 
-    /* ---------------------------------------------------- */
+
     /**
      * Set the name of the realm
      *
@@ -114,7 +116,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         _realmName = name;
     }
 
-    /* ------------------------------------------------------------ */
+
     /** Get the identityService.
      * @return the identityService
      */
@@ -124,7 +126,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         return _identityService;
     }
 
-    /* ------------------------------------------------------------ */
+
     /** Set the identityService.
      * @param identityService the identityService to set
      */
@@ -134,7 +136,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         _identityService = identityService;
     }
 
-    /* ------------------------------------------------------------ */
+
     /**
      * Set the name to use to index into the config
      * file of LoginModules.
@@ -146,44 +148,41 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         _loginModuleName = name;
     }
 
-    /* ------------------------------------------------------------ */
+
     public void setCallbackHandlerClass (String classname)
     {
         _callbackHandlerClass = classname;
     }
 
-    /* ------------------------------------------------------------ */
+
     public void setRoleClassNames (String[] classnames)
     {
-        ArrayList<String> tmp = new ArrayList<String>();
-
-        if (classnames != null)
-            tmp.addAll(Arrays.asList(classnames));
-
-        if (!tmp.contains(DEFAULT_ROLE_CLASS_NAME))
-            tmp.add(DEFAULT_ROLE_CLASS_NAME);
-        _roleClassNames = tmp.toArray(new String[tmp.size()]);
+        if (classnames == null || classnames.length == 0)
+        {
+            _roleClassNames = DEFAULT_ROLE_CLASS_NAMES;
+            return;
+        }
+        
+        _roleClassNames = ArrayUtil.addToArray(classnames, DEFAULT_ROLE_CLASS_NAME, String.class);
     }
 
-    /* ------------------------------------------------------------ */
+
     public String[] getRoleClassNames()
     {
         return _roleClassNames;
     }
 
-    /* ------------------------------------------------------------ */
-    /**
-     * @see org.eclipse.jetty.util.component.AbstractLifeCycle#doStart()
-     */
+
+
     @Override
     protected void doStart() throws Exception
     {
         if (_identityService==null)
-            _identityService=new DefaultIdentityService();
+            _identityService = new DefaultIdentityService();
         super.doStart();
     }
 
-    /* ------------------------------------------------------------ */
+
     @Override
     public UserIdentity login(final String username,final Object credentials, final ServletRequest request)
     {
@@ -243,34 +242,14 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
 
             return _identityService.newUserIdentity(subject,userPrincipal,getGroups(subject));
         }
-        catch (LoginException e)
-        {
-            LOG.warn(e);
-        }
-        catch (IOException e)
-        {
-            LOG.warn(e);
-        }
-        catch (UnsupportedCallbackException e)
-        {
-           LOG.warn(e);
-        }
-        catch (InstantiationException e)
-        {
-            LOG.warn(e);
-        }
-        catch (IllegalAccessException e)
-        {
-            LOG.warn(e);
-        }
-        catch (ClassNotFoundException e)
+        catch (LoginException | IOException | UnsupportedCallbackException | InstantiationException | IllegalAccessException | ClassNotFoundException e)
         {
             LOG.warn(e);
         }
         return null;
     }
 
-    /* ------------------------------------------------------------ */
+
     @Override
     public boolean validate(UserIdentity user)
     {
@@ -278,7 +257,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         return true;
     }
 
-    /* ------------------------------------------------------------ */
+
     private String getUserName(CallbackHandler callbackHandler) throws IOException, UnsupportedCallbackException
     {
         NameCallback nameCallback = new NameCallback("foo");
@@ -286,7 +265,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
         return nameCallback.getName();
     }
 
-    /* ------------------------------------------------------------ */
+
     @Override
     public void logout(UserIdentity user)
     {
@@ -303,31 +282,64 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService
     }
 
 
-    /* ------------------------------------------------------------ */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private String[] getGroups (Subject subject)
+    /**
+     * Get all of the groups for the user.
+     * 
+     * @param subject the Subject representing the user
+     * 
+     * @return all the names of groups that the user is in, or 0 length array if none
+     */
+    protected String[] getGroups (Subject subject)
     {
-        //get all the roles of the various types
-        String[] roleClassNames = getRoleClassNames();
-        Collection<String> groups = new LinkedHashSet<String>();
-        try
+        Collection<String> groups = new LinkedHashSet<>();
+        Set<Principal> principals = subject.getPrincipals();
+        for (Principal principal : principals)
         {
-            for (String roleClassName : roleClassNames)
+            Class<?> c = principal.getClass();
+            while (c!=null)
             {
-                Class load_class = Thread.currentThread().getContextClassLoader().loadClass(roleClassName);
-                Set<Principal> rolesForType = subject.getPrincipals(load_class);
-                for (Principal principal : rolesForType)
+                if (roleClassNameMatches(c.getName()))
                 {
                     groups.add(principal.getName());
+                    break;
                 }
+                
+                boolean added = false;
+                for (Class<?> ci:c.getInterfaces())
+                {
+                    if (roleClassNameMatches(ci.getName()))
+                    {
+                        groups.add(principal.getName());
+                        added = true;
+                        break;
+                    }
+                }
+                
+                if (!added)
+                {
+                    c = c.getSuperclass();
+                }
+                else
+                    break;
             }
+        }
 
-            return groups.toArray(new String[groups.size()]);
-        }
-        catch (ClassNotFoundException e)
+        return groups.toArray(new String[groups.size()]);
+    }
+    
+    
+    private boolean roleClassNameMatches (String classname)
+    {
+        boolean result = false;
+        for (String roleClassName:getRoleClassNames())
         {
-            throw new RuntimeException(e);
+            if (roleClassName.equals(classname))
+            {
+                result = true;
+                break;
+            }
         }
+        return result;
     }
 
 }

--- a/jetty-jaas/src/test/java/org/eclipse/jetty/jaas/JAASLoginServiceTest.java
+++ b/jetty-jaas/src/test/java/org/eclipse/jetty/jaas/JAASLoginServiceTest.java
@@ -1,0 +1,146 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.jaas;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.security.Principal;
+
+import javax.security.auth.Subject;
+
+import org.junit.Test;
+
+/**
+ * JAASLoginServiceTest
+ *
+ *
+ */
+public class JAASLoginServiceTest
+{
+    interface SomeRole
+    {
+        
+    }
+
+    public class TestRole implements Principal, SomeRole
+    {
+        String _name;
+
+        public TestRole (String name)
+        {
+            _name = name;
+        }
+
+        public String getName()
+        {
+            return _name;    
+        }
+    }
+    
+    
+    public class AnotherTestRole extends TestRole
+    {
+        public AnotherTestRole(String name)
+        {
+            super(name);
+        }   
+    }
+    
+    public class NotTestRole implements Principal
+    {
+        String _name;
+        
+        public NotTestRole (String n)
+        {
+            _name = n;
+        }
+        
+        public String getName()
+        {
+            return _name;    
+        }
+    }
+    
+    
+
+    @Test
+    public void testLoginServiceRoles () throws Exception
+    {
+        JAASLoginService ls = new JAASLoginService("foo");
+        
+        //test that we always add in the DEFAULT ROLE CLASSNAME
+        ls.setRoleClassNames(new String[] {"arole", "brole"});
+        String[] roles = ls.getRoleClassNames();
+        assertEquals(3, roles.length);
+        assertEquals(JAASLoginService.DEFAULT_ROLE_CLASS_NAME, roles[2]);
+        
+        ls.setRoleClassNames(new String[] {});
+        assertEquals(1, ls.getRoleClassNames().length);
+        assertEquals(JAASLoginService.DEFAULT_ROLE_CLASS_NAME, ls.getRoleClassNames()[0]);
+
+        ls.setRoleClassNames(null);
+        assertEquals(1, ls.getRoleClassNames().length);
+        assertEquals(JAASLoginService.DEFAULT_ROLE_CLASS_NAME, ls.getRoleClassNames()[0]);
+
+        //test a custom role class where some of the roles are subclasses of it
+        ls.setRoleClassNames(new String[] {TestRole.class.getName()});
+        Subject subject = new Subject();
+        subject.getPrincipals().add(new NotTestRole("w"));
+        subject.getPrincipals().add(new TestRole("x"));
+        subject.getPrincipals().add(new TestRole("y"));
+        subject.getPrincipals().add(new AnotherTestRole("z"));
+        
+        String[] groups = ls.getGroups(subject);
+        assertEquals(3, groups.length);
+        for (String g:groups)
+            assertTrue(g.equals("x") || g.equals("y") || g.equals("z"));
+        
+        //test a custom role class
+        ls.setRoleClassNames(new String[] {AnotherTestRole.class.getName()});
+        Subject subject2 = new Subject();
+        subject2.getPrincipals().add(new NotTestRole("w"));
+        subject2.getPrincipals().add(new TestRole("x"));
+        subject2.getPrincipals().add(new TestRole("y"));
+        subject2.getPrincipals().add(new AnotherTestRole("z"));
+        assertEquals(1, ls.getGroups(subject2).length);
+        assertEquals("z", ls.getGroups(subject2)[0]);
+        
+        //test a custom role class that implements an interface
+        ls.setRoleClassNames(new String[] {SomeRole.class.getName()});
+        Subject subject3 = new Subject();
+        subject3.getPrincipals().add(new NotTestRole("w"));
+        subject3.getPrincipals().add(new TestRole("x"));
+        subject3.getPrincipals().add(new TestRole("y"));
+        subject3.getPrincipals().add(new AnotherTestRole("z"));
+        assertEquals(3, ls.getGroups(subject3).length);
+        for (String g:groups)
+            assertTrue(g.equals("x") || g.equals("y") || g.equals("z"));
+        
+        //test a class that doesn't match
+        ls.setRoleClassNames(new String[] {NotTestRole.class.getName()});
+        Subject subject4 = new Subject();
+        subject4.getPrincipals().add(new TestRole("x"));
+        subject4.getPrincipals().add(new TestRole("y"));
+        subject4.getPrincipals().add(new AnotherTestRole("z"));
+        assertEquals(0, ls.getGroups(subject4).length);       
+    }
+
+}


### PR DESCRIPTION
This is a very old bug. I decided to implement the OP's suggestion and avoid any classloading during jaas role checking.