### PR TITLE
Issue #1555 WWW-Authenticate realm header ordering

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -42,7 +42,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
 {
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
-    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s+realm=\"([^\"]*)\"(.*)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*)realm=\"([^\"]*)\"(.*)", Pattern.CASE_INSENSITIVE);
 
     private final HttpClient client;
     private final int maxContentLength;
@@ -241,8 +241,8 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                 if (matcher.matches())
                 {
                     String type = matcher.group(1);
-                    String realm = matcher.group(2);
-                    String params = matcher.group(3);
+                    String realm = matcher.group(3);
+                    String params = matcher.group(2) + matcher.group(4);
                     Authentication.HeaderInfo headerInfo = new Authentication.HeaderInfo(type, realm, params, getAuthorizationHeader());
                     result.add(headerInfo);
                 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -42,7 +42,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
 {
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
-    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*)realm=\"([^\"]*)\"(.*)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*,\\s*)?realm=\"([^\"]*)\"\\s*,?\\s*(.*)", Pattern.CASE_INSENSITIVE);
 
     private final HttpClient client;
     private final int maxContentLength;
@@ -242,7 +242,12 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                 {
                     String type = matcher.group(1);
                     String realm = matcher.group(3);
-                    String params = matcher.group(2) + matcher.group(4);
+                    String params;
+                    if(matcher.group(2) != null)
+                        params = matcher.group(2) + matcher.group(4);
+                    else
+                        params = matcher.group(4);
+
                     Authentication.HeaderInfo headerInfo = new Authentication.HeaderInfo(type, realm, params, getAuthorizationHeader());
                     result.add(headerInfo);
                 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -42,7 +42,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
 {
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
-    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*,\\s*)?realm=\"([^\"]*)\"\\s*,?\\s*(.*)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s+(.*,\\s*)?realm=\"([^\"]*)\"\\s*,?\\s*(.*)", Pattern.CASE_INSENSITIVE);
 
     private final HttpClient client;
     private final int maxContentLength;
@@ -242,12 +242,15 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                 {
                     String type = matcher.group(1);
                     String realm = matcher.group(3);
+                    String beforeRealm = matcher.group(2);
+                    String afterRealm = matcher.group(4);
+                    
                     String params;
-                    if(matcher.group(2) != null)
-                        params = matcher.group(2) + matcher.group(4);
+                    if (beforeRealm != null)
+                        params = beforeRealm + afterRealm;
                     else
-                        params = matcher.group(4);
-
+                        params = afterRealm;
+                    
                     Authentication.HeaderInfo headerInfo = new Authentication.HeaderInfo(type, realm, params, getAuthorizationHeader());
                     result.add(headerInfo);
                 }


### PR DESCRIPTION
Changed regex for AUTHENTICATE_PATTERN so that the realm doesn't need to appear as first parameter. #1555

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>