### PR TITLE
Change access of LowResourceCheck to public

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
@@ -442,7 +442,7 @@ public class LowResourceMonitor extends ContainerLifeCycle
     {
     }
 
-    interface LowResourceCheck
+    public interface LowResourceCheck
     {
         boolean isLowOnResources();
 


### PR DESCRIPTION
This interface is currently package-private while it's in the
signature of several public methods (e.g. addLowResourceCheck, getLowResourceChecks)

Signed-off-by: Bjørn Christian Seime <bjorncs@yahoo-inc.com>