### PR TITLE
Issue #2325 - Allow form limits to be set via context-params

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -504,6 +504,19 @@ public class Request implements HttpServletRequest
             {
                 maxFormContentSize = _context.getContextHandler().getMaxFormContentSize();
                 maxFormKeys = _context.getContextHandler().getMaxFormKeys();
+
+                if (maxFormContentSize < 0)
+                {
+                    String str = _context.getInitParameter("org.eclipse.jetty.server.Request.maxFormContentSize");
+                    if (str != null)
+                        maxFormContentSize = Integer.parseInt(str.trim());
+                }
+                if (maxFormKeys < 0)
+                {
+                    String str = _context.getInitParameter("org.eclipse.jetty.server.Request.maxFormKeys");
+                    if (str != null)
+                        maxFormKeys = Integer.parseInt(str.trim());
+                }
             }
 
             if (maxFormContentSize < 0)

--- a/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebAppContextTest.java
+++ b/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebAppContextTest.java
@@ -135,12 +135,16 @@ public class WebAppContextTest
         server.start();
 
         // Generate a Form request exceeding maxFormContentSize
-        String content = "name1=test&name2=test2&name3=&name4=test";
-        String request = "POST /test/dsd HTTP/1.1\r\n" + //
+        int contentLength = 300;
+        StringBuilder content = new StringBuilder();
+        for (int i = 0; i < contentLength; i++)
+            content.append("a");
+
+        String request = "POST /test/form HTTP/1.1\r\n" + //
                 "Host: whatever\r\n" + //
                 "Content-Type: " + MimeTypes.Type.FORM_ENCODED.asString() + "\r\n" + //
-                "Content-Length: " + 300 + "\r\n" + //
-                "Connection: close\r\n" + "\r\n" + content;
+                "Content-Length: " + contentLength + "\r\n" + //
+                "Connection: close\r\n" + "\r\n" + content.toString();
 
         String res = connector.getResponse(request);
         assertTrue(res.contains("Form too large"));

--- a/jetty-webapp/src/test/resources/web_maxform.xml
+++ b/jetty-webapp/src/test/resources/web_maxform.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+  version="3.1">
+  <context-param>
+    <param-name>org.eclipse.jetty.server.Request.maxFormContentSize</param-name>
+    <param-value>100</param-value>
+  </context-param>
+  <context-param>
+    <param-name>org.eclipse.jetty.server.Request.maxFormKeys</param-name>
+    <param-value>100</param-value>
+  </context-param>
+</web-app>


### PR DESCRIPTION
I assumed the context xml file would be checked first and if maxFormContentSize or maxFormKeys are not set, web.inf will be checked next.