### PR TITLE
Issue #2696 Fix generation of gcloud deps

### DIFF
--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -99,6 +99,7 @@
               <outputFile>${project.build.directory}/deps.txt</outputFile>
               <sort>true</sort>
               <excludeGroupIds>org.eclipse.jetty</excludeGroupIds>
+              <excludeGroupIds>javax.servlet</excludeGroupIds>
               <prependGroupId>true</prependGroupId>
               <includeScope>runtime</includeScope>
             </configuration>
@@ -118,7 +119,7 @@
             <configuration>
               <tasks>
                 <replaceregexp file="${project.build.directory}/deps.txt"
-                               match=" *(.*):(.*):jar:(.*):[a-z]*"
+                               match=" *(.*):(.*):jar:(.*):.*$"
                                replace="maven://\1/\2/\3|lib/gcloud/\2-\3.jar"
                                byline="true"
                 />


### PR DESCRIPTION
Fix to generation of gcloud dependencies after mvn dependency plugin changed format of output. Also needed to exclude javax.servlet jar.