### PR TITLE
Jetty 9.3.x #2954 report cause

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractHttpClientTransport.java
@@ -135,6 +135,7 @@ public abstract class AbstractHttpClientTransport extends ContainerLifeCycle imp
             catch (IOException xx)
             {
                 LOG.ignore(xx);
+                x.addSuppressed(xx);
             }
             finally
             {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponseException.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponseException.java
@@ -26,7 +26,12 @@ public class HttpResponseException extends RuntimeException
 
     public HttpResponseException(String message, Response response)
     {
-        super(message);
+        this(message, response, null);
+    }
+    
+    public HttpResponseException(String message, Response response, Throwable cause)
+    {
+        super(message, cause);
         this.response = response;
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -303,12 +303,18 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     @Override
     public void badMessage(int status, String reason)
     {
+        badMessage(status, reason, null);
+    }
+    
+    @Override
+    public void badMessage(int status, String reason, Throwable cause)
+    {
         HttpExchange exchange = getHttpExchange();
         if (exchange != null)
         {
             HttpResponse response = exchange.getResponse();
             response.status(status).reason(reason);
-            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response));
+            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response, cause));
         }
     }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.util.FutureResponseListener;
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
@@ -204,6 +205,8 @@ public class HttpReceiverOverHTTPTest
         catch (ExecutionException e)
         {
             Assert.assertTrue(e.getCause() instanceof HttpResponseException);
+            Assert.assertTrue(e.getCause().getCause() instanceof BadMessageException);
+            Assert.assertTrue(e.getCause().getCause().getCause() instanceof NumberFormatException);
         }
     }
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -258,11 +258,14 @@ public class ManagedSelector extends AbstractLifeCycle implements Runnable, Dump
             }
             catch (Throwable x)
             {
-                closeNoExceptions(_selector);
                 if (isRunning())
                     LOG.warn(x);
                 else
+                {
+                    LOG.warn(x.toString());
                     LOG.debug(x);
+                }
+                closeNoExceptions(_selector);
             }
             return false;
         }


### PR DESCRIPTION
Issue #2954 report cause

This change has already mostly been made in 9.4, so essentially this is a back port.  However the
primary signature of HttpParser.Handler for badMessage has not been changed and a default method
used to handle the cause. This avoids breaking any usages of the interface.

Signed-off-by: Greg Wilkins <gregw@webtide.com>
