### PR TITLE
Support root base or home for quickstart #2446

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
@@ -81,11 +81,12 @@ public class AttributeNormalizer
     private static URI toCanonicalURI(URI uri)
     {
         uri = uri.normalize();
-        String ascii = uri.toASCIIString();
-        if (ascii.endsWith("/"))
+        String path = uri.getPath();
+        if (path!=null && path.length()>1 && path.endsWith("/"))
         {
             try
             {
+                String ascii = uri.toASCIIString();
                 uri = new URI(ascii.substring(0,ascii.length()-1));
             }
             catch(URISyntaxException e)

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
@@ -96,6 +96,15 @@ public class AttributeNormalizer
         }
         return uri;
     }
+    
+    public static String toCanonicalURI(String uri)
+    {
+        if (uri!=null && uri.length()>1 && uri.endsWith("/"))
+        {
+            return uri.substring(0,uri.length()-1);
+        }
+        return uri;
+    }
 
     public static Path toCanonicalPath(String path)
     {
@@ -149,8 +158,8 @@ public class AttributeNormalizer
         
         public URIAttribute(String key, URI uri, int weight)
         {
-            super(key,uri.toASCIIString(),weight);
-            this.uri = uri;
+            super(key,toCanonicalURI(uri.toASCIIString()),weight);
+            this.uri = toCanonicalURI(uri);
         }
         
         @Override
@@ -234,7 +243,7 @@ public class AttributeNormalizer
             {
                 LOG.debug(attr.toString());
             }
-        }
+        }        
     }
 
     private void addSystemProperty(List<PathAttribute> paths, List<URIAttribute> uris, String key, int weight)

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
@@ -63,7 +63,7 @@ public class AttributeNormalizer
 {
     private static final Logger LOG = Log.getLogger(AttributeNormalizer.class);
     private static final Pattern __propertyPattern = Pattern.compile("(?<=[^$]|^)\\$\\{([^}]*)\\}");
-    
+
     private static class Attribute
     {
         final String key;
@@ -78,7 +78,7 @@ public class AttributeNormalizer
         }
     }
 
-    private static URI toCanonicalURI(URI uri)
+    public static URI toCanonicalURI(URI uri)
     {
         uri = uri.normalize();
         String path = uri.getPath();
@@ -96,8 +96,8 @@ public class AttributeNormalizer
         }
         return uri;
     }
-    
-    private static Path toCanonicalPath(String path)
+
+    public static Path toCanonicalPath(String path)
     {
         if (path == null)
             return null;
@@ -199,17 +199,6 @@ public class AttributeNormalizer
         }
     };
 
-    private static void add(List<PathAttribute>paths,List<URIAttribute> uris,String key,int weight)
-    {
-        String value = System.getProperty(key);
-        if (value!=null)
-        {
-            Path path = toCanonicalPath(value);
-            paths.add(new PathAttribute(key,path,weight));
-            uris.add(new URIAttribute(key+".uri",toCanonicalURI(path.toUri()),weight));
-        }
-    }
-
     private URI warURI;
     private Map<String,Attribute> attributes = new HashMap<>();
     private List<PathAttribute> paths = new ArrayList<>();
@@ -224,10 +213,10 @@ public class AttributeNormalizer
         if (!warURI.isAbsolute())
             throw new IllegalArgumentException("WAR URI is not absolute: " + warURI);
         
-        add(paths,uris,"jetty.base",9);
-        add(paths,uris,"jetty.home",8);
-        add(paths,uris,"user.home",7);
-        add(paths,uris,"user.dir",6);
+        addSystemProperty(paths, uris,"jetty.base",9);
+        addSystemProperty(paths, uris,"jetty.home",8);
+        addSystemProperty(paths, uris,"user.home",7);
+        addSystemProperty(paths, uris,"user.dir",6);
 
         if (warURI.getScheme().equalsIgnoreCase("file"))
             paths.add(new PathAttribute("WAR.path",toCanonicalPath(new File(warURI).toString()),10));
@@ -245,6 +234,17 @@ public class AttributeNormalizer
             {
                 LOG.debug(attr.toString());
             }
+        }
+    }
+
+    private void addSystemProperty(List<PathAttribute> paths, List<URIAttribute> uris, String key, int weight)
+    {
+        String value = System.getProperty(key);
+        if (value!=null)
+        {
+            Path path = toCanonicalPath(value);
+            paths.add(new PathAttribute(key,path,weight));
+            uris.add(new URIAttribute(key+".uri",path.toUri(),weight));
         }
     }
 

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizerTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizerTest.java
@@ -244,6 +244,7 @@ public class AttributeNormalizerTest
     {
         // Normalize jetty.home as URI path        
         String expected = jettyBase.equals(jettyHome)?"${jetty.base.uri}":"${jetty.home.uri}";
+        
         // Path.toUri() typically includes an URI authority
         assertNormalize(jettyHome.toUri(), expected);
     }

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizerTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizerTest.java
@@ -63,6 +63,16 @@ public class AttributeNormalizerTest
         data.add(new Object[]{arch, title, env});
         
         // ------
+        title = "Old Setup";
+        
+        env = new HashMap<>();
+        env.put("jetty.home", asTargetPath(title,"jetty-distro"));
+        env.put("jetty.base", asTargetPath(title,"jetty-distro"));
+        env.put("WAR", asTargetPath(title,"jetty-distro/webapps/FOO"));
+        
+        data.add(new Object[]{arch, title, env});
+        
+        // ------
         // This puts the jetty.home inside of the jetty.base
         title = "Overlap Setup";
         env = new HashMap<>();
@@ -82,6 +92,16 @@ public class AttributeNormalizerTest
         env.put("WAR", asTargetPath(title,"app%2Fnasty/base/webapps/FOO"));
         
         data.add(new Object[]{arch, title, env});
+
+        // ------
+        title = "Root Path Setup";
+        env = new HashMap<>();
+        env.put("jetty.home", "/");
+        env.put("jetty.base", "/");
+        env.put("WAR", asTargetPath(title,"webapps/root"));
+        
+        data.add(new Object[]{arch, title, env});
+        
         return data;
     }
     
@@ -183,7 +203,8 @@ public class AttributeNormalizerTest
     public void testNormalizeJettyHomeAsFile()
     {
         // Normalize jetty.home as File path
-        assertNormalize(new File(jettyHome), "${jetty.home}");
+        String expected = jettyBase.equals(jettyHome)?"${jetty.base}":"${jetty.home}";
+        assertNormalize(new File(jettyHome), expected);
     }
     
     @Test
@@ -196,8 +217,9 @@ public class AttributeNormalizerTest
     @Test
     public void testNormalizeJettyHomeAsURI()
     {
-        // Normalize jetty.home as URI path
-        assertNormalize(new File(jettyHome).toURI(), "${jetty.home.uri}");
+        // Normalize jetty.home as URI path        
+        String expected = jettyBase.equals(jettyHome)?"${jetty.base.uri}":"${jetty.home.uri}";
+        assertNormalize(new File(jettyHome).toURI(), expected);
     }
     
     @Test

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizer_ToCanonicalUriTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizer_ToCanonicalUriTest.java
@@ -38,18 +38,14 @@ public class AttributeNormalizer_ToCanonicalUriTest
     {
         List<Object[]> data = new ArrayList<>();
 
+        
         // root without authority
         data.add(new String[]{ "file:/", "file:/" });
-        data.add(new String[]{ "file:/F:/", "file:/F:/" });
+        data.add(new String[]{ "file:/F:/", "file:/F:" });
+        
         // root with empty authority
-        data.add(new String[]{ "file:///", "file://" });
-        data.add(new String[]{ "file:///F:/", "file:///F:/" });
-
-        // system identified root directories
-        FileSystems.getDefault().getRootDirectories().forEach((root) -> {
-            String rootUri = root.toUri().toASCIIString();
-            data.add(new String[]{rootUri, rootUri});
-        });
+        data.add(new String[]{ "file:///", "file:///" });
+        data.add(new String[]{ "file:///F:/", "file:///F:" });
 
         // deep directory - no authority
         data.add(new String[]{ "file:/home/user/code/", "file:/home/user/code" });

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizer_ToCanonicalUriTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/AttributeNormalizer_ToCanonicalUriTest.java
@@ -1,0 +1,82 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.quickstart;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AttributeNormalizer_ToCanonicalUriTest
+{
+    @Parameterized.Parameters(name = "[{index}] {0} - {1}")
+    public static List<Object[]> data()
+    {
+        List<Object[]> data = new ArrayList<>();
+
+        // root without authority
+        data.add(new String[]{ "file:/", "file:/" });
+        data.add(new String[]{ "file:/F:/", "file:/F:/" });
+        // root with empty authority
+        data.add(new String[]{ "file:///", "file://" });
+        data.add(new String[]{ "file:///F:/", "file:///F:/" });
+
+        // system identified root directories
+        FileSystems.getDefault().getRootDirectories().forEach((root) -> {
+            String rootUri = root.toUri().toASCIIString();
+            data.add(new String[]{rootUri, rootUri});
+        });
+
+        // deep directory - no authority
+        data.add(new String[]{ "file:/home/user/code/", "file:/home/user/code" });
+        data.add(new String[]{ "file:/C:/code/", "file:/C:/code" });
+
+        // deep directory - with authority
+        data.add(new String[]{ "file:///home/user/code/", "file:///home/user/code" });
+        data.add(new String[]{ "file:///C:/code/", "file:///C:/code" });
+
+        // Some non-file tests
+        data.add(new String[]{ "http://webtide.com/", "http://webtide.com/" });
+        data.add(new String[]{ "http://webtide.com/cometd/", "http://webtide.com/cometd" });
+
+        return data;
+    }
+
+    @Parameterized.Parameter
+    public String input;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Test
+    public void testCanonicalURI()
+    {
+        URI inputURI = URI.create(input);
+        URI actual = AttributeNormalizer.toCanonicalURI(inputURI);
+        assertThat(input, actual.toASCIIString(), is(expected));
+    }
+}


### PR DESCRIPTION
Fix #2446 by only stripping trailing '/' from non-root URIs.  

Signed-off-by: Greg Wilkins <gregw@webtide.com>