### PR TITLE
Using new Declarative Jenkinsfile format

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,94 +1,96 @@
 #!groovy
 
-def mainJdk = "jdk8"
-def jdks = [mainJdk, "jdk11"]
-def oss = ["linux"]
-def builds = [:]
-for (def os in oss) {
-  for (def jdk in jdks) {
-    builds[os+"_"+jdk] = getFullBuild( jdk, os, mainJdk == jdk )
-  }
-}
+pipeline {
+  agent any
+  stages {
+    stage("Parallel Stage") {
+      parallel {
+        stage("Build / Test - JDK8") {
+          agent { node { label 'linux' } }
+          options { timeout(time: 120, unit: 'MINUTES') }
+          steps {
+            mavenBuild("jdk8", "-Pmongodb install")
+            junit '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml'
+            // Collect up the jacoco execution results (only on main build)
+            jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
+                exclusionPattern: '' +
+                    // build tools
+                    '**/org/eclipse/jetty/ant/**' +
+                    ',**/org/eclipse/jetty/maven/**' +
+                    ',**/org/eclipse/jetty/jspc/**' +
+                    // example code / documentation
+                    ',**/org/eclipse/jetty/embedded/**' +
+                    ',**/org/eclipse/jetty/asyncrest/**' +
+                    ',**/org/eclipse/jetty/demo/**' +
+                    // special environments / late integrations
+                    ',**/org/eclipse/jetty/gcloud/**' +
+                    ',**/org/eclipse/jetty/infinispan/**' +
+                    ',**/org/eclipse/jetty/osgi/**' +
+                    ',**/org/eclipse/jetty/spring/**' +
+                    ',**/org/eclipse/jetty/http/spi/**' +
+                    // test classes
+                    ',**/org/eclipse/jetty/tests/**' +
+                    ',**/org/eclipse/jetty/test/**',
+                execPattern: '**/target/jacoco.exec',
+                classPattern: '**/target/classes',
+                sourcePattern: '**/src/main/java'
+            warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
 
-parallel builds
-
-def getFullBuild(jdk, os, mainJdk) {
-  return {
-    node(os) {
-      // System Dependent Locations
-      def mvnName = 'maven3.5'
-      def localRepo = "${env.JENKINS_HOME}/${env.EXECUTOR_NUMBER}" // ".repository" //
-      def settingsName = 'oss-settings.xml'
-      def mavenOpts = '-Xms1g -Xmx4g -Djava.awt.headless=true'
-
-      stage("Build / Test - $jdk") {
-        timeout(time: 120, unit: 'MINUTES') {
-          // Checkout
-          checkout scm
-          withMaven(
-                  maven: mvnName,
-                  jdk: "$jdk",
-                  publisherStrategy: 'EXPLICIT',
-                  globalMavenSettingsConfig: settingsName,
-                  mavenOpts: mavenOpts,
-                  mavenLocalRepo: localRepo) {
-            // Testing
-            sh "mvn -V -B install -Dmaven.test.failure.ignore=true -T5 -e -Djetty.testtracker.log=true -Pmongodb -Dunix.socket.tmp=" + env.JENKINS_HOME
-            // Javadoc only
-            sh "mvn -V -B javadoc:javadoc -T6 -e -Dmaven.test.failure.ignore=false"
+            script {
+              step([$class         : 'MavenInvokerRecorder', reportsFilenamePattern: "**/target/invoker-reports/BUILD*.xml",
+                    invokerBuildDir: "**/target/its"])
+            }
           }
         }
 
-        // Report failures in the jenkins UI
-        junit testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml'
-        consoleParsers = [[parserName: 'JavaDoc'],
-                          [parserName: 'JavaC']]
-
-        if (mainJdk) {
-          // Collect up the jacoco execution results
-          def jacocoExcludes =
-                  // build tools
-                  "**/org/eclipse/jetty/ant/**" + ",**/org/eclipse/jetty/maven/**" +
-                          ",**/org/eclipse/jetty/jspc/**" +
-                          // example code / documentation
-                          ",**/org/eclipse/jetty/embedded/**" + ",**/org/eclipse/jetty/asyncrest/**" +
-                          ",**/org/eclipse/jetty/demo/**" +
-                          // special environments / late integrations
-                          ",**/org/eclipse/jetty/gcloud/**" + ",**/org/eclipse/jetty/infinispan/**" +
-                          ",**/org/eclipse/jetty/osgi/**" + ",**/org/eclipse/jetty/spring/**" +
-                          ",**/org/eclipse/jetty/http/spi/**" +
-                          // test classes
-                          ",**/org/eclipse/jetty/tests/**" + ",**/org/eclipse/jetty/test/**"
-          jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
-                 exclusionPattern: jacocoExcludes,
-                 execPattern: '**/target/jacoco.exec',
-                 classPattern: '**/target/classes',
-                 sourcePattern: '**/src/main/java'
-          consoleParsers = [[parserName: 'Maven'],
-                            [parserName: 'JavaDoc'],
-                            [parserName: 'JavaC']]
-
-          step([$class: 'MavenInvokerRecorder', reportsFilenamePattern: "**/target/invoker-reports/BUILD*.xml",
-                invokerBuildDir: "**/target/its"])
+        stage("Build / Test - JDK11") {
+          agent { node { label 'linux' } }
+          options { timeout(time: 120, unit: 'MINUTES') }
+          steps {
+            mavenBuild("jdk11", "-Pmongodb install")
+            junit '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml'
+            warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
+          }
         }
 
-        // Report on Maven and Javadoc warnings
-        step([$class        : 'WarningsPublisher',
-              consoleParsers: consoleParsers])
-      }
+        stage("Build Javadoc") {
+          agent { node { label 'linux' } }
+          options { timeout(time: 30, unit: 'MINUTES') }
+          steps {
+            mavenBuild("jdk8", "javadoc:javadoc")
+            warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'JavaDoc'], [parserName: 'Java']]
+          }
+        }
 
-      stage ("Compact3 - ${jdk}") {
-        withMaven(
-            maven: mvnName,
-            jdk: "$jdk",
-            publisherStrategy: 'EXPLICIT',
-            globalMavenSettingsConfig: settingsName,
-            mavenOpts: mavenOpts,
-            mavenLocalRepo: localRepo) {
-          sh "mvn -f aggregates/jetty-all-compact3 -V -B -Pcompact3 clean install -T6"
+        stage("Build Compact3") {
+          agent { node { label 'linux' } }
+          options { timeout(time: 120, unit: 'MINUTES') }
+          steps {
+            mavenBuild("jdk8", "-Pcompact3 package")
+            warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
+          }
         }
       }
     }
+  }
+}
+
+
+def mavenBuild(jdk, cmdline) {
+  def mvnName = 'maven3.5'
+  def localRepo = "${env.JENKINS_HOME}/${env.EXECUTOR_NUMBER}" // ".repository" //
+  def settingsName = 'oss-settings.xml'
+  def mavenOpts = '-Xms1g -Xmx4g -Djava.awt.headless=true'
+
+  withMaven(
+      maven: mvnName,
+      jdk: "$jdk",
+      publisherStrategy: 'EXPLICIT',
+      globalMavenSettingsConfig: settingsName,
+      mavenOpts: mavenOpts,
+      mavenLocalRepo: localRepo) {
+    // Some common Maven command line + provided command line
+    sh "mvn -V -B -T3 -e -Dmaven.test.failure.ignore=true -Djetty.testtracker.log=true $cmdline -Dunix.socket.tmp=" + env.JENKINS_HOME
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
           agent { node { label 'linux' } }
           options { timeout(time: 30, unit: 'MINUTES') }
           steps {
-            mavenBuild("jdk8", "javadoc:javadoc")
+            mavenBuild("jdk8", "install javadoc:javadoc -DskipTests")
             warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'JavaDoc'], [parserName: 'Java']]
           }
         }
@@ -66,7 +66,7 @@ pipeline {
           agent { node { label 'linux' } }
           options { timeout(time: 120, unit: 'MINUTES') }
           steps {
-            mavenBuild("jdk8", "-Pcompact3 package")
+            mavenBuild("jdk8", "-Pcompact3 install -DskipTests")
             warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
           }
         }
@@ -75,7 +75,15 @@ pipeline {
   }
 }
 
-
+/**
+ * To other developers, if you are using this method above, please use the following syntax.
+ *
+ * mavenBuild("<jdk>", "<profiles> <goals> <plugins> <properties>"
+ *
+ * @param jdk the jdk tool name (in jenkins) to use for this build
+ * @param cmdline the command line in "<profiles> <goals> <properties>"`format.
+ * @return the Jenkinsfile step representing a maven build
+ */
 def mavenBuild(jdk, cmdline) {
   def mvnName = 'maven3.5'
   def localRepo = "${env.JENKINS_HOME}/${env.EXECUTOR_NUMBER}" // ".repository" //


### PR DESCRIPTION
+ Makes things easier to maintain.
+ Does not solve for bad "unstable" flagging of multiple
  stages when only one is failing.
  See: https://issues.jenkins-ci.org/browse/JENKINS-39203
  But this Declarative format will help once that bug is fixed.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>