### PR TITLE
Issue #2413 - Using Instant.toString() to be consistent with timestamp

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
@@ -18,13 +18,12 @@
 
 package org.eclipse.jetty.util;
 
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Properties;
+
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
-
-import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Properties;
 
 public class Jetty
 {
@@ -88,8 +87,8 @@ public class Jetty
     {
         try
         {
-            return new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ssXXX" )
-                .format( new Date( Long.valueOf( timestamp ) ) );
+            long epochMillis = Long.parseLong(timestamp);
+            return Instant.ofEpochMilli(epochMillis).toString();
         }
         catch ( NumberFormatException e )
         {


### PR DESCRIPTION
Example output:

JDK 8:

2018-04-04 22:30:25.578:INFO:oejs.Server:main: jetty-9.4.10-SNAPSHOT; built: 2018-04-04T22:22:03.202Z; git: 2b32f82aeb64acc6105c08d8a7a141279f8b91d0; jvm 1.8.0_131-b11

JDK 9:

2018-04-04 22:29:39.035:INFO:oejs.Server:main: jetty-9.4.10-SNAPSHOT; built: 2018-04-04T22:22:03.202Z; git: 2b32f82aeb64acc6105c08d8a7a141279f8b91d0; jvm 9+181

JDK 10:

2018-04-04 17:29:07.568:INFO:oejs.Server:main: jetty-9.4.10-SNAPSHOT; built: 2018-04-04T22:22:03.202Z; git: 2b32f82aeb64acc6105c08d8a7a141279f8b91d0; jvm 10+46

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>