### PR TITLE
Issue #2740 Ensure OSGiWebappClassLoader uses bundleloader for all loadClass methods

### DIFF
--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/webapp/OSGiWebappClassLoader.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/webapp/OSGiWebappClassLoader.java
@@ -93,11 +93,10 @@ public class OSGiWebappClassLoader extends WebAppClassLoader implements BundleRe
         _osgiBundleClassLoader = BundleClassLoaderHelperFactory.getFactory().getHelper().getBundleClassLoader(contributor);
     }
     
-    
 
-    /* ------------------------------------------------------------ */
+
     @Override
-    public Class<?> loadClass(String name) throws ClassNotFoundException
+    protected Class<?> findClass(String name) throws ClassNotFoundException
     {
         try
         {
@@ -107,7 +106,8 @@ public class OSGiWebappClassLoader extends WebAppClassLoader implements BundleRe
         {
             try
             {
-                return super.loadClass(name);
+
+                return super.findClass(name);
             }
             catch (ClassNotFoundException cne2)
             {
@@ -147,6 +147,48 @@ public class OSGiWebappClassLoader extends WebAppClassLoader implements BundleRe
         return url != null ? url : super.getResource(name);
     }
     
+    
+    
+    
+    @Override
+    public URL findResource(String name)
+    {
+        URL url = _osgiBundleClassLoader.getResource(name);
+        return url != null ? url : super.findResource(name);
+    }
+    
+    
+
+    /** 
+     * Try to load the class from the bundle classloader.
+     * We do NOT load it as a resource as the WebAppClassLoader does because the
+     * url that is returned is an osgi-special url that does not play
+     * properly with WebAppClassLoader's method of extracting the class
+     * from the resource.  This implementation directly asks the osgi
+     * bundle classloader to load the given class name.
+     * 
+     * @see org.eclipse.jetty.webapp.WebAppClassLoader#loadAsResource(java.lang.String, boolean)
+     */
+    @Override
+    protected Class<?> loadAsResource(String name, boolean checkSystemResource) throws ClassNotFoundException
+    {
+        try
+        {
+            return _osgiBundleClassLoader.loadClass(name);
+        }
+        catch (ClassNotFoundException cne)
+        {
+            try
+            {
+                return super.loadAsResource(name, checkSystemResource);
+            }
+            catch (ClassNotFoundException cne2)
+            {
+                throw cne;
+            }
+        }
+    }
+
     /* ------------------------------------------------------------ */
     private List<URL> toList(Enumeration<URL> e, Enumeration<URL> e2)
     {


### PR DESCRIPTION
When the WebAppClassLoader changed in jetty-9.4 in commit https://github.com/eclipse/jetty.project/commit/afb750515e3f5bd2f3ebb7a84b5dc34f7cdcef6a#diff-2640580777fa432610309ad6bf8dedff  it meant that the OSGiWebappClassLoader was no longer always consulting the bundle classloader first.  This change ensures that the OSGiWebAppClassLoader integrates properly with the WebAppClassLoader, respecting all of the checks for system/server classes, yet uses the bundle classloader to actually load classes (where possible).