### PR TITLE
Jetty 10.0.x fix surefire arg line (to avoid locale dependent build)

### DIFF
--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.alpn.java.server=org.eclipse.jetty.server
           </argLine>
         </configuration>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.alpn.java.server=org.eclipse.jetty.server
           </argLine>
         </configuration>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.alpn.java.server=org.eclipse.jetty.server
           </argLine>
         </configuration>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.alpn.java.server=org.eclipse.jetty.server
           </argLine>
         </configuration>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-opens org.eclipse.jetty.annotations/org.eclipse.jetty.annotations.resources=org.eclipse.jetty.plus
           </argLine>
         </configuration>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-opens org.eclipse.jetty.annotations/org.eclipse.jetty.annotations.resources=org.eclipse.jetty.plus
           </argLine>
         </configuration>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-opens org.eclipse.jetty.annotations/org.eclipse.jetty.annotations.resources=org.eclipse.jetty.plus
           </argLine>
         </configuration>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-opens org.eclipse.jetty.annotations/org.eclipse.jetty.annotations.resources=org.eclipse.jetty.plus
           </argLine>
         </configuration>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -19,7 +19,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.client=javax.servlet.api
             --add-modules java.security.jgss
             --add-modules javax.servlet.api

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -19,7 +19,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.client=javax.servlet.api
             --add-modules java.security.jgss
             --add-modules javax.servlet.api

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -19,7 +19,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.client=javax.servlet.api
             --add-modules java.security.jgss
             --add-modules javax.servlet.api

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -19,7 +19,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.client=javax.servlet.api
             --add-modules java.security.jgss
             --add-modules javax.servlet.api

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} ${surefire.base.argLine}
             --add-modules org.eclipse.jetty.jmx
             --add-reads org.eclipse.jetty.deploy=org.eclipse.jetty.http
           </argLine>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-modules org.eclipse.jetty.jmx
             --add-reads org.eclipse.jetty.deploy=org.eclipse.jetty.http
           </argLine>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-modules org.eclipse.jetty.jmx
             --add-reads org.eclipse.jetty.deploy=org.eclipse.jetty.http
           </argLine>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -44,7 +44,10 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-modules javax.servlet.api</argLine>
+          <argLine>
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            --add-modules javax.servlet.api
+          </argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -45,7 +45,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-modules javax.servlet.api
           </argLine>
         </configuration>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -45,7 +45,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-modules javax.servlet.api
           </argLine>
         </configuration>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -45,7 +45,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-modules javax.servlet.api
           </argLine>
         </configuration>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.http2.client=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.http2.client=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.http2.client=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.http2.client=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.http2.http.client.transport=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.http2.http.client.transport=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.http2.http.client.transport=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.http2.http.client.transport=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.http2.server=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.http2.server=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.http2.server=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.http2.server=javax.servlet.api
             --add-modules javax.servlet.api
           </argLine>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -18,7 +18,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.jmx=ALL-UNNAMED
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.util.log.jmx=ALL-UNNAMED
           </argLine>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -18,7 +18,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.jmx=ALL-UNNAMED
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.util.log.jmx=ALL-UNNAMED
           </argLine>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -18,7 +18,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.jmx=ALL-UNNAMED
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.util.log.jmx=ALL-UNNAMED
           </argLine>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -18,7 +18,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.jmx=ALL-UNNAMED
             --add-opens org.eclipse.jetty.jmx/org.eclipse.jetty.util.log.jmx=ALL-UNNAMED
           </argLine>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --patch-module javax.servlet.api=${jetty-schemas-jar}
           </argLine>
         </configuration>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --patch-module javax.servlet.api=${jetty-schemas-jar}
           </argLine>
         </configuration>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --patch-module javax.servlet.api=${jetty-schemas-jar}
           </argLine>
         </configuration>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --patch-module javax.servlet.api=${jetty-schemas-jar}
           </argLine>
         </configuration>

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -23,7 +23,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-modules javax.servlet.api
             --add-modules org.eclipse.jetty.util
             --add-modules org.eclipse.jetty.io

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -23,7 +23,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-modules javax.servlet.api
             --add-modules org.eclipse.jetty.util
             --add-modules org.eclipse.jetty.io

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -23,7 +23,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-modules javax.servlet.api
             --add-modules org.eclipse.jetty.util
             --add-modules org.eclipse.jetty.io

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -23,7 +23,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-modules javax.servlet.api
             --add-modules org.eclipse.jetty.util
             --add-modules org.eclipse.jetty.io

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -64,7 +64,10 @@
             <systemPropertyVariables>
               <mavenRepoPath>${settings.localRepository}</mavenRepoPath>
             </systemPropertyVariables>
-            <argLine>@{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails --add-modules javax.servlet.api,org.slf4j</argLine>
+            <argLine>
+              @{argLine} ${surefire.base.argLine}
+              --add-modules javax.servlet.api,org.slf4j
+            </argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -64,7 +64,7 @@
             <systemPropertyVariables>
               <mavenRepoPath>${settings.localRepository}</mavenRepoPath>
             </systemPropertyVariables>
-            <argLine>@{argLine} --add-modules javax.servlet.api,org.slf4j</argLine>
+            <argLine>@{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails --add-modules javax.servlet.api,org.slf4j</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -65,7 +65,7 @@
               <mavenRepoPath>${settings.localRepository}</mavenRepoPath>
             </systemPropertyVariables>
             <argLine>
-              @{argLine} ${surefire.base.argLine}
+              @{argLine} ${surefire.argLine}
               --add-modules javax.servlet.api,org.slf4j
             </argLine>
           </configuration>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -65,7 +65,7 @@
               <mavenRepoPath>${settings.localRepository}</mavenRepoPath>
             </systemPropertyVariables>
             <argLine>
-              @{argLine} ${surefire.argLine}
+              @{argLine} ${jetty.surefire.argLine}
               --add-modules javax.servlet.api,org.slf4j
             </argLine>
           </configuration>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -44,7 +44,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-modules org.eclipse.jetty.jmx
           </argLine>
           <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -44,7 +44,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-modules org.eclipse.jetty.jmx
           </argLine>
           <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -44,7 +44,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-modules org.eclipse.jetty.jmx
           </argLine>
           <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -44,7 +44,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-modules org.eclipse.jetty.jmx
           </argLine>
           <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
+            @{argLine} ${surefire.base.argLine}
             --add-reads org.eclipse.jetty.websocket.javax.common=org.eclipse.jetty.websocket.javax.server
           </argLine>
         </configuration>

--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine}
+            @{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails
             --add-reads org.eclipse.jetty.websocket.javax.common=org.eclipse.jetty.websocket.javax.server
           </argLine>
         </configuration>

--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.argLine}
+            @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.websocket.javax.common=org.eclipse.jetty.websocket.javax.server
           </argLine>
         </configuration>

--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            @{argLine} ${surefire.base.argLine}
+            @{argLine} ${surefire.argLine}
             --add-reads org.eclipse.jetty.websocket.javax.common=org.eclipse.jetty.websocket.javax.server
           </argLine>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
 
+    <surefire.base.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails</surefire.base.argLine>
+
     <!-- some maven plugins versions -->
     <maven.surefire.version>2.22.1</maven.surefire.version>
     <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
@@ -590,7 +592,9 @@
           <version>${maven.surefire.version}</version>
           <configuration>
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
-            <argLine>@{argLine} -Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails</argLine>
+            <argLine>
+              @{argLine} ${surefire.base.argLine}
+            </argLine>
             <failIfNoTests>false</failIfNoTests>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks> <!-- to work around crash at https://github.com/junit-team/junit5/issues/801 -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
 
-    <surefire.base.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -XX:+PrintGCDetails</surefire.base.argLine>
+    <surefire.base.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -Xlog:gc:stderr:time,level,tags</surefire.base.argLine>
 
     <!-- some maven plugins versions -->
     <maven.surefire.version>2.22.1</maven.surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
 
-    <surefire.base.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -Xlog:gc:stderr:time,level,tags</surefire.base.argLine>
+    <surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -Xlog:gc:stderr:time,level,tags</surefire.argLine>
 
     <!-- some maven plugins versions -->
     <maven.surefire.version>2.22.1</maven.surefire.version>
@@ -593,7 +593,7 @@
           <configuration>
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
             <argLine>
-              @{argLine} ${surefire.base.argLine}
+              @{argLine} ${surefire.argLine}
             </argLine>
             <failIfNoTests>false</failIfNoTests>
             <forkCount>1</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
 
-    <surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -Xlog:gc:stderr:time,level,tags</surefire.argLine>
+    <jetty.surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx1g -Xms1g -Xlog:gc:stderr:time,level,tags</jetty.surefire.argLine>
 
     <!-- some maven plugins versions -->
     <maven.surefire.version>2.22.1</maven.surefire.version>
@@ -593,7 +593,7 @@
           <configuration>
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
             <argLine>
-              @{argLine} ${surefire.argLine}
+              @{argLine} ${jetty.surefire.argLine}
             </argLine>
             <failIfNoTests>false</failIfNoTests>
             <forkCount>1</forkCount>


### PR DESCRIPTION
Currently the build is locale dependent. (9.4.x branch is not)
With my locale en_AUS date parsing is failing.