### PR TITLE
Issue #2439 - Remove HTTP/2 data copy.

### DIFF
--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AsyncServletTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/AsyncServletTest.java
@@ -103,7 +103,7 @@ public class AsyncServletTest extends AbstractTest
             {
                 try
                 {
-                    buffer.write(BufferUtil.toArray(frame.getData()));
+                    BufferUtil.writeTo(frame.getData(), buffer);
                     callback.succeeded();
                     if (frame.isEndStream())
                         latch.countDown();

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/FlowControlStrategyTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/FlowControlStrategyTest.java
@@ -679,13 +679,7 @@ public abstract class FlowControlStrategyTest
                     @Override
                     public void onData(Stream stream, DataFrame frame, Callback callback)
                     {
-                        // Since we echo back the data
-                        // asynchronously we must copy it.
-                        ByteBuffer data = frame.getData();
-                        ByteBuffer copy = ByteBuffer.allocateDirect(data.remaining());
-                        copy.put(data).flip();
-                        completable.thenRun(() ->
-                                stream.data(new DataFrame(stream.getId(), copy, frame.isEndStream()), callback));
+                        completable.thenRun(() -> stream.data(frame, callback));
                     }
                 };
             }

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/PrefaceTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/PrefaceTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
@@ -165,6 +166,7 @@ public class PrefaceTest extends AbstractTest
                     settings.offer(frame);
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             ByteBuffer buffer = byteBufferPool.acquire(1024, true);
             while (true)
@@ -307,6 +309,7 @@ public class PrefaceTest extends AbstractTest
                         responded.set(true);
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             // HTTP/2 parsing.
             while (true)

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/RawHTTP2ProxyTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/RawHTTP2ProxyTest.java
@@ -263,14 +263,6 @@ public class RawHTTP2ProxyTest
         Assert.assertTrue(latch2.await(5, TimeUnit.SECONDS));
     }
 
-    private static DataFrame copyDataFrame(DataFrame frame)
-    {
-        ByteBuffer data = frame.getData();
-        ByteBuffer dataCopy = ByteBuffer.allocate(data.remaining());
-        dataCopy.put(data).flip();
-        return new DataFrame(frame.getStreamId(), dataCopy, frame.isEndStream(), frame.padding());
-    }
-
     private static class ClientToProxySessionListener extends ServerSessionListener.Adapter
     {
         private final Map<Integer, ClientToProxyToServer> forwarders = new ConcurrentHashMap<>();
@@ -505,8 +497,7 @@ public class RawHTTP2ProxyTest
         {
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug("CPS received {} on {}", frame, stream);
-            // Must copy the bytes because they are not consumed here.
-            offer(stream, copyDataFrame(frame), callback);
+            offer(stream, frame, callback);
         }
 
         @Override
@@ -668,8 +659,7 @@ public class RawHTTP2ProxyTest
         {
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug("SPC received {} on {}", frame, stream);
-            // Must copy the bytes because they are not consumed here.
-            offer(stream, copyDataFrame(frame), callback);
+            offer(stream, frame, callback);
         }
 
         @Override

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/StreamCloseTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/StreamCloseTest.java
@@ -132,23 +132,17 @@ public class StreamCloseTest extends AbstractTest
                     {
                         Assert.assertTrue(((HTTP2Stream)stream).isRemotelyClosed());
 
-                        // We must copy the data that we send asynchronously.
-                        ByteBuffer data = frame.getData();
-                        ByteBuffer copy = ByteBuffer.allocate(data.remaining());
-                        copy.put(data).flip();
-
-                        completable.thenRun(() ->
-                                stream.data(new DataFrame(stream.getId(), copy, frame.isEndStream()), new Callback()
-                                {
-                                    @Override
-                                    public void succeeded()
-                                    {
-                                        Assert.assertTrue(stream.isClosed());
-                                        Assert.assertEquals(0, stream.getSession().getStreams().size());
-                                        callback.succeeded();
-                                        serverDataLatch.countDown();
-                                    }
-                                }));
+                        completable.thenRun(() -> stream.data(frame, new Callback()
+                        {
+                            @Override
+                            public void succeeded()
+                            {
+                                Assert.assertTrue(stream.isClosed());
+                                Assert.assertEquals(0, stream.getSession().getStreams().size());
+                                callback.succeeded();
+                                serverDataLatch.countDown();
+                            }
+                        }));
                     }
                 };
             }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -360,8 +360,8 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
         {
             NetworkBuffer buffer = producer.buffer;
             buffer.retain();
-            // TODO: remove downcast.
-            ((HTTP2Session)session).onData(frame, buffer);
+            Callback callback = buffer;
+            session.onData(frame, callback);
         }
 
         @Override

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -21,10 +21,21 @@ package org.eclipse.jetty.http2;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.GoAwayFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.PingFrame;
+import org.eclipse.jetty.http2.frames.PriorityFrame;
+import org.eclipse.jetty.http2.frames.PushPromiseFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
+import org.eclipse.jetty.http2.frames.SettingsFrame;
+import org.eclipse.jetty.http2.frames.WindowUpdateFrame;
 import org.eclipse.jetty.http2.parser.Parser;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -32,6 +43,7 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Retainable;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -66,6 +78,7 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
             executor = new TryExecutor.NoTryExecutor(executor);
         this.strategy = new EatWhatYouKill(producer, executor);
         LifeCycle.start(strategy);
+        parser.init(ParserListener::new);
     }
 
     @Override
@@ -92,7 +105,8 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
 
     protected void setInputBuffer(ByteBuffer buffer)
     {
-        producer.buffer = buffer;
+        if (buffer != null)
+            producer.setInputBuffer(buffer);
     }
 
     @Override
@@ -192,9 +206,17 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
 
     protected class HTTP2Producer implements ExecutionStrategy.Producer
     {
+        private final List<NetworkBuffer> pendingBuffers = new LinkedList<>();
         private final Callback fillableCallback = new FillableCallback();
-        private ByteBuffer buffer;
+        private NetworkBuffer buffer;
         private boolean shutdown;
+
+        private void setInputBuffer(ByteBuffer byteBuffer)
+        {
+            if (buffer == null)
+                buffer = acquireNetworkBuffer();
+            buffer.put(byteBuffer);
+        }
 
         @Override
         public Runnable produce()
@@ -209,38 +231,48 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
                 return null;
 
             if (buffer == null)
-                buffer = byteBufferPool.acquire(bufferSize, false); // TODO: make directness customizable
-            boolean looping = BufferUtil.hasContent(buffer);
+                buffer = acquireNetworkBuffer();
+            boolean parse = buffer.hasRemaining();
             while (true)
             {
-                if (looping)
+                if (parse)
                 {
                     while (buffer.hasRemaining())
-                        parser.parse(buffer);
+                        parser.parse(buffer.buffer);
+
+                    boolean released = buffer.tryReleased();
 
                     task = pollTask();
                     if (LOG.isDebugEnabled())
                         LOG.debug("Dequeued new task {}", task);
                     if (task != null)
                     {
-                        release();
+                        if (released)
+                            releaseNetworkBuffer();
+                        else
+                            buffer = null;
                         return task;
+                    }
+                    else
+                    {
+                        if (!released)
+                            buffer = acquireNetworkBuffer();
                     }
                 }
 
-                int filled = fill(getEndPoint(), buffer);
+                int filled = fill(getEndPoint(), buffer.buffer);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Filled {} bytes", filled);
+                    LOG.debug("Filled {} bytes in {}", filled, buffer);
 
                 if (filled == 0)
                 {
-                    release();
+                    releaseNetworkBuffer();
                     getEndPoint().fillInterested(fillableCallback);
                     return null;
                 }
                 else if (filled < 0)
                 {
-                    release();
+                    releaseNetworkBuffer();
                     shutdown = true;
                     session.onShutdown();
                     return null;
@@ -248,17 +280,27 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
                 else
                 {
                     bytesIn.addAndGet(filled);
+                    parse = true;
                 }
-
-                looping = true;
             }
         }
 
-        private void release()
+        private NetworkBuffer acquireNetworkBuffer()
         {
-            if (buffer != null && !buffer.hasRemaining())
+            NetworkBuffer networkBuffer = new NetworkBuffer();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Acquired {}", networkBuffer);
+            return networkBuffer;
+        }
+
+        private void releaseNetworkBuffer()
+        {
+            if (!buffer.hasRemaining())
             {
-                byteBufferPool.release(buffer);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Released {}", buffer);
+                buffer.release();
+                byteBufferPool.release(buffer.buffer);
                 buffer = null;
             }
         }
@@ -288,6 +330,173 @@ public class HTTP2Connection extends AbstractConnection implements WriteFlusher.
         public InvocationType getInvocationType()
         {
             return InvocationType.EITHER;
+        }
+    }
+
+    private class ParserListener implements Parser.Listener
+    {
+        private final Parser.Listener listener;
+
+        private ParserListener(Parser.Listener listener)
+        {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onData(DataFrame frame)
+        {
+            NetworkBuffer buffer = producer.buffer;
+            buffer.retain();
+            // TODO: remove downcast.
+            ((HTTP2Session)session).onData(frame, buffer);
+        }
+
+        @Override
+        public void onHeaders(HeadersFrame frame)
+        {
+            listener.onHeaders(frame);
+        }
+
+        @Override
+        public void onPriority(PriorityFrame frame)
+        {
+            listener.onPriority(frame);
+        }
+
+        @Override
+        public void onReset(ResetFrame frame)
+        {
+            listener.onReset(frame);
+        }
+
+        @Override
+        public void onSettings(SettingsFrame frame)
+        {
+            listener.onSettings(frame);
+        }
+
+        @Override
+        public void onPushPromise(PushPromiseFrame frame)
+        {
+            listener.onPushPromise(frame);
+        }
+
+        @Override
+        public void onPing(PingFrame frame)
+        {
+            listener.onPing(frame);
+        }
+
+        @Override
+        public void onGoAway(GoAwayFrame frame)
+        {
+            listener.onGoAway(frame);
+        }
+
+        @Override
+        public void onWindowUpdate(WindowUpdateFrame frame)
+        {
+            listener.onWindowUpdate(frame);
+        }
+
+        @Override
+        public void onConnectionFailure(int error, String reason)
+        {
+            listener.onConnectionFailure(error, reason);
+        }
+    }
+
+    private class NetworkBuffer implements Callback, Retainable
+    {
+        private final ByteBuffer buffer;
+        private int refCount;
+
+        private NetworkBuffer()
+        {
+            buffer = byteBufferPool.acquire(bufferSize, false); // TODO: make directness customizable
+        }
+
+        private void put(ByteBuffer source)
+        {
+            BufferUtil.append(buffer, source);
+        }
+
+        private boolean hasRemaining()
+        {
+            return buffer.hasRemaining();
+        }
+
+        @Override
+        public void retain()
+        {
+            synchronized (this)
+            {
+                ++refCount;
+            }
+        }
+
+        @Override
+        public void succeeded()
+        {
+            release();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            release();
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return InvocationType.NON_BLOCKING;
+        }
+
+        private void release()
+        {
+            boolean release = false;
+            synchronized (this)
+            {
+                --refCount;
+                if (refCount == 0 && !hasRemaining())
+                    release = producer.pendingBuffers.remove(this);
+            }
+            if (release)
+            {
+                byteBufferPool.release(buffer);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Released retained {}", this);
+            }
+        }
+
+        /**
+         * <p>Similar to {@code isReleased()}, but with side effects.</p>
+         * <p>Atomically checks whether this NetworkBuffer is released,
+         * and if not stores it away for later, asynchronous, release.</p>
+         *
+         * @return whether this NetworkBuffer is released
+         */
+        private boolean tryReleased()
+        {
+            synchronized (this)
+            {
+                if (refCount > 0)
+                {
+                    List<NetworkBuffer> pendingBuffers = producer.pendingBuffers;
+                    pendingBuffers.add(this);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Retained {}, total: {}", this, pendingBuffers.size());
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s@%x[%s]", getClass().getSimpleName(), hashCode(), buffer);
         }
     }
 }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -222,6 +222,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         onData(frame, Callback.NOOP);
     }
 
+    @Override
     public void onData(final DataFrame frame, Callback callback)
     {
         if (LOG.isDebugEnabled())

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.util.Atomics;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.CountingCallback;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.Retainable;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
@@ -216,7 +217,12 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
     }
 
     @Override
-    public void onData(final DataFrame frame)
+    public void onData(DataFrame frame)
+    {
+        onData(frame, Callback.NOOP);
+    }
+
+    public void onData(final DataFrame frame, Callback callback)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Received {}", frame);
@@ -233,39 +239,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         {
             if (getRecvWindow() < 0)
             {
-                close(ErrorCode.FLOW_CONTROL_ERROR.code, "session_window_exceeded", Callback.NOOP);
+                close(ErrorCode.FLOW_CONTROL_ERROR.code, "session_window_exceeded", callback);
             }
             else
             {
-                stream.process(frame, new Callback()
-                {
-                    @Override
-                    public void succeeded()
-                    {
-                        complete();
-                    }
-
-                    @Override
-                    public void failed(Throwable x)
-                    {
-                        // Consume also in case of failures, to free the
-                        // session flow control window for other streams.
-                        complete();
-                    }
-
-                    @Override
-                    public InvocationType getInvocationType()
-                    {
-                        return InvocationType.NON_BLOCKING;
-                    }
-
-                    private void complete()
-                    {
-                        notIdle();
-                        stream.notIdle();
-                        flowControl.onDataConsumed(HTTP2Session.this, stream, flowControlLength);
-                    }
-                });
+                stream.process(frame, new DataCallback(callback, stream, flowControlLength));
             }
         }
         else
@@ -275,6 +253,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             // We must enlarge the session flow control window,
             // otherwise other requests will be stalled.
             flowControl.onDataConsumed(this, null, flowControlLength);
+            callback.succeeded();
         }
     }
 
@@ -1411,6 +1390,50 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         public void failed(Throwable x)
         {
             promise.failed(x);
+        }
+    }
+
+    private class DataCallback extends Callback.Nested implements Retainable
+    {
+        private final IStream stream;
+        private final int flowControlLength;
+
+        public DataCallback(Callback callback, IStream stream, int flowControlLength)
+        {
+            super(callback);
+            this.stream = stream;
+            this.flowControlLength = flowControlLength;
+        }
+
+        @Override
+        public void retain()
+        {
+            Callback callback = getCallback();
+            if (callback instanceof Retainable)
+                ((Retainable)callback).retain();
+        }
+
+        @Override
+        public void succeeded()
+        {
+            complete();
+            super.succeeded();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            // Consume also in case of failures, to free the
+            // session flow control window for other streams.
+            complete();
+            super.failed(x);
+        }
+
+        private void complete()
+        {
+            notIdle();
+            stream.notIdle();
+            flowControl.onDataConsumed(HTTP2Session.this, stream, flowControlLength);
         }
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/ISession.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/ISession.java
@@ -117,7 +117,7 @@ public interface ISession extends Session
      *
      * @see #onShutdown()
      * @see #close(int, String, Callback)
-     * @return <code>true</code> if the session has expired
+     * @return {@code true} if the session has expired
      */
     public boolean onIdleTimeout();
 
@@ -133,4 +133,12 @@ public interface ISession extends Session
      * @return the number of bytes written by this session
      */
     public long getBytesWritten();
+
+    /**
+     * <p>Callback method invoked when a DATA frame is received.</p>
+     *
+     * @param frame the DATA frame received
+     * @param callback the callback to notify when the frame has been processed
+     */
+    public void onData(DataFrame frame, Callback callback);
 }

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpField;
@@ -61,6 +62,7 @@ public class ContinuationParseTest
                 frames.add(new HeadersFrame(null, null, false));
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure the parser is properly reset.
         for (int i = 0; i < 2; ++i)

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/DataGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/DataGenerateParseTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.DataGenerator;
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
@@ -98,6 +99,7 @@ public class DataGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure generator and parser are properly reset.
         for (int i = 0; i < 2; ++i)
@@ -137,6 +139,7 @@ public class DataGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure generator and parser are properly reset.
         for (int i = 0; i < 2; ++i)

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/GoAwayGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/GoAwayGenerateParseTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.GoAwayGenerator;
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
@@ -49,6 +50,7 @@ public class GoAwayGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int lastStreamId = 13;
         int error = 17;
@@ -90,6 +92,7 @@ public class GoAwayGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int lastStreamId = 13;
         int error = 17;

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/HeadersGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/HeadersGenerateParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpField;
@@ -61,6 +62,7 @@ public class HeadersGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure generator and parser are properly reset.
         for (int i = 0; i < 2; ++i)
@@ -113,6 +115,7 @@ public class HeadersGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure generator and parser are properly reset.
         for (int i = 0; i < 2; ++i)

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PingGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PingGenerateParseTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
 import org.eclipse.jetty.http2.generator.PingGenerator;
@@ -49,6 +50,7 @@ public class PingGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         byte[] payload = new byte[8];
         new Random().nextBytes(payload);
@@ -89,6 +91,7 @@ public class PingGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         byte[] payload = new byte[8];
         new Random().nextBytes(payload);
@@ -129,6 +132,7 @@ public class PingGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         ByteBufferPool.Lease lease = new ByteBufferPool.Lease(byteBufferPool);
         PingFrame ping = new PingFrame(System.nanoTime(), true);

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PriorityGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PriorityGenerateParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
 import org.eclipse.jetty.http2.generator.PriorityGenerator;
@@ -48,6 +49,7 @@ public class PriorityGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int parentStreamId = 17;
@@ -92,6 +94,7 @@ public class PriorityGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int parentStreamId = 17;

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PushPromiseGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/PushPromiseGenerateParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpField;
@@ -55,6 +56,7 @@ public class PushPromiseGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int promisedStreamId = 17;
@@ -107,6 +109,7 @@ public class PushPromiseGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int promisedStreamId = 17;

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/ResetGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/ResetGenerateParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
 import org.eclipse.jetty.http2.generator.ResetGenerator;
@@ -48,6 +49,7 @@ public class ResetGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int error = 17;
@@ -88,6 +90,7 @@ public class ResetGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int error = 17;

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/SettingsGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/SettingsGenerateParseTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
@@ -81,6 +82,7 @@ public class SettingsGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         // Iterate a few times to be sure generator and parser are properly reset.
         for (int i = 0; i < 2; ++i)
@@ -115,6 +117,7 @@ public class SettingsGenerateParseTest
                 errorRef.set(error);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         Map<Integer, Integer> settings1 = new HashMap<>();
         settings1.put(13, 17);
@@ -149,6 +152,7 @@ public class SettingsGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         Map<Integer, Integer> settings1 = new HashMap<>();
         int key = 13;

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/WindowUpdateGenerateParseTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/WindowUpdateGenerateParseTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.frames;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http2.generator.HeaderGenerator;
 import org.eclipse.jetty.http2.generator.WindowUpdateGenerator;
@@ -48,6 +49,7 @@ public class WindowUpdateGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int windowUpdate = 17;
@@ -88,6 +90,7 @@ public class WindowUpdateGenerateParseTest
                 frames.add(frame);
             }
         }, 4096, 8192);
+        parser.init(UnaryOperator.identity());
 
         int streamId = 13;
         int windowUpdate = 17;

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.http2.client.http;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
@@ -154,7 +153,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
         }
         else
         {
-            contentNotifier.offer(new DataInfo(exchange, frame.getData(), callback, frame.isEndStream()));
+            contentNotifier.offer(new DataInfo(exchange, frame, callback));
             contentNotifier.iterate();
         }
     }
@@ -203,13 +202,13 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
             if (dataInfo == null)
             {
                 DataInfo prevDataInfo = this.dataInfo;
-                if (prevDataInfo != null && prevDataInfo.last)
+                if (prevDataInfo != null && prevDataInfo.frame.isEndStream())
                     return Action.SUCCEEDED;
                 return Action.IDLE;
             }
 
             this.dataInfo = dataInfo;
-            responseContent(dataInfo.exchange, dataInfo.buffer, this);
+            responseContent(dataInfo.exchange, dataInfo.frame.getData(), this);
             return Action.SCHEDULED;
         }
 
@@ -245,16 +244,14 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
     private static class DataInfo
     {
         private final HttpExchange exchange;
-        private final ByteBuffer buffer;
+        private final DataFrame frame;
         private final Callback callback;
-        private final boolean last;
 
-        private DataInfo(HttpExchange exchange, ByteBuffer buffer, Callback callback, boolean last)
+        private DataInfo(HttpExchange exchange, DataFrame frame, Callback callback)
         {
             this.exchange = exchange;
-            this.buffer = buffer;
+            this.frame = frame;
             this.callback = callback;
-            this.last = last;
         }
     }
 }

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -499,6 +500,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
                         }
                     }
                 }, 4096, 8192);
+                parser.init(UnaryOperator.identity());
 
                 byte[] bytes = new byte[1024];
                 while (true)

--- a/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/CloseTest.java
+++ b/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/CloseTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
@@ -107,6 +108,7 @@ public class CloseTest extends AbstractServerTest
                     }
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -163,6 +165,7 @@ public class CloseTest extends AbstractServerTest
                     responseLatch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -231,6 +234,7 @@ public class CloseTest extends AbstractServerTest
                     closeLatch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 

--- a/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2CServerTest.java
+++ b/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2CServerTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -166,6 +167,7 @@ public class HTTP2CServerTest extends AbstractServerTest
                     latchRef.get().countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -263,6 +265,7 @@ public class HTTP2CServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 

--- a/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2ServerTest.java
+++ b/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2ServerTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -59,7 +60,6 @@ import org.eclipse.jetty.http2.parser.Parser;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ChannelEndPoint;
 import org.eclipse.jetty.io.ManagedSelector;
-import org.eclipse.jetty.io.SelectChannelEndPoint;
 import org.eclipse.jetty.io.SocketChannelEndPoint;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -99,6 +99,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -149,6 +150,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -214,6 +216,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -260,6 +263,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -297,6 +301,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                     latch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
 
             parseResponse(client, parser);
 
@@ -363,6 +368,7 @@ public class HTTP2ServerTest extends AbstractServerTest
             // The server will close the connection abruptly since it
             // cannot write and therefore cannot even send the GO_AWAY.
             Parser parser = new Parser(byteBufferPool, new Parser.Listener.Adapter(), 4096, 8192);
+            parser.init(UnaryOperator.identity());
             boolean closed = parseResponse(client, parser, 2 * delay);
             Assert.assertTrue(closed);
         }
@@ -397,6 +403,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                 output.flush();
 
                 Parser parser = new Parser(byteBufferPool, new Parser.Listener.Adapter(), 4096, 8192);
+                parser.init(UnaryOperator.identity());
                 boolean closed = parseResponse(client, parser);
 
                 Assert.assertTrue(closed);
@@ -575,6 +582,7 @@ public class HTTP2ServerTest extends AbstractServerTest
                         clientLatch.countDown();
                 }
             }, 4096, 8192);
+            parser.init(UnaryOperator.identity());
             boolean closed = parseResponse(client, parser);
 
             Assert.assertTrue(clientLatch.await(5, TimeUnit.SECONDS));

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Retainable.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Retainable.java
@@ -1,0 +1,24 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+public interface Retainable
+{
+    public void retain();
+}


### PR DESCRIPTION
Implemented reference counting for the network buffer, with the
semantic that calling succeeded() on callbacks decrements the
reference count.
Introduced interface Retainable, used by the client when notifying
multiple application content listeners.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>