### PR TITLE
Issue #2754 Only instantiate listener if it will be used

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/WebListenerAnnotation.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/WebListenerAnnotation.java
@@ -79,10 +79,10 @@ public class WebListenerAnnotation extends DiscoveredAnnotation
                     HttpSessionAttributeListener.class.isAssignableFrom(clazz) ||
                     HttpSessionIdListener.class.isAssignableFrom(clazz))
             {
-                java.util.EventListener listener = (java.util.EventListener)_context.getServletContext().createInstance(clazz);      
-                MetaData metaData = _context.getMetaData();
+                MetaData metaData = _context.getMetaData();           
                 if (metaData.getOrigin(clazz.getName()+".listener") == Origin.NotSet)
                 {
+                    java.util.EventListener listener = (java.util.EventListener)_context.getServletContext().createInstance(clazz); 
                     ListenerHolder h = _context.getServletHandler().newListenerHolder(new Source(Source.Origin.ANNOTATION, clazz.getName()));
                     h.setListener(listener);
                     _context.getServletHandler().addListener(h);

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ListenerHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ListenerHolder.java
@@ -62,4 +62,13 @@ public class ListenerHolder extends BaseHolder<EventListener>
         
         super.doStart();
     }
+
+
+    @Override
+    public String toString()
+    {
+        return super.toString()+(_listener == null?"":": "+getClassName());
+    }
+    
+    
 }


### PR DESCRIPTION
The WebListener annotation handling was eagerly creating a listener then throwing it away if a listener for the same class already existed. Moved the creation down to after the check, so we only create iff an instance does not already exist.

I also added the name of the listener class into the dump output for ListenerHolder.