### PR TITLE
Fix operator priority in ProxyConnectionFactory

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -522,7 +522,7 @@ public class ProxyConnectionFactory extends AbstractConnectionFactory
                             { 
                                 int i=0;
                                 int client = 0xff & value[i++];
-                                int verify = (0xff & value[i++])<<24 + (0xff & value[i++])<<16 + (0xff & value[i++])<<8 + (0xff&value[i++]);
+                                int verify = ((0xff & value[i++])<<24) + ((0xff & value[i++])<<16) + ((0xff & value[i++])<<8) + (0xff&value[i++]);
                                 while(i<value.length)
                                 {
                                     int ssl_type = 0xff & value[i++];


### PR DESCRIPTION
Due to shift operations taking less precedence over addition the expression was parsed in an unintended way.

With this change the intention is made more clear and the intended order of calculations (shift the single byte values into some variable) is actually implemented.