### PR TITLE
Issue #2824 - Request.getParameters() should not reparse or recreate _parameters Map

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -370,7 +370,7 @@ public class Request implements HttpServletRequest
     /* ------------------------------------------------------------ */
     private MultiMap<String> getParameters()
     {
-        if (!_contentParamsExtracted) 
+        if (!_contentParamsExtracted)
         {
             // content parameters need boolean protection as they can only be read
             // once, but may be reset to null by a reset
@@ -411,7 +411,7 @@ public class Request implements HttpServletRequest
             _parameters=_contentParameters;
         else if (isNoParams(_contentParameters) || _contentParameters.size()==0)
             _parameters=_queryParameters;
-        else
+        else if(_parameters == null)
         {
             _parameters = new MultiMap<>();
             _parameters.addAllValues(_queryParameters);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.server;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1060,7 +1061,7 @@ public class RequestTest
         String response = _connector.getResponse(request);
         assertThat(response, containsString(" 200 OK"));
     }
-    
+
     @Test
     public void testPartialRead() throws Exception
     {
@@ -1252,7 +1253,7 @@ public class RequestTest
                     200, TimeUnit.MILLISECONDS
                     );
         assertThat(response, containsString("200"));
-        assertThat(response, Matchers.not(containsString("Connection: close")));
+        assertThat(response, not(containsString("Connection: close")));
         assertThat(response, containsString("Hello World"));
 
         response=_connector.getResponse(
@@ -1282,7 +1283,7 @@ public class RequestTest
                     "\n"
                     );
         assertThat(response, containsString("200"));
-        assertThat(response, Matchers.not(containsString("Connection: close")));
+        assertThat(response, not(containsString("Connection: close")));
         assertThat(response, containsString("Hello World"));
 
         response=_connector.getResponse(


### PR DESCRIPTION

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>