### PR TITLE
Issue #3274 - Exclude org osgi foundation jar for conflicts with java base classes

### DIFF
--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -140,6 +140,11 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <!-- cannot override core java classes with Java 9+ -->
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.foundation</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>