### PR TITLE
Issue #3332 jetty-maven-plugin - loading in-project transitive dependencies - for single WAR

### DIFF
--- a/examples/async-rest/async-rest-jar/pom.xml
+++ b/examples/async-rest/async-rest-jar/pom.xml
@@ -1,18 +1,21 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>example-async-rest</artifactId>
-       <version>9.4.15-SNAPSHOT</version>
-  </parent>  
+    <version>9.4.15-SNAPSHOT</version>
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.example-async-rest</groupId>
   <artifactId>example-async-rest-jar</artifactId>
   <packaging>jar</packaging>
   <name>Example Async Rest :: Jar</name>
-  <url>http://www.eclipse.org/jetty</url>
+
   <properties>
-    <bundle-symbolic-name>${project.groupId}.examples.async.rest</bundle-symbolic-name>
+    <bundle-symbolic-name>${project.parent.groupId}.examples.async.rest</bundle-symbolic-name>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/examples/async-rest/async-rest-webapp/pom.xml
+++ b/examples/async-rest/async-rest-webapp/pom.xml
@@ -1,17 +1,21 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>example-async-rest</artifactId>
     <version>9.4.15-SNAPSHOT</version>
-  </parent>  
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.example-async-rest</groupId>
   <artifactId>example-async-rest-webapp</artifactId>
   <packaging>war</packaging>
   <name>Example Async Rest :: Webapp</name>
+
   <build>
     <finalName>async-rest</finalName>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.example-async-rest</groupId>
@@ -24,10 +28,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-      <dependency>
-         <groupId>javax.servlet</groupId>
-         <artifactId>javax.servlet-api</artifactId>
-         <scope>provided</scope>
-       </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/examples/async-rest/pom.xml
+++ b/examples/async-rest/pom.xml
@@ -1,17 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.examples</groupId>
     <artifactId>examples-parent</artifactId>
     <version>9.4.15-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>example-async-rest</artifactId>
   <packaging>pom</packaging>
   <name>Example Async Rest</name>
+
   <modules>
     <module>async-rest-jar</module>
     <module>async-rest-webapp</module>
   </modules>
+
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
     <version>9.4.15-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.examples</groupId>
   <artifactId>examples-parent</artifactId>
   <name>Jetty Examples :: Parent</name>
   <packaging>pom</packaging>
+
   <properties>
     <sonar.skip>true</sonar.skip>
   </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -26,6 +29,7 @@
       </plugin>
     </plugins>
   </build>
+
   <modules>
     <!--
     - The async-rest and embedded are examples that have historical locations,

--- a/jetty-jmh/pom.xml
+++ b/jetty-jmh/pom.xml
@@ -1,14 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
     <version>9.4.15-SNAPSHOT</version>
   </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jmh</artifactId>
   <name>Jetty :: Jmh</name>
   <description>Jmh classes for Jetty</description>
-  <url>http://www.eclipse.org/jetty</url>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.jmh</bundle-symbolic-name>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -39,8 +45,7 @@
               <finalName>${jmhjar.name}</finalName>
               <shadeTestJar>true</shadeTestJar>
               <transformers>
-                <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                 </transformer>
               </transformers>
@@ -72,6 +77,7 @@
       </plugins>
     </pluginManagement>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -21,13 +21,15 @@ package org.eclipse.jetty.maven.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -38,7 +40,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.jetty.maven.plugin.utils.MavenProjectHelper;
 import org.eclipse.jetty.util.PathWatcher;
 import org.eclipse.jetty.util.PathWatcher.PathWatchEvent;
 import org.eclipse.jetty.util.resource.Resource;
@@ -256,7 +258,7 @@ public class JettyRunMojo extends AbstractJettyMojo
     public void configureWebApplication() throws Exception
     {
        super.configureWebApplication();
-       
+
        //Set up the location of the webapp.
        //There are 2 parts to this: setWar() and setBaseResource(). On standalone jetty,
        //the former could be the location of a packed war, while the latter is the location
@@ -284,8 +286,15 @@ public class JettyRunMojo extends AbstractJettyMojo
        if (useTestScope && (testClassesDirectory != null))
            webApp.setTestClasses (testClassesDirectory);
 
-       webApp.setWebInfLib(getDependencyFiles());
-
+        MavenProjectHelper mavenProjectHelper = new MavenProjectHelper(project);
+        List<File> webInfLibs = getWebInfLibArtifacts(project).stream()
+                .map(a -> {
+                    Path p = mavenProjectHelper.getArtifactPath(a);
+                    getLog().debug("Artifact " + a.getId() + " loaded from " + p + " added to WEB-INF/lib");
+                    return p.toFile();
+                }).collect(Collectors.toList());
+        getLog().info("WEB-INF/lib initialized (at root)");
+        webApp.setWebInfLib(webInfLibs);
 
        //if we have not already set web.xml location, need to set one up
        if (webApp.getDescriptor() == null)
@@ -519,63 +528,40 @@ public class JettyRunMojo extends AbstractJettyMojo
         getLog().info("Restart completed at "+new Date().toString());
     }
     
-    
-    
-    
-    /**
-     * @return
-     */
-    private List<File> getDependencyFiles()
+    private Collection<Artifact> getWebInfLibArtifacts(Set<Artifact> artifacts)
     {
-        List<File> dependencyFiles = new ArrayList<>();
-        for ( Artifact artifact : projectArtifacts)
-        {
-            // Include runtime and compile time libraries, and possibly test libs too
-            if(artifact.getType().equals("war"))
-                continue;
-
-            if (Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))
-                continue; //never add dependencies of scope=provided to the webapp's classpath (see also <useProvidedScope> param)
-
-            if (Artifact.SCOPE_TEST.equals(artifact.getScope()) && !useTestScope)
-                continue; //only add dependencies of scope=test if explicitly required
-
-            MavenProject mavenProject = getProjectReference( artifact, project );
-            if (mavenProject != null)
-            {
-                File projectPath = Paths.get(mavenProject.getBuild().getOutputDirectory()).toFile();
-                getLog().debug( "Adding project directory " + projectPath.toString() );
-                dependencyFiles.add( projectPath );
-                continue;
-            }
-
-            dependencyFiles.add(artifact.getFile());
-            getLog().debug( "Adding artifact " + artifact.getFile().getName() + " with scope "+artifact.getScope()+" for WEB-INF/lib " );   
-        }
-              
-        return dependencyFiles; 
+        return artifacts.stream()
+                .filter(this::canPutArtifactInWebInfLib)
+                .collect(Collectors.toList());
     }
 
-    protected MavenProject getProjectReference(Artifact artifact, MavenProject project )
+    private Collection<Artifact> getWebInfLibArtifacts(MavenProject mavenProject)
     {
-        if ( project.getProjectReferences() == null || project.getProjectReferences().isEmpty() )
+        String type = mavenProject.getArtifact().getType();
+        if (!"war".equalsIgnoreCase(type) && !"zip".equalsIgnoreCase(type))
         {
-            return null;
+            return Collections.emptyList();
         }
-        Collection<MavenProject> mavenProjects = project.getProjectReferences().values();
-        for ( MavenProject mavenProject : mavenProjects )
-        {
-            if ( StringUtils.equals( mavenProject.getId(), artifact.getId() ) )
-            {
-                return mavenProject;
-            }
-        }
-        return null;
+        return getWebInfLibArtifacts(mavenProject.getArtifacts());
     }
 
+    private boolean canPutArtifactInWebInfLib(Artifact artifact)
+    {
+        if ("war".equalsIgnoreCase(artifact.getType()))
+        {
+            return false;
+        }
+        if (Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))
+        {
+            return false;
+        }
+        if (Artifact.SCOPE_TEST.equals(artifact.getScope()) && !useTestScope)
+        {
+            return false;
+        }
+        return true;
+    }
 
-    
-    
     private List<Overlay> getOverlays()
     throws Exception
     {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
@@ -1,0 +1,92 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.maven.plugin.utils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+
+public class MavenProjectHelper
+{
+
+    private final Map<String, MavenProject> artifactToLocalProjectMap;
+
+    public MavenProjectHelper(MavenProject project)
+    {
+        Set<MavenProject> mavenProjects = resolveProjectDependencies(project, new HashSet<>());
+        artifactToLocalProjectMap = mavenProjects.stream()
+                .collect(Collectors.toMap(MavenProject::getId, Function.identity()));
+        artifactToLocalProjectMap.put(project.getArtifact().getId(), project);
+    }
+
+    /**
+     * Gets maven project if referenced in reactor
+     * @param artifact - maven artifact
+     * @return {@link MavenProject} if artifact is referenced in reactor, otherwise null
+     */
+    public MavenProject getMavenProject(Artifact artifact)
+    {
+        return artifactToLocalProjectMap.get(artifact.getId());
+    }
+
+    /**
+     * Gets path to artifact.
+     * If artifact is referenced in reactor, returns path to ${project.build.outputDirectory}.
+     * Otherwise, returns path to location in local m2 repo.
+     *
+     * Cannot return null - maven will complain about unsatisfied dependency during project built.
+     *
+     * @param artifact maven artifact
+     * @return path to artifact
+     */
+    public Path getArtifactPath(Artifact artifact)
+    {
+        Path path = Paths.get(artifact.getFile().toURI());
+        MavenProject mavenProject = getMavenProject(artifact);
+        if (mavenProject != null)
+        {
+            path = Paths.get(mavenProject.getBuild().getOutputDirectory());
+        }
+        return path;
+    }
+
+    private static Set<MavenProject> resolveProjectDependencies(MavenProject project, Set<MavenProject> visitedProjects)
+    {
+        if (visitedProjects.contains(project))
+        {
+            return Collections.emptySet();
+        }
+        visitedProjects.add(project);
+        Set<MavenProject> availableProjects = new HashSet<>(project.getProjectReferences().values());
+        for (MavenProject ref : project.getProjectReferences().values())
+        {
+            availableProjects.addAll(resolveProjectDependencies(ref, visitedProjects));
+        }
+        return availableProjects;
+    }
+
+}

--- a/jetty-osgi/jetty-osgi-alpn/pom.xml
+++ b/jetty-osgi/jetty-osgi-alpn/pom.xml
@@ -9,7 +9,7 @@
   <name>Jetty :: OSGi ALPN Fragment</name>
   <packaging>jar</packaging>
   <properties>
-    <bundle-symbolic-name>org.eclipse.jetty.osgi.alpn.fragment</bundle-symbolic-name>
+    <bundle-symbolic-name>${project.groupId}.alpn.fragment</bundle-symbolic-name>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <unix.socket.tmp></unix.socket.tmp>
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
+    <jpms-module-name>${bundle-symbolic-name}</jpms-module-name>
 
     <!-- some maven plugins versions -->
     <maven.surefire.version>3.0.0-M2</maven.surefire.version>
@@ -514,6 +515,7 @@
             <archive>
               <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               <manifestEntries>
+                <Automatic-Module-Name>${jpms-module-name}</Automatic-Module-Name>
                 <Implementation-Version>${project.version}</Implementation-Version>
                 <Implementation-Vendor>Eclipse Jetty Project</Implementation-Vendor>
                 <url>${jetty.url}</url>


### PR DESCRIPTION
Greetings,
PR fixes incorrect dependency resolution in goal jetty:run. 
Scope of this PR is restricted to fixing dependencies for "single war".  (moduleA or moduleB case)

```
Module A
org.mca.jetty.moduleA.ModuleA_api -> /C:/jettyProject/module-a/module-a-api/target/classes/org/mca/jetty/moduleA/ModuleA_api.class
org.mca.jetty.moduleA.ModuleA_impl -> /C:/jettyProject/module-a/module-a-impl/target/classes/org/mca/jetty/moduleA/ModuleA_impl.class
org.mca.jetty.moduleA.ModuleA_servlet -> /C:/jettyProject/module-a/module-a-war/target/classes/org/mca/jetty/moduleA/ModuleA_servlet.class
```
Scanner is triggering hot reload correctly now.

Logic around overlays is still broken (still depends on "unpack" functionality) and will be fixed in future PR.

For more info review #3332.

Cheers,
-- mb