### PR TITLE
Issue #2811 - Dump fix JreDisabled:java.security to JVM:disabled

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -353,34 +353,40 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
     
         try
         {
-            /* Use a pristine SSLEngine (not one from this SslContextFactory).
-             * This will allow for proper detection and identification
-             * of JRE/lib/security/java.security level disabled features
-             */
-            SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine();
-    
-            List<Object> selections = new ArrayList<>();
-            
-            // protocols
-            selections.add(new SslSelectionDump("Protocol",
-                    sslEngine.getSupportedProtocols(),
-                    sslEngine.getEnabledProtocols(),
-                    getExcludeProtocols(),
-                    getIncludeProtocols()));
-            
-            // ciphers
-            selections.add(new SslSelectionDump("Cipher Suite",
-                    sslEngine.getSupportedCipherSuites(),
-                    sslEngine.getEnabledCipherSuites(),
-                    getExcludeCipherSuites(),
-                    getIncludeCipherSuites()));
-            
+            List<SslSelectionDump> selections = selectionDump();
             ContainerLifeCycle.dump(out, indent, selections);
         }
         catch (NoSuchAlgorithmException ignore)
         {
             LOG.ignore(ignore);
         }
+    }
+
+    List<SslSelectionDump> selectionDump() throws NoSuchAlgorithmException
+    {
+        /* Use a pristine SSLEngine (not one from this SslContextFactory).
+         * This will allow for proper detection and identification
+         * of JRE/lib/security/java.security level disabled features
+         */
+        SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine();
+
+        List<SslSelectionDump> selections = new ArrayList<>();
+
+        // protocols
+        selections.add(new SslSelectionDump("Protocol",
+                sslEngine.getSupportedProtocols(),
+                sslEngine.getEnabledProtocols(),
+                getExcludeProtocols(),
+                getIncludeProtocols()));
+
+        // ciphers
+        selections.add(new SslSelectionDump("Cipher Suite",
+                sslEngine.getSupportedCipherSuites(),
+                sslEngine.getEnabledCipherSuites(),
+                getExcludeCipherSuites(),
+                getIncludeCipherSuites()));
+
+        return selections;
     }
     
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslSelectionDump.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslSelectionDump.java
@@ -30,9 +30,9 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
 
-public class SslSelectionDump extends ContainerLifeCycle implements Dumpable
+class SslSelectionDump extends ContainerLifeCycle implements Dumpable
 {
-    private static class CaptionedList extends ArrayList<String> implements Dumpable
+    static class CaptionedList extends ArrayList<String> implements Dumpable
     {
         private final String caption;
         
@@ -57,9 +57,9 @@ public class SslSelectionDump extends ContainerLifeCycle implements Dumpable
         }
     }
     
-    private final String type;
-    private SslSelectionDump.CaptionedList enabled = new SslSelectionDump.CaptionedList("Enabled");
-    private SslSelectionDump.CaptionedList disabled = new SslSelectionDump.CaptionedList("Disabled");
+    final String type;
+    final SslSelectionDump.CaptionedList enabled = new SslSelectionDump.CaptionedList("Enabled");
+    final SslSelectionDump.CaptionedList disabled = new SslSelectionDump.CaptionedList("Disabled");
     
     public SslSelectionDump(String type,
                             String[] supportedByJVM,
@@ -87,16 +87,7 @@ public class SslSelectionDump extends ContainerLifeCycle implements Dumpable
                     
                     StringBuilder s = new StringBuilder();
                     s.append(entry);
-                    if (!jvmEnabled.contains(entry))
-                    {
-                        if (isPresent)
-                        {
-                            s.append(" -");
-                            isPresent = false;
-                        }
-                        s.append(" JreDisabled:java.security");
-                    }
-                    
+
                     for (Pattern pattern : excludedPatterns)
                     {
                         Matcher m = pattern.matcher(entry);
@@ -114,10 +105,11 @@ public class SslSelectionDump extends ContainerLifeCycle implements Dumpable
                             s.append(" ConfigExcluded:'").append(pattern.pattern()).append('\'');
                         }
                     }
-                    
+
+                    boolean isIncluded = false;
+
                     if (!includedPatterns.isEmpty())
                     {
-                        boolean isIncluded = false;
                         for (Pattern pattern : includedPatterns)
                         {
                             Matcher m = pattern.matcher(entry);
@@ -139,10 +131,22 @@ public class SslSelectionDump extends ContainerLifeCycle implements Dumpable
                             {
                                 s.append(",");
                             }
-                            s.append(" ConfigIncluded:NotSpecified");
+
+                            s.append(" ConfigIncluded:NotSelected");
                         }
                     }
-                    
+
+                    if (!isIncluded && !jvmEnabled.contains(entry))
+                    {
+                        if (isPresent)
+                        {
+                            s.append(" -");
+                            isPresent = false;
+                        }
+
+                        s.append(" JVM:disabled");
+                    }
+
                     if (isPresent)
                     {
                         enabled.add(s.toString());


### PR DESCRIPTION
+ ensuring SLOTH fix still works with updated testcase
+ Dump detection of JreDisabled:java.security only checked
  default SSLEngine.enabledCipherSuites
  New implementation changes meaning to be more general
  JVM:disabled (as in not selected by default), and
  only reports it as disabled in the dump if not specifically
  included from the SSLEngine.supportedCipherSuites via
  the SslContextFactory.includedCipherSuites configuration

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>