### PR TITLE
Issue #2938 - NPE fix for BufferingResponseListener

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/BufferingResponseListener.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/BufferingResponseListener.java
@@ -116,6 +116,10 @@ public abstract class BufferingResponseListener extends Listener.Adapter
     public void onContent(Response response, ByteBuffer content)
     {
         int length = content.remaining();
+        
+        if (length == 0)
+            return;
+        
         if (length > BufferUtil.space(buffer))
         {
             int requiredCapacity = buffer == null ? length : buffer.capacity() + length;


### PR DESCRIPTION
+ Only triggers if onContent() has 0 remaining buffer

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>