### PR TITLE
Apply Optimize Java 8 Streams refactoring

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/AttributeNormalizer.java
@@ -235,7 +235,7 @@ public class AttributeNormalizer
         Collections.sort(paths,attrComparator);
         Collections.sort(uris,attrComparator);
         
-        Stream.concat(paths.stream(),uris.stream()).forEach(a->attributes.put(a.key,a));        
+        Stream.concat(paths.stream(),uris.parallelStream()).forEach(a->attributes.put(a.key,a));        
         
         if (LOG.isDebugEnabled())
         {

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -370,7 +370,7 @@ public class Modules implements Iterable<Module>
             {
                 // Is there an obvious default?
                 Optional<Module> dftProvider = (providers.size()==1)
-                    ?providers.parallelStream().findFirst()
+                    ?providers.stream().findFirst()
                     :providers.stream().filter(m->m.getName().equals(dependsOn)).findFirst();
 
                 if (dftProvider.isPresent())

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -82,8 +82,8 @@ public class Modules implements Iterable<Module>
 
     public void dump(List<String> tags)
     {
-        Set<String> exclude = tags.stream().filter(t->t.startsWith("-")).map(t->t.substring(1)).collect(Collectors.toSet());
-        Set<String> include = tags.stream().filter(t->!t.startsWith("-")).collect(Collectors.toSet());
+        Set<String> exclude = tags.parallelStream().filter(t->t.startsWith("-")).map(t->t.substring(1)).collect(Collectors.toSet());
+        Set<String> include = tags.parallelStream().filter(t->!t.startsWith("-")).collect(Collectors.toSet());
         boolean all = include.contains("*") || include.isEmpty();
         AtomicReference<String> tag = new AtomicReference<>();
         
@@ -246,7 +246,7 @@ public class Modules implements Iterable<Module>
 
     public List<Module> getEnabled()
     {
-        List<Module> enabled = _modules.stream().filter(m->{return m.isEnabled();}).collect(Collectors.toList());
+        List<Module> enabled = _modules.parallelStream().filter(m->{return m.isEnabled();}).collect(Collectors.toList());
 
         TopologicalSort<Module> sort = new TopologicalSort<>();
         for (Module module: enabled)
@@ -357,20 +357,20 @@ public class Modules implements Iterable<Module>
                     if (providers==null || providers.isEmpty())
                         throw new UsageException("Module %s does not provide %s",_baseHome.toShortForm(file),dependsOn);
 
-                    enable(newlyEnabled,providers.stream().findFirst().get(),"dynamic dependency of "+module.getName(),true);
+                    enable(newlyEnabled,providers.parallelStream().findFirst().get(),"dynamic dependency of "+module.getName(),true);
                     continue;
                 }
                 throw new UsageException("No module found to provide %s for %s",dependsOn,module);
             }
             
             // If a provider is already enabled, then add a transitive enable
-            if (providers.stream().filter(Module::isEnabled).count()>0)
+            if (providers.parallelStream().filter(Module::isEnabled).count()>0)
                 providers.stream().filter(m->m.isEnabled()&&!m.equals(module)).forEach(m->enable(newlyEnabled,m,"transitive provider of "+dependsOn+" for "+module.getName(),true));
             else
             {
                 // Is there an obvious default?
                 Optional<Module> dftProvider = (providers.size()==1)
-                    ?providers.stream().findFirst()
+                    ?providers.parallelStream().findFirst()
                     :providers.stream().filter(m->m.getName().equals(dependsOn)).findFirst();
 
                 if (dftProvider.isPresent())


### PR DESCRIPTION
# Apply Optimize Java 8 Streams Refactoring

## Description

This is a semantics-preserving automated refactoring that attempts to optimize code using Java 8 streams when it is *safe* and possibly *advantageous* to do so. It may make certain streams parallel, others sequential, and unorder streams where necessarily. The tool **does not** add new functionality; it only rearranges _existing_ code in an effort to increase its performance. Your program's results should be the same before and after the refactoring.

## Details

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Optimize Java 8 Streams Refactoring](https://github.com/ponder-lab/Optimize-Java-8-Streams-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made.
- The source code should be semantically equivalent to the original.
- There was one manual change reversal due to parallelization of a stream with only one element.
- The tool does not assess overhead vs. the amount of data processed; it only performs the refactoring when it is *safe* and *possibly* advantageous to do so. However, we ran several performance tests on the refactored code (see below).

## Performance Evaluation

We did not find dedicated performance tests in your project (please let us know if we missed it). But, we did evaluate our tool on other projects (see https://github.com/iluwatar/java-design-patterns/pull/786#issue-209596294 and https://github.com/numenta/htm.java/pull/539#issue-176637754). We have found an average speedup of ~3.25 as a result of our refactoring across all of our tests thus far.

## Feedback

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if _each_ of the proposed changes are helpful or not.