### PR TITLE
Issue #3329 Hazelcast remove session fails

### DIFF
--- a/jetty-hazelcast/src/main/java/org/eclipse/jetty/hazelcast/session/HazelcastSessionDataStore.java
+++ b/jetty-hazelcast/src/main/java/org/eclipse/jetty/hazelcast/session/HazelcastSessionDataStore.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.hazelcast.session;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.server.session.AbstractSessionDataStore;
@@ -74,7 +75,12 @@ public class HazelcastSessionDataStore
     public boolean delete( String id )
         throws Exception
     {
-        return sessionDataMap == null ? false : sessionDataMap.remove( getCacheKey( id ) ) != null;
+        if (sessionDataMap == null)
+            return false;
+        
+        //use delete which does not deserialize the SessionData object being removed
+        sessionDataMap.delete( getCacheKey(id));
+        return true;
     }
 
     public IMap<String, SessionData> getSessionDataMap()


### PR DESCRIPTION
Issue #3329 

There is a failure when hazelcast expires a session: the HazelcastSessionDataStore.delete(id) calls Hazelcast.remove(key), which will fetch and deserialize the SessionData object being removed. This requires that the calling thread is anointed with the correct classloader (by using ContextHandler.handle(Runnable).  

However, as the SessionData object is never used, we can save on the deserialization and just call Hazelcast.delete(key) instead, which does not fetch the deleted object.