### PR TITLE
Issue #2427 Stop and start session idle timer

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -158,6 +158,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
 
     
     
+    
     /**
      * PlaceHolder
      */
@@ -547,7 +548,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                         //reactivate the session
                         session.didActivate();    
                         session.setResident(true);
-                        doPutIfAbsent(id,session);//ensure it is in our map  
+                        doPutIfAbsent(id,session);//ensure it is in our map
                         if (LOG.isDebugEnabled())LOG.debug("Session reactivated id={}",id);
                     }
                 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
@@ -224,5 +224,4 @@ public class DefaultSessionCache extends AbstractSessionCache
         return result;
     }
 
-
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
@@ -156,7 +156,6 @@ public class DefaultSessionCache extends AbstractSessionCache
                 //if we have a backing store so give the session to it to write out if necessary
                 if (_sessionDataStore != null)
                 {
-                    session.stopInactivityTimer(true); //stop the idle timer and get rid of it
                     session.willPassivate();
                     try
                     {
@@ -167,6 +166,7 @@ public class DefaultSessionCache extends AbstractSessionCache
                         LOG.warn(e);
                     }
                     doDelete (session.getId()); //remove from memory
+                    session.setResident(false);
                 }
                 else
                 {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
@@ -156,6 +156,7 @@ public class DefaultSessionCache extends AbstractSessionCache
                 //if we have a backing store so give the session to it to write out if necessary
                 if (_sessionDataStore != null)
                 {
+                    session.stopInactivityTimer(true); //stop the idle timer and get rid of it
                     session.willPassivate();
                     try
                     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
@@ -113,7 +113,4 @@ public class NullSessionCache extends AbstractSessionCache
     {
         LOG.warn("Ignoring eviction setting:"+evictionTimeout);
     }
-    
-    
-
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -1333,6 +1333,7 @@ public class SessionHandler extends ScopedHandler
             if (_sessionIdManager.getSessionHouseKeeper() != null && _sessionIdManager.getSessionHouseKeeper().getIntervalSec() > 0)
             {
                 _candidateSessionIdsForExpiry.add(session.getId());
+                session.stopInactivityTimer(true);
                 if (LOG.isDebugEnabled())LOG.debug("Session {} is candidate for expiry", session.getId());
             }
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -131,7 +131,7 @@ public class SessionHandler extends ScopedHandler
             
     public Set<SessionTrackingMode> __defaultSessionTrackingModes =
         Collections.unmodifiableSet(
-            new HashSet<SessionTrackingMode>(
+            new HashSet<>(
                     Arrays.asList(new SessionTrackingMode[]{SessionTrackingMode.COOKIE,SessionTrackingMode.URL})));
 
     
@@ -1103,7 +1103,7 @@ public class SessionHandler extends ScopedHandler
     /* ------------------------------------------------------------ */
     public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes)
     {
-        _sessionTrackingModes=new HashSet<SessionTrackingMode>(sessionTrackingModes);
+        _sessionTrackingModes=new HashSet<>(sessionTrackingModes);
         _usingCookies=_sessionTrackingModes.contains(SessionTrackingMode.COOKIE);
         _usingURLs=_sessionTrackingModes.contains(SessionTrackingMode.URL);
     }
@@ -1262,7 +1262,7 @@ public class SessionHandler extends ScopedHandler
         //arrive during this processing will be dealt with on 
         //subsequent call to scavenge
         String[] ss = _candidateSessionIdsForExpiry.toArray(new String[0]);
-        Set<String> candidates = new HashSet<String>(Arrays.asList(ss));
+        Set<String> candidates = new HashSet<>(Arrays.asList(ss));
         _candidateSessionIdsForExpiry.removeAll(candidates);
         if (LOG.isDebugEnabled())
             LOG.debug("{} scavenging session ids {}", this, candidates);
@@ -1333,7 +1333,6 @@ public class SessionHandler extends ScopedHandler
             if (_sessionIdManager.getSessionHouseKeeper() != null && _sessionIdManager.getSessionHouseKeeper().getIntervalSec() > 0)
             {
                 _candidateSessionIdsForExpiry.add(session.getId());
-                session.stopInactivityTimer(true);
                 if (LOG.isDebugEnabled())LOG.debug("Session {} is candidate for expiry", session.getId());
             }
         }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionCookieTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionCookieTest.java
@@ -136,7 +136,7 @@ public class SessionCookieTest
         
         long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
         
-        Session session = new Session(null, new SessionData("123", "_foo", "0.0.0.0", now, now, now, 30)); 
+        Session session = new Session(mgr, new SessionData("123", "_foo", "0.0.0.0", now, now, now, 30)); 
 
         SessionCookieConfig sessionCookieConfig = mgr.getSessionCookieConfig();
         sessionCookieConfig.setSecure(true);

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/IdleSessionTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/IdleSessionTest.java
@@ -110,7 +110,6 @@ public class IdleSessionTest
             //check session reactivated
             assertTrue(contextHandler.getSessionHandler().getSessionCache().contains(id));
 
-            
             //wait again for the session to be passivated
             pause(evictionSec*2);
             

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/NullSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/NullSessionCacheTest.java
@@ -1,0 +1,76 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.server.session;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Test;
+
+/**
+ * NullSessionCacheTest
+ *
+ *
+ */
+public class NullSessionCacheTest
+{
+
+    
+    @Test
+    public void testEvictOnExit() throws Exception
+    {
+        Server server = new Server();
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);       
+        context.setContextPath("/test");
+        context.setServer(server);
+
+        NullSessionCacheFactory cacheFactory = new NullSessionCacheFactory();
+        
+        NullSessionCache cache = (NullSessionCache)cacheFactory.getSessionCache(context.getSessionHandler());
+
+        TestSessionDataStore store = new TestSessionDataStore();
+        cache.setSessionDataStore(store);
+        context.getSessionHandler().setSessionCache(cache);
+        context.start();
+        
+        //make a session
+        long now = System.currentTimeMillis();
+        SessionData data = store.newSessionData("1234", now-20, now-10, now-20, TimeUnit.MINUTES.toMillis(10));
+        data.setExpiry(now+TimeUnit.DAYS.toMillis(1));
+        Session session = cache.newSession(null, data); //mimic a request making a session
+        session.complete(); //mimic request leaving session
+        cache.put("1234", session); //null cache doesn't store the session
+        assertFalse(cache.contains("1234"));
+        assertTrue(store.exists("1234"));
+        
+        session = cache.get("1234"); //get the session again
+        session.access(now); //simulate a request
+        session.complete(); //simulate a request leaving
+        cache.put("1234", session); //finish with the session
+        
+        assertFalse(session.isResident());
+    }
+
+}

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SameNodeLoadTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SameNodeLoadTest.java
@@ -61,7 +61,7 @@ public class SameNodeLoadTest
         
         String contextPath = "";
         String servletMapping = "/server";
-        TestServer server1 = new TestServer(0, -1, 4, cacheFactory, storeFactory);
+        TestServer server1 = new TestServer(0, 60, 5, cacheFactory, storeFactory);
 
 
         server1.addContext( contextPath ).addServlet( TestServlet.class, servletMapping );


### PR DESCRIPTION
Replace the session IdleTimeout with CyclicTimeout and start and stop the timer appropriately as requests leave and enter the session, and the session moves through its lifecycle.