### PR TITLE
Fixes #3210 - Threadpool module creates unmanged threadpool.

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-threadpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
-<Configure id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
-
+<Configure>
   <!-- =========================================================== -->
   <!-- Configure the Server Thread Pool.                           -->
   <!-- The server holds a common thread pool which is used by      -->
@@ -20,9 +19,11 @@
   <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
   <!-- for all configuration that may be set here.                 -->
   <!-- =========================================================== -->
-  <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
-  <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
-  <Set name="reservedThreads" type="int"><Property name="jetty.threadPool.reservedThreads" default="-1"/></Set>
-  <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
-  <Set name="detailedDump" type="boolean"><Property name="jetty.threadPool.detailedDump" default="false"/></Set>
+  <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+    <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+    <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+    <Set name="reservedThreads" type="int"><Property name="jetty.threadPool.reservedThreads" default="-1"/></Set>
+    <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+    <Set name="detailedDump" type="boolean"><Property name="jetty.threadPool.detailedDump" default="false"/></Set>
+  </New>
 </Configure>


### PR DESCRIPTION
#3210
The thread pool is now created as a nested object, rather than a top
level object, so that it is not started before the Server instance.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>