### PR TITLE
Issue #3307 WebAppClassLoader.loadClass should only call resolveClass if resolve is true

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
@@ -525,7 +525,8 @@ public class WebAppClassLoader extends URLClassLoader
                     // If it is a server class, doesn't matter as we have loaded it from the 
                     // webapp
                     webapp_class = this.findClass(name);
-                    resolveClass(webapp_class);
+                    if (resolve)
+                        resolveClass(webapp_class);
                     if (LOG.isDebugEnabled())
                         LOG.debug("PLP webapp loaded {}",webapp_class);
                     return webapp_class;


### PR DESCRIPTION
Issue #3307 

WebAppClassloader.loadClass never uses the resolve parameter that is passed into it. To be correct, we should probably only call Classloader.resolveClass if resolve==true. 

Note that the OP originally reported an NPE, but it turns out that the NPE was caused by a 3rd party (GWT) subclass of WebAppClassLoader that didn't implement the api contract of Classloader.findClass properly (it it returned null instead of ClassNotFoundException if it didn't find a class).  As findClass is never supposed to return null, I'm not in favour of doing a null check before calling resolveClass.