### PR TITLE
Removing unnecessary CACHE.put calls in HttpParser

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -228,12 +228,6 @@ public class HttpParser
         for (HttpHeader h:HttpHeader.values())
             if (!CACHE.put(new HttpField(h,(String)null)))
                 throw new IllegalStateException("CACHE FULL");
-        // Add some more common headers
-        CACHE.put(new HttpField(HttpHeader.REFERER,(String)null));
-        CACHE.put(new HttpField(HttpHeader.IF_MODIFIED_SINCE,(String)null));
-        CACHE.put(new HttpField(HttpHeader.IF_NONE_MATCH,(String)null));
-        CACHE.put(new HttpField(HttpHeader.AUTHORIZATION,(String)null));
-        CACHE.put(new HttpField(HttpHeader.COOKIE,(String)null));
     }
 
     private static HttpCompliance compliance()


### PR DESCRIPTION
the HttpFields being added to the CACHE in lines 232-236
are already being added in the previous loop
https://github.com/eclipse/jetty.project/blob/c45ca9e38bf7f8beaba1dd45e361fae6d8e2962a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java#L228-L230

