### PR TITLE
Issue #2349 - Review HTTP/2 max streams enforcement.

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/CloseState.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/CloseState.java
@@ -21,20 +21,20 @@ package org.eclipse.jetty.http2;
 /**
  * The set of close states for a stream or a session.
  * <pre>
- *                rcv eos
- * NOT_CLOSED ---------------> REMOTELY_CLOSED
+ *                rcv hc
+ * NOT_CLOSED ---------------&gt; REMOTELY_CLOSED
  *      |                             |
  *   gen|                             |gen
- *   eos|                             |eos
+ *    hc|                             |hc
  *      |                             |
- *      v              rcv eos        v
- * LOCALLY_CLOSING --------------> CLOSING
+ *      v              rcv hc         v
+ * LOCALLY_CLOSING --------------&gt; CLOSING
  *      |                             |
  *   snd|                             |gen
- *   eos|                             |eos
+ *    hc|                             |hc
  *      |                             |
- *      v              rcv eos        v
- * LOCALLY_CLOSED ----------------> CLOSED
+ *      v              rcv hc         v
+ * LOCALLY_CLOSED ----------------&gt; CLOSED
  * </pre>
  */
 public enum CloseState

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/CloseState.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/CloseState.java
@@ -18,7 +18,56 @@
 
 package org.eclipse.jetty.http2;
 
+/**
+ * The set of close states for a stream or a session.
+ * <pre>
+ *                rcv eos
+ * NOT_CLOSED ---------------> REMOTELY_CLOSED
+ *      |                             |
+ *   gen|                             |gen
+ *   eos|                             |eos
+ *      |                             |
+ *      v              rcv eos        v
+ * LOCALLY_CLOSING --------------> CLOSING
+ *      |                             |
+ *   snd|                             |gen
+ *   eos|                             |eos
+ *      |                             |
+ *      v              rcv eos        v
+ * LOCALLY_CLOSED ----------------> CLOSED
+ * </pre>
+ */
 public enum CloseState
 {
-    NOT_CLOSED, LOCALLY_CLOSED, REMOTELY_CLOSED, CLOSED
+    /**
+     * Fully open.
+     */
+    NOT_CLOSED,
+    /**
+     * A half-close frame has been generated.
+     */
+    LOCALLY_CLOSING,
+    /**
+     * A half-close frame has been generated and sent.
+     */
+    LOCALLY_CLOSED,
+    /**
+     * A half-close frame has been received.
+     */
+    REMOTELY_CLOSED,
+    /**
+     * A half-close frame has been received and a half-close frame has been generated, but not yet sent.
+     */
+    CLOSING,
+    /**
+     * Fully closed.
+     */
+    CLOSED;
+
+    public enum Event
+    {
+        RECEIVED,
+        BEFORE_SEND,
+        AFTER_SEND
+    }
 }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -462,12 +462,12 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
     public void close()
     {
         CloseState oldState = closeState.getAndSet(CloseState.CLOSED);
-        if (oldState == CloseState.CLOSING)
-            updateStreamCount(-1, -1);
-        else
-            updateStreamCount(-1, 0);
         if (oldState != CloseState.CLOSED)
+        {
+            int deltaClosing = oldState == CloseState.CLOSING ? -1 : 0;
+            updateStreamCount(-1, deltaClosing);
             onClose();
+        }
     }
 
     private void updateStreamCount(int deltaStream, int deltaClosing)

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
@@ -76,12 +76,10 @@ public interface IStream extends Stream, Closeable
      * <p>Updates the close state of this stream.</p>
      *
      * @param update whether to update the close state
-     * @param local  whether the update comes from a local operation
-     *               (such as sending a frame that ends the stream)
-     *               or a remote operation (such as receiving a frame
+     * @param event  the event that caused the close state update
      * @return whether the stream has been fully closed by this invocation
      */
-    public boolean updateClose(boolean update, boolean local);
+    public boolean updateClose(boolean update, CloseState.Event event);
 
     /**
      * <p>Forcibly closes this stream.</p>

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/EmptyServerHandler.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/EmptyServerHandler.java
@@ -1,0 +1,42 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.http2.client.http;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class EmptyServerHandler extends AbstractHandler.ErrorDispatchHandler
+{
+    @Override
+    protected final void doNonErrorHandle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+        jettyRequest.setHandled(true);
+        service(target, jettyRequest, request, response);
+    }
+
+    protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+    }
+}

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/MaxConcurrentStreamsTest.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/MaxConcurrentStreamsTest.java
@@ -18,11 +18,10 @@
 
 package org.eclipse.jetty.http2.client.http;
 
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -32,7 +31,6 @@ import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,12 +51,11 @@ public class MaxConcurrentStreamsTest extends AbstractTest
     public void testOneConcurrentStream() throws Exception
     {
         long sleep = 1000;
-        start(1, new AbstractHandler()
+        start(1, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                baseRequest.setHandled(true);
                 // Sleep a bit to allow the second request to be queued.
                 sleep(sleep);
             }
@@ -92,16 +89,41 @@ public class MaxConcurrentStreamsTest extends AbstractTest
     }
 
     @Test
+    public void testManyIterationsWithConcurrentStreams() throws Exception
+    {
+        int concurrency = 1;
+        start(concurrency, new EmptyServerHandler());
+
+        int iterations = 50;
+        IntStream.range(0, concurrency).parallel().forEach(i ->
+                IntStream.range(0, iterations).forEach(j ->
+                {
+                    try
+                    {
+                        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+                                .path("/" + i + "_" + j)
+                                .timeout(5, TimeUnit.SECONDS)
+                                .send();
+                        Assert.assertEquals(HttpStatus.OK_200, response.getStatus());
+                    }
+                    catch (Throwable x)
+                    {
+                        throw new RuntimeException(x);
+                    }
+                })
+        );
+    }
+
+    @Test
     public void testTwoConcurrentStreamsThirdWaits() throws Exception
     {
         int maxStreams = 2;
         long sleep = 1000;
-        start(maxStreams, new AbstractHandler()
+        start(maxStreams, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                baseRequest.setHandled(true);
                 sleep(sleep);
             }
         });
@@ -140,12 +162,11 @@ public class MaxConcurrentStreamsTest extends AbstractTest
     public void testAbortedWhileQueued() throws Exception
     {
         long sleep = 1000;
-        start(1, new AbstractHandler()
+        start(1, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                baseRequest.setHandled(true);
                 sleep(sleep);
             }
         });
@@ -170,12 +191,11 @@ public class MaxConcurrentStreamsTest extends AbstractTest
     {
         int maxConcurrent = 10;
         long sleep = 500;
-        start(maxConcurrent, new AbstractHandler()
+        start(maxConcurrent, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                baseRequest.setHandled(true);
                 sleep(sleep);
             }
         });


### PR DESCRIPTION
Changed the max concurrent remote streams enforcement algorithm.
It is now based on the stream count and the closing stream count,
updated atomically in a state machine in HTTP2Stream.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>