### PR TITLE
Issue #2919 Ensure jetty classes in session attribute can be marshalled by infinispan

### DIFF
--- a/jetty-infinispan/pom.xml
+++ b/jetty-infinispan/pom.xml
@@ -41,8 +41,18 @@
          <version>${infinispan.version}</version>
     </dependency>
     <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream</artifactId>
+         <version>4.1.0.Final</version>
+    </dependency>
+    <dependency>
        <groupId>org.eclipse.jetty</groupId>
        <artifactId>jetty-server</artifactId>
+       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+       <groupId>org.eclipse.jetty</groupId>
+       <artifactId>jetty-webapp</artifactId>
        <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/jetty-infinispan/src/main/config/etc/sessions/infinispan/remote.xml
+++ b/jetty-infinispan/src/main/config/etc/sessions/infinispan/remote.xml
@@ -4,15 +4,78 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
 
+  <!-- ===================================================================== -->
+  <!-- Set up infinispan to use protobuf marshalling instead of default.     -->
+  <!-- Avoids classloading issues when marshalling/demarshalling webapps     -->
+  <!-- that use jetty server classes in their attributes.                    -->
+  <!-- ===================================================================== -->
+
+  <New id="properties" class="java.util.Properties">
+    <Call name="load">
+      <Arg>
+      <New class="java.io.FileInputStream">
+              <Arg><Property name="jetty.base" default="."/>/resources/hotrod-client.properties</Arg>
+          </New>
+      </Arg>
+    </Call>
+    <!--
+    <Call name="put">
+      <Arg><Get class="org.hibernate.search.cfg.Environment" name="MODEL_MAPPING"/></Arg>
+      <Arg><Ref refid="mapping"/></Arg>
+    </Call>
+-->
+  </New>
+
+  <New class="org.infinispan.client.hotrod.configuration.ConfigurationBuilder">
+    <Call name="withProperties">
+      <Arg><Ref refid="properties"/></Arg>
+    </Call>
+    <Call name="marshaller">
+      <Arg>
+          <New class="org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller"/>
+       </Arg>
+    </Call>
+    <Call id="config" name="build"/>
+  </New>
+
+
+    <New id="remoteCacheManager" class="org.infinispan.client.hotrod.RemoteCacheManager">
+    <Arg><Ref refid="config"/></Arg>
+  </New>
+
+  <Call id="serial_context" class="org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller" name="getSerializationContext">
+    <Arg>
+      <Ref refid="remoteCacheManager"/>
+    </Arg>
+    <Call name="registerProtoFiles">
+      <Arg>
+        <New class="org.infinispan.protostream.FileDescriptorSource">
+          <Call name="addProtoFiles">
+            <Arg>
+              <Array type="java.lang.String">
+                <Item>/session.proto</Item>
+              </Array>
+            </Arg>
+          </Call>
+        </New>
+      </Arg>
+    </Call>
+    <Call name="registerMarshaller">
+      <Arg>
+        <New class="org.eclipse.jetty.session.infinispan.SessionDataMarshaller"/>
+      </Arg>
+    </Call>
+  </Call>
 
   <!-- ===================================================================== -->
   <!-- Get a reference to the remote cache.                                  -->
   <!-- ===================================================================== -->
-  <New id="hotrodMgr" class="org.infinispan.client.hotrod.RemoteCacheManager">
+  <Ref refid="remoteCacheManager">
     <Call id="remoteCache" name="getCache">
       <Arg><Property name="jetty.session.infinispan.remoteCacheName" default="sessions"/></Arg>
     </Call>
-  </New>
+  </Ref>
+
   
   <!-- ===================================================================== -->
   <!-- Configure a factory for InfinispanSessionDataStore using an           -->

--- a/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/InfinispanSessionDataStore.java
+++ b/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/InfinispanSessionDataStore.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.webapp.WebAppClassLoader;
 import org.infinispan.commons.api.BasicCache;
 
 /**
@@ -79,6 +80,16 @@ public class InfinispanSessionDataStore extends AbstractSessionDataStore
 
     
     
+    @Override
+    protected void doStart() throws Exception
+    {
+        super.doStart();
+        if (_cache == null)
+            throw new IllegalStateException ("No cache");
+    }
+
+
+
     /** 
      * @see org.eclipse.jetty.server.session.SessionDataStore#load(String)
      */
@@ -93,20 +104,23 @@ public class InfinispanSessionDataStore extends AbstractSessionDataStore
             @Override
             public void run ()
             {
+
+                
                 try
                 {
-
                     if (LOG.isDebugEnabled())
                         LOG.debug("Loading session {} from infinispan", id);
-     
-                    SessionData sd = (SessionData)_cache.get(getCacheKey(id));
-                    reference.set(sd);
+                    //WebAppClassLoader.runWithServerClassAccess(()->{
+                        SessionData sd = (SessionData)_cache.get(getCacheKey(id));
+                        reference.set(sd);
+                        //return sd;
+                   // });
                 }
                 catch (Exception e)
                 {
                     exception.set(new UnreadableSessionDataException(id, _context, e));
                 }
-            }
+            }      
         };
         
         //ensure the load runs in the context classloader scope

--- a/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/SessionDataMarshaller.java
+++ b/jetty-infinispan/src/main/java/org/eclipse/jetty/session/infinispan/SessionDataMarshaller.java
@@ -1,0 +1,115 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.session.infinispan;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ClassLoadingObjectInputStream;
+import org.eclipse.jetty.server.session.SessionData;
+import org.infinispan.protostream.MessageMarshaller;
+
+/**
+ * SessionDataMarshaller
+ *
+ * A marshaller for converting a SessionData object into protobuf format,
+ * which supports queries.
+ */
+public class SessionDataMarshaller implements MessageMarshaller<SessionData>
+{
+    @Override
+    public Class<? extends SessionData> getJavaClass()
+    {
+        return SessionData.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "org_eclipse_jetty_session_infinispan.SessionData";
+    }
+
+    @Override
+    public SessionData readFrom(ProtoStreamReader in) throws IOException
+    {
+        String id = in.readString("id"); //session id
+        String cpath = in.readString("contextPath"); //context path
+        String vhost = in.readString("vhost"); //first vhost
+
+        long accessed = in.readLong("accessed");//accessTime
+        long lastAccessed = in.readLong("lastAccessed"); //lastAccessTime
+        long created = in.readLong("created"); //time created
+        long cookieSet = in.readLong("cookieSet");//time cookie was set
+        String lastNode = in.readString("lastNode"); //name of last node managing
+  
+        long expiry = in.readLong("expiry"); 
+        long maxInactiveMs = in.readLong("maxInactiveMs");
+        
+        
+        byte[] attributeArray = in.readBytes("attributes");
+        ByteArrayInputStream bin = new ByteArrayInputStream(attributeArray);
+        
+        Map<String, Object> attributes;
+        try (ClassLoadingObjectInputStream ois = new ClassLoadingObjectInputStream(bin))
+        {
+            Object o = ois.readObject();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> a = Map.class.cast(o);
+            attributes = a;
+        }
+        catch(ClassNotFoundException e)
+        {
+            throw new IOException(e);
+        }
+
+        SessionData sd = new SessionData(id, cpath, vhost, created, accessed, lastAccessed, maxInactiveMs);
+        sd.putAllAttributes(attributes);
+        sd.setCookieSet(cookieSet);
+        sd.setLastNode(lastNode);
+        sd.setExpiry(expiry);
+        return sd;
+        
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter out, SessionData sdata) throws IOException
+    {
+        out.writeString("id", sdata.getId()); //session id
+        out.writeString("contextPath", sdata.getContextPath()); //context path
+        out.writeString("vhost", sdata.getVhost()); //first vhost
+
+        out.writeLong("accessed", sdata.getAccessed());//accessTime
+        out.writeLong("lastAccessed", sdata.getLastAccessed()); //lastAccessTime
+        out.writeLong("created", sdata.getCreated()); //time created
+        out.writeLong("cookieSet", sdata.getCookieSet());//time cookie was set
+        out.writeString("lastNode", sdata.getLastNode()); //name of last node managing
+  
+        out.writeLong("expiry", sdata.getExpiry()); 
+        out.writeLong("maxInactiveMs", sdata.getMaxInactiveMs());
+        
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ObjectOutputStream oout = new ObjectOutputStream(bout);
+        oout.writeObject(sdata.getAllAttributes());
+        out.writeBytes("attributes", bout.toByteArray()); 
+    }
+}

--- a/jetty-infinispan/src/main/resources/session.proto
+++ b/jetty-infinispan/src/main/resources/session.proto
@@ -1,0 +1,18 @@
+package org_eclipse_jetty_session_infinispan;
+
+message SessionData
+{
+    required string id = 1;
+    required string contextPath = 2;
+    required string vhost = 3;
+    
+    required sint64 accessed = 4;
+    required sint64 lastAccessed = 5;
+    required sint64 created = 6;
+    required sint64 cookieSet = 7;
+    required string lastNode = 8;
+      
+    required sint64 expiry = 9;
+    required sint64 maxInactiveMs = 10;
+    required bytes attributes = 11;
+}

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -114,6 +114,12 @@
       <version>9.1.0.Final</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-remote-query-client</artifactId>
+      <version>9.1.0.Final</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <!-- to test hotrod, configure a cache called "remote-session-test" -->

--- a/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/SessionDump.java
+++ b/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/SessionDump.java
@@ -31,6 +31,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.eclipse.jetty.util.MultiMap;
+
 /** 
  * Test Servlet Sessions.
  */
@@ -83,6 +85,7 @@ public class SessionDump extends HttpServlet
                 session = request.getSession(true);
                 session.setAttribute("test","value");
                 session.setAttribute("obj", new ObjectAttributeValue(System.currentTimeMillis()));
+                session.setAttribute("jettyobj", new MultiMap());
             }
             else if (session!=null)
             {


### PR DESCRIPTION
The default infinispan marshalling  uses the webapp context classloader to unmarshall all of the session attributes: if any of them are jetty classes these are hidden from the webapp classloader.  The solution here is to use the alternate infinispan protobuf marshalling, which in our impl uses our own serialization/deserialization for the session attributes. This de/serialization is the same for all of the other types of SessionDataStore eg jdbc, mongo, gcloud etc, so this change both brings infinispan into line with all the other SessionDataStores, and also solves the class visibility problem.