### PR TITLE
Issue #2936 - BadMessageException should be able to be handled by ErrorPageErrorHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Attributes;
@@ -195,8 +196,24 @@ public class Dispatcher implements RequestDispatcher
                 baseRequest.setContextPath(_contextHandler.getContextPath());
                 baseRequest.setServletPath(null);
                 baseRequest.setPathInfo(_pathInContext);
-                if (_uri.getQuery()!=null || old_uri.getQuery()!=null)
-                    baseRequest.mergeQueryParameters(old_uri.getQuery(),_uri.getQuery(), true);
+    
+                if (_uri.getQuery() != null || old_uri.getQuery() != null)
+                {
+                    try
+                    {
+                        baseRequest.mergeQueryParameters(old_uri.getQuery(), _uri.getQuery(), true);
+                    }
+                    catch (BadMessageException e)
+                    {
+                        // Only throw BME if not in Error Dispatch Mode
+                        // This allows application ErrorPageErrorHandler to handle BME messages
+                        Boolean inErrorDispatch = (Boolean) request.getAttribute(__ERROR_DISPATCH);
+                        if(inErrorDispatch == null || !inErrorDispatch)
+                        {
+                            throw e;
+                        }
+                    }
+                }
                 
                 baseRequest.setAttributes(attr);
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -36,9 +36,13 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.MultiMap;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 
 public class Dispatcher implements RequestDispatcher
 {
+    private static final Logger LOG = Log.getLogger(Dispatcher.class);
+    
     public final static String __ERROR_DISPATCH="org.eclipse.jetty.server.Dispatcher.ERROR";
     
     /** Dispatch include attribute names */
@@ -207,10 +211,13 @@ public class Dispatcher implements RequestDispatcher
                     {
                         // Only throw BME if not in Error Dispatch Mode
                         // This allows application ErrorPageErrorHandler to handle BME messages
-                        Boolean inErrorDispatch = (Boolean) request.getAttribute(__ERROR_DISPATCH);
-                        if(inErrorDispatch == null || !inErrorDispatch)
+                        if (dispatch != DispatcherType.ERROR)
                         {
                             throw e;
+                        }
+                        else
+                        {
+                            LOG.warn("Ignoring Original Bad Request Query String: " + old_uri, e);
                         }
                     }
                 }

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ErrorPageTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ErrorPageTest.java
@@ -92,7 +92,6 @@ public class ErrorPageTest
     public void testSendErrorClosedResponse() throws Exception
     {
         String response = _connector.getResponse("GET /fail-closed/ HTTP/1.0\r\n\r\n");
-        System.out.println(response);
         assertThat(response,Matchers.containsString("HTTP/1.1 599 599"));
         assertThat(response,Matchers.containsString("DISPATCH: ERROR"));
         assertThat(response,Matchers.containsString("ERROR_PAGE: /599"));
@@ -166,16 +165,19 @@ public class ErrorPageTest
     @Test
     public void testBadMessage() throws Exception
     {
-        String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad query encoding"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
-        assertThat(response, Matchers.containsString("ERROR_MESSAGE: Bad query encoding"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 400"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query encoding"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.servlet.ErrorPageTest$AppServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /app"));
-        assertThat(response, Matchers.containsString("getParameterMap()= {}"));
+        try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
+        {
+            String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
+            assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad query encoding"));
+            assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
+            assertThat(response, Matchers.containsString("ERROR_MESSAGE: Bad query encoding"));
+            assertThat(response, Matchers.containsString("ERROR_CODE: 400"));
+            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query encoding"));
+            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
+            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.servlet.ErrorPageTest$AppServlet-"));
+            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /app"));
+            assertThat(response, Matchers.containsString("getParameterMap()= {}"));
+        }
     }
 
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ErrorPageTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ErrorPageTest.java
@@ -167,11 +167,11 @@ public class ErrorPageTest
     public void testBadMessage() throws Exception
     {
         String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad Request"));
+        assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad query encoding"));
         assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
-        assertThat(response, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));
+        assertThat(response, Matchers.containsString("ERROR_MESSAGE: Bad query encoding"));
         assertThat(response, Matchers.containsString("ERROR_CODE: 400"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Unable to parse URI query"));
+        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query encoding"));
         assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
         assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.servlet.ErrorPageTest$AppServlet-"));
         assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /app"));


### PR DESCRIPTION
The BadMessageException occurring during the process outlined in Issue #2936 was not able to be handled by an ErrorPageErrorHandler.

This PR changes the `Dispatcher.error()` and subsequent `Dispatcher.forward()` to be forgiving on the `Request.mergeQueryParameters()` failure only during ERROR dispatch behaviors.