### PR TITLE
Include Vary:Origin on all responses from CrossOriginFilter

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -400,8 +400,7 @@ public class CrossOriginFilter implements Filter
     {
         response.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, origin);
         //W3C CORS spec http://www.w3.org/TR/cors/#resource-implementation
-        if (!anyOriginAllowed)
-            response.addHeader("Vary", ORIGIN_HEADER);
+        response.addHeader("Vary", ORIGIN_HEADER);
         if (allowCredentials)
             response.setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
         if (!exposedHeaders.isEmpty())

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CrossOriginFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CrossOriginFilterTest.java
@@ -135,7 +135,7 @@ public class CrossOriginFilterTest
         Set<String> fieldNames = response.getFieldNamesCollection();
         assertThat(response.toString(), CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, isIn(fieldNames));
         assertThat(response.toString(), CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, isIn(fieldNames));
-        assertThat(response.toString(), "Vary", not(isIn(fieldNames)));
+        assertThat(response.toString(), "Vary", isIn(fieldNames));
         assertTrue(latch.await(1, TimeUnit.SECONDS));
     }
 


### PR DESCRIPTION
Currently, the `CrossOriginFilter` will echo the request's "`Origin`" value into the "`Access-Control-Allow-Origin`" response header when it is configured to allow any origin: https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java#L401

```
    private void handleSimpleResponse(HttpServletRequest request, HttpServletResponse response, String origin)
    {
        response.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, origin);
        //W3C CORS spec http://www.w3.org/TR/cors/#resource-implementation
        if (!anyOriginAllowed)
            response.addHeader("Vary", ORIGIN_HEADER);
        if (allowCredentials)
            response.setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
        if (!exposedHeaders.isEmpty())
            response.setHeader(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER, commify(exposedHeaders));
    }
```

This is really useful behaviour, as Firefox disallows certain operations for `Access-Control-Allow-Origin:*` responses.

This behaviour does mean that the response does vary according to the request's "`Origin`" header, but the code currently does not emit a "`Vary: Origin`" header in this scenario, which is a bug.

The effect of this bug is that users who cache responses from servers using `CrossOriginFilter` from across multiple Origin domains (for example, if you have a TEST server and a LIVE server, both of which use the same static assets server), then some of them will be rejected by an incorrectly cached CORS header.

This PR fixes the issue by emitting "`Vary: Origin`" in all cases.