### PR TITLE
#150: Ability to handle JAR directories in extraClasspath. 

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
@@ -278,12 +278,18 @@ public class WebAppClassLoader extends URLClassLoader
         StringTokenizer tokenizer= new StringTokenizer(classPath, ",;");
         while (tokenizer.hasMoreTokens())
         {
-            Resource resource= _context.newResource(tokenizer.nextToken().trim());
+            String token = tokenizer.nextToken().trim();
+            Resource resource= _context.newResource(token);
             if (LOG.isDebugEnabled())
                 LOG.debug("Path resource=" + resource);
 
-            // Add the resource
-            if (resource.isDirectory() && resource instanceof ResourceCollection)
+            if(token.endsWith("/*")) {
+                if(token.length() > 2) {
+                    token = token.substring(0, token.length() - 1);
+                    resource= _context.newResource(token);
+                    addJars(resource);
+                }
+            } else if (resource.isDirectory() && resource instanceof ResourceCollection)
                 addClassPath(resource);
             else
             {


### PR DESCRIPTION
In keeping with Java conventions[0], any directory paths ending in /* should be considered a JAR directory and all jars in that directory will be added (non recursively) to the classpath.

[0] https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html