### PR TITLE
Issue #2702 - ArithmeticException in Credential.stringEquals and .byteEquals

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
@@ -105,7 +105,7 @@ public abstract class Credential implements Serializable
         int l1 = known.length();
         int l2 = unknown.length();
         for (int i = 0; i < l2; ++i)
-            result &= known.charAt(i%l1) == unknown.charAt(i);
+            result &= ((l1==0)?unknown.charAt(l2-i-1):known.charAt(i%l1)) == unknown.charAt(i);
         return result && l1 == l2;
     }
 
@@ -127,7 +127,7 @@ public abstract class Credential implements Serializable
         int l1 = known.length;
         int l2 = unknown.length;
         for (int i = 0; i < l2; ++i)
-            result &= known[i%l1] == unknown[i];
+            result &= ((l1==0)?unknown[l2-i-1]:known[i%l1]) == unknown[i];
         return result && l1 == l2;
     }
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/security/CredentialTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/security/CredentialTest.java
@@ -20,12 +20,12 @@
 package org.eclipse.jetty.util.security;
 
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.eclipse.jetty.util.security.Credential.Crypt;
 import org.eclipse.jetty.util.security.Credential.MD5;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -93,5 +93,21 @@ public class CredentialTest
         assertFalse(Credential.byteEquals("foo".getBytes(),"fooo".getBytes()));
         assertFalse(Credential.byteEquals("foo".getBytes(),"fo".getBytes()));
         assertFalse(Credential.byteEquals("foo".getBytes(),"bar".getBytes()));
+    }
+
+    @Test
+    public void testEmptyString()
+    {
+        assertFalse(Credential.stringEquals("fooo",""));
+        assertFalse(Credential.stringEquals("","fooo"));
+        assertTrue(Credential.stringEquals("",""));
+    }
+
+    @Test
+    public void testEmptyBytes()
+    {
+        assertFalse(Credential.byteEquals("fooo".getBytes(),"".getBytes()));
+        assertFalse(Credential.byteEquals("".getBytes(),"fooo".getBytes()));
+        assertTrue(Credential.byteEquals("".getBytes(),"".getBytes()));
     }
 }


### PR DESCRIPTION
fixes ArithmeticException in Credential.stringEquals and .byteEquals when given empty known string

Closes #2702 