### PR TITLE
Fixes #3333 - Jetty 10 standalone cannot start on the module-path.

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -585,6 +585,7 @@ public class StartArgs
                 }
             }
         }
+        jmodAdds.add("ALL-MODULE-PATH");
         StartLog.debug("Expanded JPMS directives:%nadd-modules: %s%npatch-modules: %s%nadd-opens: %s%nadd-exports: %s%nadd-reads: %s",
                 jmodAdds, jmodPatch, jmodOpens, jmodExports, jmodReads);
     }
@@ -1110,7 +1111,8 @@ public class StartArgs
         if ("--jpms".equals(arg))
         {
             jpms = true;
-            // Need to fork because we cannot use JDK 9 Module APIs.
+            // Forking is simpler; otherwise we need to add the
+            // JPMS directives such as "--add-modules" via API.
             exec = true;
             return;
         }

--- a/jetty-websocket/javax-websocket-server/src/main/config/modules/websocket.mod
+++ b/jetty-websocket/javax-websocket-server/src/main/config/modules/websocket.mod
@@ -1,15 +1,18 @@
 DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
-  [description]
-  Enable websockets for deployed web applications
+[description]
+Enable websockets for deployed web applications
 
-  [depend]
-  # websocket client needs jetty-client
-  client
-  # javax.websocket needs annotations
-  annotations
+[depend]
+# websocket client needs jetty-client
+client
+# javax.websocket needs annotations
+annotations
 
-  [lib]
-  lib/websocket/*.jar
+[lib]
+lib/websocket/*.jar
 
-
+[jpms]
+# The implementation needs to access method handles in
+# classes that are in the web application classloader.
+add-reads: org.eclipse.jetty.websocket.javax.common=ALL-UNNAMED


### PR DESCRIPTION
Added --add-modules=ALL-MODULE-PATH by default because now Jetty has
proper JPMS modules and when starting in standalone mode only the
org.eclipse.jetty.xml module will be in the module graph - while
before automatic modules where added to the module graph implicitly.

Added --add-reads=ALL-UNNAMED to the websocket module to allow the
websocket implementation to access method handles of application
classes (the websocket endpoints) that live in the web application
classloader (which forms an unnamed module).

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>