### PR TITLE
Issue #2571 HPACK table overflow

### DIFF
--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.http2.hpack;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -254,6 +255,7 @@ public class HpackContext
         {
             if (LOG.isDebugEnabled())
                 LOG.debug(String.format("HdrTbl[%x] !added size %d>%d",hashCode(),size,_maxDynamicTableSizeInBytes));
+            _dynamicTable.evictAll();
             return null;
         }
         _dynamicTableSizeInBytes+=size;
@@ -390,7 +392,18 @@ public class HpackContext
             if (LOG.isDebugEnabled())
                 LOG.debug(String.format("HdrTbl[%x] entries=%d, size=%d, max=%d",HpackContext.this.hashCode(),_dynamicTable.size(),_dynamicTableSizeInBytes,_maxDynamicTableSizeInBytes));
         }
-
+        
+        private void evictAll()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug(String.format("HdrTbl[%x] evictAll",HpackContext.this.hashCode()));
+            _fieldMap.clear();
+            _nameMap.clear();
+            _offset = 0;
+            _size = 0;
+            _dynamicTableSizeInBytes = 0;
+            Arrays.fill(_entries,null);
+        }
     }
 
     public static class Entry

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -242,15 +242,9 @@ public class HpackDecoder
                 // emit the field
                 _builder.emit(field);
 
-                // if indexed
+                // if indexed add to dynamic table
                 if (indexed)
-                {
-                    // add to dynamic table
                     _context.add(field);
-                    // if (_context.add(field)==null)
-                    //    throw new BadMessageException(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431,"Indexed field value too large");
-                }
-
             }
         }
 

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -329,11 +329,9 @@ public class HpackEncoder
                 }
             }
 
-            // If we want the field referenced, then we add it to our
-            // table and reference set.
+            // If we want the field referenced, then we add it to our table and reference set.
             if (indexed)
-                if (_context.add(field)==null)
-                    throw new IllegalStateException();
+                _context.add(field);
         }
 
         if (_debug)

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/MetaDataBuilder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/MetaDataBuilder.java
@@ -166,6 +166,11 @@ public class MetaDataBuilder
                 return new MetaData.Request(_method,_scheme,_authority,_path,HttpVersion.HTTP_2,fields,_contentLength);
             if (_status!=0)
                 return new MetaData.Response(HttpVersion.HTTP_2,_status,fields,_contentLength);
+            if (_path!=null)
+                fields.put(HttpHeader.C_PATH,_path);
+            if (_authority!=null)
+                fields.put(HttpHeader.HOST,_authority.getValue());
+                
             return new MetaData(HttpVersion.HTTP_2,fields,_contentLength);
         }
         finally

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
@@ -27,10 +27,10 @@ import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.TypeUtil;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -249,7 +249,4 @@ public class HpackEncoderTest
         context.get(HpackContext.STATIC_SIZE+1).getSize()+context.get(HpackContext.STATIC_SIZE+2).getSize()));
         
     }
-
-    
-
 }


### PR DESCRIPTION
#2571 When an entry that is too large for the dynamic table is added, the entire table should be evicted as per the RFC. Previously we were throwing a 431 Bad Message.   This will require that the OP should retest #1134.

Signed-off-by: Greg Wilkins <gregw@webtide.com>