### PR TITLE
Issue #901 - Overriding SSL context KeyStoreType requires explicit override of TrustStoreType.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -1082,10 +1082,14 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
     {
         String type = Objects.toString(getTrustStoreType(), getKeyStoreType());
         String provider = Objects.toString(getTrustStoreProvider(), getKeyStoreProvider());
-        String passwd = Objects.toString(_trustStorePassword, Objects.toString(_keyStorePassword, null));
-        if (resource == null)
+        Password passwd = _trustStorePassword;
+        if (resource == null || resource.equals(_keyStoreResource))
+        {
             resource = _keyStoreResource;
-        return CertificateUtils.getKeyStore(resource, type, provider, passwd);
+            if (passwd == null)
+                passwd = _keyStorePassword;
+        }
+        return CertificateUtils.getKeyStore(resource, type, provider, Objects.toString(passwd, null));
     }
 
     /**


### PR DESCRIPTION
Improved defaulting values for the truststore, avoiding to default
the password, which is often missing for a truststore.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>