### PR TITLE
Issue #3216 - Autobahn WebSocketServer failures in jetty 10

### DIFF
--- a/jetty-websocket/websocket-core/fuzzingclient.json
+++ b/jetty-websocket/websocket-core/fuzzingclient.json
@@ -12,9 +12,7 @@
       }
     }
   ],
-  "cases": [
-    "*"
-  ],
+  "cases": ["*"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/CompressExtension.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/CompressExtension.java
@@ -18,6 +18,16 @@
 
 package org.eclipse.jetty.websocket.core.internal.compress;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import java.util.zip.ZipException;
+
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
@@ -28,16 +38,6 @@ import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.FrameEntry;
 import org.eclipse.jetty.websocket.core.internal.WebSocketChannel;
-
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.zip.DataFormatException;
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
-import java.util.zip.ZipException;
 
 public abstract class CompressExtension extends AbstractExtension
 {
@@ -93,17 +93,6 @@ public abstract class CompressExtension extends AbstractExtension
     protected AtomicInteger decompressCount = new AtomicInteger(0);
     private int tailDrop = TAIL_DROP_NEVER;
     private int rsvUse = RSV_USE_ALWAYS;
-    private int maxFrameSize = Integer.MAX_VALUE;
-
-    public int getMaxFrameSize()
-    {
-        return maxFrameSize;
-    }
-
-    public void setMaxFrameSize(int maxFrameSize)
-    {
-        this.maxFrameSize = maxFrameSize;
-    }
 
     protected CompressExtension()
     {
@@ -115,9 +104,6 @@ public abstract class CompressExtension extends AbstractExtension
     public void setWebSocketChannel(WebSocketChannel webSocketChannel)
     {
         super.setWebSocketChannel(webSocketChannel);
-        if (webSocketChannel.getMaxFrameSize() > Integer.MAX_VALUE)
-            throw new IllegalArgumentException("maxFrameSize too large");
-        setMaxFrameSize((int)webSocketChannel.getMaxFrameSize());
     }
 
     public Deflater getDeflater()

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/DeflateFrameExtension.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/DeflateFrameExtension.java
@@ -18,12 +18,12 @@
 
 package org.eclipse.jetty.websocket.core.internal.compress;
 
+import java.util.zip.DataFormatException;
+
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.BadPayloadException;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
-
-import java.util.zip.DataFormatException;
 
 /**
  * Implementation of the
@@ -65,7 +65,10 @@ public class DeflateFrameExtension extends CompressExtension
 
         try
         {
-            ByteAccumulator accumulator = new ByteAccumulator(getMaxFrameSize());
+            //TODO fix this to use long instead of int
+            if (getWebSocketChannel().getMaxFrameSize() > Integer.MAX_VALUE)
+                throw new IllegalArgumentException("maxFrameSize too large for ByteAccumulator");
+            ByteAccumulator accumulator = new ByteAccumulator((int)getWebSocketChannel().getMaxFrameSize());
             decompress(accumulator, frame.getPayload());
             decompress(accumulator, TAIL_BYTES_BUF.slice());
             forwardIncoming(frame, callback, accumulator);

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/PerMessageDeflateExtension.java
@@ -18,6 +18,11 @@
 
 package org.eclipse.jetty.websocket.core.internal.compress;
 
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.DataFormatException;
+
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.log.Log;
@@ -26,11 +31,6 @@ import org.eclipse.jetty.websocket.core.BadPayloadException;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
-
-import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.zip.DataFormatException;
 
 /**
  * Per Message Deflate Compression extension for WebSocket.
@@ -73,7 +73,10 @@ public class PerMessageDeflateExtension extends CompressExtension
             return;
         }
 
-        ByteAccumulator accumulator = new ByteAccumulator(getMaxFrameSize());
+        //TODO fix this to use long instead of int
+        if (getWebSocketChannel().getMaxFrameSize() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException("maxFrameSize too large for ByteAccumulator");
+        ByteAccumulator accumulator = new ByteAccumulator((int)getWebSocketChannel().getMaxFrameSize());
 
         try
         {

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnWebSocketNegotiator.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnWebSocketNegotiator.java
@@ -18,6 +18,10 @@
 
 package org.eclipse.jetty.websocket.core.autobahn;
 
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
@@ -25,10 +29,6 @@ import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.WebSocketExtensionRegistry;
 import org.eclipse.jetty.websocket.core.server.Negotiation;
 import org.eclipse.jetty.websocket.core.server.WebSocketNegotiator;
-
-import java.io.IOException;
-import java.time.Duration;
-import java.util.List;
 
 class AutobahnWebSocketNegotiator implements WebSocketNegotiator
 {
@@ -85,7 +85,7 @@ class AutobahnWebSocketNegotiator implements WebSocketNegotiator
     public void customize(FrameHandler.CoreSession session)
     {
         session.setIdleTimeout(Duration.ofMillis(5000));
-
+        session.setMaxFrameSize(65536*2);
     }
 
     @Override

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
@@ -18,14 +18,29 @@
 
 package org.eclipse.jetty.websocket.core.extensions;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.toolchain.test.ByteBufferAssert;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.websocket.core.AbstractTestFrameHandler;
+import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.CapturedHexPayloads;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.Frame;
@@ -34,19 +49,14 @@ import org.eclipse.jetty.websocket.core.IncomingFramesCapture;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.OutgoingFrames;
 import org.eclipse.jetty.websocket.core.OutgoingNetworkBytesCapture;
+import org.eclipse.jetty.websocket.core.WebSocketExtensionRegistry;
+import org.eclipse.jetty.websocket.core.internal.ExtensionStack;
 import org.eclipse.jetty.websocket.core.internal.Generator;
+import org.eclipse.jetty.websocket.core.internal.Negotiated;
 import org.eclipse.jetty.websocket.core.internal.Parser;
+import org.eclipse.jetty.websocket.core.internal.WebSocketChannel;
 import org.eclipse.jetty.websocket.core.internal.compress.DeflateFrameExtension;
 import org.junit.jupiter.api.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Random;
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
 
 import static org.eclipse.jetty.websocket.core.OpCode.TEXT;
 import static org.hamcrest.CoreMatchers.is;
@@ -229,7 +239,7 @@ public class DeflateFrameExtensionTest extends AbstractExtensionTest
 
     private void init(DeflateFrameExtension ext)
     {
-        ext.setMaxFrameSize(20 * 1024 * 1024);
+        ext.setWebSocketChannel(channelWithMaxMessageSize(20 * 1024 * 1024));
         ext.init(new ExtensionConfig(ext.getName()), bufferPool);
     }
 
@@ -371,11 +381,11 @@ public class DeflateFrameExtensionTest extends AbstractExtensionTest
 
         DeflateFrameExtension clientExtension = new DeflateFrameExtension();
         init(clientExtension);
-        clientExtension.setMaxFrameSize(maxMessageSize);
+        clientExtension.setWebSocketChannel(channelWithMaxMessageSize(maxMessageSize));
 
         final DeflateFrameExtension serverExtension = new DeflateFrameExtension();
         init(serverExtension);
-        serverExtension.setMaxFrameSize(maxMessageSize);
+        serverExtension.setWebSocketChannel(channelWithMaxMessageSize(maxMessageSize));
 
         // Chain the next element to decompress.
         clientExtension.setNextOutgoingFrames(new OutgoingFrames()
@@ -413,5 +423,17 @@ public class DeflateFrameExtensionTest extends AbstractExtensionTest
         clientExtension.sendFrame(frame, null, false);
 
         assertArrayEquals(input, result.toByteArray());
+    }
+
+
+    private WebSocketChannel channelWithMaxMessageSize(int maxMessageSize)
+    {
+        ByteBufferPool bufferPool = new MappedByteBufferPool();
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+
+        WebSocketChannel channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.SERVER, Negotiated.from(exStack));
+        channel.setMaxFrameSize(maxMessageSize);
+        return channel;
     }
 }


### PR DESCRIPTION
removed maxFrameSize from `CompressExtension` now use the `WebSocketChannel.getMaxFrameSize()` to fix a bug where a change in the `WebSocketChanel` maxFrameSize was not reaching the `CompressExtension`

create dummy `WebSocketChannel` in all tests which were using a `CompressExtension` without
a channel, as the the extension now uses the channels maxFrameSize

increased the maxFrameSize in `AutobahnWebSocketNegotiator` to fix
autobahn tests being over maxFrameSize after being inflated

#3216