### PR TITLE
Issue #2599 Fix AsyncServletIOTest

### DIFF
--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.servlet;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -695,7 +696,8 @@ public class AsyncServletIOTest
             LOG.debug("last: "+last);
             
             // last non empty line should not contain end chunk
-            assertThat(last,not(containsString("0")));
+            assertThat(last, notNullValue());
+            assertThat(last.trim(),not(startsWith("0")));
         }
 
         assertTrue(_servlet4.completed.await(5, TimeUnit.SECONDS));


### PR DESCRIPTION
By only testing for contains 0, it left open the possibility that the start of a chunk containing a 0 eg '10' might arrive before the write is blocked and async.complete is called.