### PR TITLE
Fix RFC 2965 cookie compliance

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
@@ -139,13 +139,12 @@ public class CookieCutterTest
      * Example from RFC2965
      */
     @Test
-    @Disabled("comma separation no longer supported by new RFC6265")
     public void testRFC2965_CookieSpoofingExample()
     {
         String rawCookie = "$Version=\"1\"; session_id=\"1234\", " +
                 "$Version=\"1\"; session_id=\"1111\"; $Domain=\".cracker.edu\"";
         
-        Cookie cookies[] = parseCookieHeaders(CookieCompliance.RFC6265,rawCookie);
+        Cookie cookies[] = parseCookieHeaders(CookieCompliance.RFC2965,rawCookie);
         
         assertThat("Cookies.length", cookies.length, is(2));
         assertCookie("Cookies[0]", cookies[0], "session_id", "1234", 1, null);


### PR DESCRIPTION
When RFC 2965 cookie compliance was set,
the comma character ',' was not recognized
as a separator.

Since the original implementation was quite
complex and the fix would add additional
complexity, I decided to refactor the parsing
algorithm.

Signed-off-by: Jan Borik <janborik5@gmail.com>