### PR TITLE
Issue #1785 Added vhost@connectorname format for AND behaviour

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -138,10 +138,41 @@ public class ContextHandlerTest
         IsHandledHandler handlerC = new IsHandledHandler();
         contextC.setHandler(handlerC);
 
+        ContextHandler contextD = new ContextHandler("/");
+        IsHandledHandler handlerD = new IsHandledHandler();
+        contextD.setHandler(handlerD);
+        contextD.setVirtualHosts(new String[]{ "www.example.com@name" });
+        
+        ContextHandler contextE = new ContextHandler("/");
+        IsHandledHandler handlerE = new IsHandledHandler();
+        contextE.setHandler(handlerE);
+        contextE.setVirtualHosts(new String[]{ "*.example.com" });
+        
+        ContextHandler contextF = new ContextHandler("/");
+        IsHandledHandler handlerF = new IsHandledHandler();
+        contextF.setHandler(handlerF);
+        contextF.setVirtualHosts(new String[]{ "*.example.com@name" });
+        
+        ContextHandler contextG = new ContextHandler("/");
+        IsHandledHandler handlerG = new IsHandledHandler();
+        contextG.setHandler(handlerG);
+        contextG.setVirtualHosts(new String[]{ "*.com@name" });
+        
+        ContextHandler contextH = new ContextHandler("/");
+        IsHandledHandler handlerH = new IsHandledHandler();
+        contextH.setHandler(handlerH);
+        contextH.setVirtualHosts(new String[]{ "*.com" });
+        
         HandlerCollection c = new HandlerCollection();
         c.addHandler(contextA);
         c.addHandler(contextB);
         c.addHandler(contextC);
+        c.addHandler(contextD);
+        c.addHandler(contextE);
+        c.addHandler(contextF);
+        c.addHandler(contextG);
+        c.addHandler(contextH);
+        
         server.setHandler(c);
 
         server.start();
@@ -151,39 +182,175 @@ public class ContextHandlerTest
             Assert.assertTrue(handlerA.isHandled());
             Assert.assertFalse(handlerB.isHandled());
             Assert.assertFalse(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
             handlerA.reset();
             handlerB.reset();
             handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
 
             connector.getResponse("GET / HTTP/1.0\n" + "Host: localhost\n\n");
             Assert.assertFalse(handlerA.isHandled());
             Assert.assertFalse(handlerB.isHandled());
             Assert.assertTrue(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
             handlerA.reset();
             handlerB.reset();
             handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
 
             connectorN.getResponse("GET / HTTP/1.0\n" + "Host: www.example.com.\n\n");
             Assert.assertTrue(handlerA.isHandled());
             Assert.assertFalse(handlerB.isHandled());
             Assert.assertFalse(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
             handlerA.reset();
             handlerB.reset();
             handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
 
             connectorN.getResponse("GET / HTTP/1.0\n" + "Host: localhost\n\n");
             Assert.assertFalse(handlerA.isHandled());
             Assert.assertTrue(handlerB.isHandled());
             Assert.assertFalse(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
             handlerA.reset();
             handlerB.reset();
             handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
 
         }
         finally
         {
             server.stop();
         }
+        
+        // Reversed order to check priority when multiple matches
+        HandlerCollection d = new HandlerCollection();
+        d.addHandler(contextH);
+        d.addHandler(contextG);
+        d.addHandler(contextF);
+        d.addHandler(contextE);
+        d.addHandler(contextD);
+        d.addHandler(contextC);
+        d.addHandler(contextB);
+        d.addHandler(contextA);
+        
+        
+        server.setHandler(d);
+
+        server.start();
+        try
+        {
+            connector.getResponse("GET / HTTP/1.0\n" + "Host: www.example.com.\n\n");
+            Assert.assertFalse(handlerA.isHandled());
+            Assert.assertFalse(handlerB.isHandled());
+            Assert.assertFalse(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertTrue(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
+            handlerA.reset();
+            handlerB.reset();
+            handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
+
+            connector.getResponse("GET / HTTP/1.0\n" + "Host: localhost\n\n");
+            Assert.assertFalse(handlerA.isHandled());
+            Assert.assertFalse(handlerB.isHandled());
+            Assert.assertTrue(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
+            handlerA.reset();
+            handlerB.reset();
+            handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
+
+            connectorN.getResponse("GET / HTTP/1.0\n" + "Host: www.example.com.\n\n");
+            Assert.assertFalse(handlerA.isHandled());
+            Assert.assertFalse(handlerB.isHandled());
+            Assert.assertFalse(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertTrue(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
+            handlerA.reset();
+            handlerB.reset();
+            handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
+
+            connectorN.getResponse("GET / HTTP/1.0\n" + "Host: localhost\n\n");
+            Assert.assertFalse(handlerA.isHandled());
+            Assert.assertFalse(handlerB.isHandled());
+            Assert.assertTrue(handlerC.isHandled());
+            Assert.assertFalse(handlerD.isHandled());
+            Assert.assertFalse(handlerE.isHandled());
+            Assert.assertFalse(handlerF.isHandled());
+            Assert.assertFalse(handlerG.isHandled());
+            Assert.assertFalse(handlerH.isHandled());
+            handlerA.reset();
+            handlerB.reset();
+            handlerC.reset();
+            handlerD.reset();
+            handlerE.reset();
+            handlerF.reset();
+            handlerG.reset();
+            handlerH.reset();
+
+        }
+        finally
+        {
+            server.stop();
+        }
+        
 
     }
 


### PR DESCRIPTION
Allows for combined virtualhost@connectorname  format when specifying virtualhosts.  This format will only match if both the hostname AND connector name match.  Currently if you specify a connector name  in a list of virtualhosts it will always match if that connector matches regardless of the hostname.    This change is backwards compatible with existing functionality and if you select just "@connectorname" then any hostname will match as long as the connector does.

This change would allow for a context to match if the connector is https or the connector is http and localhost only for example




Signed-off-by: Steve Bolton <steve@boltn.com>