### PR TITLE
Issue #2274 Fix timing in CreationTest and other fixes

### DIFF
--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredOrphanedSessionTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredOrphanedSessionTest.java
@@ -55,15 +55,15 @@ public abstract class AbstractClusteredOrphanedSessionTest extends AbstractTestB
         String contextPath = "/";
         String servletMapping = "/server";
         int inactivePeriod = 5;
-        DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
-        cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT);
-        SessionDataStoreFactory storeFactory = createSessionDataStoreFactory();
-        if (storeFactory instanceof AbstractSessionDataStoreFactory)
+        DefaultSessionCacheFactory cacheFactory1 = new DefaultSessionCacheFactory();
+        cacheFactory1.setEvictionPolicy(SessionCache.NEVER_EVICT);
+        SessionDataStoreFactory storeFactory1 = createSessionDataStoreFactory();
+        if (storeFactory1 instanceof AbstractSessionDataStoreFactory)
         {
-            ((AbstractSessionDataStoreFactory)storeFactory).setGracePeriodSec(0);
+            ((AbstractSessionDataStoreFactory)storeFactory1).setGracePeriodSec(0);
         }
         
-        TestServer server1 = new TestServer(0, inactivePeriod, -1, cacheFactory, storeFactory);
+        TestServer server1 = new TestServer(0, inactivePeriod, -1, cacheFactory1, storeFactory1);
         server1.addContext(contextPath).addServlet(TestServlet.class, servletMapping);
         try
         {
@@ -71,10 +71,13 @@ public abstract class AbstractClusteredOrphanedSessionTest extends AbstractTestB
             int port1 = server1.getPort();
             int scavengePeriod = 2;
             
-            DefaultSessionCacheFactory evictCacheFactory = new DefaultSessionCacheFactory();
-          //  cacheFactory.setEvictionPolicy(2);//evict after idle for 2 sec
-            
-            TestServer server2 = new TestServer(0, inactivePeriod, scavengePeriod, evictCacheFactory, storeFactory);
+            DefaultSessionCacheFactory cacheFactory2 = new DefaultSessionCacheFactory();
+            SessionDataStoreFactory storeFactory2 = createSessionDataStoreFactory();
+            if (storeFactory2 instanceof AbstractSessionDataStoreFactory)
+            {
+                ((AbstractSessionDataStoreFactory)storeFactory2).setGracePeriodSec(0);
+            }
+            TestServer server2 = new TestServer(0, inactivePeriod, scavengePeriod, cacheFactory2, storeFactory2);
             server2.addContext(contextPath).addServlet(TestServlet.class, servletMapping);         
             try
             {

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
@@ -71,13 +71,13 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
         int maxInactivePeriod = 5; //session will timeout after 5 seconds
         int scavengePeriod = 1; //scavenging occurs every 1 seconds
         
-        DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
-        cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT); //don't evict sessions
-        SessionDataStoreFactory storeFactory = createSessionDataStoreFactory();
-        ((AbstractSessionDataStoreFactory)storeFactory).setGracePeriodSec(scavengePeriod);
-        ((AbstractSessionDataStoreFactory)storeFactory).setSavePeriodSec(0); //always save when the session exits
+        DefaultSessionCacheFactory cacheFactory1 = new DefaultSessionCacheFactory();
+        cacheFactory1.setEvictionPolicy(SessionCache.NEVER_EVICT); //don't evict sessions
+        SessionDataStoreFactory storeFactory1 = createSessionDataStoreFactory();
+        ((AbstractSessionDataStoreFactory)storeFactory1).setGracePeriodSec(scavengePeriod);
+        ((AbstractSessionDataStoreFactory)storeFactory1).setSavePeriodSec(0); //always save when the session exits
         
-        TestServer server1 = new TestServer(0, maxInactivePeriod, scavengePeriod, cacheFactory, storeFactory);
+        TestServer server1 = new TestServer(0, maxInactivePeriod, scavengePeriod, cacheFactory1, storeFactory1);
         TestServlet servlet1 = new TestServlet();
         ServletHolder holder1 = new ServletHolder(servlet1);
         ServletContextHandler context = server1.addContext(contextPath);
@@ -92,7 +92,12 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
             server1.start();
             int port1=server1.getPort();
             
-            TestServer server2 = new TestServer(0, maxInactivePeriod, scavengePeriod, cacheFactory, storeFactory);
+            DefaultSessionCacheFactory cacheFactory2 = new DefaultSessionCacheFactory();
+            cacheFactory2.setEvictionPolicy(SessionCache.NEVER_EVICT); //don't evict sessions
+            SessionDataStoreFactory storeFactory2 = createSessionDataStoreFactory();
+            ((AbstractSessionDataStoreFactory)storeFactory2).setGracePeriodSec(scavengePeriod);
+            ((AbstractSessionDataStoreFactory)storeFactory2).setSavePeriodSec(0); //always save when the session exits
+            TestServer server2 = new TestServer(0, maxInactivePeriod, scavengePeriod, cacheFactory2, storeFactory2);
             ServletContextHandler context2 = server2.addContext(contextPath);
             context2.addServlet(TestServlet.class, servletMapping);
             SessionHandler m2 = context2.getSessionHandler();

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestContextScopeListener.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestContextScopeListener.java
@@ -1,0 +1,68 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.server.session;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
+import org.eclipse.jetty.server.handler.ContextHandler.ContextScopeListener;
+
+public class TestContextScopeListener implements ContextScopeListener
+{
+    CountDownLatch _exitSynchronizer;
+    
+    
+
+    /**
+     * @return the exitSynchronizer
+     */
+    public CountDownLatch getExitSynchronizer()
+    {
+        return _exitSynchronizer;
+    }
+
+
+    /**
+     * @param exitSynchronizer the exitSynchronizer to set
+     */
+    public void setExitSynchronizer(CountDownLatch exitSynchronizer)
+    {
+        _exitSynchronizer = exitSynchronizer;
+    }
+
+
+
+
+
+    @Override
+    public void enterScope(Context context, org.eclipse.jetty.server.Request request, Object reason)
+    {
+       //noop
+    }
+
+
+    @Override
+    public void exitScope(Context context, org.eclipse.jetty.server.Request request)
+    {
+        if (_exitSynchronizer != null)
+            _exitSynchronizer.countDown();
+    }
+    
+}

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/ModifyMaxInactiveIntervalTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/ModifyMaxInactiveIntervalTest.java
@@ -509,7 +509,6 @@ public class ModifyMaxInactiveIntervalTest extends AbstractTestBase
             try
             {
                 // Perform a request to create a session
-
                 ContentResponse response = client.GET("http://localhost:" + port + "/mod/test?action=create");
 
                 assertEquals(HttpServletResponse.SC_OK,response.getStatus());


### PR DESCRIPTION
Fixes a timing problem in session CreationTest, and applies the same fix in other tests that could potentially suffer from similar problem.  Also fixed a problem in the abstract test classes used for the various flavours of SessionDataStore tests, whereby SessionDataStoreFactories were being shared between different servers/contexts.