### PR TITLE
Issue #2135 - proposal for Android 8.1 with SSL and direct buffers

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
@@ -39,8 +39,8 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
     private final ByteBufferPool byteBufferPool;
     private final Executor executor;
     private final ClientConnectionFactory connectionFactory;
-    private boolean _useDirectBuffersForEncryption = false;
-    private boolean _useDirectBuffersForDecryption = false;
+    private boolean _directBuffersForEncryption = true;
+    private boolean _directBuffersForDecryption = true;
 
     public SslClientConnectionFactory(SslContextFactory sslContextFactory, ByteBufferPool byteBufferPool, Executor executor, ClientConnectionFactory connectionFactory)
     {
@@ -52,12 +52,22 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
 
     public void setDirectBuffersForEncryption(boolean useDirectBuffers)
     {
-        this._useDirectBuffersForEncryption = useDirectBuffers;
+        this._directBuffersForEncryption = useDirectBuffers;
     }
 
     public void setDirectBuffersForDecryption(boolean useDirectBuffers)
     {
-        this._useDirectBuffersForDecryption = useDirectBuffers;
+        this._directBuffersForDecryption = useDirectBuffers;
+    }
+
+    public boolean isDirectBuffersForDecryption()
+    {
+        return _directBuffersForDecryption;
+    }
+
+    public boolean isDirectBuffersForEncryption()
+    {
+        return _directBuffersForEncryption;
     }
 
     @Override
@@ -80,6 +90,6 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
 
     protected SslConnection newSslConnection(ByteBufferPool byteBufferPool, Executor executor, EndPoint endPoint, SSLEngine engine)
     {
-        return new SslConnection(byteBufferPool, executor, endPoint, engine, _useDirectBuffersForEncryption, _useDirectBuffersForDecryption);
+        return new SslConnection(byteBufferPool, executor, endPoint, engine, isDirectBuffersForEncryption(), isDirectBuffersForDecryption());
     }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
@@ -39,6 +39,8 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
     private final ByteBufferPool byteBufferPool;
     private final Executor executor;
     private final ClientConnectionFactory connectionFactory;
+    private boolean _useDirectBuffersForEncryption = false;
+    private boolean _useDirectBuffersForDecryption = false;
 
     public SslClientConnectionFactory(SslContextFactory sslContextFactory, ByteBufferPool byteBufferPool, Executor executor, ClientConnectionFactory connectionFactory)
     {
@@ -46,6 +48,16 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
         this.byteBufferPool = byteBufferPool;
         this.executor = executor;
         this.connectionFactory = connectionFactory;
+    }
+
+    public void setDirectBuffersForEncryption(boolean useDirectBuffers)
+    {
+        this._useDirectBuffersForEncryption = useDirectBuffers;
+    }
+
+    public void setDirectBuffersForDecryption(boolean useDirectBuffers)
+    {
+        this._useDirectBuffersForDecryption = useDirectBuffers;
     }
 
     @Override
@@ -68,6 +80,6 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
 
     protected SslConnection newSslConnection(ByteBufferPool byteBufferPool, Executor executor, EndPoint endPoint, SSLEngine engine)
     {
-        return new SslConnection(byteBufferPool, executor, endPoint, engine);
+        return new SslConnection(byteBufferPool, executor, endPoint, engine, _useDirectBuffersForEncryption, _useDirectBuffersForDecryption);
     }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -88,8 +88,8 @@ public class SslConnection extends AbstractConnection
     private ByteBuffer _decryptedInput;
     private ByteBuffer _encryptedInput;
     private ByteBuffer _encryptedOutput;
-    private final boolean _encryptedDirectBuffers = false;
-    private final boolean _decryptedDirectBuffers = false;
+    private final boolean _encryptedDirectBuffers;
+    private final boolean _decryptedDirectBuffers;
     private final Runnable _runCompletWrite = new Runnable()
     {
         @Override
@@ -102,12 +102,20 @@ public class SslConnection extends AbstractConnection
 
     public SslConnection(ByteBufferPool byteBufferPool, Executor executor, EndPoint endPoint, SSLEngine sslEngine)
     {
+        this(byteBufferPool, executor, endPoint, sslEngine, false, false);
+    }
+
+    public SslConnection(ByteBufferPool byteBufferPool, Executor executor, EndPoint endPoint, SSLEngine sslEngine,
+                         boolean useDirectBuffersForEncryption, boolean useDirectBuffersForDecryption)
+    {
         // This connection does not execute calls to onfillable, so they will be called by the selector thread.
         // onfillable does not block and will only wakeup another thread to do the actual reading and handling.
         super(endPoint, executor, !EXECUTE_ONFILLABLE);
         this._bufferPool = byteBufferPool;
         this._sslEngine = sslEngine;
         this._decryptedEndPoint = newDecryptedEndPoint();
+        this._encryptedDirectBuffers = useDirectBuffersForEncryption;
+        this._decryptedDirectBuffers = useDirectBuffersForDecryption;
     }
 
     protected DecryptedEndPoint newDecryptedEndPoint()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java
@@ -34,6 +34,8 @@ public class SslConnectionFactory extends AbstractConnectionFactory
 {
     private final SslContextFactory _sslContextFactory;
     private final String _nextProtocol;
+    private boolean _useDirectBuffersForEncryption = false;
+    private boolean _useDirectBuffersForDecryption = false;
 
     public SslConnectionFactory()
     {
@@ -56,6 +58,16 @@ public class SslConnectionFactory extends AbstractConnectionFactory
     public SslContextFactory getSslContextFactory()
     {
         return _sslContextFactory;
+    }
+
+    public void setDirectBuffersForEncryption(boolean useDirectBuffers)
+    {
+        this._useDirectBuffersForEncryption = useDirectBuffers;
+    }
+
+    public void setDirectBuffersForDecryption(boolean useDirectBuffers)
+    {
+        this._useDirectBuffersForDecryption = useDirectBuffers;
     }
 
     @Override
@@ -91,7 +103,7 @@ public class SslConnectionFactory extends AbstractConnectionFactory
 
     protected SslConnection newSslConnection(Connector connector, EndPoint endPoint, SSLEngine engine)
     {
-        return new SslConnection(connector.getByteBufferPool(), connector.getExecutor(), endPoint, engine);
+        return new SslConnection(connector.getByteBufferPool(), connector.getExecutor(), endPoint, engine, _useDirectBuffersForEncryption, _useDirectBuffersForDecryption);
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java
@@ -34,8 +34,8 @@ public class SslConnectionFactory extends AbstractConnectionFactory
 {
     private final SslContextFactory _sslContextFactory;
     private final String _nextProtocol;
-    private boolean _useDirectBuffersForEncryption = false;
-    private boolean _useDirectBuffersForDecryption = false;
+    private boolean _directBuffersForEncryption = false;
+    private boolean _directBuffersForDecryption = false;
 
     public SslConnectionFactory()
     {
@@ -62,12 +62,22 @@ public class SslConnectionFactory extends AbstractConnectionFactory
 
     public void setDirectBuffersForEncryption(boolean useDirectBuffers)
     {
-        this._useDirectBuffersForEncryption = useDirectBuffers;
+        this._directBuffersForEncryption = useDirectBuffers;
     }
 
     public void setDirectBuffersForDecryption(boolean useDirectBuffers)
     {
-        this._useDirectBuffersForDecryption = useDirectBuffers;
+        this._directBuffersForDecryption = useDirectBuffers;
+    }
+
+    public boolean isDirectBuffersForDecryption()
+    {
+        return _directBuffersForDecryption;
+    }
+
+    public boolean isDirectBuffersForEncryption()
+    {
+        return _directBuffersForEncryption;
     }
 
     @Override
@@ -103,7 +113,7 @@ public class SslConnectionFactory extends AbstractConnectionFactory
 
     protected SslConnection newSslConnection(Connector connector, EndPoint endPoint, SSLEngine engine)
     {
-        return new SslConnection(connector.getByteBufferPool(), connector.getExecutor(), endPoint, engine, _useDirectBuffersForEncryption, _useDirectBuffersForDecryption);
+        return new SslConnection(connector.getByteBufferPool(), connector.getExecutor(), endPoint, engine, isDirectBuffersForEncryption(), isDirectBuffersForDecryption());
     }
 
     @Override

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/io/WebSocketClientSelectorManager.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/io/WebSocketClientSelectorManager.java
@@ -82,7 +82,7 @@ public class WebSocketClientSelectorManager extends SelectorManager
                 if (sslContextFactory != null)
                 {
                     SSLEngine engine = newSSLEngine(sslContextFactory,channel);
-                    SslConnection sslConnection = new SslConnection(bufferPool,getExecutor(),endPoint,engine);
+                    SslConnection sslConnection = new SslConnection(bufferPool,getExecutor(),endPoint,engine,true,true);
                     sslConnection.setRenegotiationAllowed(sslContextFactory.isRenegotiationAllowed());
                     EndPoint sslEndPoint = sslConnection.getDecryptedEndPoint();
 


### PR DESCRIPTION
Allow the Direct ByteBuffer usage to be configurable at the SslConnectionFactory level for benefit of Android 8.1+ users.