### PR TITLE
Issue #2164 Make osgi.serviceloader mostly optional

### DIFF
--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -24,7 +24,7 @@
                 <Export-Package>org.eclipse.jetty.apache.jsp.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}",
                                 org.eclipse.jetty.jsp.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"
                 </Export-Package>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=javax.servlet.ServletContainerInitializer,osgi.serviceloader;osgi.serviceloader=org.apache.juli.logging.Log</Provide-Capability>
                 <_nouses>true</_nouses>
               </instructions>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -24,7 +24,7 @@
             <configuration>
               <instructions>
                <Import-Package>org.eclipse.jetty.alpn;resolution:=optional,*</Import-Package>
-               <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client)";cardinality:=multiple</Require-Capability>
+               <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client)";resolution:=optional;cardinality:=multiple</Require-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -46,7 +46,7 @@
                  <Bundle-Description>Conscrypt Client ALPN</Bundle-Description>
                  <Import-Package>org.conscrypt;version="${conscrypt.version}",*</Import-Package>
                  <Export-Package>*</Export-Package>
-                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                  <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client</Provide-Capability>
                  <_nouses>true</_nouses>
                </instructions>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -49,7 +49,7 @@
                <instructions>
                  <Bundle-Description>Conscrypt ALPN</Bundle-Description>
                  <Import-Package>org.conscrypt;version="${conscrypt.version}",*</Import-Package>
-                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                  <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server</Provide-Capability>
                  <_nouses>true</_nouses>
                </instructions>

--- a/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -35,7 +35,7 @@
                     <instructions>
                       <Bundle-Description>JDK9 Client ALPN</Bundle-Description>
                       <Export-Package>*</Export-Package>
-                      <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                      <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                       <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client</Provide-Capability>
                       <_nouses>true</_nouses>
                     </instructions>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -33,7 +33,7 @@
                <configuration>
                  <instructions>
                    <Bundle-Description>JDK9 Server ALPN</Bundle-Description>
-                   <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                   <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                    <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server</Provide-Capability>
                    <_nouses>true</_nouses>
                  </instructions>

--- a/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
@@ -62,7 +62,7 @@
                  <Bundle-Description>OpenJDK8 Client ALPN</Bundle-Description>
                  <Import-Package>org.eclipse.jetty.alpn;version="${alpn.majorVersion}.${alpn.minorVersion}.${alpn.incrementalVersion}",*</Import-Package>
                  <Export-Package>*</Export-Package>
-                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                  <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client</Provide-Capability>
                  <_nouses>true</_nouses>
                </instructions>

--- a/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
@@ -67,7 +67,7 @@
                  <Bundle-Description>OpenJDK8 Server ALPN</Bundle-Description>
                  <Export-Package>*</Export-Package>
                  <Import-Package>org.eclipse.jetty.alpn;version="${alpn.majorVersion}.${alpn.minorVersion}.${alpn.incrementalVersion}",*</Import-Package>
-                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                  <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server</Provide-Capability>
                  <_nouses>true</_nouses>
                </instructions>

--- a/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-server/pom.xml
@@ -49,7 +49,7 @@
               <Bundle-SymbolicName>${bundle-symbolic-name};singleton:=true</Bundle-SymbolicName>
               <Export-Package>org.eclipse.jetty.alpn.server,*</Export-Package>
               <Import-Package>org.eclipse.jetty.alpn;version="${alpn.majorVersion}.${alpn.minorVersion}.${alpn.incrementalVersion}",*</Import-Package>
-              <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server)";resolution:=optional;cardinality:=multiple</Require-Capability>
+              <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server)";resolution:=optional;cardinality:=multiple</Require-Capability>
             </instructions>
         </configuration>
       </plugin>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -21,7 +21,7 @@
             <configuration>
               <instructions>
                 <Import-Package>org.objectweb.asm;version="[5.0,7)",*</Import-Package>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=javax.servlet.ServletContainerInitializer)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=javax.servlet.ServletContainerInitializer)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
               </instructions>
             </configuration>
       </plugin>

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -52,7 +52,7 @@
             <configuration>
               <instructions>
                 <Bundle-Description>Jetty Http SPI</Bundle-Description>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                 <Provide-Capability>osgi.serviceloader; osgi.serviceloader=com.sun.net.httpserver.spi.HttpServerProvider</Provide-Capability>
                 <_nouses>true</_nouses>
               </instructions>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -38,9 +38,6 @@
             <configuration>
               <instructions>
                 <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
-<!--
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
--->
                 <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder</Provide-Capability>
               </instructions>
             </configuration>

--- a/jetty-http2/http2-hpack/pom.xml
+++ b/jetty-http2/http2-hpack/pom.xml
@@ -51,7 +51,7 @@
             <configuration>
               <instructions>
                 <Bundle-Description>Http2 Hpack</Bundle-Description>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.http.HttpFieldPreEncoder</Provide-Capability>
                 <_nouses>true</_nouses>
               </instructions>

--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/JettyBootstrapActivator.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/JettyBootstrapActivator.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -69,6 +70,11 @@ public class JettyBootstrapActivator implements BundleActivator
     @Override
     public void start(final BundleContext context) throws Exception
     {
+        ServiceReference[] references = context.getAllServiceReferences("org.eclipse.jetty.http.HttpFieldPreEncoder", null);
+        
+        if (references == null || references.length==0)
+            LOG.warn("OSGi support for java.util.ServiceLoader may not be present. You may experience runtime errors.");
+        
         INSTANCE = this;
 
         // track other bundles and fragments attached to this bundle that we

--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -30,7 +30,7 @@
         <extensions>true</extensions>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.xml.ConfigurationProcessorFactory</Provide-Capability>
               </instructions>
             </configuration>

--- a/jetty-websocket/javax-websocket-client-impl/pom.xml
+++ b/jetty-websocket/javax-websocket-client-impl/pom.xml
@@ -65,7 +65,7 @@
                       <instructions>
                         <Bundle-Description>javax.websocket.client Implementation</Bundle-Description>
                         <Export-Package>org.eclipse.jetty.websocket.jsr356.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
-                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                         <Provide-Capability>osgi.serviceloader;osgi.serviceloader=javax.websocket.ContainerProvider</Provide-Capability>
                       </instructions>
                   </configuration>

--- a/jetty-websocket/javax-websocket-server-impl/pom.xml
+++ b/jetty-websocket/javax-websocket-server-impl/pom.xml
@@ -63,7 +63,7 @@
                       <instructions>
                         <Bundle-Description>javax.websocket.server Implementation</Bundle-Description>
                         <Export-Package>org.eclipse.jetty.websocket.jsr356.server.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
-                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                         <Provide-Capability>osgi.serviceloader;osgi.serviceloader=javax.servlet.ServletContainerInitializer,osgi.serviceloader;osgi.serviceloader=javax.websocket.server.ServerEndpointConfig$Configurator</Provide-Capability>                      
                       </instructions>
                   </configuration>

--- a/jetty-websocket/websocket-api/pom.xml
+++ b/jetty-websocket/websocket-api/pom.xml
@@ -59,7 +59,7 @@
               <extensions>true</extensions>
                   <configuration>
                     <instructions>
-                      <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.websocket.api.extensions.Extension)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
+                      <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.websocket.api.extensions.Extension)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
                     </instructions>
                   </configuration>
             </plugin>

--- a/jetty-websocket/websocket-common/pom.xml
+++ b/jetty-websocket/websocket-common/pom.xml
@@ -82,7 +82,7 @@
         <extensions>true</extensions>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.websocket.api.extensions.Extension</Provide-Capability>
                 <_nouses>true</_nouses>
               </instructions>

--- a/jetty-websocket/websocket-server/pom.xml
+++ b/jetty-websocket/websocket-server/pom.xml
@@ -28,8 +28,8 @@
               </goals>
               <configuration>
                 <instructions>
-                  <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
-                  <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.websocket.servlet.WebSocketServletFactory</Provide-Capability>
+                  <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                  <Provide-Capability>osgi.serviceloader; osgi.serviceloader=javax.servlet.ServletContainerInitializer</Provide-Capability>
                   <_nouses>true</_nouses>
                 </instructions>
               </configuration>

--- a/jetty-websocket/websocket-servlet/pom.xml
+++ b/jetty-websocket/websocket-servlet/pom.xml
@@ -34,7 +34,6 @@
                         <Bundle-Classpath />
                         <_nouses>true</_nouses>
                         <DynamicImport-Package>org.eclipse.jetty.websocket.server.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}",org.eclipse.jetty.websocket.server.pathmap.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}"</DynamicImport-Package>
-                        <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.websocket.servlet.WebSocketServletFactory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR is following on from the discussion in #2164 and PR #2377.

In PR #2377 it is apparent that there are some use-cases where jetty is deployed into an osgi container where the osgi.serviceloader capability is not present (eg SpiFly is not deployed).  Although jetty uses the java.util.ServiceLoader more and more, there are usecases that avoid invoking code in a bundle that uses the ServiceLoader. Therefore, making the osgi.serviceloader.processor and osgi.serviceloader.registrar mandatory breaks those use cases.

The solution adopted is to always make the osgi.serviceloader.processor/registrar requirement resolution=optional, but in the jetty-boot bundle print out a warning if we can detect that it is not present. 