### PR TITLE
Revert backport of HttpClient executor bean handling.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -204,6 +204,7 @@ public class HttpClient extends ContainerLifeCycle
     @Override
     protected void doStart() throws Exception
     {
+        // TODO use #addBean in constructor?
         if (sslContextFactory != null)
             addBean(sslContextFactory);
 
@@ -212,18 +213,21 @@ public class HttpClient extends ContainerLifeCycle
             QueuedThreadPool threadPool = new QueuedThreadPool();
             threadPool.setName(name);
             executor = threadPool;
-            addBean(executor);
         }
+        // TODO use #updateBean in #setExecutor
+        addBean(executor);
         
         if (byteBufferPool == null)
             byteBufferPool = new MappedByteBufferPool(2048,
                 executor instanceof ThreadPool.SizedThreadPool
                     ? ((ThreadPool.SizedThreadPool)executor).getMaxThreads()/2
                     : ProcessorUtils.availableProcessors()*2);
+        // TODO use #updateBean in #setByteBufferPool?
         addBean(byteBufferPool);
 
         if (scheduler == null)
             scheduler = new ScheduledExecutorScheduler(name + "-scheduler", false);
+        // TODO use #updateBean in #setScheduler?
         addBean(scheduler);
 
         transport.setHttpClient(this);
@@ -796,7 +800,8 @@ public class HttpClient extends ContainerLifeCycle
      */
     public void setExecutor(Executor executor)
     {
-        updateBean(this.executor, executor);
+        if (isRunning())
+            LOG.warn("setExecutor called when in {} state",getState());
         this.executor = executor;
     }
 

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -603,9 +603,9 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
     }
 
     /**
-     * @param bindAddress
-     *            the address to bind to
-     * @deprecated (this is a bad bad bad typo) use {@link #setBindAddress(SocketAddress)} instead
+     * @param bindAddress the address to bind to
+     * @deprecated (this is a bad bad bad typo) use {@link HttpClient#setBindAddress(SocketAddress)}
+     * on instance passed to {@link #WebSocketClient(HttpClient)}
      */
     @Deprecated
     public void setBindAdddress(SocketAddress bindAddress)
@@ -613,11 +613,23 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
         setBindAddress(bindAddress);
     }
 
+
+    /**
+     * @param bindAddress the address to bind to
+     * @deprecated Use {@link HttpClient#setBindAddress(SocketAddress)}
+     * on instance passed to {@link #WebSocketClient(HttpClient)}
+     */
+    @Deprecated
     public void setBindAddress(SocketAddress bindAddress)
     {
         this.httpClient.setBindAddress(bindAddress);
     }
 
+    /**
+     * @param bufferPool The buffer pool
+     * @deprecated Use {@link HttpClient#setByteBufferPool(ByteBufferPool)}
+     * on the instance passed to {@link #WebSocketClient(HttpClient)}
+     */
     public void setBufferPool(ByteBufferPool bufferPool)
     {
         this.httpClient.setByteBufferPool(bufferPool);
@@ -625,15 +637,21 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
 
     /**
      * Set the timeout for connecting to the remote server.
-     *
-     * @param ms
-     *            the timeout in milliseconds
+     * @param ms the timeout in millisecondspool
+     * @deprecated Use {@link HttpClient#setConnectTimeout(long)}
+     * on the instance passed to {@link #WebSocketClient(HttpClient)}
      */
     public void setConnectTimeout(long ms)
     {
         this.httpClient.setConnectTimeout(ms);
     }
 
+    /**
+     * @param cookieStore The cookie store
+     * @deprecated Use {@link HttpClient#setCookieStore(CookieStore)} on the HttpClient instance passed
+     * to {@link #WebSocketClient(HttpClient)}
+     */
+    @Deprecated
     public void setCookieStore(CookieStore cookieStore)
     {
         this.httpClient.setCookieStore(cookieStore);
@@ -655,6 +673,12 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
         this.httpClient.setDispatchIO(dispatchIO);
     }
 
+    /**
+     * @param executor The executor to use
+     * @deprecated Use {@link HttpClient#setExecutor(Executor)}
+     * on the instance passed to {@link #WebSocketClient(HttpClient)}
+     */
+    @Deprecated
     public void setExecutor(Executor executor)
     {
         this.httpClient.setExecutor(executor);
@@ -680,8 +704,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
      * <p>
      * Existing connections will not have their max idle timeout adjusted.
      *
-     * @param ms
-     *            the timeout in milliseconds
+     * @param ms the timeout in milliseconds
      */
     public void setMaxIdleTimeout(long ms)
     {


### PR DESCRIPTION
Revert to the not-so-good bean handling for the HttpClient executor
Added TODOs so that the bean handling can be updated in future.
Deprecated Websocket client setters that hide dependency on internal HttpClient instance.

Signed-off-by: Greg Wilkins <gregw@webtide.com>