### PR TITLE
Issue #2720 Ensure standard jetty properties available in jetty-env.xml

### DIFF
--- a/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/EnvConfiguration.java
+++ b/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/EnvConfiguration.java
@@ -115,6 +115,7 @@ public class EnvConfiguration extends AbstractConfiguration
                 {
                     localContextRoot.getRoot().addListener(listener);
                     XmlConfiguration configuration = new XmlConfiguration(jettyEnvXmlUrl);
+                    configuration.setJettyStandardIdsAndProperties(context.getServer(), null);
                     WebAppClassLoader.runWithServerClassAccess(()->{configuration.configure(context);return null;});
                 }
                 finally

--- a/tests/test-webapps/test-jndi-webapp/src/main/java/com/acme/JNDITest.java
+++ b/tests/test-webapps/test-jndi-webapp/src/main/java/com/acme/JNDITest.java
@@ -51,6 +51,7 @@ public class JNDITest extends HttpServlet
     private Double wiggle;
     private Integer woggle;
     private Double gargle;
+    private String svr;
     
     private String resourceNameMappingInjectionResult;
     private String envEntryOverrideResult;
@@ -60,6 +61,7 @@ public class JNDITest extends HttpServlet
     private String envEntryWebAppScopeResult;
     private String userTransactionResult;
     private String mailSessionResult;
+    private String svrResult;
     
     
     public void setMyDatasource(DataSource ds)
@@ -91,6 +93,9 @@ public class JNDITest extends HttpServlet
             woggle = (Integer)ic.lookup("java:comp/env/woggle");
             envEntryGlobalScopeResult = "EnvEntry defined in context xml lookup result (java:comp/env/woggle): "+(woggle==4000?"<span class=\"pass\">PASS":"<span class=\"fail\">FAIL(expected 4000, got "+woggle+")")+"</span>";
             gargle = (Double)ic.lookup("java:comp/env/gargle");
+            svr = (String)ic.lookup("java:comp/env/svr");
+            svrResult = "Ref to Server in jetty-env.xml result: "+(svr!=null?"<span class=\"pass\">PASS":"<span class=\"fail\">FAIL")+"</span>";
+            
             envEntryWebAppScopeResult = "EnvEntry defined in jetty-env.xml lookup result (java:comp/env/gargle): "+(gargle==100.0?"<span class=\"pass\">PASS":"<span class=\"fail\">FAIL(expected 100, got "+gargle+")")+"</span>";
             UserTransaction utx = (UserTransaction)ic.lookup("java:comp/UserTransaction");
             userTransactionResult = "UserTransaction lookup result (java:comp/UserTransaction): "+(utx!=null?"<span class=\"pass\">PASS":"<span class=\"fail\">FAIL")+"</span>";
@@ -141,6 +146,7 @@ public class JNDITest extends HttpServlet
             out.println("<p>"+preDestroyResult+"</p>");
             out.println("<p>"+envEntryGlobalScopeResult+"</p>");
             out.println("<p>"+envEntryWebAppScopeResult+"</p>");
+            out.println("<p>"+svrResult+"</p>");
             out.println("<p>"+userTransactionResult+"</p>");
             out.println("<p>"+mailSessionResult+"</p>");
         

--- a/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -27,7 +27,18 @@
   </New>
 
 
-
+ <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
+   <Arg><Ref refid='wac'/></Arg>
+   <Arg>svr</Arg>
+   <Arg type="java.lang.String">
+     <Ref id="Server">
+       <Get name="class">
+         <Get name="name"/>
+       </Get>
+     </Ref>
+   </Arg>
+   <Arg type="boolean">true</Arg>
+ </New>
 
 
 </Configure>


### PR DESCRIPTION
Ensure that the usual jetty properties eg Server, jetty.home, jetty.base are available for reference in jetty-env.xml files.