### PR TITLE
Issue #2612 - Improve semantics of Session.renewId for null session cache

### DIFF
--- a/jetty-server/src/main/config/etc/sessions/session-cache-reftracking.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-cache-reftracking.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+
+  <!-- ===================================================================== -->
+  <!-- Configure a factory for ReferenceTrackingSessionCache                 -->
+  <!-- ===================================================================== -->
+  <Call name="addBean">
+   <Arg>
+    <New class="org.eclipse.jetty.server.session.ReferenceTrackingSessionCacheFactory">
+     <Set name="saveOnCreate"><Property name="jetty.session.saveOnCreate" default="false" /></Set>
+     <Set name="removeUnloadableSessions"><Property name="jetty.session.removeUnloadableSessions" default="false"/></Set>
+    </New>
+   </Arg>
+  </Call>
+
+</Configure>

--- a/jetty-server/src/main/config/modules/session-cache-reftracking.mod
+++ b/jetty-server/src/main/config/modules/session-cache-reftracking.mod
@@ -1,0 +1,20 @@
+DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+A SessionCache that does not share sessions, but does track references to sessions.
+
+[tags]
+session
+
+[provides]
+session-cache
+
+[depends]
+sessions
+
+[xml]
+etc/sessions/session-cache-reftracking.xml
+
+[ini-template]
+#jetty.session.saveOnCreate=false
+#jetty.session.removeUnloadableSessions=false

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -746,10 +746,11 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     /**
      * Swap the id on a session.
      * 
-     * @param session
-     * @param newId
-     * @param newExtendedId
-     * @throws Exception
+     * @param session the session for which to swap the id
+     * @param newId the new id
+     * @param newExtendedId the full id including node id
+     * 
+     * @throws Exception if an error occurred saving the change
      */
     protected void renewSessionId (Session session, String newId, String newExtendedId)
     throws Exception

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -150,13 +150,12 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
 
     
     /**
-     * Remove the session with this identity from the store
+     * Remove the session with this identity from the cache
      * @param id the id
      * @return true if removed false otherwise
      */
     public abstract Session doDelete (String id);
 
-    
     
     
     /**
@@ -449,7 +448,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
      * @return a Session object filled with data or null if the session doesn't exist
      * @throws Exception
      */
-    private Session loadSession (String id)
+    protected Session loadSession (String id)
     throws Exception
     {
         SessionData data = null;
@@ -728,11 +727,9 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     
 
 
-    /** 
-     * @see org.eclipse.jetty.server.session.SessionCache#renewSessionId(java.lang.String, java.lang.String)
-     */
+
     @Override
-    public Session renewSessionId (String oldId, String newId)
+    public Session renewSessionId (String oldId, String newId, String oldExtendedId, String newExtendedId)
     throws Exception
     {
         if (StringUtil.isBlank(oldId))
@@ -741,17 +738,38 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             throw new IllegalArgumentException ("New session id is null");
 
         Session session = get(oldId);
-        if (session == null)
-            return null;
+        renewSessionId(session, newId, newExtendedId);
 
+        return session;
+    }
+    
+    /**
+     * Swap the id on a session.
+     * 
+     * @param session
+     * @param newId
+     * @param newExtendedId
+     * @throws Exception
+     */
+    protected void renewSessionId (Session session, String newId, String newExtendedId)
+    throws Exception
+    {
+        if (session == null)
+            return;
+        
         try (Lock lock = session.lock())
         {
+            String oldId = session.getId();
             session.checkValidForWrite(); //can't change id on invalid session
             session.getSessionData().setId(newId);
             session.getSessionData().setLastSaved(0); //pretend that the session has never been saved before to get a full save
-            session.getSessionData().setDirty(true);  //ensure we will try to write the session out
+            session.getSessionData().setDirty(true);  //ensure we will try to write the session out    
+            session.setExtendedId(newExtendedId); //remember the new extended id
+            session.setIdChanged(true); //session id changed
+            
             doPutIfAbsent(newId, session); //put the new id into our map
             doDelete (oldId); //take old out of map
+            
             if (_sessionDataStore != null)
             {
                 _sessionDataStore.delete(oldId);  //delete the session data with the old id
@@ -759,7 +777,6 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             }
             if (LOG.isDebugEnabled())
                 LOG.debug ("Session id {} swapped for new id {}", oldId, newId);
-            return session;
         }
     }
     

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
@@ -139,8 +139,7 @@ public class DefaultSessionCache extends AbstractSessionCache
         return  s;
     }
     
-
-
+   
 
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCache.java
@@ -1,0 +1,346 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.session;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jetty.util.thread.Locker.Lock;
+
+
+/**
+ * ReferenceTrackingSessionCache
+ *
+ * This is a session cache that does not actually share Session instances. In this
+ * respect it is like the NullSessionCache: every time
+ * get(id) is called, the session data is freshly loaded from the
+ * SessionDataStore and a new Session instance is created.  Unlike the
+ * NullSessionCache, this cache maintains references to each
+ * Session that is returned.  This allows the cache to respond to
+ * invalidation and session id renewal by ensuring that all in-use Session objects
+ * will be updated. This cache would be of use in a non-sticky load
+ * balancer situation where session data is very likely to change on
+ * another node, but you still want to ensure that if any Request on this
+ * node invalidates a Session, or changes the id of the Session, that
+ * all other copies of the Session are similarly invalidated or changed and
+ * the appropriate listeners called.
+ */
+public class ReferenceTrackingSessionCache extends NullSessionCache
+{
+    protected Map<String, Set<Session>> _references = new HashMap<>();
+  
+    
+    
+    /**
+     * @param handler The SessionHandler related to this SessionCache
+     */
+    public ReferenceTrackingSessionCache(SessionHandler handler)
+    {
+        super(handler);
+        super.setEvictionPolicy(EVICT_ON_SESSION_EXIT);
+    }
+
+    @Override
+    public void shutdown()
+    {
+        _references.clear();
+    }
+
+
+
+    @Override
+    public Session doDelete(String id)
+    {
+        synchronized (_references)
+        {
+            _references.remove(id);
+        }
+        return null;
+    }
+    
+    
+
+    @Override
+    public Session delete(String id) throws Exception
+    { 
+        //Always delete it from the backing data store
+        if (_sessionDataStore != null)
+        {
+            boolean dsdel = _sessionDataStore.delete(id);
+            if (LOG.isDebugEnabled()) LOG.debug("Session {} deleted in session data store {}",id, dsdel);                   
+        }
+        
+        Set<Session> sessions = null;
+        
+        synchronized (_references)
+        {            
+           sessions = _references.remove(id); //delete all references to sessions
+        }
+        
+        if (sessions != null)
+        {
+            for (Session s:sessions)
+            {
+                try (Lock lock = s.lock())
+                {
+                    try
+                    {
+                        if (s.beginInvalidate()) //session has not already begun being invalidated, so its not the one on which session.invalidate was called
+                        {
+                            s.setResident(false);
+                            _handler.callSessionListeners(s);                  
+                            s.finishInvalidate();
+                        }
+                    }
+                    catch (IllegalStateException e)
+                    {
+                        //the session on which invalidate was called will already be invalid
+                        LOG.ignore(e);
+                    }
+                }
+            }
+            return null; //don't return a session, they've all been handled already either here or on the session that was originally invalidated
+        }
+        else
+        {
+            //no sessions with that id are being referenced by a request
+            //load one, just to call the listeners
+            Session session = loadSession(id);
+            if (session == null) //so such session
+                return null;
+
+            try (Lock lock = session.lock())
+            {
+                session.setResident(false); //don't put it in the reference list
+            }
+            return session; //let the SessionHandler handle the invalidation
+        }
+    }
+        
+
+
+    @Override
+    public Session get(String id) throws Exception
+    {
+        //Always load a fresh session from the backing sessiondatastore
+        if (_sessionDataStore == null)
+            return null;
+
+        Session session = loadSession(id);
+        if (session != null)
+        {
+            session.setResident(true);
+            addReference(session);
+        }
+        return session;
+    }
+
+
+
+    @Override
+    public void put(String id, Session session) throws Exception
+    {
+        //A request is finished with the session,remove it from the references
+        synchronized (_references)
+        {
+            Set<Session> sessions = _references.get(id);
+            if (sessions != null &&  sessions.contains(session))
+            {
+                if (LOG.isDebugEnabled()) LOG.debug("Existing session {} put back into cache", session);
+                
+                //session exists, so the request is finished with it
+                sessions.remove(session);
+
+                if (sessions.isEmpty())
+                    _references.remove(id); //last reference to that id is removed
+                
+                
+                //if the session isn't valid, don't save it
+                if (!session.isValid())
+                    return; 
+                //save the session
+                if (!_sessionDataStore.isPassivating())
+                {
+                    //if our backing datastore isn't the passivating kind, just save the session
+                    _sessionDataStore.store(id, session.getSessionData());
+                    session.setResident(false);
+                }
+                else
+                {
+                    //backing store supports passivation, call the listeners
+                    session.willPassivate();
+                    if (LOG.isDebugEnabled()) LOG.debug("Session passivating id={}", id);
+                    _sessionDataStore.store(id, session.getSessionData());
+                    session.setResident(false); 
+                }
+            }
+            else
+            {
+                if (LOG.isDebugEnabled()) LOG.debug("New session {} added to ReferenceTrackingSessionCache", session);
+                //no existing sessions for this id at all, or this precise session is not in use by a request
+                addReference(session); 
+                session.setResident(true); 
+            }
+        } 
+    }
+
+    
+    /**
+     * Returns number of session instances refering to the same id.
+     * 
+     * @param id the session id to check
+     * @return The number of references for the same session id.
+     */
+    protected int references (String id)
+    {
+        synchronized (_references)
+        {
+            Set<Session> sessions = _references.get(id);
+            if (sessions == null)
+                return 0;
+            return sessions.size();
+        }
+    }
+    
+    
+    
+    @Override
+    public Session renewSessionId(String oldId, String newId, String oldExtendedId, String newExtendedId) throws Exception
+    {
+        Session firstValidSession = null;
+
+        synchronized (_references)
+        {
+            //delete the old key
+            Set<Session> sessions = _references.remove(oldId);
+            
+            //if there are existing references to sessions in use by requests
+            if (sessions != null)
+            {
+                boolean written = false;
+                for (Session session: sessions)
+                {
+                    try (Lock lock = session.lock())
+                    {
+                        //change the id over
+                        renewSessionId (session, newId, newExtendedId);
+
+                        //A random session is the one that is written out!! TODO
+                        if (!written)
+                        {
+                            //only update the database with the first one
+                            written = true;
+                            writeNewSessionId(session, oldId, newId);
+                        }
+                        //call the listeners on all existing sessions
+                        _handler.callSessionIdListeners(session, oldId);
+                    }
+                    catch (IllegalStateException e)
+                    {
+                        //If the session is not valid for writing, ignore changing its id
+                        LOG.warn("Session with old id={} invalid for writing, skipping update to new id={}", oldId, newId);
+                    }
+                }
+
+                //update all the references
+                _references.put(newId, sessions); 
+                return null; //all sessions handled here
+            }
+            else
+            {
+                //there are no sessions loaded for this id in this context, we need to load one so we can change it
+                //but do NOT put it in the reference map because no request is accessing it. Return null;               
+                Session session = loadSession(oldId);
+                if (session != null)
+                {
+                    //session with this old id exists
+                    try (Lock lock = session.lock())
+                    {
+                        renewSessionId(firstValidSession, newId, newExtendedId);
+                        writeNewSessionId(firstValidSession, oldId, newId);
+                    }
+                    _handler.callSessionIdListeners(session, oldId);
+                }
+                return null;
+            }
+        }       
+    }
+    
+    
+
+    @Override
+    protected void renewSessionId(Session session, String newId, String newExtendedId) throws Exception
+    {
+        try (Lock lock = session.lock())
+        {
+            session.checkValidForWrite(); //can't change id on invalid session
+            session.getSessionData().setId(newId);
+            session.getSessionData().setLastSaved(0); //pretend that the session has never been saved before to get a full save
+            session.getSessionData().setDirty(true);  //ensure we will try to write the session out    
+            session.setExtendedId(newExtendedId); //remember the new extended id
+            session.setIdChanged(true); //session id changed
+        }
+    }
+    
+    
+    /**
+     * Change the session id in the store.
+     * 
+     * @param session the session to change
+     * @param oldId the old session id
+     * @param newId the new session id to save it as
+     * @throws Exception
+     */
+    protected void writeNewSessionId (Session session, String oldId, String newId)
+    throws Exception
+    {
+        if (_sessionDataStore != null)
+        {
+            _sessionDataStore.delete(oldId);  //delete the session data with the old id
+            _sessionDataStore.store(newId, session.getSessionData()); //save the session data with the new id
+        }
+        if (LOG.isDebugEnabled())
+            LOG.debug ("Session id {} swapped for new id {}", oldId, newId);
+    }
+
+
+    
+    /**
+     * Add a new reference to a session.
+     * 
+     * @param session the newly created session to remember
+     */
+    protected void addReference(Session session)
+    {
+        synchronized (_references)
+        {        
+            Set<Session> sessions = _references.get(session.getId());
+            if (sessions == null)
+            {
+                sessions = new HashSet<>();
+                _references.put(session.getId(), sessions);
+            }
+
+            sessions.add(session);
+            if (LOG.isDebugEnabled()) LOG.debug("Added new session {} to references for id={}",session, session.getId());
+        }
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCacheFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCacheFactory.java
@@ -1,0 +1,86 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.server.session;
+
+/**
+ * ReferenceTrackingSessionCacheFactory
+ *
+ * Factory for ReferenceTrackingSessionCaches.
+ */
+public class ReferenceTrackingSessionCacheFactory implements SessionCacheFactory
+{    
+    boolean _saveOnCreate;
+    boolean _removeUnloadableSessions;
+    
+
+    /**
+     * @return the saveOnCreate
+     */
+    public boolean isSaveOnCreate()
+    {
+        return _saveOnCreate;
+    }
+
+
+
+    /**
+     * @param saveOnCreate the saveOnCreate to set
+     */
+    public void setSaveOnCreate(boolean saveOnCreate)
+    {
+        _saveOnCreate = saveOnCreate;
+    }
+
+
+
+    /**
+     * @return the removeUnloadableSessions
+     */
+    public boolean isRemoveUnloadableSessions()
+    {
+        return _removeUnloadableSessions;
+    }
+
+
+
+    /**
+     * @param removeUnloadableSessions the removeUnloadableSessions to set
+     */
+    public void setRemoveUnloadableSessions(boolean removeUnloadableSessions)
+    {
+        _removeUnloadableSessions = removeUnloadableSessions;
+    }
+
+
+
+    /** 
+     * @see org.eclipse.jetty.server.session.SessionCacheFactory#getSessionCache(org.eclipse.jetty.server.session.SessionHandler)
+     */
+    @Override
+    public SessionCache getSessionCache(SessionHandler handler)
+    {
+        ReferenceTrackingSessionCache cache = new ReferenceTrackingSessionCache(handler);
+        cache.setSaveOnCreate(isSaveOnCreate());
+        cache.setRemoveUnloadableSessions(isRemoveUnloadableSessions());
+        return cache;
+        
+    }
+
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
@@ -97,8 +97,8 @@ public interface SessionCache extends LifeCycle
      * 
      * @param oldId the current session id
      * @param newId the new session id
-     * @param the current extended session id
-     * @param the new extended session id
+     * @param oldExtendedId the current extended session id
+     * @param newExtendedId the new extended session id
      * @return the Session after changing its id
      * @throws Exception if any error occurred
      */

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
@@ -97,10 +97,12 @@ public interface SessionCache extends LifeCycle
      * 
      * @param oldId the current session id
      * @param newId the new session id
+     * @param the current extended session id
+     * @param the new extended session id
      * @return the Session after changing its id
      * @throws Exception if any error occurred
      */
-    Session renewSessionId (String oldId, String newId) throws Exception;
+    Session renewSessionId (String oldId, String newId, String oldExtendedId, String newExtendedId) throws Exception;
     
     
     /**

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DefaultSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DefaultSessionCacheTest.java
@@ -178,7 +178,7 @@ public class DefaultSessionCacheTest
        cache.put("1234", session);
        assertTrue(cache.contains("1234"));
 
-       cache.renewSessionId("1234", "5678");
+       cache.renewSessionId("1234", "5678", "1234.foo", "5678.foo");
        
        assertTrue(cache.contains("5678"));
        assertFalse(cache.contains("1234"));

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/ReferenceTrackingSessionCacheTest.java
@@ -1,0 +1,341 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.server.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionIdListener;
+import javax.servlet.http.HttpSessionListener;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.Test;
+
+/**
+ * ReferenceTrackingSessionCacheTest
+ *
+ *
+ */
+public class ReferenceTrackingSessionCacheTest
+{
+    public class MyHttpSessionIdListener implements HttpSessionIdListener
+    {
+        List<Session> _called = new ArrayList<>();
+        
+        @Override
+        public void sessionIdChanged(HttpSessionEvent event, String oldSessionId)
+        {
+           _called.add((Session)event.getSession());
+        }
+        
+        public List<Session> getCalled()
+        {
+            return _called;
+        }
+    }
+    
+    
+    
+    
+    public class MyHttpSessionListener implements HttpSessionListener
+    {
+        List<Session> _createdCalled = new ArrayList<>();
+        List<Session> _destroyedCalled = new ArrayList<>();
+        
+        @Override
+        public void sessionCreated(HttpSessionEvent se)
+        {
+           _createdCalled.add((Session)se.getSession());
+        }
+
+        @Override
+        public void sessionDestroyed(HttpSessionEvent se)
+        {
+            _destroyedCalled.add((Session)se.getSession());
+        }
+        
+        public List<Session> getCreatedCalled()
+        {
+            return _createdCalled;
+        }       
+
+        public List<Session> getDestroyedCalled()
+        {
+            return _destroyedCalled;
+        }
+        
+        
+        public void clear()
+        {
+            _createdCalled.clear();
+            _destroyedCalled.clear();
+        }
+    }
+    
+    
+    
+    @Test
+    public void testInvalidation() throws Exception
+    {
+        //Test that invalidation happens on ALL copies of the session that are in-use by requests
+        Server server = new Server();
+
+        SessionIdManager sessionIdManager = new DefaultSessionIdManager(server);
+        server.setSessionIdManager(sessionIdManager);
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);       
+        context.setContextPath("/test");
+        context.setServer(server);
+        context.getSessionHandler().setMaxInactiveInterval((int)TimeUnit.DAYS.toSeconds(1));
+        context.getSessionHandler().setSessionIdManager(sessionIdManager);
+
+        ReferenceTrackingSessionCacheFactory cacheFactory = new ReferenceTrackingSessionCacheFactory();
+        cacheFactory.setSaveOnCreate(true); //ensures that a session is persisted as soon as it is created
+        
+        ReferenceTrackingSessionCache cache = (ReferenceTrackingSessionCache)cacheFactory.getSessionCache(context.getSessionHandler());
+
+        TestSessionDataStore store = new TestSessionDataStore();
+        cache.setSessionDataStore(store);
+        context.getSessionHandler().setSessionCache(cache);
+        MyHttpSessionListener listener = new MyHttpSessionListener();
+        context.getSessionHandler().addEventListener(listener);
+
+        server.setHandler(context);
+        try
+        {
+            server.start();
+
+            //test creating a new session
+            Session session = (Session)context.getSessionHandler().newHttpSession(null);
+            String id = session.getId();
+            context.getSessionHandler().access(session, false); //simulate accessing the request
+            assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+            context.getSessionHandler().complete(session); //simulate completing the request
+            assertEquals(0, cache.references(id)); //no references stored
+            List<Session> called = listener.getCreatedCalled();
+            assertNotNull(called);
+            assertFalse(called.isEmpty());
+            assertEquals(1, called.size());
+            
+            //zero out listener calls
+            listener.clear();
+            
+            //make 1st request
+            session = context.getSessionHandler().getSession(id); //get the session again
+            assertNotNull(session);
+            context.getSessionHandler().access(session, false); //simulate accessing the request
+            assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+
+            System.err.println("-------------------------");
+            
+            //make 2nd request and invalidate
+            Session session2 = context.getSessionHandler().getSession(id); //get the session again
+            context.getSessionHandler().access(session2, false); //simulate accessing the request
+            assertNotNull(session2);
+            assertTrue(session != session2);
+            assertEquals(session.getId(), session2.getId());
+            assertEquals(2, cache.references(id)); //another request means another reference
+            
+            session2.invalidate();
+            assertEquals(0, cache.references(id)); //no refs for id
+
+            called = listener.getDestroyedCalled();
+            assertNotNull(called);
+            assertFalse(called.isEmpty());
+//            assertEquals(2, called.size());
+            assertTrue(called.contains(session));
+            assertTrue(called.contains(session2));
+            
+            try
+            {
+                session.invalidate();
+                fail("Should already be invalid");
+            }
+            catch (IllegalStateException e)
+            {
+                //Expect it to be already invalid
+            }            
+            try
+            {
+                session2.invalidate();
+                fail("Should already be invalid");
+            }
+            catch (IllegalStateException e)
+            {
+                //Expect it to be already invalid
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+    
+    
+    @Test
+    public void testSessionIdRenewalMultipleRequests() throws Exception
+    {
+        //Test that the id is changed on ALL copies of the session that are in-use by requests
+        Server server = new Server();
+
+        SessionIdManager sessionIdManager = new DefaultSessionIdManager(server);
+        server.setSessionIdManager(sessionIdManager);
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);       
+        context.setContextPath("/test");
+        context.setServer(server);
+        context.getSessionHandler().setMaxInactiveInterval((int)TimeUnit.DAYS.toSeconds(1));
+        context.getSessionHandler().setSessionIdManager(sessionIdManager);
+
+        ReferenceTrackingSessionCacheFactory cacheFactory = new ReferenceTrackingSessionCacheFactory();
+        cacheFactory.setSaveOnCreate(true); //ensures that a session is persisted as soon as it is created
+        
+        ReferenceTrackingSessionCache cache = (ReferenceTrackingSessionCache)cacheFactory.getSessionCache(context.getSessionHandler());
+
+        TestSessionDataStore store = new TestSessionDataStore();
+        cache.setSessionDataStore(store);
+        context.getSessionHandler().setSessionCache(cache);
+        MyHttpSessionIdListener listener = new MyHttpSessionIdListener();
+        context.getSessionHandler().addEventListener(listener);
+
+        server.setHandler(context);
+        try
+        {
+            server.start();
+
+            //test creating a new session
+            Session session = (Session)context.getSessionHandler().newHttpSession(null);
+            String id = session.getId();
+            context.getSessionHandler().access(session, false); //simulate accessing the request
+            assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+            context.getSessionHandler().complete(session); //simulate completing the request
+            assertEquals(0, cache.references(id)); //no references stored
+
+            //make 1 request
+            session = context.getSessionHandler().getSession(id); //get the session again
+            assertNotNull(session);
+            context.getSessionHandler().access(session, false); //simulate accessing the request
+            assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+
+            String originalId = session.getId();
+
+            System.err.println("-------------------------");
+            
+            //make 2nd request and change the id
+            Session session2 = context.getSessionHandler().getSession(id); //get the session again\
+            context.getSessionHandler().access(session2, false); //simulate accessing the request
+            assertNotNull(session2);
+            assertTrue(session != session2);
+            assertEquals(session.getId(), session2.getId());
+            assertEquals(2, cache.references(originalId)); //another request means another reference
+            
+            session2.renewId(new Request(null, null));
+            assertEquals(0, cache.references(originalId)); //no refs for old id
+            assertEquals(2, cache.references(session2.getId())); //still 2 refs for new id
+            System.err.println("old="+originalId+" session1="+session.getId()+" session2="+session2.getId());
+
+            assertFalse(originalId.equals(session.getId()));
+            assertFalse(originalId.equals(session2.getId()));
+            assertEquals(session.getId(), session2.getId());
+            List<Session> called = listener.getCalled();
+            assertNotNull(called);
+            assertFalse(called.isEmpty());
+            assertEquals(2, called.size());
+            assertTrue(called.contains(session));
+            assertTrue(called.contains(session2));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+
+    @Test
+    public void testEvictOnExit() throws Exception
+    {
+        Server server = new Server();
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);       
+        context.setContextPath("/test");
+        context.setServer(server);
+        context.getSessionHandler().setMaxInactiveInterval((int)TimeUnit.DAYS.toSeconds(1));
+
+        ReferenceTrackingSessionCacheFactory cacheFactory = new ReferenceTrackingSessionCacheFactory();
+        cacheFactory.setSaveOnCreate(true); //ensures that a session is persisted as soon as it is created
+        
+        ReferenceTrackingSessionCache cache = (ReferenceTrackingSessionCache)cacheFactory.getSessionCache(context.getSessionHandler());
+
+        TestSessionDataStore store = new TestSessionDataStore();
+        cache.setSessionDataStore(store);
+        context.getSessionHandler().setSessionCache(cache);
+        context.start();
+        
+        //test creating a new session
+        Session session = (Session)context.getSessionHandler().newHttpSession(null);
+        String id = session.getId();
+        context.getSessionHandler().access(session, false); //simulate accessing the request
+        assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+        context.getSessionHandler().complete(session); //simulate completing the request
+        assertFalse(cache.contains(id)); //should not be in the cache
+        assertEquals(0, cache.references(id)); //no references stored
+        assertTrue(store.exists(id)); //but should be in the store
+        
+        //test retrieving the session
+         session = context.getSessionHandler().getSession(id); //get the session again
+        assertNotNull(session);
+        context.getSessionHandler().access(session, false); //simulate accessing the request
+        assertEquals(1, cache.references(id)); //the simulated request is referencing the session
+        context.getSessionHandler().complete(session); //simulate completing the request
+        assertEquals(0, cache.references(id)); //no reference after request exits
+        assertFalse(cache.contains(id));
+        assertTrue(store.exists(id));
+        assertFalse(session.isResident());
+        assertTrue(session.isValid());
+        
+        //test creating multiple requests creates multiple sessions
+        Session session1 = (Session)context.getSessionHandler().newHttpSession(null);
+        String id1 = session1.getId();
+        context.getSessionHandler().access(session1, false); //simulate accessing the request
+        assertEquals(1, cache.references(id1)); //the simulated request is referencing the session
+        
+        Session session2 = context.getSessionHandler().getSession(id1); //get the session again
+        assertNotNull(session2);
+        context.getSessionHandler().access(session2, false); //simulate accessing the request
+        assertEquals(2, cache.references(id1)); //another request means another reference
+        assertFalse(session1 == session2); //should be different objects
+        
+        context.getSessionHandler().complete(session2); //simulate 2nd request complete
+        assertEquals(1, cache.references(id1)); //only 1 request left
+        context.getSessionHandler().complete(session1); //complete 1st request
+        assertEquals(0, cache.references(id1));
+    }
+
+}


### PR DESCRIPTION
This is a bit of an experimental-work-in-progress:  it attempts to work around the fact that because sessions are never shared between requests, it is possible for one request to change a session id and another request to resurrect the old id (because all copies of the same session are entirely independent), and also possible for multiple requests to change the session id at the same time.