### PR TITLE
Fix hot redeployment problem on Windows

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -642,8 +642,14 @@ public class WebInfConfiguration extends AbstractConfiguration
                     }
                     else
                     {
+                        long lastModified;
+                        // read last modified without caching a war file
+                        // so that webapp can be redeployed on Windows
+                        try (Resource r = Resource.newResource("jar:" + web_app + "!/", false)) {
+                            lastModified = r.lastModified();
+                        }
                         //only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
-                        if (web_app.lastModified() > extractedWebAppDir.lastModified() || extractionLock.exists())
+                        if (lastModified > extractedWebAppDir.lastModified() || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
                             IO.delete(extractedWebAppDir);

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -645,7 +645,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                         long lastModified;
                         // read last modified without caching a war file
                         // so that webapp can be redeployed on Windows
-                        try (Resource r = Resource.newResource("jar:" + web_app + "!/", false)) {
+                        try (Resource r = Resource.newResource(web_app.getURL().toExternalForm(), false)) {
                             lastModified = r.lastModified();
                         }
                         //only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction


### PR DESCRIPTION
# Tl;dr

Getting lastModified for JarFileResource initialized with useCaches=true causes JVM to keep file handle on a war file forever thus preventing any overwriting or deleting operations over this file on Windows.

# Details

We use Jetty autodeploy feature where you can copy war file into "monitored" directory at a runtime. We noticed that on Windows the process that copies over war files fails with `The process cannot access the file because it is being used by another process` exception:

```
The process cannot access the file because it is being used by another process.

    at sun.nio.fs.WindowsException.translateToIOException(Unknown Source) ~[?:1.8.0_171]
    at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source) ~[?:1.8.0_171]
    at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source) ~[?:1.8.0_171]
    at sun.nio.fs.WindowsFileSystemProvider.implDelete(Unknown Source) ~[?:1.8.0_171]
    at sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(Unknown Source) ~[?:1.8.0_171]
    at java.nio.file.Files.deleteIfExists(Unknown Source) ~[?:1.8.0_171]
    at java.nio.file.Files.copy(Unknown Source) ~[?:1.8.0_171]
...
```

I attached [File Leak Detector](http://file-leak-detector.kohsuke.org/) JVM agent to Jetty server and noticed that reading last modified timestamp for a war file is keeping file handle on a war file. 

```
#897 C:\jetty\monitored-directory\my.war by thread:main on Wed Jul 18 02:59:11 UTC 2018
    at java.util.zip.ZipFile.<init>(ZipFile.java:150)
    at java.util.jar.JarFile.<init>(JarFile.java:166)
    at java.util.jar.JarFile.<init>(JarFile.java:103)
    at sun.net.www.protocol.jar.URLJarFile.<init>(URLJarFile.java:93)
    at sun.net.www.protocol.jar.URLJarFile.getJarFile(URLJarFile.java:69)
    at sun.net.www.protocol.jar.JarFileFactory.get(JarFileFactory.java:94)
    at sun.net.www.protocol.jar.JarURLConnection.connect(JarURLConnection.java:122)
    at sun.net.www.protocol.jar.JarURLConnection.getJarFile(JarURLConnection.java:89)
    at org.eclipse.jetty.util.resource.JarFileResource.newConnection(JarFileResource.java:129)
    at org.eclipse.jetty.util.resource.JarResource.checkConnection(JarResource.java:74)
    at org.eclipse.jetty.util.resource.JarFileResource.checkConnection(JarFileResource.java:96)
    at org.eclipse.jetty.util.resource.JarFileResource.lastModified(JarFileResource.java:255)
    at org.eclipse.jetty.webapp.WebInfConfiguration.unpack(WebInfConfiguration.java:478)
```

Note that copying / extracting war file into a working directory does not cause this file leak though. There was [477895](https://bugs.eclipse.org/bugs/show_bug.cgi?id=477895) and fix 697b0cccf2 for that.

In the proposed fix I'm avoiding war file to be cached (and thus war file to be "leaked") by explicitly setting `useCaches=false` for operation that just reads last modified timestamp. 

I verified that this solution fixes the problem with Jetty 9.3.8 on Windows
* I can overwrite war files now
* [File Leak Detector](http://file-leak-detector.kohsuke.org/) does not show war files anymore