### PR TITLE
Issue #2762: Fixed typo when checking JETTY_START_TIMEOUT.

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -385,7 +385,7 @@ fi
 #####################################################
 # Set STARTED timeout
 #####################################################
-if [ -z "$JETTY_START_TIMEOUT"]
+if [ -z "$JETTY_START_TIMEOUT" ]
 then
   JETTY_START_TIMEOUT=60
 fi


### PR DESCRIPTION
Signed-off-by: David Shepherdson <david@shepherdson.name>