### PR TITLE
Eliminated redundant invocations of HandlerCollection.getHandlers()

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -85,7 +85,8 @@ public class ContextHandlerCollection extends HandlerCollection
     {
         _contextBranches.clear();
         
-        if (getHandlers()==null)
+        Handler[] handlers = getHandlers();
+        if (handlers==null)
         {
             _pathBranches=new ArrayTernaryTrie<>(false,16);
             return;
@@ -93,7 +94,7 @@ public class ContextHandlerCollection extends HandlerCollection
         
         // Create map of contextPath to handler Branch
         Map<String,Branch[]> map = new HashMap<>();
-        for (Handler handler:getHandlers())
+        for (Handler handler:handlers)
         {
             Branch branch=new Branch(handler);
             for (String contextPath : branch.getContextPaths())

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandlerCollection.java
@@ -184,8 +184,9 @@ public class HandlerCollection extends AbstractHandlerContainer
     @Override
     protected void expandChildren(List<Handler> list, Class<?> byClass)
     {
-        if (getHandlers()!=null)
-            for (Handler h:getHandlers())
+        Handler[] handlers = getHandlers();
+        if (handlers!=null)
+            for (Handler h:handlers)
                 expandHandler(h, list, byClass);
     }
 
@@ -207,6 +208,6 @@ public class HandlerCollection extends AbstractHandlerContainer
     public String toString()
     {
         Handler[] handlers=getHandlers();
-        return super.toString()+(handlers==null?"[]":Arrays.asList(getHandlers()).toString());
+        return super.toString()+(handlers==null?"[]":Arrays.asList(handlers).toString());
     }
 }


### PR DESCRIPTION
Just a minor improvement to avoid calling `HandlerCollection.getHandlers()` more often than needed within the same method.