### PR TITLE
Issue #2549 ConsumeAll forced EOF or EarlyEOF

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
@@ -102,8 +102,8 @@ public class HttpChannelOverHTTP extends HttpChannel
         if ((response.getVersion() == HttpVersion.HTTP_1_1) && 
             (response.getStatus() == HttpStatus.SWITCHING_PROTOCOLS_101))
         {
-            String connection = response.getHeaders().get(HttpHeader.CONNECTION);
-            if ((connection == null) || !connection.toLowerCase(Locale.US).contains("upgrade"))
+            String next_connection = response.getHeaders().get(HttpHeader.CONNECTION);
+            if ((next_connection == null) || !next_connection.toLowerCase(Locale.US).contains("upgrade"))
             {
                 return new Result(result,new HttpResponseException("101 Switching Protocols without Connection: Upgrade not supported",response));
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -686,6 +686,11 @@ public class HttpInput extends ServletInputStream implements Runnable
                 LOG.debug(e);
                 return false;
             }
+            finally
+            {
+                if (!EOFState.class.isInstance(_state))
+                    _state = EARLY_EOF;
+            }
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -679,17 +679,17 @@ public class HttpInput extends ServletInputStream implements Runnable
 
                     skip(item, item.remaining());
                 }
-                return isFinished() && !isError();
-            }
-            catch (IOException e)
-            {
-                LOG.debug(e);
+                if (isFinished())
+                    return !isError();
+
+                _state = EARLY_EOF;
                 return false;
             }
-            finally
+            catch (Throwable e)
             {
-                if (!EOFState.class.isInstance(_state))
-                    _state = EARLY_EOF;
+                LOG.debug(e);
+                _state = new ErrorState(e);
+                return false;
             }
         }
     }


### PR DESCRIPTION
Issue #2549 ConsumeAll forced EOF or EarlyEOF

It is not clear how the input stream can be left in STREAM state by the time `Request.recycle()` is called.   So this is a defensive change to force an  EOF state while we do more investigation.  This does not close #2549 


