### PR TITLE
copying base resources must happen when preparing packaging 

### DIFF
--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -29,7 +29,7 @@
         <executions>
           <execution>
             <id>copy-base-assembly-tree</id>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>


### PR DESCRIPTION
we must not rely on id.
This was preventing having the logs directory within the distribution.

Signed-off-by: olivier lamy <oliver.lamy@gmail.com>