### PR TITLE
Fixes #3090 - MBeanContainer throws NPE for arrays.

### DIFF
--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanTest.java
@@ -24,6 +24,7 @@ import javax.management.Attribute;
 import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
+import javax.management.ObjectName;
 
 import com.acme.Derived;
 import com.acme.Managed;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -52,6 +54,46 @@ public class ObjectMBeanTest
     {
         container.destroy();
         container = null;
+    }
+
+    @Test
+    public void testMBeanForNull()
+    {
+        Object mBean = container.mbeanFor(null);
+        assertNull(mBean);
+    }
+
+    @Test
+    public void testMBeanForString()
+    {
+        String obj = "foo";
+        Object mbean = container.mbeanFor(obj);
+        assertNotNull(mbean);
+        container.beanAdded(null, obj);
+        ObjectName objectName = container.findMBean(obj);
+        assertNotNull(objectName);
+    }
+
+    @Test
+    public void testMBeanForStringArray()
+    {
+        String[] obj = {"a", "b"};
+        Object mbean = container.mbeanFor(obj);
+        assertNotNull(mbean);
+        container.beanAdded(null, obj);
+        ObjectName objectName = container.findMBean(obj);
+        assertNotNull(objectName);
+    }
+
+    @Test
+    public void testMBeanForIntArray()
+    {
+        int[] obj = {0, 1, 2};
+        Object mbean = container.mbeanFor(obj);
+        assertNotNull(mbean);
+        container.beanAdded(null, obj);
+        ObjectName objectName = container.findMBean(obj);
+        assertNotNull(objectName);
     }
 
     @Test

--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanUtilTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ObjectMBeanUtilTest.java
@@ -71,13 +71,6 @@ public class ObjectMBeanUtilTest
     }
 
     @Test
-    public void testMbeanForNullCheck()
-    {
-        Object mBean = container.mbeanFor(null);
-        assertNull(mBean, "As we are passing null value the output should be null");
-    }
-
-    @Test
     public void testGetAttributeMBeanException() throws Exception
     {
         Attribute attribute = new Attribute("doodle4", "charu");
@@ -151,7 +144,7 @@ public class ObjectMBeanUtilTest
     }
 
     @Test
-    public void testSetAttributesForCollectionTypeAttribue() throws Exception
+    public void testSetAttributesForCollectionTypeAttribute() throws Exception
     {
         ArrayList<Derived> aliasNames = new ArrayList<>(Arrays.asList(getArrayTypeAttribute()));
 
@@ -231,7 +224,7 @@ public class ObjectMBeanUtilTest
         ReflectionException e = assertThrows(ReflectionException.class, () ->
                 objectMBean.invoke("good", new Object[0], new String[]{"int aone"}));
 
-        assertNotNull(e, "An ReflectionException must have occurred by now as we cannot call a methow with wrong signature");
+        assertNotNull(e, "A ReflectionException must have occurred by now as we cannot call a method with wrong signature");
     }
 
     @Test


### PR DESCRIPTION
Issue #3090.
Corrected places that were making unguarded calls to Class.getPackage().
Added tests for various array cases.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>