### PR TITLE
Fix NPE in PreEncodedHttpField constructor

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/PreEncodedHttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/PreEncodedHttpField.java
@@ -101,7 +101,7 @@ public class PreEncodedHttpField extends HttpField
     {
         super(header,name, value);
         for (int i=0;i<__encoders.length;i++)
-            _encodedField[i]=__encoders[i].getEncodedField(header,header.asString(),value);
+            _encodedField[i]=__encoders[i].getEncodedField(header,name,value);
     }
     
     public PreEncodedHttpField(HttpHeader header,String value)

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -180,5 +181,15 @@ public class HttpFieldTest
         String s=BufferUtil.toString(buf);
         
         assertEquals("Accept: something\r\n",s);
+    }
+
+    @Test
+    public void testCachedFieldWithHeaderName()
+    {
+        PreEncodedHttpField field = new PreEncodedHttpField("X-My-Custom-Header", "something");
+
+        assertNull(field.getHeader());
+        assertEquals("X-My-Custom-Header", field.getName());
+        assertEquals("something", field.getValue());
     }
 }


### PR DESCRIPTION
Which might happen when given `HttpHeader` is null. It might be null when most generic constructor `#PreEncodedHttpField(HttpHeader, String, String)` is invoked with a null argument or when `#PreEncodedHttpField(String, String)` constructor is used. Later is valuable for custom headers. NPE happens because of an attempt to call `HttpHeader#asString()` on a null argument.

This PR fixes the problem by making encoders use specified header name, instead of trying to retrieve it from the `HttpHeader` object.

Signed-off-by: lutovich <konstantin.lutovich@neo4j.com>