### PR TITLE
Bring back packageRoot parameter in jetty-jspc-maven-plugin

### DIFF
--- a/jetty-jspc-maven-plugin/src/it/package-root/invoker.properties
+++ b/jetty-jspc-maven-plugin/src/it/package-root/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = test -fae
+invoker.debug = true

--- a/jetty-jspc-maven-plugin/src/it/package-root/pom.xml
+++ b/jetty-jspc-maven-plugin/src/it/package-root/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.jetty.its.jspc</groupId>
+  <artifactId>simple-jsp</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Jetty :: Simple Jsp</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+    <jetty.version>@project.version@</jetty.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-jspc-maven-plugin</artifactId>
+        <version>${jetty.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jspc</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <jspc>
+                <package>org.eclipse.jetty.test</package>
+              </jspc>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jetty-jspc-maven-plugin/src/it/package-root/postbuild.groovy
+++ b/jetty-jspc-maven-plugin/src/it/package-root/postbuild.groovy
@@ -1,0 +1,9 @@
+
+
+System.out.println( "running postbuild.groovy" )
+
+File file = new File( basedir, "target/classes/org/eclipse/jetty/test/foo_jsp.class" );
+if ( !file.isFile() )
+{
+    throw new FileNotFoundException( "Could not find generated class in the proper package name: " + file );
+}

--- a/jetty-jspc-maven-plugin/src/it/package-root/src/main/webapp/foo.jsp
+++ b/jetty-jspc-maven-plugin/src/it/package-root/src/main/webapp/foo.jsp
@@ -1,0 +1,23 @@
+<html><head>
+<%@ page import="java.util.Enumeration" %>
+</head><body>
+<h1>JSP Dump</h1>
+
+<table border="1">
+<tr><th>Request URI:</th><td><%= request.getRequestURI() %></td></tr>
+<tr><th>ServletPath:</th><td><%= request.getServletPath() %></td></tr>
+<tr><th>PathInfo:</th><td><%= request.getPathInfo() %></td></tr>
+
+<%
+   Enumeration e =request.getParameterNames();
+   while(e.hasMoreElements())
+   {
+       String name = (String)e.nextElement();
+%>
+<tr>
+  <th>getParameter("<%= name %>")</th>
+  <td><%= request.getParameter(name) %></td></tr>
+<% } %>
+
+</table>
+</body></html>

--- a/jetty-jspc-maven-plugin/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
+++ b/jetty-jspc-maven-plugin/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
@@ -42,7 +42,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -137,7 +136,7 @@ public class JspcMojo extends AbstractMojo
      * @since jetty-7.6.3
      */
     @Parameter(defaultValue = "${project.artifacts}", readonly = true)
-    private Set projectArtifacts;
+    private Set<Artifact> projectArtifacts;
     
     
     /**
@@ -152,7 +151,7 @@ public class JspcMojo extends AbstractMojo
      * The artifacts for the plugin itself.
      */
     @Parameter(defaultValue = "${plugin.artifacts}", readonly = true)
-    private List pluginArtifacts;
+    private List<Artifact> pluginArtifacts;
     
     
     /**
@@ -336,7 +335,7 @@ public class JspcMojo extends AbstractMojo
             jspc = new JettyJspC();
         
 
-        jspc.setWebXmlFragment(webXmlFragment);
+        jspc.setWebXmlInclude(webXmlFragment);
         jspc.setUriroot(webAppSourceDirectory);     
         jspc.setOutputDir(generatedClasses);
         jspc.setClassLoader(fakeWebAppClassLoader);
@@ -373,7 +372,7 @@ public class JspcMojo extends AbstractMojo
     private String getJspFiles(String webAppSourceDirectory)
     throws Exception
     {
-        List fileNames =  FileUtils.getFileNames(new File(webAppSourceDirectory),includes, excludes, false);
+        List<String> fileNames =  FileUtils.getFileNames(new File(webAppSourceDirectory),includes, excludes, false);
         return StringUtils.join(fileNames.toArray(new String[0]), ",");
 
     }
@@ -532,7 +531,7 @@ public class JspcMojo extends AbstractMojo
         //add the dependencies of the webapp (which will form WEB-INF/lib)
         for (Iterator<Artifact> iter = project.getArtifacts().iterator(); iter.hasNext();)
         {
-            Artifact artifact = (Artifact)iter.next();
+            Artifact artifact = iter.next();
 
             // Include runtime and compile time libraries
             if (!Artifact.SCOPE_TEST.equals(artifact.getScope()) && !Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))


### PR DESCRIPTION
Fixes #3156 . First patch is a general cleanup the other one restores the packageRoot parameter implementation.