### PR TITLE
fix default jetty.xml. not sure it is the best way to do it...

### DIFF
--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -62,7 +62,8 @@
       <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
       <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
       <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="blockingTimeout"><Property deprecated="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
+
+      <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" deprecated="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
       <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
       <Set name="cookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.cookieCompliance" default="RFC6265"/></Arg></Call></Set>
       <Set name="multiPartFormDataCompliance"><Call class="org.eclipse.jetty.server.MultiPartFormDataCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.multiPartFormDataCompliance" default="RFC7578"/></Arg></Call></Set>


### PR DESCRIPTION
We had some failure using the default jetty.xml
```
Config error at <Set name="blockingTimeout"><Property deprecated="jetty.httpConfig.blockingTimeout" default="-1"/></Set> java.lang.IllegalStateException: Must have attr 'name' or element 'Name' in file:/Users/olamy/dev/sources/open-sources/jetty/jetty.project/jetty-maven-plugin/target/it/jetty-run-distro-mojo-it/jetty-simple-webapp/target/jetty-home-9.4.11-SNAPSHOT/etc/jetty.xml
2018-05-16 13:41:14.253:WARN:oejx.XmlConfiguration:main: Config error at <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration"><Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https"/></Set><Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443"/></Set><Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768"/></Set><Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192"/></Set><Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192"/></Set><Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192"/></Set><Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true"/></Set><Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false"/></Set><Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512"/></Set><Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set><Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set><Set name="blockingTimeout"><Property deprecated="jetty.httpConfig.blockingTimeout" default="-1"/></Set><Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set><Set name="cookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.cookieCompliance" default="RFC6265"/></Arg></Call></Set><Set name="multiPartFormDataCompliance"><Call class="org.eclipse.jetty.server.MultiPartFormDataCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.multiPartFormDataCompliance" default="RFC7578"/></Arg></Call></Set></New> java.lang.IllegalStateException: Must have attr 'name' or element 'Name' in file:/Users/olamy/dev/sources/open-sources/jetty/jetty.project/jetty-maven-plugin/target/it/jetty-run-distro-mojo-it/jetty-simple-webapp/target/jetty-home-9.4.11-SNAPSHOT/etc/jetty.xml
```
Signed-off-by: olivier lamy <oliver.lamy@gmail.com>