### PR TITLE
Issue #2679 - h2spec compliance Huffman encoding

### DIFF
--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackContextTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackContextTest.java
@@ -411,7 +411,7 @@ public class HpackContextTest
     }
     
     @Test
-    public void testStaticHuffmanValues()
+    public void testStaticHuffmanValues() throws Exception
     {
         HpackContext ctx = new HpackContext(4096);
         for (int i=2;i<=14;i++)

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
@@ -487,7 +487,7 @@ public class HpackDecoderTest
     {
         HpackDecoder decoder = new HpackDecoder(4096, 8192);
 
-        String encoded = "82868441" + "83" + "49509FFF";
+        String encoded = "82868441" + "84" + "49509FFF";
         ByteBuffer buffer = ByteBuffer.wrap(TypeUtil.fromHexString(encoded));
 
         try
@@ -518,7 +518,7 @@ public class HpackDecoderTest
         }
         catch (StreamException ex)
         {
-            Assert.assertThat(ex.getMessage(), Matchers.containsString("Zero padded"));
+            Assert.assertThat(ex.getMessage(), Matchers.containsString("Incorrect padding"));
         }
     }
 

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
@@ -462,25 +462,84 @@ public class HpackDecoderTest
         }        
     }
 
-    
-    /*
-        8.1.2.6. Malformed Requests and Responses
-          × 1: Sends a HEADERS frame with the "content-length" header field which does not equal the DATA frame payload length
-          × 2: Sends a HEADERS frame with the "content-length" header field which does not equal the sum of the multiple DATA frames payload length
 
-      5. Primitive Type Representations
-        5.2. String Literal Representation
-          × 1: Sends a Huffman-encoded string literal representation with padding longer than 7 bits
-            -> The endpoint MUST treat this as a decoding error.
-               Expected: GOAWAY Frame (Error Code: COMPRESSION_ERROR)
-                         Connection closed
-                 Actual: DATA Frame (length:687, flags:0x01, stream_id:1)
-          × 2: Sends a Huffman-encoded string literal representation padded by zero
-            -> The endpoint MUST treat this as a decoding error.
-               Expected: GOAWAY Frame (Error Code: COMPRESSION_ERROR)
-                         Connection closed
-                 Actual: DATA Frame (length:687, flags:0x01, stream_id:1)
-          ✔ 3: Sends a Huffman-encoded string literal representation containing the EOS symbol
-    */
-    
+    @Test()
+    public void testHuffmanEncodedStandard() throws Exception
+    {
+        HpackDecoder decoder = new HpackDecoder(4096, 8192);
+
+        String encoded = "82868441" + "83" + "49509F";
+        ByteBuffer buffer = ByteBuffer.wrap(TypeUtil.fromHexString(encoded));
+
+        MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
+
+        assertEquals("GET", request.getMethod());
+        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
+        assertEquals("/", request.getURI().getPath());
+        assertEquals("test", request.getURI().getHost());
+        assertFalse(request.iterator().hasNext());
+    }
+
+
+    /* 5.2.1: Sends a Huffman-encoded string literal representation with padding longer than 7 bits */
+    @Test()
+    public void testHuffmanEncodedExtraPadding() throws Exception
+    {
+        HpackDecoder decoder = new HpackDecoder(4096, 8192);
+
+        String encoded = "82868441" + "83" + "49509FFF";
+        ByteBuffer buffer = ByteBuffer.wrap(TypeUtil.fromHexString(encoded));
+
+        try
+        {
+            decoder.decode(buffer);
+            Assert.fail();
+        }
+        catch (StreamException ex)
+        {
+            Assert.assertThat(ex.getMessage(), Matchers.containsString("Padding length exceeded"));
+        }
+    }
+
+
+    /* 5.2.2: Sends a Huffman-encoded string literal representation padded by zero */
+    @Test()
+    public void testHuffmanEncodedZeroPadding() throws Exception
+    {
+        HpackDecoder decoder = new HpackDecoder(4096, 8192);
+
+        String encoded = "82868441" + "83" + "495090";
+        ByteBuffer buffer = ByteBuffer.wrap(TypeUtil.fromHexString(encoded));
+
+        try
+        {
+            decoder.decode(buffer);
+            Assert.fail();
+        }
+        catch (StreamException ex)
+        {
+            Assert.assertThat(ex.getMessage(), Matchers.containsString("Zero padded"));
+        }
+    }
+
+
+    /* 5.2.3: Sends a Huffman-encoded string literal representation containing the EOS symbol */
+    @Test()
+    public void testHuffmanEncodedWithEOS() throws Exception
+    {
+        HpackDecoder decoder = new HpackDecoder(4096, 8192);
+
+        String encoded = "82868441" + "87" + "497FFFFFFF427F";
+        ByteBuffer buffer = ByteBuffer.wrap(TypeUtil.fromHexString(encoded));
+
+        try
+        {
+            decoder.decode(buffer);
+            Assert.fail();
+        }
+        catch (StreamException ex)
+        {
+            Assert.assertThat(ex.getMessage(), Matchers.containsString("EOS in content"));
+        }
+    }
 }

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HuffmanTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HuffmanTest.java
@@ -51,17 +51,6 @@ public class HuffmanTest
     }
 
     @Test
-    public void testDecodeTrailingFF() throws Exception
-    {
-        for (String[] test:tests)
-        {
-            byte[] encoded=TypeUtil.fromHexString(test[1]+"FF");
-            String decoded=Huffman.decode(ByteBuffer.wrap(encoded));
-            Assert.assertEquals(test[0],test[2],decoded);
-        }
-    }
-
-    @Test
     public void testEncode() throws Exception
     {
         for (String[] test:tests)


### PR DESCRIPTION
#2679 and #2695
throw StreamException if huffman encoded string has:
- more than 7 bits of padding
- is padded by 0's and not 1's 
- has a string literal representation containing the EOS symbol
