### PR TITLE
Issue #2866 Put back jstl dep for jetty jspc maven plugin

### DIFF
--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -112,6 +112,11 @@
       <version>${project.version}</version>
      </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jstl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
       <version>1.8.4</version>


### PR DESCRIPTION
I don't know why I removed jstl as a dep in commit b4e400f236179c89d7d5ecb0be2cf2f4d97fab3b.  The purpose of having in on the path for the jspc compiler is to allow folks to precompile their jsps without having to add an explicit <scope>provided</scope> for the jstl libs (because these are automatically supplied by jetty distro, so having to put it explicitly into the build seems perverse).