### PR TITLE
when processing trailer header do not call responseSuccess to avoid closing the request too early

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.http2.client.http;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
@@ -105,7 +106,11 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
         {
             HttpFields trailers = metaData.getFields();
             trailers.forEach(httpResponse::trailer);
-            responseSuccess(exchange);
+
+            DataFrame dataFrame = new DataFrame(stream.getId(), ByteBuffer.allocate(0), true);
+            contentNotifier.offer(new DataInfo(exchange, dataFrame, Callback.NOOP));
+            contentNotifier.iterate();
+            // responseSuccess(exchange);
         }
     }
 


### PR DESCRIPTION
This pull request is not meant to be taken 1:1 as I am pretty sure, this is not the correct way to solve the problem.

The problem I have is when I try to send "trailer" data from the (dropwizard) server to the client.
In this case, the application does not receive all of the data sent over the wire. In Wireshark I can see that the server sent all the data correctly. Anyway, the jetty-client stops processing any data it has already received from the server as soon as the trailer header arrives.
It seems, that the responseSuccess() call terminates further processing of already received data - and purges it.

When I fake an empty DataFrame (instead of calling responseSuccess) to end the stream it seems everthing is working fine.

I am using the at.steinbach.excited.networking.client.jettyConnector.InputStreamResponseListener and I am able to grab the trailer fields from within the onContent() method then.

I hope this make some sense, because I don't know how to create a reproducible test. If you do have some pointers, I can try that.