### PR TITLE
Cancel async IO on completion

### DIFF
--- a/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpTransportOverFCGI.java
+++ b/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpTransportOverFCGI.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.fcgi.generator.ServerGenerator;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.HttpTransport;
 import org.eclipse.jetty.util.BufferUtil;
@@ -146,6 +147,13 @@ public class HttpTransportOverFCGI implements HttpTransport
             LOG.debug("abort {} {}",this,failure);
         aborted = true;
         flusher.shutdown();
+    }
+    
+    @Override
+    public boolean cancelIO(Throwable failure)
+    {
+        // TODO implement???
+        return false;
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
@@ -79,7 +79,8 @@ public class MimeTypes
         TEXT_JSON_UTF_8("text/json;charset=utf-8",TEXT_JSON),
 
         APPLICATION_JSON_8859_1("application/json;charset=iso-8859-1",APPLICATION_JSON),
-        APPLICATION_JSON_UTF_8("application/json;charset=utf-8",APPLICATION_JSON);
+        APPLICATION_JSON_UTF_8("application/json;charset=utf-8",APPLICATION_JSON),
+        APPLICATION_OCTET_STREAM("application/octet-stream");
 
 
         /* ------------------------------------------------------------ */

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
@@ -293,10 +293,16 @@ public class HttpTransportOverHTTP2 implements HttpTransport
     {
         IStream stream = this.stream;
         if (LOG.isDebugEnabled())
-            LOG.debug("HTTP2 Response #{}/{} aborted", stream == null ? -1 : stream.getId(),
-                    stream == null ? -1 : Integer.toHexString(stream.getSession().hashCode()));
+            LOG.debug("HTTP2 Response #{}/{} aborted for {}", stream == null ? -1 : stream.getId(),
+                    stream == null ? -1 : Integer.toHexString(stream.getSession().hashCode()), failure);
         if (stream != null)
             stream.reset(new ResetFrame(stream.getId(), ErrorCode.INTERNAL_ERROR.code), Callback.NOOP);
+    }
+    
+    @Override
+    public boolean cancelIO(Throwable failure)
+    {
+        return false;
     }
 
     private class TransportCallback implements Callback

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
@@ -232,11 +232,17 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
     {
     }
 
+    public boolean cancelIO(Throwable failure)
+    {
+        boolean flush_fail = _writeFlusher.onFail(failure);
+        boolean fill_fail = _fillInterest.onFail(failure);
+        return flush_fail || fill_fail;
+    }
+    
     protected void onClose(Throwable failure)
     {
         super.onClose();
-        _writeFlusher.onFail(failure);
-        _fillInterest.onFail(failure);
+        cancelIO(failure);
     }
 
     @Override
@@ -403,8 +409,7 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
 
         boolean output_shutdown=isOutputShutdown();
         boolean input_shutdown=isInputShutdown();
-        boolean fillFailed = _fillInterest.onFail(timeout);
-        boolean writeFailed = _writeFlusher.onFail(timeout);
+        boolean ioFailed = cancelIO(timeout);
 
         // If the endpoint is half closed and there was no fill/write handling, then close here.
         // This handles the situation where the connection has completed its close handling
@@ -413,7 +418,7 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
         // for a dispatched servlet or suspended request to extend beyond the connections idle
         // time.  So if this test would always close an idle endpoint that is not handled, then
         // we would need a mode to ignore timeouts for some HTTP states
-        if (isOpen() && (output_shutdown || input_shutdown) && !(fillFailed || writeFailed))
+        if (isOpen() && (output_shutdown || input_shutdown) && !ioFailed)
             close();
         else
             LOG.debug("Ignored idle endpoint {}",this);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
@@ -171,4 +171,10 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         else if (e != _throwable)
             _throwable.addSuppressed(e);
     }
+    
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x{c=%s,d=%b,t=%s,ex=%s}",AsyncContextEvent.class.getSimpleName(),this.hashCode(),_context,_dispatchContext!=null||_dispatchPath!=null,_timeoutTask,_throwable);
+    }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ChannelEndPoint;
 import org.eclipse.jetty.io.EndPoint;
@@ -390,10 +391,22 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
 
                     case ERROR_DISPATCH:
                     {
+                        Throwable failure = (Throwable)_request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+                        if (failure==null)
+                            failure = _state.getAsyncContextEvent().getThrowable();
+                        Integer icode = (Integer)_request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+                        
+                        if (_response.isCommitted())
+                        {
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("Committed prior to ERROR dispatch for " + failure);
+                            abort(failure);
+                            break;
+                        }
+                        
                         try
                         {
                             _response.reset(true);
-                            Integer icode = (Integer)_request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
                             int code = icode != null ? icode : HttpStatus.INTERNAL_SERVER_ERROR_500;
                             _response.setStatus(code);
                             _request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE,code);
@@ -420,18 +433,12 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                         catch (Throwable x)
                         {
                             if (LOG.isDebugEnabled())
-                                LOG.debug("Could not perform ERROR dispatch, aborting", x);
-                            Throwable failure = (Throwable)_request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+                                LOG.debug("Could not perform ERROR dispatch for " + failure, x);
                             if (failure==null)
-                            {
-                                minimalErrorResponse(x);
-                            }
+                                failure = x;
                             else
-                            {
-                                if (x != failure)
-                                    failure.addSuppressed(x);
-                                minimalErrorResponse(failure);
-                            }
+                                failure.addSuppressed(x);
+                            minimalErrorResponse(failure);
                         }
                         break;
                     }
@@ -449,21 +456,13 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                     
                     case READ_CALLBACK:
                     {
-                        ContextHandler handler=_state.getContextHandler();
-                        if (handler!=null)
-                            handler.handle(_request,_request.getHttpInput());
-                        else
-                            _request.getHttpInput().run();
+                        _request.getHttpInput().run(_state.getContextHandler());
                         break;
                     }
 
                     case WRITE_CALLBACK:
                     {
-                        ContextHandler handler=_state.getContextHandler();
-                        if (handler!=null)
-                            handler.handle(_request,_response.getHttpOutput());
-                        else
-                            _response.getHttpOutput().run();
+                        _response.getHttpOutput().run(_state.getContextHandler());
                         break;
                     }
 
@@ -490,6 +489,26 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                                     _response.sendError(HttpStatus.INTERNAL_SERVER_ERROR_500,"insufficient content written");
                             }
                         }
+                        
+                        if (_state.isAsync())
+                        {
+                            Throwable failure = _state.getAsyncContextEvent()==null?null:_state.getAsyncContextEvent().getThrowable();
+                            if (failure==null)
+                                failure = new IOException("Complete");
+
+                            if (cancelIO(failure))
+                                abort(failure);
+                            try
+                            {
+                                _request.getHttpInput().run(_state.getContextHandler());
+                                _response.getHttpOutput().run(_state.getContextHandler());
+                            }
+                            catch (Throwable th)
+                            {
+                                LOG.ignore(th);
+                            }
+                        }
+                       
                         _response.closeOutput();
                         _request.setHandled(true);
 
@@ -589,18 +608,23 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
 
     private void minimalErrorResponse(Throwable failure)
     {
-        try
-        {
-            Integer code=(Integer)_request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
-            _response.reset(true);
-            _response.setStatus(code == null ? 500 : code);
-            _response.flushBuffer();
-        }
-        catch (Throwable x)
-        {
-            if (x != failure)
-                failure.addSuppressed(x);
+        if (_response.isCommitted())
             abort(failure);
+        else
+        {
+            try
+            {
+                Integer code=(Integer)_request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+                _response.reset(true);
+                _response.setStatus(code == null ? 500 : code);
+                _response.flushBuffer();
+            }
+            catch (Throwable x)
+            {
+                if (x != failure)
+                    failure.addSuppressed(x);
+                abort(failure);
+            }
         }
     }
 
@@ -893,6 +917,17 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         _transport.abort(failure);
     }
 
+    /**
+     * Called to cancel any outstanding IO operations by calling {@link HttpTransport#cancelIO(Throwable)}.
+     *
+     * @param failure the exception that caused the cancellation
+     * @return true iff an IO operation was outstanding.
+     */
+    public boolean cancelIO(Throwable failure)
+    {
+        return _transport.cancelIO(failure);
+    }
+    
     private void notifyRequestBegin(Request request)
     {
         notifyEvent1(listener -> listener::onRequestBegin, request);
@@ -1274,4 +1309,5 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                 notifyResponseEnd(_request);
         }
     }
+
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
@@ -550,9 +551,20 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     {
         if (LOG.isDebugEnabled())
             LOG.debug("abort {} {}",this,failure);
+
         // Do a direct close of the output, as this may indicate to a client that the
         // response is bad either with RST or by abnormal completion of chunked response.
         getEndPoint().close();
+    }
+    
+    @Override
+    public boolean cancelIO(Throwable failure)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("cancel {} {}",this,failure);
+        if (getEndPoint() instanceof AbstractEndPoint)
+            return ((AbstractEndPoint)getEndPoint()).cancelIO(failure);
+        return false;
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.RuntimeIOException;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.Destroyable;
@@ -838,6 +839,14 @@ public class HttpInput extends ServletInputStream implements Runnable
         return false;
     }
 
+    public void run(ContextHandler contextHandler)
+    {
+        if (contextHandler == null)
+            run();
+        else
+            contextHandler.handle(this);
+    }
+    
     /*
      * <p> While this class is-a Runnable, it should never be dispatched in it's own thread. It is a runnable only so that the calling thread can use {@link
      * ContextHandler#handle(Runnable)} to setup classloaders etc. </p>
@@ -852,6 +861,8 @@ public class HttpInput extends ServletInputStream implements Runnable
         synchronized (_inputQ)
         {
             listener = _listener;
+            if (listener == null)
+                return;
 
             if (_state == EOF)
                 return;
@@ -1156,4 +1167,5 @@ public class HttpInput extends ServletInputStream implements Runnable
             return "AEOF";
         }
     };
+
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -33,6 +33,7 @@ import javax.servlet.WriteListener;
 
 import org.eclipse.jetty.http.HttpContent;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -1016,6 +1017,14 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             }
         }
     }
+    
+    public void run(ContextHandler contextHandler)
+    {
+        if (contextHandler == null)
+            run();
+        else
+            contextHandler.handle(this);
+    }
 
     @Override
     public void run()
@@ -1089,7 +1098,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     @Override
     public String toString()
     {
-        return String.format("%s@%x{%s}", this.getClass().getSimpleName(), hashCode(), _state.get());
+        return String.format("%s@%x{%s,%s}", this.getClass().getSimpleName(), hashCode(), _state.get(),_onError);
     }
 
     private abstract class AsyncICB extends IteratingCallback

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpTransport.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpTransport.java
@@ -70,6 +70,18 @@ public interface HttpTransport
      * @param failure the failure that caused the abort.
      */
     void abort(Throwable failure);
+    
+    /** Cancel IO operations/
+     * <p>
+     * If any IO operations are pending, they are cancelled and the passed
+     * failure is used to call their failure callbacks. 
+     * If there are no IO operations pending, this call is a noop.
+     * If pending IO operations cannot be cancelled, then this call may be
+     * equivalent to {@link #abort(Throwable)}.
+     * @param failure the exception that caused the cancel
+     * @return true iff an IO operation was cancelled.
+     */
+    boolean cancelIO(Throwable failure);
 
     /* ------------------------------------------------------------ */
     /** Is the underlying transport optimized for DirectBuffer usage

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.toolchain.test.AdvancedRunner;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.IO;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -169,7 +170,7 @@ public class AsyncRequestReadTest
 
             InputStream in = socket.getInputStream();
             String response = IO.toString(in);
-            assertTrue(tst,response.indexOf("200 OK")>0);
+            assertThat(tst,response,Matchers.containsString(" 200 OK"));
 
             long total=__total.poll(30,TimeUnit.SECONDS);
             assertEquals(tst,content.length, total);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -1257,7 +1257,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
         try (Socket client = newSocket(_serverURI.getHost(), _serverURI.getPort());
              StacklessLogging stackless = new StacklessLogging(HttpChannel.class))
         {
-            ((AbstractLogger)Log.getLogger(HttpChannel.class)).info("Expecting exception after commit then could not send 500....");
+            ((AbstractLogger)Log.getLogger(HttpChannel.class)).info("Expecting exception after commit....");
             OutputStream os = client.getOutputStream();
             InputStream is = client.getInputStream();
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -178,6 +178,12 @@ public class ResponseTest
             }
 
             @Override
+            public boolean cancelIO(Throwable failure)
+            {
+                return false;
+            }
+
+            @Override
             public boolean isOptimizedForDirectBuffers()
             {
                 return false;

--- a/jetty-servlet/src/test/resources/jetty-logging.properties
+++ b/jetty-servlet/src/test/resources/jetty-logging.properties
@@ -1,8 +1,8 @@
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
-org.eclipse.jetty.LEVEL=INFO
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.servlet.LEVEL=DEBUG
 #org.eclipse.jetty.io.ChannelEndPoint.LEVEL=DEBUG
 #org.eclipse.jetty.server.DebugListener.LEVEL=DEBUG
 #org.eclipse.jetty.server.HttpChannelState.LEVEL=DEBUG
+#org.eclipse.jetty.server.HttpChannel.LEVEL=DEBUG


### PR DESCRIPTION
This is a proposed for #2689 

The asyncContext timeouts and errors are kept separate from async IO errors.
However, on HttpChannel completion, any outstanding async IO operations are cancelled so the channel can be closed.
