### PR TITLE
Fixes #2913 - ClassNotFoundException: sun.reflect.Reflection with JDK 11

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -2594,10 +2594,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                 // classloader, or a parent of it, as required by the javadoc specification.
 
                 // Wrap so that only Jetty code requires the "createSecurityManager" permission.
-                Caller caller = AccessController.doPrivileged((PrivilegedAction<Caller>)Caller::new);
-                Class<?> callerClass = caller.getCallerClass(2);
                 boolean ok = false;
-                ClassLoader callerLoader = callerClass == null ? null : callerClass.getClassLoader();
+                Caller caller = AccessController.doPrivileged((PrivilegedAction<Caller>)Caller::new);
+                ClassLoader callerLoader = caller.getCallerClassLoader(2);
                 while (!ok && callerLoader != null)
                 {
                     if (callerLoader == _classLoader)
@@ -3081,14 +3080,14 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
 
     private static class Caller extends SecurityManager
     {
-        public Class<?> getCallerClass(int depth)
+        public ClassLoader getCallerClassLoader(int depth)
         {
             if (depth < 0)
                 return null;
             Class<?>[] classContext = getClassContext();
             if (classContext.length <= depth)
                 return null;
-            return classContext[depth];
+            return classContext[depth].getClassLoader();
         }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -2593,21 +2593,17 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                 // check to see if the classloader of the caller is the same as the context
                 // classloader, or a parent of it, as required by the javadoc specification.
 
-                // Wrap so that only Jetty code requires the "createSecurityManager" permission.
-                boolean ok = false;
+                // Wrap in a PrivilegedAction so that only Jetty code will require the
+                // "createSecurityManager" permission, not also application code that calls this method.
                 Caller caller = AccessController.doPrivileged((PrivilegedAction<Caller>)Caller::new);
                 ClassLoader callerLoader = caller.getCallerClassLoader(2);
-                while (!ok && callerLoader != null)
+                while (callerLoader != null)
                 {
                     if (callerLoader == _classLoader)
-                        ok = true;
+                        return _classLoader;
                     else
                         callerLoader = callerLoader.getParent();
                 }
-
-                if (ok)
-                    return _classLoader;
-
                 AccessController.checkPermission(new RuntimePermission("getClassLoader"));
                 return _classLoader;
             }


### PR DESCRIPTION
Issue #2913.
Replaced usage of sun.reflect.Reflection with a
SecurityManager subclass, so that it works in all JDKs.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>