### PR TITLE
Support direct buffers in hpack

### DIFF
--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/Huffman.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/Huffman.java
@@ -350,23 +350,16 @@ public class Huffman
         return decode(buffer,buffer.remaining());
     }
 
-    public static String decode(ByteBuffer buffer,int length) throws HpackException.CompressionException
+    public static String decode(ByteBuffer buffer, int length) throws HpackException.CompressionException
     {        
         StringBuilder out = new StringBuilder(length*2);
         int node = 0;
         int current = 0;
         int bits = 0;
 
-        byte[] array = buffer.array();
-        int position=buffer.position();
-        int start=buffer.arrayOffset()+position;
-        int end=start+length;
-        buffer.position(position+length);
-
-
-        for (int i=start; i<end; i++)
+        for (int i=0; i<length; i++)
         {
-            int b = array[i]&0xFF;
+            int b = buffer.get()&0xFF;
             current = (current << 8) | b;
             bits += 8;
             while (bits >= 8) 
@@ -460,10 +453,6 @@ public class Huffman
     {
         long current = 0;
         int n = 0;
-
-        byte[] array = buffer.array();
-        int p=buffer.arrayOffset()+buffer.position();
-
         int len = s.length();
         for (int i=0;i<len;i++)
         {
@@ -480,18 +469,17 @@ public class Huffman
             while (n >= 8) 
             {
                 n -= 8;
-                array[p++]=(byte)(current >> n);
+                buffer.put((byte)(current >> n));
             }
         }
 
-        if (n > 0) 
+        if (n > 0)
         {
-          current <<= (8 - n);
-          current |= (0xFF >>> n); 
-          array[p++]=(byte)current;
+            current <<= (8 - n);
+            current |= (0xFF >>> n);
+            buffer.put((byte)(current));
         }
-        
-        buffer.position(p-buffer.arrayOffset());
+
     }
 
 }

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
@@ -19,10 +19,9 @@
 package org.eclipse.jetty.http2.hpack;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.ByteBuffer;
@@ -51,7 +50,7 @@ public class HpackTest
     {
         HpackEncoder encoder = new HpackEncoder();
         HpackDecoder decoder = new HpackDecoder(4096,8192);
-        ByteBuffer buffer = BufferUtil.allocate(16*1024);
+        ByteBuffer buffer = BufferUtil.allocateDirect(16*1024);
         
         HttpFields fields0 = new HttpFields();
         fields0.add(HttpHeader.CONTENT_TYPE,"text/html");
@@ -104,7 +103,7 @@ public class HpackTest
     {
         HpackEncoder encoder = new HpackEncoder();
         HpackDecoder decoder = new HpackDecoder(4096,164);
-        ByteBuffer buffer = BufferUtil.allocate(16*1024);
+        ByteBuffer buffer = BufferUtil.allocateDirect(16*1024);
         
         HttpFields fields0 = new HttpFields();
         fields0.add("1234567890","1234567890123456789012345678901234567890");
@@ -144,7 +143,7 @@ public class HpackTest
     {
         HpackEncoder encoder = new HpackEncoder(200,200);
         HpackDecoder decoder = new HpackDecoder(200,1024);
-        ByteBuffer buffer = BufferUtil.allocate(16*1024);
+        ByteBuffer buffer = BufferUtil.allocateDirect(16*1024);
         
         HttpFields fields0 = new HttpFields();
         fields0.add("123456789012345678901234567890123456788901234567890","value");

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HuffmanTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HuffmanTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.http2.hpack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -79,7 +80,7 @@ public class HuffmanTest
         assertThrows(IllegalArgumentException.class,
                 () -> Huffman.octetsNeeded(s));
 
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(BufferOverflowException.class,
                 () -> Huffman.encode(BufferUtil.allocate(32), s));
     }
 }

--- a/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ByteBufferBenchmark.java
+++ b/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ByteBufferBenchmark.java
@@ -1,0 +1,154 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2018 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.io.jmh;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class ByteBufferBenchmark
+{
+    public long test(ByteBuffer buffer)
+    {
+        buffer.clear();
+        while(buffer.hasRemaining())
+        {
+            int size = ThreadLocalRandom.current().nextInt(1024);
+            byte[] bytes = new byte[size];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            buffer.put(bytes,0,Math.min(bytes.length,buffer.remaining()));
+        }
+
+        buffer.flip();
+
+        long sum = 0;
+        while(buffer.hasRemaining())
+            sum += buffer.get();
+
+        return sum;
+    }
+
+
+    public long testArray(ByteBuffer buffer)
+    {
+        buffer.clear();
+        byte[] array = buffer.array();
+        int offset = buffer.arrayOffset();
+        int end = offset + buffer.remaining();
+        while(offset<end)
+        {
+            int size = ThreadLocalRandom.current().nextInt(1024);
+            byte[] bytes = new byte[size];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            System.arraycopy(bytes,0,array,offset,Math.min(bytes.length,end-offset));
+            offset += bytes.length;
+        }
+        buffer.position(buffer.limit());
+        buffer.flip();
+
+        long sum = 0;
+        array = buffer.array();
+        offset = buffer.arrayOffset();
+        end = offset + buffer.remaining();
+
+        while(offset<end)
+            sum += array[offset++];
+        buffer.position(buffer.limit());
+        return sum;
+    }
+
+
+
+    @Benchmark
+    @BenchmarkMode({ Mode.Throughput})
+    public long testDirect()
+    {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(32768);
+        long sum = 0;
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        return sum;
+    }
+
+
+    @Benchmark
+    @BenchmarkMode({ Mode.Throughput})
+    public long testInDirect()
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(32768);
+        long sum = 0;
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        sum ^= test(buffer);
+        return sum;
+    }
+
+    @Benchmark
+    @BenchmarkMode({ Mode.Throughput})
+    public long testInDirectArray()
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(32768);
+        long sum = 0;
+        sum ^= testArray(buffer);
+        sum ^= testArray(buffer);
+        sum ^= testArray(buffer);
+        sum ^= testArray(buffer);
+        sum ^= testArray(buffer);
+        return sum;
+    }
+
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(ByteBufferBenchmark.class.getSimpleName())
+            .warmupIterations(20)
+            .measurementIterations(10)
+            // .addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(10)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+}


### PR DESCRIPTION
Testing indicates that there is no longer any performance advantage to using arrays to access byte buffer, so this PR adds direct buffer support to HPACK so HTTP2 can use direct buffers

Signed-off-by: Greg Wilkins <gregw@webtide.com>