### PR TITLE
Issue #2706 - Resource Service Incorrectly Returning 404

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -269,14 +269,11 @@ public class ResourceHandler extends HandlerWrapper implements ResourceFactory,W
         if (baseRequest.isHandled())
             return;
 
-        if (!HttpMethod.GET.is(request.getMethod()))
+        if (!HttpMethod.GET.is(request.getMethod()) && !HttpMethod.HEAD.is(request.getMethod()))
         {
-            if (!HttpMethod.HEAD.is(request.getMethod()))
-            {
-                // try another handler
-                super.handle(target,baseRequest,request,response);
-                return;
-            }
+            // try another handler
+            super.handle(target,baseRequest,request,response);
+            return;
         }
 
         _resourceService.doGet(request,response);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -40,6 +40,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -304,5 +305,34 @@ public class ResourceHandlerTest
             Assert.assertEquals('D',buffer.get(buffer.limit()-2));
             
         }
+    }
+
+
+
+    @Test
+    public void testConditionalGetResponseCommitted() throws Exception
+    {
+        _config.setOutputBufferSize(8);
+        _resourceHandler.setEtags(true);
+
+        HttpTester.Response response = HttpTester.parseResponse(_local.getResponse("GET /resource/big.txt HTTP/1.0\r\n" +
+                                                                                              "If-Match: \"NO_MATCH\"\r\n" +
+                                                                                              "\r\n"));
+
+        assertThat(response.getStatus(),equalTo(HttpStatus.PRECONDITION_FAILED_412));
+    }
+
+
+    @Test
+    public void testConditionalHeadResponseCommitted() throws Exception
+    {
+        _config.setOutputBufferSize(8);
+        _resourceHandler.setEtags(true);
+
+        HttpTester.Response response = HttpTester.parseResponse(_local.getResponse("HEAD /resource/big.txt HTTP/1.0\r\n" +
+                                                                                              "If-Match: \"NO_MATCH\"\r\n" +
+                                                                                              "\r\n"));
+
+        assertThat(response.getStatus(),equalTo(HttpStatus.PRECONDITION_FAILED_412));
     }
 }


### PR DESCRIPTION
Flush response buffer in places where the response needs to be committed.
Removed if statement preventing HEAD requests processing conditional headers.
Added two new test cases which failed before the changes and should now pass.

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>