### PR TITLE
Incorrect sigil used for example of --list-config command

### DIFF
--- a/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
+++ b/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
@@ -114,7 +114,7 @@ You can see the configuration of the `demo-base` by using the following commands
 > java -jar $JETTY_HOME/start.jar --list-modules
 ...
 
-> java -jar %JETTY_HOME/start.jar --list-config
+> java -jar $JETTY_HOME/start.jar --list-config
 ...
 ----
 


### PR DESCRIPTION
changed % to $ in the example of --list-config command

Signed-off-by: Jameson Allen <jameson.f.allen@gmail.com>