### PR TITLE
Fixes #2717 - Async requests are not considered when shutting down gracefully.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -584,7 +584,7 @@ public class StatisticsHandler extends HandlerWrapper implements Graceful
         FutureCallback shutdown=new FutureCallback(false);
         _shutdown.compareAndSet(null,shutdown);
         shutdown=_shutdown.get();
-        if (_dispatchedStats.getCurrent()==0)
+        if (_requestStats.getCurrent()==0)
             shutdown.succeeded();
         return shutdown;
     }


### PR DESCRIPTION
#2717.

Now using _requestStats instead of _dispatchedStats to check for
requests completed when shutting down StatisticsHandler.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>