### PR TITLE
Fixes #2694 - Dynamic imports of Websocket servlet

### DIFF
--- a/jetty-websocket/websocket-servlet/pom.xml
+++ b/jetty-websocket/websocket-servlet/pom.xml
@@ -33,7 +33,7 @@
                         <Bundle-Description>Websocket Servlet Interface</Bundle-Description>
                         <Bundle-Classpath />
                         <_nouses>true</_nouses>
-                        <DynamicImport-Package>org.eclipse.jetty.websocket.server.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}",org.eclipse.jetty.websocket.server.pathmap.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}"</DynamicImport-Package>
+                        <DynamicImport-Package>org.eclipse.jetty.websocket.server;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}",org.eclipse.jetty.websocket.server.pathmap;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}"</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Closes #2694

Fixes the dynamic imports of `org.eclipse.jetty.websocket.server` and `org.eclipse.jetty.websocket.server.pathmap` as explained in the issue #2694 proposition 2. (previously the content of `org.eclipse.jetty.websocket.server` was not imported)

Signed-off-by: Clément Delgrange <cl.delgrange@protonmail.com>