### PR TITLE
accept parameters ending with =

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -47,7 +47,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
     
-    private static final Pattern PARAM_PATTERN = Pattern.compile("([^=]+)=([^=]+)?");
+    private static final Pattern PARAM_PATTERN = Pattern.compile("([^=]+)=([^=]+=?)?");
     private static final Pattern TYPE_PATTERN = Pattern.compile("([^\\s]+)(\\s+(.*))?");
     private static final Pattern MULTIPLE_CHALLENGE_PATTERN = Pattern.compile("(.*?)\\s*,\\s*([^=\\s,]+(\\s+[^=\\s].*)?)");
     private static final Pattern BASE64_PATTERN = Pattern.compile("[\\+\\-\\.\\/\\dA-Z_a-z~]+=*");

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -47,7 +47,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 16*1024;
     public static final Logger LOG = Log.getLogger(AuthenticationProtocolHandler.class);
     
-    private static final Pattern PARAM_PATTERN = Pattern.compile("([^=]+)=([^=]+=?)?");
+    private static final Pattern PARAM_PATTERN = Pattern.compile("([^=]+)=([^=]+=*)?");
     private static final Pattern TYPE_PATTERN = Pattern.compile("([^\\s]+)(\\s+(.*))?");
     private static final Pattern MULTIPLE_CHALLENGE_PATTERN = Pattern.compile("(.*?)\\s*,\\s*([^=\\s,]+(\\s+[^=\\s].*)?)");
     private static final Pattern BASE64_PATTERN = Pattern.compile("[\\+\\-\\.\\/\\dA-Z_a-z~]+=*");


### PR DESCRIPTION
Had an issue with a Nonce in a Digest authentication that was base64 encoded and ended in =, this fixed it.

May be the Pattern should be even more accepting?