### PR TITLE
Jetty 9.4.x #1555 wwwAuthenticate Parsing

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -42,7 +42,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
 {
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
-    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*)realm=\"([^\"]*)\"(.*)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTHENTICATE_PATTERN = Pattern.compile("([^\\s]+)\\s(.*,\\s*)?realm=\"([^\"]*)\"\\s*,?\\s*(.*)", Pattern.CASE_INSENSITIVE);
 
     private final HttpClient client;
     private final int maxContentLength;
@@ -242,7 +242,12 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                 {
                     String type = matcher.group(1);
                     String realm = matcher.group(3);
-                    String params = matcher.group(2) + matcher.group(4);
+                    String params;
+                    if(matcher.group(2) != null)
+                        params = matcher.group(2) + matcher.group(4);
+                    else
+                        params = matcher.group(4);
+
                     Authentication.HeaderInfo headerInfo = new Authentication.HeaderInfo(type, realm, params, getAuthorizationHeader());
                     result.add(headerInfo);
                 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Authentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Authentication.java
@@ -19,9 +19,11 @@
 package org.eclipse.jetty.client.api;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.Attributes;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * {@link Authentication} represents a mechanism to authenticate requests for protected resources.
@@ -76,19 +78,18 @@ public interface Authentication
      */
     public static class HeaderInfo
     {
-        private final String type;
-        private final String realm;
-        private final String params;
         private final HttpHeader header;
+        private final String type;
+        private final Map<String,String> params;
 
-        public HeaderInfo(String type, String realm, String params, HttpHeader header)
+        
+        public HeaderInfo(HttpHeader header, String type, Map<String,String> params) throws IllegalArgumentException
         {
-            this.type = type;
-            this.realm = realm;
-            this.params = params;
             this.header = header;
+            this.type = type;
+            this.params = params;
         }
-
+        
         /**
          * @return the authentication type (for example "Basic" or "Digest")
          */
@@ -98,19 +99,27 @@ public interface Authentication
         }
 
         /**
-         * @return the realm name
+         * @return the realm name or null if there is no realm parameter
          */
         public String getRealm()
         {
-            return realm;
+            return params.get("realm");
         }
 
         /**
          * @return additional authentication parameters
          */
-        public String getParameters()
+        public Map<String, String> getParameters()
         {
             return params;
+        }
+        
+        /**
+         * @return specified authentication parameter or null if does not exist
+         */
+        public String getParameter(String paramName)
+        {
+            return params.get(StringUtil.asciiToLowerCase(paramName));
         }
 
         /**

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Authentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Authentication.java
@@ -107,6 +107,14 @@ public interface Authentication
         }
 
         /**
+         * @return the base64 content as a string if it exists otherwise null
+         */
+        public String getBase64()
+        {
+            return params.get("base64");
+        }
+        
+        /**
          * @return additional authentication parameters
          */
         public Map<String, String> getParameters()

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -689,7 +689,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));
         Assert.assertTrue(headerInfo.getParameter("realm") == null);
         
-        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Scheme1 ,  Scheme2 ");
+        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Scheme1 ,  Scheme2");
         Assert.assertEquals(headerInfos.size(), 2);
         Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Scheme1"));
         Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Scheme2"));

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -689,10 +689,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));
         Assert.assertTrue(headerInfo.getParameter("realm") == null);
         
-        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Scheme1 ,  Scheme2");
-        Assert.assertEquals(headerInfos.size(), 2);
+        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Scheme1    ,    Scheme2        ,      Scheme3");
+        Assert.assertEquals(3, headerInfos.size());
         Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Scheme1"));
         Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Scheme2"));
+        Assert.assertTrue(headerInfos.get(2).getType().equalsIgnoreCase("Scheme3"));
         
         headerInfo = aph.getHeaderInfo("Scheme name=\"value\", other=\"value2\"").get(0);
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -43,6 +43,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Response.Listener;
 import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.api.Authentication.HeaderInfo;
 import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.DeferredContentProvider;
 import org.eclipse.jetty.client.util.DigestAuthentication;
@@ -612,5 +613,35 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
                 }
             };
         }
+    }
+    
+    @Test
+    public void testParamOrdering() {
+        AuthenticationProtocolHandler aph = new WWWAuthenticationProtocolHandler(client);
+        
+        HeaderInfo headerInfo = aph.newHeaderInfo("Digest realm=\"thermostat\", qop=\"auth\", nonce=\"1523430383\"");
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
+        Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
+        Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
+        
+        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", realm=\"thermostat\", nonce=\"1523430383\"");
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
+        Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
+        Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
+        
+        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\", realm=\"thermostat\"");
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
+        Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
+        Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
+        
+        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\"");
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
+        Assert.assertTrue(headerInfo.getParameter("realm") == null);
+        Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
+        
     }
 }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +65,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -616,32 +618,117 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     }
     
     @Test
-    public void testParamOrdering() {
+    public void testTestHeaderInfoParsing() {
         AuthenticationProtocolHandler aph = new WWWAuthenticationProtocolHandler(client);
         
-        HeaderInfo headerInfo = aph.newHeaderInfo("Digest realm=\"thermostat\", qop=\"auth\", nonce=\"1523430383\"");
+        HeaderInfo headerInfo = aph.getHeaderInfo("Digest realm=\"thermostat\", qop=\"auth\", nonce=\"1523430383\"").get(0);
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
         Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
         Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
         Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
         
-        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", realm=\"thermostat\", nonce=\"1523430383\"");
+        headerInfo = aph.getHeaderInfo("Digest qop=\"auth\", realm=\"thermostat\", nonce=\"1523430383\"").get(0);
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
         Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
         Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
         Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
         
-        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\", realm=\"thermostat\"");
+        headerInfo = aph.getHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\", realm=\"thermostat\"").get(0);
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
         Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
         Assert.assertTrue(headerInfo.getParameter("realm").equals("thermostat"));
         Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
         
-        headerInfo = aph.newHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\"");
+        headerInfo = aph.getHeaderInfo("Digest qop=\"auth\", nonce=\"1523430383\"").get(0);
         Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Digest"));
         Assert.assertTrue(headerInfo.getParameter("qop").equals("auth"));
         Assert.assertTrue(headerInfo.getParameter("realm") == null);
         Assert.assertTrue(headerInfo.getParameter("nonce").equals("1523430383"));
         
+        
+        // test multiple authentications
+        List<HeaderInfo> headerInfoList = aph.getHeaderInfo("Digest qop=\"auth\", realm=\"thermostat\", nonce=\"1523430383\", "
+                                                          + "Digest realm=\"thermostat2\", qop=\"auth2\", nonce=\"4522530354\", "
+                                                          + "Digest qop=\"auth3\", nonce=\"9523570528\", realm=\"thermostat3\", "
+                                                          + "Digest qop=\"auth4\", nonce=\"3526435321\"");
+        
+        Assert.assertTrue(headerInfoList.get(0).getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfoList.get(0).getParameter("qop").equals("auth"));
+        Assert.assertTrue(headerInfoList.get(0).getParameter("realm").equals("thermostat"));
+        Assert.assertTrue(headerInfoList.get(0).getParameter("nonce").equals("1523430383"));
+        
+        Assert.assertTrue(headerInfoList.get(1).getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfoList.get(1).getParameter("qop").equals("auth2"));
+        Assert.assertTrue(headerInfoList.get(1).getParameter("realm").equals("thermostat2"));
+        Assert.assertTrue(headerInfoList.get(1).getParameter("nonce").equals("4522530354"));
+        
+        Assert.assertTrue(headerInfoList.get(2).getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfoList.get(2).getParameter("qop").equals("auth3"));
+        Assert.assertTrue(headerInfoList.get(2).getParameter("realm").equals("thermostat3"));
+        Assert.assertTrue(headerInfoList.get(2).getParameter("nonce").equals("9523570528"));
+        
+        Assert.assertTrue(headerInfoList.get(3).getType().equalsIgnoreCase("Digest"));
+        Assert.assertTrue(headerInfoList.get(3).getParameter("qop").equals("auth4"));
+        Assert.assertTrue(headerInfoList.get(3).getParameter("realm") == null);
+        Assert.assertTrue(headerInfoList.get(3).getParameter("nonce").equals("3526435321"));
+        
+        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"\", Basic realm=\"simple\"");
+        Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Newauth"));
+        Assert.assertTrue(headerInfos.get(0).getParameter("realm").equals("apps"));
+        Assert.assertTrue(headerInfos.get(0).getParameter("type").equals("1"));
+        Assert.assertThat(headerInfos.get(0).getParameter("title"), Matchers.equalTo("Login to \"apps\""));
+        Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Basic"));
+        Assert.assertTrue(headerInfos.get(1).getParameter("realm").equals("simple"));        
+    }
+    
+    @Test
+    public void testTestHeaderInfoParsingUnusualCases() {
+        AuthenticationProtocolHandler aph = new WWWAuthenticationProtocolHandler(client);
+        
+        HeaderInfo headerInfo = aph.getHeaderInfo("Scheme").get(0);
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));
+        Assert.assertTrue(headerInfo.getParameter("realm") == null);
+        
+        List<HeaderInfo> headerInfos = aph.getHeaderInfo("Scheme1 ,  Scheme2 ");
+        Assert.assertEquals(headerInfos.size(), 2);
+        Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Scheme1"));
+        Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Scheme2"));
+        
+        headerInfo = aph.getHeaderInfo("Scheme name=\"value\", other=\"value2\"").get(0);
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));
+        Assert.assertTrue(headerInfo.getParameter("name").equals("value"));
+        Assert.assertTrue(headerInfo.getParameter("other").equals("value2"));
+        
+        headerInfo = aph.getHeaderInfo("Scheme   name   = value   , other   =  \"value2\"    ").get(0);
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Scheme"));
+        Assert.assertTrue(headerInfo.getParameter("name").equals("value"));
+        Assert.assertTrue(headerInfo.getParameter("other").equals("value2"));
+        
+        headerInfos = aph.getHeaderInfo("Scheme name=value, Scheme2   name=value2");
+        Assert.assertEquals(headerInfos.size(), 2);
+        Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Scheme"));
+        Assert.assertTrue(headerInfos.get(0).getParameter("nAmE").equals("value"));
+        Assert.assertThat(headerInfos.get(1).getType(), Matchers.equalToIgnoringCase("Scheme2"));
+        Assert.assertTrue(headerInfos.get(1).getParameter("nAmE").equals("value2"));
+        
+        headerInfos = aph.getHeaderInfo("Scheme ,   ,, ,, name=value, Scheme2 name=value2");
+        Assert.assertEquals(headerInfos.size(), 2);
+        Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Scheme"));
+        Assert.assertTrue(headerInfos.get(0).getParameter("name").equals("value"));
+        Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Scheme2"));
+        Assert.assertTrue(headerInfos.get(1).getParameter("name").equals("value2"));
+        
+        //Negotiate with base64 Content
+        headerInfo = aph.getHeaderInfo("Negotiate TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAFAs4OAAAADw==").get(0);
+        Assert.assertTrue(headerInfo.getType().equalsIgnoreCase("Negotiate"));
+        Assert.assertTrue(headerInfo.getBase64().equals("TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAFAs4OAAAADw=="));
+        
+        headerInfos = aph.getHeaderInfo("Negotiate TlRMTVNTUAABAAAAAAAAAFAs4OAAAADw==, "
+                                    +  "Negotiate YIIJvwYGKwYBBQUCoIIJszCCCa+gJDAi=");
+        Assert.assertTrue(headerInfos.get(0).getType().equalsIgnoreCase("Negotiate"));
+        Assert.assertTrue(headerInfos.get(0).getBase64().equals("TlRMTVNTUAABAAAAAAAAAFAs4OAAAADw=="));
+        
+        Assert.assertTrue(headerInfos.get(1).getType().equalsIgnoreCase("Negotiate"));
+        Assert.assertTrue(headerInfos.get(1).getBase64().equals("YIIJvwYGKwYBBQUCoIIJszCCCa+gJDAi="));
     }
 }


### PR DESCRIPTION
Reworked the way authentication parameters are parsed to make them order independent and to allow allow for a missing realm parameter. This also prevents parsing over the parameters twice.
#1555 

- Removed the regex to separate out the realm parameter and instead parse it with the other parameters into HeaderInfo.
- Changed HeaderInfo to store the parsed parameters as a Map instead of the un-parsed parameters in a string.
- The parsing of the parameters is now done in AuthenticationProtocolHandler.newHeaderInfo(String) and then passed into the HeaderInfo instead of Parsing it in DigestAuthentication.
- Replaced the usage of splitParams(String) with QuotedCSV used to parse the parameters.
- Added test to check the ordering of parameters doesn't matter.
- Allow not to have a realm parameter, changed DigestAuthentication.matches() to not match if realm is null, so that Digest Authentication requires realm parameter but Basic Authentication can be done without it. There is currently no tests for this.