### PR TITLE
Issue #2468 - Remove SoLinger.

### DIFF
--- a/jetty-documentation/src/main/asciidoc/configuring/connectors/configuring-connectors.adoc
+++ b/jetty-documentation/src/main/asciidoc/configuring/connectors/configuring-connectors.adoc
@@ -236,9 +236,6 @@ For example, if we examine the `http.ini` file in our `start.d` directory create
 ## Connector idle timeout in milliseconds
 # jetty.http.idleTimeout=30000
 
-## Connector socket linger time in seconds (-1 to disable)
-# jetty.http.soLingerTime=-1
-
 ## Number of acceptors (-1 picks default based on number of cores)
 # jetty.http.acceptors=-1
 
@@ -385,9 +382,6 @@ Because the exact interpretation is deployment dependent, it is best to keep thi
 
 |reuseAddress |Allow the server socket to be rebound even if in http://www.ssfnet.org/Exchange/tcp/tcpTutorialNotes.html[TIME_WAIT].
 For servers it is typically OK to leave this as the default true.
-
-|soLingerTime |A value greater than zero sets the socket http://stackoverflow.com/questions/3757289/tcp-option-so-linger-zero-when-its-required[SO_LINGER] value in milliseconds.
-Jetty attempts to gently close all TCP/IP connections with proper half close semantics, so a linger timeout should not be required and thus the default is -1.
 |=======================================================================
 
 [[jetty-connectors-http-configuration]]

--- a/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-plugin.adoc
@@ -114,8 +114,6 @@ name;;
 The name of the connector, which is useful for link:#serving-webapp-from-particular-port[configuring contexts to respond only on particular connectors].
 idleTimeout;;
 Maximum idle time for a connection.
-soLinger;;
-The socket linger time.
 +
 You could instead configure the connectors in a standard link:#jetty-xml-config[jetty xml config file] and put its location into the `jettyXml` parameter.
 Note that since Jetty 9.0 it is no longer possible to configure a link:#maven-config-https[https connector] directly in the pom.xml: you need to link:#maven-config-https[use jetty xml config files to do it].

--- a/jetty-documentation/src/main/asciidoc/quick-start/configuring/how-to-configure.adoc
+++ b/jetty-documentation/src/main/asciidoc/quick-start/configuring/how-to-configure.adoc
@@ -127,9 +127,6 @@ $ cat start.d/http.ini
 ## Connector idle timeout in milliseconds
 # jetty.http.idleTimeout=30000
 
-## Connector socket linger time in seconds (-1 to disable)
-# jetty.http.soLingerTime=-1
-
 ## Number of acceptors (-1 picks default based on number of cores)
 # jetty.http.acceptors=-1
 
@@ -213,9 +210,6 @@ etc/jetty-http.xml
 
 ## Connector idle timeout in milliseconds
 # jetty.http.idleTimeout=30000
-
-## Connector socket linger time in seconds (-1 to disable)
-# jetty.http.soLingerTime=-1
 ...
 ----
 At first blush, it looks remarkable similar to the `ini` file we just looked at.
@@ -269,7 +263,6 @@ $ cat $JETTY_HOME/etc/jetty-http.xml
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
         <Get name="SelectorManager">

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -183,11 +183,9 @@ public class IOTest
             try (Socket client = SocketChannel.open(connector.socket().getLocalSocketAddress()).socket())
             {
                 client.setSoTimeout(1000);
-                client.setSoLinger(false, -1);
                 try (Socket server = connector.accept().socket())
                 {
                     server.setSoTimeout(1000);
-                    server.setSoLinger(false, -1);
 
                     // Write from client to server
                     client.getOutputStream().write(1);
@@ -245,11 +243,9 @@ public class IOTest
             try (Socket client = SocketChannel.open(connector.socket().getLocalSocketAddress()).socket())
             {
                 client.setSoTimeout(1000);
-                client.setSoLinger(false, -1);
                 try (Socket server = connector.accept().socket())
                 {
                     server.setSoTimeout(1000);
-                    server.setSoLinger(false, -1);
 
                     // Write from client to server
                     client.getOutputStream().write(1);
@@ -316,11 +312,9 @@ public class IOTest
             try (Socket client = SocketChannel.open(connector.socket().getLocalSocketAddress()).socket())
             {
                 client.setSoTimeout(2000);
-                client.setSoLinger(false, -1);
                 try (Socket server = connector.accept().socket())
                 {
                     server.setSoTimeout(2000);
-                    server.setSoLinger(false, -1);
 
                     // Write from client to server
                     client.getOutputStream().write(1);

--- a/jetty-maven-plugin/src/it/jetty-cdi-run-forked/postbuild.groovy
+++ b/jetty-maven-plugin/src/it/jetty-cdi-run-forked/postbuild.groovy
@@ -4,7 +4,6 @@ System.out.println( "postbuild.groovy port " + jettyStopPort + ", key:" + jettyS
 int port = Integer.parseInt( jettyStopPort )
 
 Socket s=new Socket(InetAddress.getByName("127.0.0.1"),port )
-s.setSoLinger(false, 0)
 
 OutputStream out=s.getOutputStream()
 out.write(( jettyStopKey +"\r\nforcestop\r\n").getBytes())

--- a/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/postbuild.groovy
+++ b/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/postbuild.groovy
@@ -4,7 +4,6 @@ System.out.println( "running postbuild.groovy port " + jettyStopPort + ", key:" 
 int port = Integer.parseInt( jettyStopPort )
 
 Socket s=new Socket(InetAddress.getByName("127.0.0.1"),port )
-s.setSoLinger(false, 0)
 
 OutputStream out=s.getOutputStream()
 out.write(( jettyStopKey +"\r\nforcestop\r\n").getBytes())

--- a/jetty-maven-plugin/src/it/jetty-run-forked-mojo-it/postbuild.groovy
+++ b/jetty-maven-plugin/src/it/jetty-run-forked-mojo-it/postbuild.groovy
@@ -5,7 +5,6 @@ System.out.println( "running postbuild.groovy port " + jettyStopPort + ", key:" 
 int port = Integer.parseInt( jettyStopPort )
 
 Socket s=new Socket(InetAddress.getByName("127.0.0.1"),port )
-s.setSoLinger(false, 0)
 
 OutputStream out=s.getOutputStream()
 out.write(( jettyStopKey +"\r\nforcestop\r\n").getBytes())

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
@@ -79,9 +79,6 @@ public class JettyStopMojo extends AbstractMojo
        
         try(Socket s=new Socket(InetAddress.getByName("127.0.0.1"),stopPort);)
         {        
-
-            s.setSoLinger(false, 0);
-
             OutputStream out=s.getOutputStream();
             out.write((stopKey+"\r\n"+command+"\r\n").getBytes());
             out.flush();

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/MavenServerConnector.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/MavenServerConnector.java
@@ -59,9 +59,7 @@ public class MavenServerConnector extends ContainerLifeCycle implements Connecto
     private String name;
     private int port;
     private long idleTimeout;
-    private int lingerTime;
-    
-    
+
     public MavenServerConnector()
     {
     }
@@ -100,10 +98,14 @@ public class MavenServerConnector extends ContainerLifeCycle implements Connecto
     {
         this.idleTimeout = idleTimeout;
     }
-    
+
+    /**
+     * @param lingerTime the socket close linger time
+     * @deprecated don't use as socket close linger time has undefined behavior for non-blocking sockets
+     */
+    @Deprecated
     public void setSoLingerTime(int lingerTime)
     {
-        this.lingerTime = lingerTime;
     }
     
     @Override
@@ -118,7 +120,6 @@ public class MavenServerConnector extends ContainerLifeCycle implements Connecto
         this.delegate.setPort(this.port);
         this.delegate.setHost(this.host);
         this.delegate.setIdleTimeout(idleTimeout);
-        this.delegate.setSoLingerTime(lingerTime);
         this.delegate.start();
 
         super.doStart();

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
@@ -22,7 +22,6 @@
           <Set name="host"><Property name="jetty.ssl.host" /></Set>
           <Set name="port"><Property name="jetty.ssl.port" default="443" /></Set>
           <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" default="30000"/></Set>
-          <Set name="soLingerTime"><Property name="jetty.ssl.soLingerTime" default="-1"/></Set>
         </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/etc/jetty-http.xml
+++ b/jetty-server/src/main/config/etc/jetty-http.xml
@@ -37,7 +37,6 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
         <Get name="SelectorManager">

--- a/jetty-server/src/main/config/etc/jetty-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl.xml
@@ -29,7 +29,6 @@
         <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.ssl.port" deprecated="ssl.port" default="8443" /></Set>
         <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" deprecated="ssl.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.ssl.soLingerTime" deprecated="ssl.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" deprecated="ssl.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.ssl.acceptQueueSize" deprecated="ssl.acceptQueueSize" default="0"/></Set>
         <Get name="SelectorManager">

--- a/jetty-server/src/main/config/modules/http.mod
+++ b/jetty-server/src/main/config/modules/http.mod
@@ -27,9 +27,6 @@ etc/jetty-http.xml
 ## Connector idle timeout in milliseconds
 # jetty.http.idleTimeout=30000
 
-## Connector socket linger time in seconds (-1 to disable)
-# jetty.http.soLingerTime=-1
-
 ## Number of acceptors (-1 picks default based on number of cores)
 # jetty.http.acceptors=-1
 

--- a/jetty-server/src/main/config/modules/ssl.mod
+++ b/jetty-server/src/main/config/modules/ssl.mod
@@ -31,9 +31,6 @@ basehome:modules/ssl/keystore|etc/keystore
 ## Connector idle timeout in milliseconds
 # jetty.ssl.idleTimeout=30000
 
-## Connector socket linger time in seconds (-1 to disable)
-# jetty.ssl.soLingerTime=-1
-
 ## Number of acceptors (-1 picks default based on number of cores)
 # jetty.ssl.acceptors=-1
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -130,7 +130,7 @@ import org.eclipse.jetty.util.thread.ThreadPoolBudget;
  * <ol>
  * <li>block waiting for new connections</li>
  * <li>accept the connection (eg socket accept)</li>
- * <li>perform any configuration of the connection (eg. socket linger times)</li>
+ * <li>perform any configuration of the connection (eg. socket configuration)</li>
  * <li>call the {@link #getDefaultConnectionFactory()} {@link ConnectionFactory#newConnection(Connector, org.eclipse.jetty.io.EndPoint)}
  * method to create a new Connection instance.</li>
  * </ol>

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -27,11 +27,9 @@ import java.net.SocketException;
 import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -41,7 +39,6 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.ManagedSelector;
 import org.eclipse.jetty.io.SelectorManager;
 import org.eclipse.jetty.io.SocketChannelEndPoint;
-import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.Name;
@@ -84,7 +81,6 @@ public class ServerConnector extends AbstractNetworkConnector
     private volatile int _localPort = -1;
     private volatile int _acceptQueueSize = 0;
     private volatile boolean _reuseAddress = true;
-    private volatile int _lingerTime = -1;
 
     /**
      * <p>Construct a ServerConnector with a private instance of {@link HttpConnectionFactory} as the only factory.</p>
@@ -384,10 +380,6 @@ public class ServerConnector extends AbstractNetworkConnector
         try
         {
             socket.setTcpNoDelay(true);
-            if (_lingerTime >= 0)
-                socket.setSoLinger(true, _lingerTime / 1000);
-            else
-                socket.setSoLinger(false, 0);
         }
         catch (SocketException e)
         {
@@ -422,22 +414,28 @@ public class ServerConnector extends AbstractNetworkConnector
     }
 
     /**
-     * @return the linger time
-     * @see Socket#getSoLinger()
+     * Returns the socket close linger time.
+     *
+     * @return -1 as the socket close linger time is always disabled.
+     * @see java.net.StandardSocketOptions#SO_LINGER
+     * @deprecated don't use as socket close linger time has undefined behavior for non-blocking sockets
      */
-    @ManagedAttribute("TCP/IP solinger time or -1 to disable")
+    @ManagedAttribute(value = "TCP/IP socket close linger time or -1 if disabled", readonly = true)
+    @Deprecated
     public int getSoLingerTime()
     {
-        return _lingerTime;
+        return -1;
     }
 
     /**
-     * @param lingerTime the linger time. Use -1 to disable.
-     * @see Socket#setSoLinger(boolean, int)
+     * @param lingerTime the socket close linger time; use -1 to disable.
+     * @see java.net.StandardSocketOptions#SO_LINGER
+     * @deprecated don't use as socket close linger time has undefined behavior for non-blocking sockets
      */
+    @Deprecated
     public void setSoLingerTime(int lingerTime)
     {
-        _lingerTime = lingerTime;
+        LOG.warn("Ignoring socket close linger time, it has undefined behavior for non-blocking socket");
     }
 
     /**

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -56,7 +56,6 @@ public class HttpServerTestFixture
         Socket socket = new Socket(host,port);
         socket.setSoTimeout(10000);
         socket.setTcpNoDelay(true);
-        socket.setSoLinger(false,0);
         return socket;
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/StressTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/StressTest.java
@@ -18,10 +18,6 @@
 
 package org.eclipse.jetty.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Queue;
@@ -47,6 +43,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(AdvancedRunner.class)
 public class StressTest
@@ -348,7 +348,6 @@ public class StressTest
             long start=TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
             Socket socket= new Socket("localhost", _connector.getLocalPort());
             socket.setSoTimeout(30000);
-            socket.setSoLinger(false,0);
 
             long connected=TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
 
@@ -417,7 +416,6 @@ public class StressTest
 
                 Socket socket = new Socket("localhost", _connector.getLocalPort());
                 socket.setSoTimeout(10000);
-                socket.setSoLinger(false,0);
 
                 _latencies[0].add(new Long(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())-start));
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SelectChannelServerSslTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SelectChannelServerSslTest.java
@@ -129,7 +129,6 @@ public class SelectChannelServerSslTest extends HttpServerTestBase
         Socket socket = _sslContext.getSocketFactory().createSocket(host,port);
         socket.setSoTimeout(10000);
         socket.setTcpNoDelay(true);
-        socket.setSoLinger(false,0);
         return socket;
     }
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/RequestURITest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/RequestURITest.java
@@ -159,7 +159,6 @@ public class RequestURITest
         Socket socket = new Socket(host,port);
         socket.setSoTimeout(10000);
         socket.setTcpNoDelay(true);
-        socket.setSoLinger(false,0);
         return socket;
     }
 

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/HttpInputIntegrationTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/HttpInputIntegrationTest.java
@@ -18,9 +18,6 @@
 
 package org.eclipse.jetty.test;
 
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Inet4Address;
@@ -70,6 +67,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class HttpInputIntegrationTest
@@ -616,7 +616,6 @@ public class HttpInputIntegrationTest
             {
                 client.setSoTimeout(5000);
                 client.setTcpNoDelay(true);
-                client.setSoLinger(true,1);
                 OutputStream out = client.getOutputStream();
 
                 StringBuilder buffer = new StringBuilder();


### PR DESCRIPTION
For non-blocking sockets, StandardSocketOptions#SO_LINGER javadocs
report that the behavior is undefined. In JDK 11 setting SoLinger
for non-blocking sockets will be ignored.

As such, there is no point in allowing SoLinger to be configured
in Jetty that only uses non-blocking sockets.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>