### PR TITLE
use maven feature placeholder ${revision} for version and add modified source plugin in a profile to remove logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 *.versionsBackup
 *.releaseBackup
 bin/
+.flattened-pom.xml
 
 # common junk
 *.log

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ def getFullBuild(jdk, os) {
       def localRepo = "${env.JENKINS_HOME}/${env.EXECUTOR_NUMBER}" // ".repository" // 
       def settingsName = 'oss-settings.xml'
       def mavenOpts = '-Xms1g -Xmx4g -Djava.awt.headless=true'
+      def extraMvnCli = getExtraMvnCli();
 
       // Environment
       List mvnEnv = ["PATH+MVN=${mvntool}/bin", "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}/", "MAVEN_HOME=${mvntool}"]
@@ -50,7 +51,7 @@ def getFullBuild(jdk, os) {
                       globalMavenSettingsConfig: settingsName,
                       mavenOpts: mavenOpts,
                       mavenLocalRepo: localRepo) {
-                sh "mvn -V -B clean install -DskipTests -T6 -e"
+                sh "mvn -V -B clean install -DskipTests -T6 $extraMvnCli"
               }
 
             }
@@ -97,7 +98,7 @@ def getFullBuild(jdk, os) {
                       //options: [invokerPublisher(disabled: false)],
                       mavenOpts: mavenOpts,
                       mavenLocalRepo: localRepo) {
-                sh "mvn -V -B install -Dmaven.test.failure.ignore=true -e -Pmongodb -T3 -DmavenHome=${mvntoolInvoker} -Dunix.socket.tmp="+env.JENKINS_HOME
+                sh "mvn -V -B install -Dmaven.test.failure.ignore=true -e -Pmongodb -T3 $extraMvnCli -DmavenHome=${mvntoolInvoker} -Dunix.socket.tmp="+env.JENKINS_HOME
               }
               // withMaven doesn't label..
               // Report failures in the jenkins UI
@@ -156,7 +157,7 @@ def getFullBuild(jdk, os) {
                     globalMavenSettingsConfig: settingsName,
                     mavenOpts: mavenOpts,
                     mavenLocalRepo: localRepo) {
-              sh "mvn -f aggregates/jetty-all-compact3 -V -B -Pcompact3 clean install -T5"
+              sh "mvn -f aggregates/jetty-all-compact3 -V -B -Pcompact3 clean install -T5 $extraMvnCli"
             }
           }
         }
@@ -180,6 +181,16 @@ def isActiveBranch()
   def branchName = "${env.BRANCH_NAME}"
   return ( branchName == "master" ||
           ( branchName.startsWith("jetty-") && branchName.endsWith(".x") ) );
+}
+
+def getExtraMvnCli()
+{
+  def branchName = "${env.BRANCH_NAME}"
+  if(branchName == "experiment/no_logging")
+  {
+    return '-Pno-logger-debug -U';
+  }
+  return ""
 }
 
 // Test if the Jenkins Pipeline or Step has marked the

--- a/aggregates/jetty-all-compact3/pom.xml
+++ b/aggregates/jetty-all-compact3/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/aggregates/jetty-all-compact3/pom.xml
+++ b/aggregates/jetty-all-compact3/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/aggregates/jetty-all/pom.xml
+++ b/aggregates/jetty-all/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/aggregates/jetty-all/pom.xml
+++ b/aggregates/jetty-all/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>apache-jsp</artifactId>

--- a/apache-jstl/pom.xml
+++ b/apache-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>apache-jstl</artifactId>

--- a/examples/async-rest/async-rest-jar/pom.xml
+++ b/examples/async-rest/async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>example-async-rest</artifactId>
-       <version>9.4.12-SNAPSHOT</version>
+       <version>${revision}</version>
   </parent>  
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.example-async-rest</groupId>

--- a/examples/async-rest/async-rest-webapp/pom.xml
+++ b/examples/async-rest/async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>example-async-rest</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>  
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.example-async-rest</groupId>

--- a/examples/async-rest/pom.xml
+++ b/examples/async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/examples/embedded/pom.xml
+++ b/examples/embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty.examples</groupId>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-client</artifactId>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -6,11 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -6,7 +6,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -4,11 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -4,7 +4,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -6,11 +6,7 @@
     <parent>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-parent</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
-        <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
+      <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -6,7 +6,11 @@
     <parent>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-parent</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
@@ -6,11 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-client/pom.xml
@@ -6,7 +6,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
@@ -4,11 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-openjdk8-server/pom.xml
@@ -4,7 +4,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-server</artifactId>

--- a/jetty-alpn/pom.xml
+++ b/jetty-alpn/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-parent</artifactId>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-annotations</artifactId>

--- a/jetty-ant/pom.xml
+++ b/jetty-ant/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ant</artifactId>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -2,7 +2,11 @@
   <groupId>org.eclipse.jetty</groupId>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-bom</artifactId>
+<<<<<<< HEAD
   <version>9.4.12-SNAPSHOT</version>
+=======
+  <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   <name>Jetty :: Bom</name>
   <description>Jetty BOM artifact</description>
   <url>http://www.eclipse.org/jetty</url>
@@ -94,331 +98,591 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jsp</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jstl</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-openjdk8-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-openjdk8-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-ant</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.cdi</groupId>
         <artifactId>cdi-core</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.cdi</groupId>
         <artifactId>cdi-servlet</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-distribution</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-distribution</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.gcloud</groupId>
         <artifactId>jetty-gcloud-session-manager</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-infinispan</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-hazelcast</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaspi</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.memcached</groupId>
         <artifactId>jetty-memcached-sessions</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-nosql</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-jsp</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-warurl</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-httpservice</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-quickstart</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-spring</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>javax-websocket-client-impl</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>javax-websocket-server-impl</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-api</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-client</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-common</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-server</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-servlet</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -2,11 +2,7 @@
   <groupId>org.eclipse.jetty</groupId>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-bom</artifactId>
-<<<<<<< HEAD
-  <version>9.4.12-SNAPSHOT</version>
-=======
   <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   <name>Jetty :: Bom</name>
   <description>Jetty BOM artifact</description>
   <url>http://www.eclipse.org/jetty</url>
@@ -98,591 +94,331 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jsp</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jstl</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-openjdk8-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-openjdk8-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-ant</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.cdi</groupId>
         <artifactId>cdi-core</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.cdi</groupId>
         <artifactId>cdi-servlet</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-distribution</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-distribution</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.gcloud</groupId>
         <artifactId>jetty-gcloud-session-manager</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-infinispan</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-hazelcast</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaspi</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.memcached</groupId>
         <artifactId>jetty-memcached-sessions</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-nosql</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-jsp</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-warurl</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-httpservice</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-quickstart</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-spring</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>javax-websocket-client-impl</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>javax-websocket-server-impl</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-api</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-client</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-common</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-server</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-servlet</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -29,6 +29,8 @@
     <jetty.url>http://www.eclipse.org/jetty</jetty.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-support-version>1.4</build-support-version>
+    <jetty.version>9.4.12-SNAPSHOT</jetty.version>
+    <revision>${jetty.version}</revision>
   </properties>
 
   <scm>

--- a/jetty-cdi/cdi-2/pom.xml
+++ b/jetty-cdi/cdi-2/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-2</artifactId>

--- a/jetty-cdi/cdi-2/pom.xml
+++ b/jetty-cdi/cdi-2/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-2</artifactId>

--- a/jetty-cdi/cdi-core/pom.xml
+++ b/jetty-cdi/cdi-core/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-core</artifactId>

--- a/jetty-cdi/cdi-full-servlet/pom.xml
+++ b/jetty-cdi/cdi-full-servlet/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-full-servlet</artifactId>

--- a/jetty-cdi/cdi-servlet/pom.xml
+++ b/jetty-cdi/cdi-servlet/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-servlet</artifactId>

--- a/jetty-cdi/cdi-websocket/pom.xml
+++ b/jetty-cdi/cdi-websocket/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-websocket</artifactId>

--- a/jetty-cdi/pom.xml
+++ b/jetty-cdi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.cdi</groupId>

--- a/jetty-cdi/test-cdi-webapp/pom.xml
+++ b/jetty-cdi/test-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.cdi</groupId>
     <artifactId>jetty-cdi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-cdi-webapp</artifactId>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-continuation/pom.xml
+++ b/jetty-continuation/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-continuation</artifactId>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-deploy</artifactId>

--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-distribution</artifactId>

--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -4,7 +4,11 @@
  <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
  </parent>
   <artifactId>jetty-documentation</artifactId>
   <name>Jetty :: Documentation</name>

--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -4,11 +4,7 @@
  <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
-    <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
+   <version>${revision}</version>
  </parent>
   <artifactId>jetty-documentation</artifactId>
   <name>Jetty :: Documentation</name>

--- a/jetty-fcgi/fcgi-client/pom.xml
+++ b/jetty-fcgi/fcgi-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-fcgi/fcgi-server/pom.xml
+++ b/jetty-fcgi/fcgi-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>fcgi-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-fcgi/pom.xml
+++ b/jetty-fcgi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-project</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -5,11 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>gcloud-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -5,7 +5,11 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>gcloud-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStore.java
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStore.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.gcloud.session;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -644,7 +645,7 @@ public class GCloudSessionDataStore extends AbstractSessionDataStore
                 .setLimit(_maxResults)
                 .build();
 
-        QueryResults<Entity> results;
+        QueryResults<Entity> results = null;
         if (LOG.isDebugEnabled())
         {
             long start = System.currentTimeMillis();
@@ -679,7 +680,7 @@ public class GCloudSessionDataStore extends AbstractSessionDataStore
                 .setLimit(_maxResults)
                 .build();
 
-        QueryResults<ProjectionEntity> presults;
+        QueryResults<ProjectionEntity> presults = null;
         
         if (LOG.isDebugEnabled())
         {
@@ -718,7 +719,7 @@ public class GCloudSessionDataStore extends AbstractSessionDataStore
                     //.setFilter(PropertyFilter.eq(_model.getId(), id))
                     .build();
 
-            QueryResults<ProjectionEntity> presults;
+            QueryResults<ProjectionEntity> presults = null;
             if (LOG.isDebugEnabled())
             {
                 long start = System.currentTimeMillis();
@@ -746,7 +747,7 @@ public class GCloudSessionDataStore extends AbstractSessionDataStore
                     //.setFilter(PropertyFilter.eq(_model.getId(), id))
                     .build();
             
-            QueryResults<Entity> results;
+            QueryResults<Entity> results = null;
             if (LOG.isDebugEnabled())
             {
                 long start = System.currentTimeMillis();

--- a/jetty-gcloud/pom.xml
+++ b/jetty-gcloud/pom.xml
@@ -3,11 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-gcloud/pom.xml
+++ b/jetty-gcloud/pom.xml
@@ -3,7 +3,11 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-hazelcast/pom.xml
+++ b/jetty-hazelcast/pom.xml
@@ -4,11 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-hazelcast/pom.xml
+++ b/jetty-hazelcast/pom.xml
@@ -4,7 +4,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -3,7 +3,11 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-home</artifactId>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -3,11 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-home</artifactId>

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-http-spi</artifactId>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-http</artifactId>

--- a/jetty-http2/http2-alpn-tests/pom.xml
+++ b/jetty-http2/http2-alpn-tests/pom.xml
@@ -3,7 +3,11 @@
     <parent>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-parent</artifactId>
+<<<<<<< HEAD
         <version>9.4.12-SNAPSHOT</version>
+=======
+        <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-alpn-tests/pom.xml
+++ b/jetty-http2/http2-alpn-tests/pom.xml
@@ -3,11 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-parent</artifactId>
-<<<<<<< HEAD
-        <version>9.4.12-SNAPSHOT</version>
-=======
         <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-common/pom.xml
+++ b/jetty-http2/http2-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-hpack/pom.xml
+++ b/jetty-http2/http2-hpack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-http2/pom.xml
+++ b/jetty-http2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-infinispan/pom.xml
+++ b/jetty-infinispan/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan</artifactId>

--- a/jetty-infinispan/pom.xml
+++ b/jetty-infinispan/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan</artifactId>

--- a/jetty-io/pom.xml
+++ b/jetty-io/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-io</artifactId>

--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jaas</artifactId>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jaspi</artifactId>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jmx</artifactId>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jndi</artifactId>

--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jspc-maven-plugin</artifactId>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-maven-plugin</artifactId>

--- a/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -3,11 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>memcached-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -3,7 +3,11 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>memcached-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-memcached/pom.xml
+++ b/jetty-memcached/pom.xml
@@ -3,11 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-memcached/pom.xml
+++ b/jetty-memcached/pom.xml
@@ -3,7 +3,11 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-nosql/pom.xml
+++ b/jetty-nosql/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-nosql</artifactId>

--- a/jetty-osgi/jetty-osgi-alpn/pom.xml
+++ b/jetty-osgi/jetty-osgi-alpn/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-osgi-alpn</artifactId>

--- a/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-osgi-boot-jsp</artifactId>

--- a/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-osgi-boot</artifactId>

--- a/jetty-osgi/jetty-osgi-httpservice/pom.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-httpservice</artifactId>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-osgi-context</artifactId>

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-osgi-context</artifactId>

--- a/jetty-osgi/test-jetty-osgi-fragment/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-fragment/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-osgi-server</artifactId>

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-osgi-server</artifactId>

--- a/jetty-osgi/test-jetty-osgi-webapp/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-osgi/test-jetty-osgi-webapp/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-plus</artifactId>

--- a/jetty-proxy/pom.xml
+++ b/jetty-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-proxy</artifactId>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>

--- a/jetty-rewrite/pom.xml
+++ b/jetty-rewrite/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-rewrite</artifactId>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-runner</artifactId>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-security</artifactId>

--- a/jetty-server/pom.xml
+++ b/jetty-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-server</artifactId>

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-servlet</artifactId>

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-servlets</artifactId>

--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-spring</artifactId>

--- a/jetty-start/pom.xml
+++ b/jetty-start/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-start</artifactId>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -2,7 +2,11 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-unixsocket</artifactId>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -2,11 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-unixsocket</artifactId>

--- a/jetty-util-ajax/pom.xml
+++ b/jetty-util-ajax/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util-ajax</artifactId>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util</artifactId>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-webapp</artifactId>

--- a/jetty-websocket/javax-websocket-client-impl/pom.xml
+++ b/jetty-websocket/javax-websocket-client-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/javax-websocket-server-impl/pom.xml
+++ b/jetty-websocket/javax-websocket-server-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/pom.xml
+++ b/jetty-websocket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jetty-project</artifactId>
         <groupId>org.eclipse.jetty</groupId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/websocket-api/pom.xml
+++ b/jetty-websocket/websocket-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/websocket-client/pom.xml
+++ b/jetty-websocket/websocket-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/websocket-common/pom.xml
+++ b/jetty-websocket/websocket-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/websocket-server/pom.xml
+++ b/jetty-websocket/websocket-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-websocket/websocket-servlet/pom.xml
+++ b/jetty-websocket/websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-project</artifactId>
-  <version>9.4.12-SNAPSHOT</version>
+  <version>${revision}</version>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>
   <packaging>pom</packaging>
@@ -34,6 +34,8 @@
     <mavenPluginToolsVersion>3.5.2</mavenPluginToolsVersion>
     <mavenVersion>3.5.0</mavenVersion>
     <unix.socket.tmp></unix.socket.tmp>
+    <src.dir>${basedir}/src/main/java</src.dir>
+    <revision>9.4.12-SNAPSHOT</revision>
   </properties>
 
   <licenses>
@@ -109,6 +111,7 @@
   </modules>
 
   <build>
+    <sourceDirectory>${src.dir}</sourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -388,6 +391,30 @@
             <phase>process-resources</phase>
             <goals>
               <goal>attach-version-text</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
             </goals>
           </execution>
         </executions>
@@ -1045,6 +1072,30 @@
   </dependencyManagement>
 
   <profiles>
+    <profile>
+      <id>no-logger-debug</id>
+      <properties>
+        <src.dir>${project.build.directory}/modified-sources</src.dir>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-modify-sources-maven-plugin</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <executions>
+              <execution>
+                <id>remove-is-debug</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>remove-log-enabled</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- use last snapshot of jacoco for jdk11 -->
     <profile>
       <id>jdk11</id>
@@ -1065,19 +1116,6 @@
           </plugins>
         </pluginManagement>
       </build>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>oss.snapshots</id>
-          <name>OSS Snapshots</name>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
     </profile>
     <profile>
       <id>errorprone</id>
@@ -1850,6 +1888,28 @@
     <pluginRepository>
       <id>apache.snapshots</id>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>oss.snapshots</id>
+      <name>OSS Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>jetty.snapshots</id>
+      <name>Jetty Snapshots</name>
+      <url>http://oss.sonatype.org/content/repositories/jetty-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,12 @@
     <mavenVersion>3.5.0</mavenVersion>
     <unix.socket.tmp></unix.socket.tmp>
     <src.dir>${basedir}/src/main/java</src.dir>
-    <revision>9.4.12-SNAPSHOT</revision>
+    <jetty.version>9.4.12-SNAPSHOT</jetty.version>
+    <revision>${jetty.version}</revision>
+
+    <distManagementSnapshotUrl>https://oss.sonatype.org/content/repositories/jetty-snapshots/</distManagementSnapshotUrl>
+    <distManagementReleaseUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distManagementReleaseUrl>
+
   </properties>
 
   <licenses>
@@ -1923,12 +1928,12 @@
     <repository>
       <id>oss.sonatype.org</id>
       <name>Jetty Staging Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>${distManagementReleaseUrl}</url>
     </repository>
     <snapshotRepository>
       <id>oss.sonatype.org</id>
       <name>Jetty Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots/</url>
+      <url>${distManagementSnapshotUrl}</url>
     </snapshotRepository>
     <site>
       <id>jetty.eclipse.website</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty.tests</groupId>

--- a/tests/test-continuation/pom.xml
+++ b/tests/test-continuation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-http-client-transport/pom.xml
+++ b/tests/test-http-client-transport/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.jetty.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>9.4.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-integration</artifactId>

--- a/tests/test-jmx/jmx-webapp-it/pom.xml
+++ b/tests/test-jmx/jmx-webapp-it/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jmx-webapp-it</artifactId>

--- a/tests/test-jmx/jmx-webapp/pom.xml
+++ b/tests/test-jmx/jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-jmx/pom.xml
+++ b/tests/test-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jmx-parent</artifactId>

--- a/tests/test-loginservice/pom.xml
+++ b/tests/test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-loginservice</artifactId>
   <name>Jetty Tests :: Login Service</name>

--- a/tests/test-quickstart/pom.xml
+++ b/tests/test-quickstart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-sessions/pom.xml
+++ b/tests/test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-sessions-parent</artifactId>
   <name>Jetty Tests :: Sessions :: Parent</name>

--- a/tests/test-sessions/test-file-sessions/pom.xml
+++ b/tests/test-sessions/test-file-sessions/pom.xml
@@ -4,11 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-file-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: File</name>

--- a/tests/test-sessions/test-file-sessions/pom.xml
+++ b/tests/test-sessions/test-file-sessions/pom.xml
@@ -4,7 +4,11 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-file-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: File</name>

--- a/tests/test-sessions/test-gcloud-sessions/pom.xml
+++ b/tests/test-sessions/test-gcloud-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-gcloud-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: GCloud</name>

--- a/tests/test-sessions/test-hazelcast-sessions/pom.xml
+++ b/tests/test-sessions/test-hazelcast-sessions/pom.xml
@@ -5,7 +5,11 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-hazelcast-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Hazelcast</name>

--- a/tests/test-sessions/test-hazelcast-sessions/pom.xml
+++ b/tests/test-sessions/test-hazelcast-sessions/pom.xml
@@ -5,11 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-hazelcast-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Hazelcast</name>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-infinispan-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Infinispan</name>

--- a/tests/test-sessions/test-jdbc-sessions/pom.xml
+++ b/tests/test-sessions/test-jdbc-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-jdbc-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: JDBC</name>

--- a/tests/test-sessions/test-memcached-sessions/pom.xml
+++ b/tests/test-sessions/test-memcached-sessions/pom.xml
@@ -4,11 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-memcached-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Memcached</name>

--- a/tests/test-sessions/test-memcached-sessions/pom.xml
+++ b/tests/test-sessions/test-memcached-sessions/pom.xml
@@ -4,7 +4,11 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
   <artifactId>test-memcached-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Memcached</name>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-mongodb-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Mongo</name>

--- a/tests/test-sessions/test-sessions-common/pom.xml
+++ b/tests/test-sessions/test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-sessions-common</artifactId>
   <name>Jetty Tests :: Sessions :: Common</name>

--- a/tests/test-webapps/pom.xml
+++ b/tests/test-webapps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-webapps-parent</artifactId>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -3,11 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-<<<<<<< HEAD
-    <version>9.4.12-SNAPSHOT</version>
-=======
     <version>${revision}</version>
->>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -3,7 +3,11 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
+<<<<<<< HEAD
     <version>9.4.12-SNAPSHOT</version>
+=======
+    <version>${revision}</version>
+>>>>>>> use Maven revision property dynamic version
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-webapps/test-jaas-webapp/pom.xml
+++ b/tests/test-webapps/test-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-jaas-webapp</artifactId>
   <name>Jetty Tests :: WebApp :: JAAS</name>

--- a/tests/test-webapps/test-jetty-webapp/pom.xml
+++ b/tests/test-webapps/test-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-webapps/test-jndi-webapp/pom.xml
+++ b/tests/test-webapps/test-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-jndi-webapp</artifactId>
   <name>Jetty Tests :: WebApp :: JNDI</name>

--- a/tests/test-webapps/test-mock-resources/pom.xml
+++ b/tests/test-webapps/test-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <name>Jetty Tests :: WebApp :: Mock Resources</name>
   <artifactId>test-mock-resources</artifactId>

--- a/tests/test-webapps/test-proxy-webapp/pom.xml
+++ b/tests/test-webapps/test-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-webapps/test-servlet-spec/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-servlet-spec-parent</artifactId>
   <name>Jetty Tests :: Spec Test WebApp :: Parent</name>

--- a/tests/test-webapps/test-servlet-spec/test-container-initializer/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-servlet-spec-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-container-initializer</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-servlet-spec-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <name>Jetty Tests :: Webapps :: Spec Webapp</name>
   <artifactId>test-spec-webapp</artifactId>

--- a/tests/test-webapps/test-servlet-spec/test-web-fragment/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-servlet-spec-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Jetty Tests :: WebApp :: Servlet Spec :: Fragment Jar</name>

--- a/tests/test-webapps/test-webapp-rfc2616/pom.xml
+++ b/tests/test-webapps/test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>9.4.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>test-webapp-rfc2616</artifactId>
   <name>Jetty Tests :: WebApp :: RFC2616</name>


### PR DESCRIPTION
@joakime my need is to be able to build/deploy versions simply using -Drevision=9.4.11-NO-LOGGER-SNAPSHOT or anything else so it's available as a SNAPSHOT for download by the load test system.
The default version will be now a simple property in the top pom.xml.
```
<revision>9.4.11-SNAPSHOT</revision>
So I can deploy a branch with changes we want to load test:
mvn deploy -Drevision=9.4.11-NO-LOGGER-SNAPSHOT
```
see https://maven.apache.org/maven-ci-friendly.html
I guess this probably need some changes in the release procedure? (maybe with http://www.mojohaus.org/build-helper-maven-plugin/ to update this property?)
