### PR TITLE
Issue #3290 - FrameFlusher and WebSocket close fixes

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractEndPoint.java
@@ -175,7 +175,7 @@ public abstract class AbstractEndPoint extends IdleTimeout implements EndPoint
         close(null);
     }
 
-    protected final void close(Throwable failure)
+    public final void close(Throwable failure)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("close({}) {}",failure,this);

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -172,6 +172,19 @@ public class CloseStatus
         return null;
     }
 
+    public static boolean isOrdinary(CloseStatus closeStatus)
+    {
+        switch (closeStatus.getCode())
+        {
+            case NORMAL:
+            case SHUTDOWN:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
     public int getCode()
     {
         return code;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -172,12 +172,14 @@ public class CloseStatus
         return null;
     }
 
+    // TODO consider defining a precedence for every CloseStatus, and change ChannelState only if higher precedence
     public static boolean isOrdinary(CloseStatus closeStatus)
     {
         switch (closeStatus.getCode())
         {
             case NORMAL:
             case SHUTDOWN:
+            case NO_CODE:
                 return true;
 
             default:

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -18,13 +18,13 @@
 
 package org.eclipse.jetty.websocket.core;
 
-import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Utf8Appendable;
-import org.eclipse.jetty.util.Utf8StringBuilder;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Utf8Appendable;
+import org.eclipse.jetty.util.Utf8StringBuilder;
 
 /**
  * Representation of a WebSocket Close (status code &amp; reason)
@@ -45,6 +45,7 @@ public class CloseStatus
     public static final int FAILED_TLS_HANDSHAKE = 1015;
 
     public static final CloseStatus NO_CODE_STATUS = new CloseStatus(NO_CODE);
+    public static final CloseStatus NO_CLOSE_STATUS = new CloseStatus(NO_CLOSE);
     public static final CloseStatus NORMAL_STATUS = new CloseStatus(NORMAL);
 
     static final int MAX_REASON_PHRASE = Frame.MAX_CONTROL_PAYLOAD - 2;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
@@ -64,6 +64,15 @@ public class FrameFlusher extends IteratingCallback
         this.buffers = new ArrayList<>((maxGather * 2) + 1);
     }
 
+
+    /**
+     * Enqueue a Frame to be written to the endpoint.
+     * @param frame The frame to queue
+     * @param callback The callback to call once the frame is sent
+     * @param batch True if batch mode is to be used
+     * @return returns true if the frame was enqueued and iterate needs to be called, returns false if the
+     * FrameFlusher was closed
+     */
     public boolean enqueue(Frame frame, Callback callback, boolean batch)
     {
         Entry entry = new Entry(frame, callback, batch);

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -527,7 +527,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
             if (frame.getOpCode() == OpCode.CLOSE)
             {
                 CloseStatus closeStatus = CloseStatus.getCloseStatus(frame);
-                if (closeStatus instanceof AbnormalCloseStatus)
+                if (closeStatus instanceof AbnormalCloseStatus && channelState.onClosed(closeStatus))
                     closeConnection(null, closeStatus, Callback.from(
                             ()->callback.failed(ex),
                             x2->

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.List;
@@ -291,11 +292,10 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         return this.connection.getBufferPool();
     }
 
-    public void onClosed(Throwable cause)
+    public void onEof()
     {
-        CloseStatus closeStatus = new CloseStatus(CloseStatus.NO_CLOSE, cause == null?null:cause.toString());
-        if (channelState.onClosed(closeStatus))
-            closeConnection(cause, closeStatus, NOOP);
+        if (channelState.onEof())
+            closeConnection(new ClosedChannelException(), channelState.getCloseStatus(), Callback.NOOP);
     }
 
     public void closeConnection(Throwable cause, CloseStatus closeStatus, Callback callback)

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannelState.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannelState.java
@@ -149,11 +149,7 @@ public class WebSocketChannelState
         synchronized (this)
         {
             if (!isOutputOpen())
-            {
-                if (opcode == OpCode.CLOSE && CloseStatus.getCloseStatus(frame) instanceof WebSocketChannel.AbnormalCloseStatus)
-                    _channelState = State.CLOSED;
                 throw new IllegalStateException(_channelState.toString());
-            }
 
             if (opcode == OpCode.CLOSE)
             {

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannelState.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannelState.java
@@ -122,6 +122,25 @@ public class WebSocketChannelState
         }
     }
 
+    public boolean onEof()
+    {
+        synchronized (this)
+        {
+            switch (_channelState)
+            {
+                case CLOSED:
+                case ISHUT:
+                    return false;
+
+                default:
+                    if (_closeStatus == null || CloseStatus.isOrdinary(_closeStatus))
+                        _closeStatus = CloseStatus.NO_CLOSE_STATUS;
+                    _channelState = State.CLOSED;
+                    return true;
+            }
+        }
+    }
+
     public boolean onOutgoingFrame(Frame frame) throws ProtocolException
     {
         byte opcode = frame.getOpCode();

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -348,7 +348,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
             if (!fillingAndParsing)
                 throw new IllegalStateException();
-            if (demand != 0)
+            if (demand != 0) //if demand was canceled, this creates synthetic demand in order to read until EOF
                 return true;
 
             fillingAndParsing = false;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -348,12 +348,10 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
             if (!fillingAndParsing)
                 throw new IllegalStateException();
-            if (demand > 0)
+            if (demand != 0)
                 return true;
 
-            if (demand == 0)
-                fillingAndParsing = false;
-
+            fillingAndParsing = false;
             if (networkBuffer.isEmpty())
                 releaseNetworkBuffer();
 
@@ -373,10 +371,9 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             if (!fillingAndParsing)
                 throw new IllegalStateException();
 
-            if (demand < 0)
-                return false;
+            if (demand > 0)
+                demand--;
 
-            demand--;
             return true;
         }
     }
@@ -412,7 +409,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
                     if (!moreDemand())
                         return;
-                    }
                 }
 
                 // buffer must be empty here because parser is fully consuming
@@ -530,43 +526,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             parser,
             flusher,
             generator);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        final int prime = 31;
-        int result = 1;
-
-        EndPoint endp = getEndPoint();
-        if (endp != null)
-        {
-            result = prime * result + endp.getLocalAddress().hashCode();
-            result = prime * result + endp.getRemoteAddress().hashCode();
-        }
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        WebSocketConnection other = (WebSocketConnection)obj;
-        EndPoint endp = getEndPoint();
-        EndPoint otherEndp = other.getEndPoint();
-        if (endp == null)
-        {
-            if (otherEndp != null)
-                return false;
-        }
-        else if (!endp.equals(otherEndp))
-            return false;
-        return true;
     }
 
     /**

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
@@ -293,7 +293,6 @@ public class WebSocketCloseTest extends WebSocketTester
         server.handler.getCoreSession().demand(1);
         assertTrue(server.handler.closed.await(5, TimeUnit.SECONDS));
         assertThat(server.handler.closeStatus.getCode(), is(CloseStatus.NO_CLOSE));
-        assertThat(server.handler.closeStatus.getReason(), containsString("IOException"));
     }
 
     @Test
@@ -306,7 +305,6 @@ public class WebSocketCloseTest extends WebSocketTester
         server.handler.getCoreSession().demand(1);
         assertTrue(server.handler.closed.await(5, TimeUnit.SECONDS));
         assertThat(server.handler.closeStatus.getCode(), is(CloseStatus.NO_CLOSE));
-        assertThat(server.handler.closeStatus.getReason(), containsString("IOException"));
     }
 
     @Test

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketTester.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketTester.java
@@ -18,6 +18,13 @@
 
 package org.eclipse.jetty.websocket.core;
 
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
@@ -26,13 +33,6 @@ import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.websocket.core.internal.Parser;
 import org.junit.jupiter.api.BeforeEach;
-
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -122,6 +122,20 @@ public class WebSocketTester
             Parser.ParsedFrame frame = parser.parse(buffer);
             if (frame != null)
                 return frame;
+        }
+    }
+
+    protected void receiveEof(InputStream in) throws IOException
+    {
+        ByteBuffer buffer = bufferPool.acquire(4096, false);
+        while (true)
+        {
+            BufferUtil.flipToFill(buffer);
+            int len = in.read(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+            if (len < 0)
+                return;
+
+            throw new IllegalStateException("unexpected content");
         }
     }
 }


### PR DESCRIPTION
#3291 

- introduce channelState check in the catch in WSChannel sendFrame to guard from multiple close notifications in the frameHandler

- removed state change in the isOutputOpen check in webSocketChannelState to as we do the state change in the catch block in WSChannel

- WebSocketConnection fillAndParse will now try to read until EOF and will call the WSChannel to decide what to do when EOF is read, the WSChannel will only treat this as an error if it is not in state ISHUT or CLOSED.

- Fix to the FrameFlusher so that when we call close(Throwable) we set a closeCause throwable which is thrown on the next call to process so that onCompleteFailure is called. This eliminates the race between a process thread and the close thread.

- improvements to WebSocketCloseTest