### PR TITLE
make JAASPrincipal thread-safe

### DIFF
--- a/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/JAASPrincipal.java
+++ b/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/JAASPrincipal.java
@@ -30,7 +30,7 @@ public class JAASPrincipal implements Principal, Serializable
 {
     private static final long serialVersionUID = -5538962177019315479L;
     
-    private String _name = null;
+    private final String _name;
     
     public JAASPrincipal(String userName)
     {


### PR DESCRIPTION
It's immutable anyway, so declare its only instance var final.

Signed-off-by: Ortwin Glück <odi@odi.ch>