### PR TITLE
Issue #2498 - new QTP.removeThread(Thread) method

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -554,6 +554,11 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
         return new Thread(_threadGroup, runnable);
     }
 
+    protected void removeThread(Thread thread)
+    {
+        _threads.remove(thread);
+    }
+
     @Override
     public void dump(Appendable out, String indent) throws IOException
     {
@@ -739,7 +744,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
                     if (_threadsStarted.decrementAndGet()<getMaxThreads())
                         startThreads(1);
                 }
-                _threads.remove(Thread.currentThread());
+                removeThread(Thread.currentThread());
             }
         }
     };


### PR DESCRIPTION
+ Adding removeThread(Thread) to allow instrumentation
  libraries to track removal of threads from Pool.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>