### PR TITLE
AsyncMiddleManServlet.Transparent class wrongly extends ProxyServlet

### DIFF
--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
@@ -695,11 +695,11 @@ public abstract class AbstractProxyServlet extends HttpServlet
      */
     protected static class TransparentDelegate
     {
-        private final ProxyServlet proxyServlet;
+        private final AbstractProxyServlet proxyServlet;
         private String _proxyTo;
         private String _prefix;
 
-        protected TransparentDelegate(ProxyServlet proxyServlet)
+        protected TransparentDelegate(AbstractProxyServlet proxyServlet)
         {
             this.proxyServlet = proxyServlet;
         }

--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AsyncMiddleManServlet.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AsyncMiddleManServlet.java
@@ -234,7 +234,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
      *
      * @see org.eclipse.jetty.proxy.AbstractProxyServlet.TransparentDelegate
      */
-    public static class Transparent extends ProxyServlet
+    public static class Transparent extends AsyncMiddleManServlet
     {
         private final TransparentDelegate delegate = new TransparentDelegate(this);
 


### PR DESCRIPTION
`AsyncMiddleManServlet.Transparent` class should extend `AsyncMiddleManServlet`
so the consumers can override the `newServerResponseContentTransformer` &
`newServerResponseContentTransformer` to provide their own ContentTransformer.

The way it is structured right now makes it impossible to use
`AsyncMiddleManServlet.Transparent` servlet as a middle man servlet.

Signed-off-by: Assim Deodia <assim.deodia@gmail.com>