### PR TITLE
fixed example for --list-config

### DIFF
--- a/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
+++ b/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
@@ -114,7 +114,7 @@ You can see the configuration of the `demo-base` by using the following commands
 > java -jar $JETTY_HOME/start.jar --list-modules
 ...
 
-> java -jar %JETTY_HOME/start.jar --list-config
+> java -jar $JETTY_HOME/start.jar --list-config
 ...
 ----
 

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/ServerConnectorListener.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/ServerConnectorListener.java
@@ -54,7 +54,7 @@ public class ServerConnectorListener extends AbstractLifeCycleListener
         {
             try
             {
-                Path tmp = Files.createTempFile( "jettyport", "tmp  " );
+                Path tmp = Files.createTempFile( "jettyport", ".tmp" );
                 try (Writer writer = Files.newBufferedWriter( tmp ))
                 {
                     writer.write( String.valueOf( ( (ServerConnector) event ).getLocalPort() ) );


### PR DESCRIPTION
example for using --list-config configuration command used incorrect sigil of % for variable JETTY_HOME should be a $