### PR TITLE
Improve error message when binding to in-use port

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.server;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -336,7 +337,11 @@ public class ServerConnector extends AbstractNetworkConnector
 
             InetSocketAddress bindAddress = getHost() == null ? new InetSocketAddress(getPort()) : new InetSocketAddress(getHost(), getPort());
             serverChannel.socket().setReuseAddress(getReuseAddress());
-            serverChannel.socket().bind(bindAddress, getAcceptQueueSize());
+            try {
+                serverChannel.socket().bind(bindAddress, getAcceptQueueSize());
+            } catch (BindException e) {
+                throw new IOException("Failed to bind to " + bindAddress, e);
+            }
         }
 
         return serverChannel;


### PR DESCRIPTION
This change adds context information when BindExceptions are thrown, so that users who see the stack trace know which port it was that the application attempted to bind (which in a complex deployment may not be obvious).