### PR TITLE
Jetty 9.4.x 2745 jdbcsessiondatastore nvarchar

### DIFF
--- a/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
@@ -6,6 +6,9 @@
 
     <New id="databaseAdaptor" class="org.eclipse.jetty.server.session.DatabaseAdaptor">
          <Set name="DatasourceName"><Property name="jetty.session.jdbc.datasourceName" default="/jdbc/sessions" /></Set>
+         <Set name="blobType"><Property name="jetty.session.jdbc.blobType"/></Set>
+         <Set name="longType"><Property name="jetty.session.jdbc.longType"/></Set>
+         <Set name="stringType"><Property name="jetty.session.jdbc.stringType"/></Set>
     </New>
 
 </Configure>

--- a/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
@@ -8,6 +8,9 @@
              <Arg><Property name="jetty.session.jdbc.driverClass"/></Arg>
              <Arg><Property name="jetty.session.jdbc.driverUrl"/></Arg>
          </Call>
+         <Set name="blobType"><Property name="jetty.session.jdbc.blobType"/></Set>
+         <Set name="longType"><Property name="jetty.session.jdbc.longType"/></Set>
+         <Set name="stringType"><Property name="jetty.session.jdbc.stringType"/></Set>
     </New>
 
 </Configure>

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -27,6 +27,10 @@ db-connection-type?=datasource
 #jetty.session.gracePeriod.seconds=3600
 #jetty.session.savePeriod.seconds=0
 
+#jetty.session.jdbc.blobType=
+#jetty.session.jdbc.longType=
+#jetty.session.jdbc.stringType=
+
 ## Connection type:Datasource
 db-connection-type=datasource
 #jetty.session.jdbc.datasourceName=/jdbc/sessions

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DatabaseAdaptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DatabaseAdaptor.java
@@ -109,7 +109,6 @@ public class DatabaseAdaptor
 
     public String getLongType ()
     {
-        System.err.println("long type null:"+(_longType==null?"null":_longType)+" dbname is oracle:"+(_dbName.startsWith("oracle")?"oracle":"no"));
         if (_longType != null)
             return _longType;
 
@@ -130,7 +129,6 @@ public class DatabaseAdaptor
     
     public String getStringType ()
     {
-        System.err.println("String type null:"+(_stringType==null?"null":_stringType));
         if (_stringType != null)
             return _stringType;
         

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DatabaseAdaptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DatabaseAdaptor.java
@@ -57,6 +57,7 @@ public class DatabaseAdaptor
     
     protected String _blobType; //if not set, is deduced from the type of the database at runtime
     protected String _longType; //if not set, is deduced from the type of the database at runtime
+    protected String _stringType; //if not set defaults to 'varchar'
     private String _driverClassName;
     private String _connectionUrl;
     private Driver _driver;
@@ -108,6 +109,7 @@ public class DatabaseAdaptor
 
     public String getLongType ()
     {
+        System.err.println("long type null:"+(_longType==null?"null":_longType)+" dbname is oracle:"+(_dbName.startsWith("oracle")?"oracle":"no"));
         if (_longType != null)
             return _longType;
 
@@ -120,6 +122,20 @@ public class DatabaseAdaptor
         return "bigint";
     }
     
+    public void setStringType (String stringType)
+    {
+        _stringType = stringType;
+    }
+    
+    
+    public String getStringType ()
+    {
+        System.err.println("String type null:"+(_stringType==null?"null":_stringType));
+        if (_stringType != null)
+            return _stringType;
+        
+        return "varchar";
+    }
 
     /**
      * Convert a camel case identifier into either upper or lower

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
@@ -234,9 +234,10 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
             
             String blobType = _dbAdaptor.getBlobType();
             String longType = _dbAdaptor.getLongType();
+            String stringType = _dbAdaptor.getStringType();
             
-            return "create table "+_tableName+" ("+_idColumn+" varchar(120), "+
-                    _contextPathColumn+" varchar(60), "+_virtualHostColumn+" varchar(60), "+_lastNodeColumn+" varchar(60), "+_accessTimeColumn+" "+longType+", "+
+            return "create table "+_tableName+" ("+_idColumn+" "+stringType+"(120), "+
+                    _contextPathColumn+" "+stringType+"(60), "+_virtualHostColumn+" "+stringType+"(60), "+_lastNodeColumn+" "+stringType+"(60), "+_accessTimeColumn+" "+longType+", "+
                     _lastAccessTimeColumn+" "+longType+", "+_createTimeColumn+" "+longType+", "+_cookieTimeColumn+" "+longType+", "+
                     _lastSavedTimeColumn+" "+longType+", "+_expiryTimeColumn+" "+longType+", "+_maxIntervalColumn+" "+longType+", "+
                     _mapColumn+" "+blobType+", primary key("+_idColumn+", "+_contextPathColumn+","+_virtualHostColumn+"))";

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
@@ -57,9 +57,9 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
     public static final String NULL_CONTEXT_PATH = "/";
     
     protected boolean _initialized = false;
-    private DatabaseAdaptor _dbAdaptor;
-    private SessionTableSchema _sessionTableSchema;
-    private boolean _schemaProvided;
+    protected DatabaseAdaptor _dbAdaptor;
+    protected SessionTableSchema _sessionTableSchema;
+    protected boolean _schemaProvided;
 
 
     
@@ -733,7 +733,7 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
     }
 
 
-    private void doInsert (String id, SessionData data) 
+    protected void doInsert (String id, SessionData data) 
     throws Exception
     {
         String s = _sessionTableSchema.getInsertSessionStatementAsString();
@@ -778,7 +778,7 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
     }
 
     
-    private void doUpdate (String id, SessionData data)
+    protected void doUpdate (String id, SessionData data)
             throws Exception
     {
         try (Connection connection = _dbAdaptor.getConnection())        


### PR DESCRIPTION
Allow the type of string columns to be explicitly set, rather than hardcoded to "varchar". Also relax visibility restrictions on JDBCSessionDataStore methods, making them at least protected, to ease subclassing.