### PR TITLE
Fixes #2530 - Client waits forever for cancelled uploads.

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -237,6 +237,9 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
 
     public void destroyEndPoint(final EndPoint endPoint)
     {
+        // Waking up the selector is necessary to clean the
+        // cancelled-key set and tell the TCP stack that the
+        // socket is closed (so that senders receive RST).
         submit(WAKEUP);
         execute(new DestroyEndPoint(endPoint));
     }


### PR DESCRIPTION
#2530: after discussion on openjdk/nio-dev, we now wakeup the selector
after closing a socket, so that the SelectionKey can be removed
from the Selector and the TCP stack notified that the socket
has been really closed, so that it can send RST to clients.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>