### PR TITLE
Fix race condition between onFillable() and resume()

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/Suspender.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/Suspender.java
@@ -1,0 +1,102 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.common.io;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+class Suspender
+{
+    private enum State
+    {
+        /** Not suspended. */
+        NORMAL,
+
+        /** Suspend requested but not yet taken effect. */
+        PENDING,
+
+        /** Suspended but resumable. */
+        SUSPENDED,
+
+        /** Permanently suspended (terminal state). */
+        EOF,
+    }
+
+    private final AtomicReference<State> ref = new AtomicReference<>(State.NORMAL);
+
+    boolean isSuspended()
+    {
+        State state = ref.get();
+        return state == State.SUSPENDED || state == State.EOF;
+    }
+
+    /**
+     * Requests that activity be suspended the next time {@link #activateRequestedSuspend()} is called.
+     */
+    void requestSuspend()
+    {
+        // Transition NORMAL -> PENDING
+        State state;
+        do
+        {
+            state = ref.get();
+        }
+        while (state == State.NORMAL && !ref.compareAndSet(state, State.PENDING));
+    }
+
+    /**
+     * Returns true if activity is suspended, whether or not it was already suspended.
+     */
+    boolean activateRequestedSuspend()
+    {
+        // Transition PENDING -> SUSPENDED
+        State state;
+        do
+        {
+            state = ref.get();
+        }
+        while (state == State.PENDING && !ref.compareAndSet(state, State.SUSPENDED));
+        return state != State.NORMAL;
+    }
+
+    /**
+     * Returns true if activity was suspended and should now resume.
+     */
+    boolean requestResume()
+    {
+        // Transition PENDING|SUSPENDED -> NORMAL
+        State state;
+        do
+        {
+            state = ref.get();
+        }
+        while ((state == State.PENDING || state == State.SUSPENDED) && !ref.compareAndSet(state, State.NORMAL));
+        return state == State.SUSPENDED;
+    }
+
+    void eof()
+    {
+        ref.set(State.EOF);
+    }
+
+    @Override
+    public String toString()
+    {
+        return ref.get().toString();
+    }
+}

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/SuspenderTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/SuspenderTest.java
@@ -1,0 +1,91 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.common.io;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class SuspenderTest {
+
+    @Test
+    public void testNotSuspended()
+    {
+        Suspender suspender = new Suspender();
+        assertThat("Initially normal", suspender.isSuspended(), is(false));
+
+        assertThat("No pending suspend to activate", suspender.activateRequestedSuspend(), is(false));
+        assertThat("No pending suspend to activate", suspender.isSuspended(), is(false));
+
+        assertThat("No pending suspend to resume", suspender.requestResume(), is(false));
+        assertThat("No pending suspend to resume", suspender.isSuspended(), is(false));
+    }
+
+    @Test
+    public void testSuspendThenResume()
+    {
+        Suspender suspender = new Suspender();
+        assertThat("Initially suspended", suspender.isSuspended(), is(false));
+
+        suspender.requestSuspend();
+        assertThat("Requesting suspend doesn't take effect immediately", suspender.isSuspended(), is(false));
+
+        assertThat("Resume from pending requires no followup", suspender.requestResume(), is(false));
+        assertThat("Resume from pending requires no followup", suspender.isSuspended(), is(false));
+
+        assertThat("Requested suspend was discarded", suspender.activateRequestedSuspend(), is(false));
+        assertThat("Requested suspend was discarded", suspender.isSuspended(), is(false));
+    }
+
+    @Test
+    public void testSuspendThenActivateThenResume()
+    {
+        Suspender suspender = new Suspender();
+        assertThat("Initially suspended", suspender.isSuspended(), is(false));
+
+        suspender.requestSuspend();
+        assertThat("Requesting suspend doesn't take effect immediately", suspender.isSuspended(), is(false));
+
+        assertThat("Suspend activated", suspender.activateRequestedSuspend(), is(true));
+        assertThat("Suspend activated", suspender.isSuspended(), is(true));
+
+        assertThat("Resumed", suspender.requestResume(), is(true));
+        assertThat("Resumed", suspender.isSuspended(), is(false));
+    }
+
+    @Test
+    public void testEof()
+    {
+        Suspender suspender = new Suspender();
+        suspender.eof();
+        assertThat(suspender.isSuspended(), is(true));
+
+        assertThat(suspender.activateRequestedSuspend(), is(true));
+
+        suspender.requestSuspend();
+        assertThat(suspender.isSuspended(), is(true));
+
+        assertThat(suspender.activateRequestedSuspend(), is(true));
+        assertThat(suspender.isSuspended(), is(true));
+
+        assertThat(suspender.requestResume(), is(false));
+        assertThat(suspender.isSuspended(), is(true));
+    }
+}


### PR DESCRIPTION
This PR fixes a bug I've run into using Jetty WebSockets in an async I/O pattern, calling `suspend()` upon receiving data from the socket and `resume()` once the data has been handled.  The symptom is that calling `resume()` doesn't actually resume reading from the WebSocket, leading to a hang until socket idle timeout.  While racy, it's fairly reproducible--on my server I can usually trigger it with about a minute of heavy activity.

[eclipse/jetty.project#1219](https://github.com/eclipse/jetty.project/pull/1219) attempted to fix a race condition in the interaction between onFillable() and resume(). But there's a race between the use of these two fields:

```
private final AtomicBoolean suspendToken;
private boolean isFilling;
```
Consider these two fragments in the current code:

```
public void onFillable()
{
    ...
    isFilling = true;
    ...
    if ((readMode != ReadMode.EOF) && (suspendToken.get() == false))   // line A
    {
        fillInterested();
    }
    else
    {
        isFilling = false;   // line D
    }
```
and

```
@Override
public void resume()
{
    if (suspendToken.getAndSet(false))   // line B
    {
        if (!isReading())    // line C
        {
            fillInterested();
        }
    }
}
```
1. Assume starting state: `suspendToken=false`, `isFilling=true`, fill interest has been registered:
2. Thread AA starts executing `onFillable()`, parsing and handling input
3. Thread AA executes `suspend()` via a callback and sets `suspendToken=true`
4. Thread AA executes line A and moves to the `else` path, does NOT call `fillInterested()`
5. Thread BB executes `resume()` due to activity triggered by the callback in step 3
6. Thread BB executes line B and sets `suspendToken=false`
7. Thread BB executes line C, sees `isFilling==true` and does NOT call `fillInterested()`
8. Thread AA executes line D and sets `isFilling=false`
9. Ending state is `suspendToken=false`, `isFilling=false`, no fill interest has been registered.

The net result is that the web socket stops reading input. It's not suspended, but no fill interest is registered.

A subsequent call to `suspend()`+`resume()` would likely get things moving again, but there isn't an obviously correct time to make those calls.

Adding `volatile` to `boolean isFilling` would likely reduce the race window, but does not eliminate it completely.

In essence, this PR combines `suspendToken` and `isFilling` into a single state value that can be modified atomically:

```
NORMAL - normal filling state
PENDING - a call to suspend() has been made, but fill interest is still registered
SUSPENDED - a call to suspend() has been made, no fill interest is registered
EOF - no fill interest is registered, terminal state
```
A `resume()` from the `PENDING` state should not register fill interest to avoid [eclipse/jetty.project#1218](https://github.com/eclipse/jetty.project/issues/1218)
A `resume()` from the `SUSPENDED` state must register fill interest to resume reads
The end of `onFillable()` must either (a) re-register a fill interest or (b) transition to one of `SUSPENDED` or `EOF` to indicate no fill interest.

Signed-off-by: Shawn Smith <shawn@thena.net>