### PR TITLE
Fixes #3154 - Add support for javax.net.ssl.HostnameVerifier to HttpClient

### DIFF
--- a/jetty-alpn/jetty-alpn-client/src/main/java/org/eclipse/jetty/alpn/client/ALPNClientConnectionFactory.java
+++ b/jetty-alpn/jetty-alpn-client/src/main/java/org/eclipse/jetty/alpn/client/ALPNClientConnectionFactory.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.alpn.client;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -34,11 +33,10 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.NegotiatingClientConnectionFactory;
 import org.eclipse.jetty.io.ssl.ALPNProcessor.Client;
 import org.eclipse.jetty.io.ssl.SslClientConnectionFactory;
-import org.eclipse.jetty.io.ssl.SslHandshakeListener;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
-public class ALPNClientConnectionFactory extends NegotiatingClientConnectionFactory implements SslHandshakeListener
+public class ALPNClientConnectionFactory extends NegotiatingClientConnectionFactory
 {
     private static final Logger LOG = Log.getLogger(ALPNClientConnectionFactory.class);
 
@@ -96,7 +94,7 @@ public class ALPNClientConnectionFactory extends NegotiatingClientConnectionFact
     }
 
     @Override
-    public Connection newConnection(EndPoint endPoint, Map<String, Object> context) throws IOException
+    public Connection newConnection(EndPoint endPoint, Map<String, Object> context)
     {
         SSLEngine engine = (SSLEngine)context.get(SslClientConnectionFactory.SSL_ENGINE_CONTEXT_KEY);
         for (Client processor : processors)

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -759,7 +759,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
         }
 
-        private void handshakeSucceeded()
+        private void handshakeSucceeded() throws SSLException
         {
             if (_handshake.compareAndSet(Handshake.INITIAL, Handshake.SUCCEEDED))
             {
@@ -1182,7 +1182,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
         }
 
-        private void notifyHandshakeSucceeded(SSLEngine sslEngine)
+        private void notifyHandshakeSucceeded(SSLEngine sslEngine) throws SSLException
         {
             SslHandshakeListener.Event event = null;
             for (SslHandshakeListener listener : handshakeListeners)
@@ -1192,6 +1192,10 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                 try
                 {
                     listener.handshakeSucceeded(event);
+                }
+                catch (SSLException x)
+                {
+                    throw x;
                 }
                 catch (Throwable x)
                 {

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslHandshakeListener.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslHandshakeListener.java
@@ -22,6 +22,7 @@ import java.util.EventListener;
 import java.util.EventObject;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 /**
  * <p>Implementations of this interface are notified of TLS handshake events.</p>
@@ -36,7 +37,7 @@ public interface SslHandshakeListener extends EventListener
      *
      * @param event the event object carrying information about the TLS handshake event
      */
-    default void handshakeSucceeded(Event event)
+    default void handshakeSucceeded(Event event) throws SSLException
     {
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -1598,11 +1598,26 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
         _sslSessionTimeout = sslSessionTimeout;
     }
 
+    /**
+     * @return the HostnameVerifier used by a client to verify host names in the server certificate
+     */
     public HostnameVerifier getHostnameVerifier()
     {
         return _hostnameVerifier;
     }
 
+    /**
+     * <p>Sets a {@code HostnameVerifier} used by a client to verify host names in the server certificate.</p>
+     * <p>The {@code HostnameVerifier} works in conjunction with {@link #setEndpointIdentificationAlgorithm(String)}.</p>
+     * <p>When {@code endpointIdentificationAlgorithm=="HTTPS"} (the default) the JDK TLS implementation
+     * checks that the host name indication set by the client matches the host names in the server certificate.
+     * If this check passes successfully, the {@code HostnameVerifier} is invoked and the application
+     * can perform additional checks and allow/deny the connection to the server.</p>
+     * <p>When {@code endpointIdentificationAlgorithm==null} the JDK TLS implementation will not check
+     * the host names, and any check is therefore performed only by the {@code HostnameVerifier.}</p>
+     *
+     * @param hostnameVerifier the HostnameVerifier used by a client to verify host names in the server certificate
+     */
     public void setHostnameVerifier(HostnameVerifier hostnameVerifier)
     {
         _hostnameVerifier = hostnameVerifier;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -51,6 +51,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.CertPathTrustManagerParameters;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SNIHostName;
@@ -194,6 +195,7 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
     private int _renegotiationLimit = 5;
     private Factory _factory;
     private PKIXCertPathChecker _pkixCertPathChecker;
+    private HostnameVerifier _hostnameVerifier;
 
     /**
      * Construct an instance of SslContextFactory
@@ -1594,6 +1596,16 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
     public void setSslSessionTimeout(int sslSessionTimeout)
     {
         _sslSessionTimeout = sslSessionTimeout;
+    }
+
+    public HostnameVerifier getHostnameVerifier()
+    {
+        return _hostnameVerifier;
+    }
+
+    public void setHostnameVerifier(HostnameVerifier hostnameVerifier)
+    {
+        _hostnameVerifier = hostnameVerifier;
     }
 
     /**


### PR DESCRIPTION
Added a SslHandshakeListener to SslConnection that performs
the host name verification (only on the client) if the
HostnameVerifier has been configured in SslContextFactory.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>