### PR TITLE
Issue #2662 "Unnecessary boxing conversions"

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
@@ -426,7 +426,7 @@ public class AnnotationConfiguration extends AbstractConfiguration
         int javaPlatform = 0;
         Object target = context.getAttribute(JavaVersion.JAVA_TARGET_PLATFORM);
         if (target!=null)
-            javaPlatform = Integer.valueOf(target.toString());
+            javaPlatform = Integer.parseInt(target.toString());
         AnnotationParser parser = createAnnotationParser(javaPlatform);
         _parserTasks = new ArrayList<ParserTask>();
 
@@ -539,7 +539,7 @@ public class AnnotationConfiguration extends AbstractConfiguration
             return ((Boolean)o).booleanValue();
         }
         //try system property to see if we should use multithreading
-        return Boolean.valueOf(System.getProperty(MULTI_THREADED, Boolean.toString(DEFAULT_MULTI_THREADED)));
+        return Boolean.parseBoolean(System.getProperty(MULTI_THREADED, Boolean.toString(DEFAULT_MULTI_THREADED)));
     }
 
    

--- a/jetty-hazelcast/src/main/java/org/eclipse/jetty/hazelcast/session/HazelcastSessionDataStore.java
+++ b/jetty-hazelcast/src/main/java/org/eclipse/jetty/hazelcast/session/HazelcastSessionDataStore.java
@@ -204,7 +204,7 @@ public class HazelcastSessionDataStore
         if (sd.getExpiry() <= 0)
             return true; //never expires
         else
-            return (Boolean.valueOf(sd.getExpiry() > System.currentTimeMillis())); //not expired yet
+            return sd.getExpiry() > System.currentTimeMillis(); //not expired yet
     }
 
     public String getCacheKey( String id )

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
@@ -72,12 +72,12 @@ public class HttpField
 
     public int getIntValue()
     {
-        return Integer.valueOf(_value);
+        return Integer.parseInt(_value);
     }
 
     public long getLongValue()
     {
-        return Long.valueOf(_value);
+        return Long.parseLong(_value);
     }
 
     public String[] getValues()
@@ -348,7 +348,7 @@ public class HttpField
 
         public IntValueHttpField(HttpHeader header, String name, String value)
         {
-            this(header,name,value,Integer.valueOf(value));
+            this(header,name,value,Integer.parseInt(value));
         }
 
         public IntValueHttpField(HttpHeader header, String name, int intValue)
@@ -386,7 +386,7 @@ public class HttpField
 
         public LongValueHttpField(HttpHeader header, String name, String value)
         {
-            this(header,name,value,Long.valueOf(value));
+            this(header,name,value,Long.parseLong(value));
         }
 
         public LongValueHttpField(HttpHeader header, String name, long value)

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/ProxyTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/ProxyTest.java
@@ -93,7 +93,7 @@ public class ProxyTest
         configuration.setSendServerVersion(false);
         String value = initParams.get("outputBufferSize");
         if (value != null)
-            configuration.setOutputBufferSize(Integer.valueOf(value));
+            configuration.setOutputBufferSize(Integer.parseInt(value));
         proxyConnector = new ServerConnector(proxy, new HTTP2ServerConnectionFactory(configuration));
         proxy.addConnector(proxyConnector);
 

--- a/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/InfinispanSessionDataStore.java
+++ b/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/InfinispanSessionDataStore.java
@@ -22,6 +22,7 @@ package org.eclipse.jetty.session.infinispan;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.server.session.AbstractSessionDataStore;
@@ -258,7 +259,7 @@ public class InfinispanSessionDataStore extends AbstractSessionDataStore
     {
         // TODO find a better way to do this that does not pull into memory the
         // whole session object
-        final AtomicReference<Boolean> reference = new AtomicReference<>();
+        final AtomicBoolean reference = new AtomicBoolean();
         final AtomicReference<Exception> exception = new AtomicReference<>();
 
         Runnable load = new Runnable()
@@ -271,14 +272,14 @@ public class InfinispanSessionDataStore extends AbstractSessionDataStore
                     SessionData sd = load(id);
                     if (sd == null)
                     {
-                        reference.set(Boolean.FALSE);
+                        reference.set(false);
                         return;
                     }
 
                     if (sd.getExpiry() <= 0)
-                        reference.set(Boolean.TRUE); //never expires
+                        reference.set(true); //never expires
                     else
-                        reference.set(Boolean.valueOf(sd.getExpiry() > System.currentTimeMillis())); //not expired yet
+                        reference.set(sd.getExpiry() > System.currentTimeMillis()); //not expired yet
                 }
                 catch (Exception e)
                 {

--- a/jetty-jaspi/src/main/java/org/eclipse/jetty/security/jaspi/modules/BaseAuthModule.java
+++ b/jetty-jaspi/src/main/java/org/eclipse/jetty/security/jaspi/modules/BaseAuthModule.java
@@ -112,7 +112,7 @@ public class BaseAuthModule implements ServerAuthModule, ServerAuthContext
     {
         String mandatory = (String) messageInfo.getMap().get(JaspiMessageInfo.MANDATORY_KEY);
         if (mandatory == null) return false;
-        return Boolean.valueOf(mandatory);
+        return Boolean.parseBoolean(mandatory);
     }
 
     protected boolean login(Subject clientSubject, String credentials, 

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AsyncMiddleManServletTest.java
@@ -131,7 +131,7 @@ public class AsyncMiddleManServletTest
         configuration.setSendServerVersion(false);
         String value = initParams.get("outputBufferSize");
         if (value != null)
-            configuration.setOutputBufferSize(Integer.valueOf(value));
+            configuration.setOutputBufferSize(Integer.parseInt(value));
         proxyConnector = new ServerConnector(proxy, new HttpConnectionFactory(configuration));
         proxy.addConnector(proxyConnector);
 

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
@@ -160,7 +160,7 @@ public class ProxyServletTest
         configuration.setSendServerVersion(false);
         String value = initParams.get("outputBufferSize");
         if (value != null)
-            configuration.setOutputBufferSize(Integer.valueOf(value));
+            configuration.setOutputBufferSize(Integer.parseInt(value));
         proxyConnector = new ServerConnector(proxy, new HttpConnectionFactory(configuration));
         proxy.addConnector(proxyConnector);
 

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
@@ -72,10 +72,10 @@ public class DigestAuthenticator extends LoginAuthenticator
 
         String mna = configuration.getInitParameter("maxNonceAge");
         if (mna != null)
-            setMaxNonceAge(Long.valueOf(mna));
+            setMaxNonceAge(Long.parseLong(mna));
         String mnc = configuration.getInitParameter("maxNonceCount");
         if (mnc != null)
-            setMaxNonceCount(Integer.valueOf(mnc));
+            setMaxNonceCount(Integer.parseInt(mnc));
     }
 
     public int getMaxNonceCount()

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/FormAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/FormAuthenticator.java
@@ -136,7 +136,7 @@ public class FormAuthenticator extends LoginAuthenticator
         if (error!=null)
             setErrorPage(error);
         String dispatch=configuration.getInitParameter(FormAuthenticator.__FORM_DISPATCH);
-        _dispatch = dispatch==null?_dispatch:Boolean.valueOf(dispatch);
+        _dispatch = dispatch==null?_dispatch:Boolean.parseBoolean(dispatch);
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -515,7 +515,7 @@ public class Request implements HttpServletRequest
                 }
                 else if (obj instanceof String)
                 {
-                    maxFormContentSize = Integer.valueOf((String)obj);
+                    maxFormContentSize = Integer.parseInt((String)obj);
                 }
             }
 
@@ -531,7 +531,7 @@ public class Request implements HttpServletRequest
                 }
                 else if (obj instanceof String)
                 {
-                    maxFormKeys = Integer.valueOf((String)obj);
+                    maxFormKeys = Integer.parseInt((String)obj);
                 }
             }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AbstractHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AbstractHandler.java
@@ -93,7 +93,7 @@ public abstract class AbstractHandler extends ContainerLifeCycle implements Hand
     protected void doError(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
     {
         Object o = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
-        int code = (o instanceof Integer)?((Integer)o).intValue():(o!=null?Integer.valueOf(o.toString()):500);
+        int code = (o instanceof Integer)?((Integer)o).intValue():(o!=null?Integer.parseInt(o.toString()):500);
         o = request.getAttribute(RequestDispatcher.ERROR_MESSAGE);
         String reason = o!=null?o.toString():null;
         

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java
@@ -354,7 +354,7 @@ public class AsyncRequestReadTest
 
             BufferedReader in = request.getReader();
             PrintWriter out =httpResponse.getWriter();
-            int read=Integer.valueOf(request.getParameter("read"));
+            int read=Integer.parseInt(request.getParameter("read"));
             // System.err.println("read="+read);
             for (int i=read;i-->0;)
             {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/DumpHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/DumpHandler.java
@@ -63,10 +63,10 @@ public class DumpHandler extends AbstractHandler.ErrorDispatchHandler
         if (!isStarted())
             return;
 
-        if (Boolean.valueOf(request.getParameter("flush")))
+        if (Boolean.parseBoolean(request.getParameter("flush")))
             response.flushBuffer();
         
-        if (Boolean.valueOf(request.getParameter("empty")))
+        if (Boolean.parseBoolean(request.getParameter("empty")))
         {
             baseRequest.setHandled(true);
             response.setStatus(200);
@@ -230,7 +230,7 @@ public class DumpHandler extends AbstractHandler.ErrorDispatchHandler
         writer.flush();
 
         // commit now
-        if (!Boolean.valueOf(request.getParameter("no-content-length")))
+        if (!Boolean.parseBoolean(request.getParameter("no-content-length")))
             response.setContentLength(buf.size()+1000);
         response.addHeader("Before-Flush",response.isCommitted()?"Committed???":"Not Committed");
         buf.writeTo(out);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
@@ -147,7 +147,7 @@ public class ExtendedServerTest extends HttpServerTestBase
             
             String s=response.substring(response.indexOf("DispatchedAt=")+13);
             s=s.substring(0,s.indexOf('\n'));
-            long dispatched=Long.valueOf(s);
+            long dispatched=Long.parseLong(s);
             
             Assert.assertThat(dispatched, Matchers.greaterThanOrEqualTo(start));
             Assert.assertThat(dispatched, Matchers.lessThan(end));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -910,7 +910,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             // read and check the times are < 999ms
             String[] times = in.readLine().split(",");
             for (String t : times)
-                Assert.assertTrue(Integer.valueOf(t) < 999);
+                Assert.assertTrue(Integer.parseInt(t) < 999);
 
 
             // read the EOF chunk
@@ -940,7 +940,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             // read and check the times are < 999ms
             times = in.readLine().split(",");
             for (String t : times)
-                Assert.assertTrue(t, Integer.valueOf(t) < 999);
+                Assert.assertTrue(t, Integer.parseInt(t) < 999);
 
             // check close
             Assert.assertTrue(in.readLine() == null);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLEngineTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLEngineTest.java
@@ -369,7 +369,7 @@ public class SSLEngineTest
             if (request.getParameter("dump")!=null)
             {
                 ServletOutputStream out=response.getOutputStream();
-                byte[] buf = new byte[Integer.valueOf(request.getParameter("dump"))];
+                byte[] buf = new byte[Integer.parseInt(request.getParameter("dump"))];
                 // System.err.println("DUMP "+buf.length);
                 for (int i=0;i<buf.length;i++)
                     buf[i]=(byte)('0'+(i%10));

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -104,7 +104,7 @@ public class StatisticsServlet extends HttpServlet
             }
         }
 
-        if (Boolean.valueOf( req.getParameter("statsReset")))
+        if (Boolean.parseBoolean( req.getParameter("statsReset")))
         {
             _statsHandler.statsReset();
             return;
@@ -114,7 +114,7 @@ public class StatisticsServlet extends HttpServlet
         if (wantXml == null)
           wantXml = req.getParameter("XML");
 
-        if (Boolean.valueOf(wantXml))
+        if (Boolean.parseBoolean(wantXml))
         {
             sendXmlResponse(resp);
         }

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncContextTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncContextTest.java
@@ -651,15 +651,15 @@ public class AsyncContextTest
             {
                 request.startAsync(request, response);
 
-                if (Boolean.valueOf(request.getParameter("dispatch")))
+                if (Boolean.parseBoolean(request.getParameter("dispatch")))
                 {
                     request.getAsyncContext().dispatch();
                 }
 
-                if (Boolean.valueOf(request.getParameter("complete")))
+                if (Boolean.parseBoolean(request.getParameter("complete")))
                 {
                     response.getOutputStream().write("completeBeforeThrow".getBytes());
-                    if (Boolean.valueOf(request.getParameter("flush")))
+                    if (Boolean.parseBoolean(request.getParameter("flush")))
                         response.flushBuffer();
                     request.getAsyncContext().complete();
                 }

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncServletIOTest.java
@@ -481,7 +481,7 @@ public class AsyncServletIOTest
 
                     while (writes!=null && _w< writes.length)
                     {
-                        int write=Integer.valueOf(writes[_w++]);
+                        int write=Integer.parseInt(writes[_w++]);
                         
                         if (write==0)
                             out.flush();

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -737,7 +737,7 @@ public class DoSFilter implements Filter
                 byte[] result = new byte[16];
                 for (int i = 0; i < result.length; i += 2)
                 {
-                    int word = Integer.valueOf(ipv6Matcher.group(i / 2 + 1), 16);
+                    int word = Integer.parseInt(ipv6Matcher.group(i / 2 + 1), 16);
                     result[i] = (byte)((word & 0xFF00) >>> 8);
                     result[i + 1] = (byte)(word & 0xFF);
                 }

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
@@ -54,7 +54,7 @@ public class PushSessionCacheFilter implements Filter
     public void init(FilterConfig config) throws ServletException
     {
         if (config.getInitParameter("associateDelay") != null)
-            _associateDelay = Long.valueOf(config.getInitParameter("associateDelay"));
+            _associateDelay = Long.parseLong(config.getInitParameter("associateDelay"));
 
         // Add a listener that is used to collect information about associated resource,
         // etags and modified dates

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -246,7 +246,7 @@ public class BaseBuilder
 
         files.addAll(startArgs.getFiles());
         if (!files.isEmpty() && processFileResources(files))
-            modified.set(Boolean.TRUE);
+            modified.set(true);
         
         return modified.get();
     }

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/TestFileInitializer.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/TestFileInitializer.java
@@ -59,6 +59,6 @@ public class TestFileInitializer extends FileInitializer
         }
         
         StartLog.log("TESTING MODE","Skipping download of " + uri);
-        return Boolean.TRUE;
+        return true;
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IPAddressMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IPAddressMap.java
@@ -281,7 +281,7 @@ public class IPAddressMap<TYPE> extends HashMap<String, TYPE>
                             {
                                 if (part.indexOf('-') < 0)
                                 {
-                                    Integer value = Integer.valueOf(part);
+                                    int value = Integer.parseInt(part);
                                     _mask.set(value);
                                 }
                                 else

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java
@@ -75,7 +75,7 @@ public class MultiReleaseJarFile implements Closeable
         if (manifest==null)
             multiRelease = false;
         else
-            multiRelease = Boolean.valueOf(String.valueOf(manifest.getMainAttributes().getValue("Multi-Release")));
+            multiRelease = Boolean.parseBoolean(String.valueOf(manifest.getMainAttributes().getValue("Multi-Release")));
 
         Map<String,VersionedJarEntry> map = new TreeMap<>();
         jarFile.stream()

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/log/Log.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/log/Log.java
@@ -208,7 +208,7 @@ public class Log
             log_class = StdErrLog.class;
             LOG = new StdErrLog();
 
-            Boolean announce = Boolean.parseBoolean(__props.getProperty("org.eclipse.jetty.util.log.announce", "true"));
+            boolean announce = Boolean.parseBoolean(__props.getProperty("org.eclipse.jetty.util.log.announce", "true"));
             if(announce)
             {
                 LOG.debug("Logging to {} via {}", LOG, log_class.getName());

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/jmh/TestConnection.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/jmh/TestConnection.java
@@ -76,7 +76,7 @@ public class TestConnection implements Producer
         {
             _request = request;
             _futureResult = futureResult;
-            _blocking = Boolean.valueOf(request.get("blocking"));
+            _blocking = Boolean.parseBoolean(request.get("blocking"));
         }
 
         @Override

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
@@ -476,7 +476,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
         String async=node.getString("async-supported",false,true);
         if (async!=null)
         {
-            boolean val = async.length()==0||Boolean.valueOf(async);
+            boolean val = async.length()==0||Boolean.parseBoolean(async);
             switch (context.getMetaData().getOrigin(name+".servlet.async-supported"))
             {
                 case NotSet:
@@ -513,7 +513,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
         String enabled = node.getString("enabled", false, true);
         if (enabled!=null)
         {
-            boolean is_enabled = enabled.length()==0||Boolean.valueOf(enabled);
+            boolean is_enabled = enabled.length()==0||Boolean.parseBoolean(enabled);
             switch (context.getMetaData().getOrigin(name+".servlet.enabled"))
             {
                 case NotSet:
@@ -1119,7 +1119,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 error = ErrorPageErrorHandler.GLOBAL_ERROR_PAGE;
         }
         else
-            code=Integer.valueOf(error);
+            code=Integer.parseInt(error);
 
         String location = node.getString("location", false, true);
         if (!location.startsWith("/"))
@@ -1814,10 +1814,10 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
 
         String async=node.getString("async-supported",false,true);
         if (async!=null)
-            holder.setAsyncSupported(async.length()==0||Boolean.valueOf(async));
+            holder.setAsyncSupported(async.length()==0||Boolean.parseBoolean(async));
         if (async!=null)
         {
-            boolean val = async.length()==0||Boolean.valueOf(async);
+            boolean val = async.length()==0||Boolean.parseBoolean(async);
             switch (context.getMetaData().getOrigin(name+".filter.async-supported"))
             {
                 case NotSet:

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
@@ -170,7 +170,7 @@ public class ExtensionConfig
         {
             return defValue;
         }
-        return Integer.valueOf(val);
+        return Integer.parseInt(val);
     }
 
     public final String getParameter(String key, String defValue)


### PR DESCRIPTION
Removed some unnecessary conversions from primitive to boxed types.

For finding them in Eclipse, I activated warnings for "Boxing and unboxing conversions", filtered for those in the "Problems" view, and quickly went through them.