### PR TITLE
Issue #2835 - Use original WAR Resource for lastModified

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -24,8 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -582,6 +580,13 @@ public class WebInfConfiguration extends AbstractConfiguration
 
             if (LOG.isDebugEnabled())
                 LOG.debug("Try webapp=" + web_app + ", exists=" + web_app.exists() + ", directory=" + web_app.isDirectory()+" file="+(web_app.getFile()));
+
+            // Track the original web_app Resource, as this could be a PathResource.
+            // Later steps force the Resource to be a JarFileResource, which introduces
+            // URLConnection caches in such a way that it prevents Hot Redeployment
+            // on MS Windows.
+            Resource originalWarResource = web_app;
+
             // Is the WAR usable directly?
             if (web_app.exists() && !web_app.isDirectory() && !web_app.toString().startsWith("jar:"))
             {
@@ -642,8 +647,9 @@ public class WebInfConfiguration extends AbstractConfiguration
                     }
                     else
                     {
-                        //only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
-                        if (web_app.lastModified() > extractedWebAppDir.lastModified() || extractionLock.exists())
+                        // Only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
+                        // Use the original War Resource to obtain lastModified to avoid filesystem locks on MS Windows.
+                        if (originalWarResource.lastModified() > extractedWebAppDir.lastModified() || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
                             IO.delete(extractedWebAppDir);


### PR DESCRIPTION
+ During WebInfConfiguration.unpack()
  If you have WebAppContext declared with .setWar()
  and it points to a file on the filesystem, use that
  original PathResource object to determine lastModified()
  instead of the forced JarFileResource.
  This is done to avoid URLConnection caching that prevents
  the original WAR file from being deleted / replaced on
  MS Windows.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>