### PR TITLE
Issue #300 - Implement Deflater Pool

### DIFF
--- a/jetty-jmh/pom.xml
+++ b/jetty-jmh/pom.xml
@@ -80,6 +80,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/DeflaterPoolBenchmark.java
+++ b/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/DeflaterPoolBenchmark.java
@@ -1,0 +1,122 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.jmh;
+
+import java.util.concurrent.TimeUnit;
+import java.util.zip.Deflater;
+
+import org.eclipse.jetty.server.DeflaterPool;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class DeflaterPoolBenchmark
+{
+    public static final String COMPRESSION_STRING = "hello world";
+    DeflaterPool _pool;
+
+    @Param({"NO_POOL", "DEFLATER_POOL_10", "DEFLATER_POOL_20", "DEFLATER_POOL_50"})
+    public static String poolType;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Exception
+    {
+        int capacity;
+
+        switch (poolType)
+        {
+            case "NO_POOL":
+                capacity = 0;
+                break;
+
+            case "DEFLATER_POOL_10":
+                capacity = 10;
+                break;
+
+            case "DEFLATER_POOL_20":
+                capacity = 20;
+                break;
+
+            case "DEFLATER_POOL_50":
+                capacity = 50;
+                break;
+
+            default:
+                throw new IllegalStateException("Unknown poolType Parameter");
+        }
+
+        _pool = new DeflaterPool(capacity, Deflater.DEFAULT_COMPRESSION, true);
+    }
+
+    @TearDown(Level.Trial)
+    public static void stopTrial() throws Exception
+    {
+    }
+
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    @SuppressWarnings("deprecation")
+    public long testPool() throws Exception
+    {
+        Deflater deflater = _pool.acquire();
+        deflater.setInput(COMPRESSION_STRING.getBytes());
+        deflater.finish();
+
+        byte[] output = new byte[COMPRESSION_STRING.length()+1];
+        int compressedDataLength = deflater.deflate(output);
+        _pool.release(deflater);
+
+        return compressedDataLength;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(DeflaterPoolBenchmark.class.getSimpleName())
+                .warmupIterations(20)
+                .measurementIterations(10)
+                .addProfiler(GCProfiler.class)
+                .forks(1)
+                .threads(100)
+                .build();
+
+        new Runner(opt).run();
+    }
+}
+
+

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -16,6 +16,7 @@
         <Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" deprecated="gzip.checkGzExists" default="false"/></Set>
         <Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" deprecated="gzip.compressionLevel" default="-1"/></Set>
         <Set name="inflateBufferSize"><Property name="jetty.gzip.inflateBufferSize" default="0"/></Set>
+        <Set name="deflaterPoolCapacity"><Property name="jetty.gzip.deflaterPoolCapacity" default="-1"/></Set>
         <Set name="syncFlush"><Property name="jetty.gzip.syncFlush" default="false" /></Set>
 
         <Set name="excludedAgentPatterns">

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -29,6 +29,9 @@ etc/jetty-gzip.xml
 ## Inflate request buffer size, or 0 for no request inflation
 # jetty.gzip.inflateBufferSize=0
 
+## Deflater pool max size (-1 for unlimited, 0 for no pool)
+# jetty.gzip.deflaterPoolCapacity=-1
+
 ## Comma separated list of included methods
 # jetty.gzip.includedMethodList=GET
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/DeflaterPool.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/DeflaterPool.java
@@ -1,0 +1,112 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.Deflater;
+
+public class DeflaterPool
+{
+    private final Queue<Deflater> _pool;
+    private final int _compressionLevel;
+    private final boolean _nowrap;
+    private int _capacity;
+    private AtomicInteger _numDeflaters = new AtomicInteger(0);
+
+    /**
+     * Create a {@link Deflater} Pool
+     *
+     * If given a capacity less or equal to zero the Deflaters will not be pooled
+     * and will be created on acquire and ended on release.
+     *
+     * @param capacity maximum number of Deflaters which can be contained in the pool
+     * @param compressionLevel the default compression level for new Deflater objects
+     * @param nowrap if true then use GZIP compatible compression for all new Deflater objects
+     */
+    public DeflaterPool(int capacity, int compressionLevel, boolean nowrap)
+    {
+        _capacity = capacity;
+        _compressionLevel = compressionLevel;
+        _nowrap = nowrap;
+
+        if (_capacity > 0)
+            _pool = new ConcurrentLinkedQueue<>();
+        else
+            _pool = null;
+    }
+
+    protected Deflater newDeflater()
+    {
+        return new Deflater(_compressionLevel, _nowrap);
+    }
+
+    /**
+     * @return Deflater taken from the pool if it is not empty or a newly created Deflater
+     */
+    public Deflater acquire()
+    {
+        if (_pool == null)
+            return newDeflater();
+
+        Deflater deflater = _pool.poll();
+        if (deflater == null)
+            deflater = newDeflater();
+        else
+        {
+            _numDeflaters.decrementAndGet();
+        }
+
+        return deflater;
+    }
+
+    /**
+     * @param deflater returns this Deflater to the pool or calls deflater.end() if the pool is full.
+     */
+    public void release(Deflater deflater)
+    {
+        if (deflater == null)
+            return;
+
+        if (_pool == null)
+        {
+            deflater.end();
+            return;
+        }
+
+        while(true)
+        {
+            int d = _numDeflaters.get();
+
+            if (d >= _capacity)
+            {
+                deflater.end();
+                break;
+            }
+
+            if (_numDeflaters.compareAndSet(d,d+1))
+            {
+                deflater.reset();
+                _pool.add(deflater);
+                break;
+            }
+        }
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -405,13 +405,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     @Override
     protected void doStart() throws Exception
     {
-        if (_deflaterPool == null)
-        {
-            _deflaterPool = getServer().getBean(DeflaterPool.class);
-            if (_deflaterPool == null)
-                _deflaterPool = new DeflaterPool(POOL_CAPACITY, getCompressionLevel(), true);
-        }
-
+        _deflaterPool = newDeflaterPool(POOL_CAPACITY);
         _vary=(_agentPatterns.size()>0)?GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING_USER_AGENT:GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING;
         super.doStart();
     }
@@ -981,27 +975,28 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
-     * Set the {@link DeflaterPool} that is used to manage instances of {@link Deflater}
-     * @param deflaterPool
+     * Gets the maximum number of Deflaters that the DeflaterPool can hold.
+     * @return the Deflater pool capacity
      */
-    public void setDeflaterPool(DeflaterPool deflaterPool)
-    {
-        if(isStarted())
-            throw new IllegalStateException(getState());
-
-        _deflaterPool = deflaterPool;
-    }
-
     public int getDeflaterPoolCapacity()
     {
         return POOL_CAPACITY;
     }
 
+    /**
+     * Sets the maximum number of Deflaters that the DeflaterPool can hold.
+     * @param capacity
+     */
     public void setDeflaterPoolCapacity(int capacity)
     {
         if(isStarted())
             throw new IllegalStateException(getState());
 
         POOL_CAPACITY = capacity;
+    }
+
+    protected DeflaterPool newDeflaterPool(int capacity)
+    {
+        return new DeflaterPool(capacity, getCompressionLevel(), true);
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.PreEncodedHttpField;
-import org.eclipse.jetty.http.QuotedCSV;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpOutput;
 import org.eclipse.jetty.server.Response;
@@ -310,6 +309,13 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
             super(callback);
             _content=content;
             _last=complete;
+        }
+
+        @Override
+        protected void onCompleteFailure(Throwable x) {
+            _factory.recycle(_deflater);
+            _deflater=null;
+            super.onCompleteFailure(x);
         }
 
         @Override


### PR DESCRIPTION
Removed the ThreadLocal pooling of deflaters in GzipHandler in favour of a new DeflaterPool class
GzipHttpOutputInterceptor.GzipBufferCB now recycles the Deflater in onCompleteFailure()
added benchmark for the DeflaterPool

#300 