### PR TITLE
Fixes #3332 jetty-maven-plugin - transitive deps in single war project

### DIFF
--- a/jetty-maven-plugin/README_INTEGRATION_TEST.md
+++ b/jetty-maven-plugin/README_INTEGRATION_TEST.md
@@ -14,8 +14,10 @@ As they can be long to run, the tests do not run per default. So to run them you
 
 Running single test
 --------------------
-You can run single or set of test as well using the command line argument: ```-Dinvoker.test=jetty-run-mojo-it,jetty-run-war*-it,!jetty-run-distro*```
+You can run single or set of test as well using the command line argument: ```-Dinvoker.test=it-parent-pom,jetty-run-mojo-it,jetty-run-war*-it,!jetty-run-distro*```
 The parameter supports pattern and exclusion with !
+
+Due to [files  filtering](http://maven.apache.org/plugins/maven-invoker-plugin/examples/filtering.html), ```it-parent-pom``` must be included - otherwise tests will fail during execution. 
 
 Running Logs
 --------------------

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/common/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/common/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+    <artifactId>jetty-multi-module-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>common</artifactId>
+
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/common/src/main/java/mca/common/CommonService.java
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/common/src/main/java/mca/common/CommonService.java
@@ -1,0 +1,24 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package mca.common;
+
+public class CommonService
+{
+
+}

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/invoker.properties
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = test

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-api/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-api/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+    <artifactId>module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-api</artifactId>
+
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-api/src/main/java/mca/module/ModuleApi.java
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-api/src/main/java/mca/module/ModuleApi.java
@@ -1,0 +1,24 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package mca.module;
+
+public interface ModuleApi
+{
+
+}

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-impl/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-impl/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+    <artifactId>module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module-impl</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+      <artifactId>module-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-impl/src/main/java/mca/module/ModuleImpl.java
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/module-impl/src/main/java/mca/module/ModuleImpl.java
@@ -1,0 +1,28 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package mca.module;
+
+import mca.common.CommonService;
+
+public class ModuleImpl implements ModuleApi
+{
+
+    private static final CommonService cs = new CommonService();
+
+}

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/module/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+    <artifactId>jetty-multi-module-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-api</module>
+    <module>module-impl</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+      <artifactId>common</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jetty.its</groupId>
+    <artifactId>it-parent-pom</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+  <artifactId>jetty-multi-module-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Jetty :: multi-module project</name>
+
+  <modules>
+    <module>common</module>
+    <module>module</module>
+    <module>webapp-war</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+    <jetty.version>@project.version@</jetty.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+        <artifactId>common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+        <artifactId>module-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+        <artifactId>module-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/postbuild.groovy
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/postbuild.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( 'Started Jetty Server' )
+
+assert buildLog.text.contains( '(1a) >> javax.servlet.ServletContextListener loaded from jar:' )
+assert buildLog.text.contains( 'local-repo/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar!/javax/servlet/ServletContextListener.class << (1b)' )
+
+assert buildLog.text.contains( '(2a) >> mca.common.CommonService loaded from file:' )
+assert buildLog.text.contains( 'common/target/classes/mca/common/CommonService.class << (2b)' )
+
+assert buildLog.text.contains( '(3a) >> mca.module.ModuleApi loaded from file:' )
+assert buildLog.text.contains( 'module/module-api/target/classes/mca/module/ModuleApi.class << (3b)' )
+
+assert buildLog.text.contains( '(4a) >> mca.module.ModuleImpl loaded from file:' )
+assert buildLog.text.contains( 'module/module-impl/target/classes/mca/module/ModuleImpl.class << (4b)' )
+
+assert buildLog.text.contains( '(5a) >> mca.webapp.WebAppServletListener loaded from file:' )
+assert buildLog.text.contains( 'webapp-war/target/classes/mca/webapp/WebAppServletListener.class << (5b)' )

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+    <artifactId>jetty-multi-module-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>webapp-war</artifactId>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>test.jetty-run-mojo-multi-module-single-war-it</groupId>
+      <artifactId>module-impl</artifactId>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <jetty.port.file>${project.build.directory}/jetty-run-mojo.txt</jetty.port.file>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>start-jetty</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <systemProperties>
+                <systemProperty>
+                  <name>jetty.port.file</name>
+                  <value>${jetty.port.file}</value>
+                </systemProperty>
+              </systemProperties>
+              <nonBlocking>true</nonBlocking>
+              <jettyXml>${basedir}/src/config/jetty.xml</jettyXml>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort"><Property name="jetty.secure.port" default="8443" /></Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="headerCacheSize">4096</Set>
+  </New>
+
+  <Call name="addConnector">
+    <Arg>
+      <New class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+            <Item>
+              <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+              </New>
+            </Item>
+          </Array>
+        </Arg>
+        <Call name="addLifeCycleListener">
+          <Arg>
+            <New class="org.eclipse.jetty.maven.plugin.ServerConnectorListener">
+              <Set name="fileName"><Property name="jetty.port.file" default="port.txt"/></Set>
+            </New>
+          </Arg>
+        </Call>
+        <Set name="host"><Property name="jetty.host" /></Set>
+        <Set name="port"><Property name="jetty.port" default="0" />0</Set>
+        <Set name="idleTimeout">30000</Set>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/main/java/mca/webapp/WebAppServletListener.java
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/main/java/mca/webapp/WebAppServletListener.java
@@ -1,0 +1,56 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package mca.webapp;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import java.net.URL;
+
+import static java.lang.String.format;
+
+public class WebAppServletListener implements ServletContextListener
+{
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent)
+    {
+        print("1", "javax.servlet.ServletContextListener");
+        print("2", "mca.common.CommonService");
+        print("3", "mca.module.ModuleApi");
+        print("4", "mca.module.ModuleImpl");
+        print("5", "mca.webapp.WebAppServletListener");
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent)
+    {
+
+    }
+
+    private void print(String counter, String className)
+    {
+        String res = className.replaceAll("\\.", "/") + ".class";
+        URL url = Thread.currentThread().getContextClassLoader().getResource(res);
+        System.out.println(
+                format("(%sa) >> %s loaded from %s << (%sb)",
+                        counter, className, url, counter)
+        );
+    }
+}

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/main/webapp/WEB-INF/web.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!DOCTYPE web-app
+        PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+        "http://java.sun.com/dtd/web-app_2_3.dtd">
+
+<web-app>
+    <listener>
+        <listener-class>mca.webapp.WebAppServletListener</listener-class>
+    </listener>
+</web-app>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -293,9 +293,8 @@ public class JettyRunMojo extends AbstractJettyMojo
                     getLog().debug("Artifact " + a.getId() + " loaded from " + p + " added to WEB-INF/lib");
                     return p.toFile();
                 }).collect(Collectors.toList());
-        getLog().info("WEB-INF/lib initialized (at root)");
+        getLog().debug("WEB-INF/lib initialized (at root)");
         webApp.setWebInfLib(webInfLibs);
-
 
        //if we have not already set web.xml location, need to set one up
        if (webApp.getDescriptor() == null)

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -21,13 +21,15 @@ package org.eclipse.jetty.maven.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -38,10 +40,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.jetty.maven.plugin.utils.MavenProjectHelper;
 import org.eclipse.jetty.util.PathWatcher;
 import org.eclipse.jetty.util.PathWatcher.PathWatchEvent;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -285,7 +286,15 @@ public class JettyRunMojo extends AbstractJettyMojo
        if (useTestScope && (testClassesDirectory != null))
            webApp.setTestClasses (testClassesDirectory);
 
-       webApp.setWebInfLib(getDependencyFiles());
+        MavenProjectHelper mavenProjectHelper = new MavenProjectHelper(project);
+        List<File> webInfLibs = getWebInfLibArtifacts(project).stream()
+                .map(a -> {
+                    Path p = mavenProjectHelper.getArtifactPath(a);
+                    getLog().debug("Artifact " + a.getId() + " loaded from " + p + " added to WEB-INF/lib");
+                    return p.toFile();
+                }).collect(Collectors.toList());
+        getLog().info("WEB-INF/lib initialized (at root)");
+        webApp.setWebInfLib(webInfLibs);
 
 
        //if we have not already set web.xml location, need to set one up
@@ -519,77 +528,41 @@ public class JettyRunMojo extends AbstractJettyMojo
         startScanner();
         getLog().info("Restart completed at "+new Date().toString());
     }
-    
-    
-    
-    
-    /**
-     * @return
-     */
-    private List<File> getDependencyFiles()
+
+    private Collection<Artifact> getWebInfLibArtifacts(Set<Artifact> artifacts)
     {
-        List<File> dependencyFiles = new ArrayList<>();
-        for ( Artifact artifact : projectArtifacts)
-        {
-            // Include runtime and compile time libraries, and possibly test libs too
-            if(artifact.getType().equals("war"))
-                continue;
-
-            if (Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))
-                continue; //never add dependencies of scope=provided to the webapp's classpath (see also <useProvidedScope> param)
-
-            if (Artifact.SCOPE_TEST.equals(artifact.getScope()) && !useTestScope)
-                continue; //only add dependencies of scope=test if explicitly required
-
-            MavenProject mavenProject = getProjectReference( artifact, project );
-
-            if (mavenProject != null)
-            {
-                File projectPath = "test-jar".equals( artifact.getType() )?
-                    Paths.get( mavenProject.getBuild().getTestOutputDirectory() ).toFile()
-                    : Paths.get( mavenProject.getBuild().getOutputDirectory() ).toFile();
-                getLog().debug( "Adding project directory " + projectPath.toString() );
-                dependencyFiles.add( projectPath );
-                continue;
-            }
-
-            dependencyFiles.add(artifact.getFile());
-            getLog().debug( "Adding artifact " + artifact.getFile().getName() + " with scope "+artifact.getScope()+" for WEB-INF/lib " );
-        }
-              
-        return dependencyFiles; 
+        return artifacts.stream()
+                .filter(this::canPutArtifactInWebInfLib)
+                .collect(Collectors.toList());
     }
 
-    protected MavenProject getProjectReference(Artifact artifact, MavenProject project )
+    private Collection<Artifact> getWebInfLibArtifacts(MavenProject mavenProject)
     {
-        if ( project.getProjectReferences() == null || project.getProjectReferences().isEmpty() )
+        String type = mavenProject.getArtifact().getType();
+        if (!"war".equalsIgnoreCase(type) && !"zip".equalsIgnoreCase(type))
         {
-            return null;
+            return Collections.emptyList();
         }
-        Collection<MavenProject> mavenProjects = project.getProjectReferences().values();
-        for ( MavenProject mavenProject : mavenProjects )
-        {
-            if ( StringUtils.equals( mavenProject.getId(), artifact.getId() ) )
-            {
-                return mavenProject;
-            }
-            if("test-jar".equals(artifact.getType()))
-            {
-                // getId use type so comparing getId will fail in case of test-jar dependency
-                if ( StringUtils.equals( mavenProject.getGroupId(), artifact.getGroupId() )
-                        && StringUtils.equals( mavenProject.getArtifactId(), artifact.getArtifactId() )
-                        && StringUtils.equals( mavenProject.getVersion(), artifact.getBaseVersion()) )
-                {
-                    return mavenProject;
-                }
-            }
-        }
-        return null;
+        return getWebInfLibArtifacts(mavenProject.getArtifacts());
     }
 
+    private boolean canPutArtifactInWebInfLib(Artifact artifact)
+    {
+        if ("war".equalsIgnoreCase(artifact.getType()))
+        {
+            return false;
+        }
+        if (Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))
+        {
+            return false;
+        }
+        if (Artifact.SCOPE_TEST.equals(artifact.getScope()) && !useTestScope)
+        {
+            return false;
+        }
+        return true;
+    }
 
-    
-    
     private List<Overlay> getOverlays()
     throws Exception
     {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
@@ -65,7 +65,7 @@ public class MavenProjectHelper
      */
     public Path getArtifactPath(Artifact artifact)
     {
-        Path path = Paths.get(artifact.getFile().toURI());
+        Path path = artifact.getFile().toPath();
         MavenProject mavenProject = getMavenProject(artifact);
         if (mavenProject != null)
         {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/utils/MavenProjectHelper.java
@@ -1,0 +1,96 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.maven.plugin.utils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+
+public class MavenProjectHelper
+{
+
+    private final Map<String, MavenProject> artifactToLocalProjectMap;
+
+    public MavenProjectHelper(MavenProject project)
+    {
+        Set<MavenProject> mavenProjects = resolveProjectDependencies(project, new HashSet<>());
+        artifactToLocalProjectMap = mavenProjects.stream()
+                .collect(Collectors.toMap(MavenProject::getId, Function.identity()));
+        artifactToLocalProjectMap.put(project.getArtifact().getId(), project);
+    }
+
+    /**
+     * Gets maven project if referenced in reactor
+     * @param artifact - maven artifact
+     * @return {@link MavenProject} if artifact is referenced in reactor, otherwise null
+     */
+    public MavenProject getMavenProject(Artifact artifact)
+    {
+        return artifactToLocalProjectMap.get(artifact.getId());
+    }
+
+    /**
+     * Gets path to artifact.
+     * If artifact is referenced in reactor, returns path to ${project.build.outputDirectory}.
+     * Otherwise, returns path to location in local m2 repo.
+     *
+     * Cannot return null - maven will complain about unsatisfied dependency during project built.
+     *
+     * @param artifact maven artifact
+     * @return path to artifact
+     */
+    public Path getArtifactPath(Artifact artifact)
+    {
+        Path path = Paths.get(artifact.getFile().toURI());
+        MavenProject mavenProject = getMavenProject(artifact);
+        if (mavenProject != null)
+        {
+            if ( "test-jar".equals( artifact.getType() )) {
+                path = Paths.get(mavenProject.getBuild().getTestOutputDirectory());
+            } else {
+                path = Paths.get(mavenProject.getBuild().getOutputDirectory());
+            }
+        }
+        return path;
+    }
+
+    private static Set<MavenProject> resolveProjectDependencies(MavenProject project, Set<MavenProject> visitedProjects)
+    {
+        if (visitedProjects.contains(project))
+        {
+            return Collections.emptySet();
+        }
+        visitedProjects.add(project);
+        Set<MavenProject> availableProjects = new HashSet<>(project.getProjectReferences().values());
+        for (MavenProject ref : project.getProjectReferences().values())
+        {
+            availableProjects.addAll(resolveProjectDependencies(ref, visitedProjects));
+        }
+        return availableProjects;
+    }
+
+}


### PR DESCRIPTION
Greetings,
PR fixes incorrect dependency resolution in goal jetty:run. 
Scope of this PR is restricted to fixing dependencies for "single war".  (moduleA or moduleB case)

```
Module A
org.mca.jetty.moduleA.ModuleA_api -> /C:/jettyProject/module-a/module-a-api/target/classes/org/mca/jetty/moduleA/ModuleA_api.class
org.mca.jetty.moduleA.ModuleA_impl -> /C:/jettyProject/module-a/module-a-impl/target/classes/org/mca/jetty/moduleA/ModuleA_impl.class
org.mca.jetty.moduleA.ModuleA_servlet -> /C:/jettyProject/module-a/module-a-war/target/classes/org/mca/jetty/moduleA/ModuleA_servlet.class
```
Scanner is triggering hot reload correctly now.

Logic around overlays is still broken (still depends on "unpack" functionality) and will be fixed in future PR.

For more info review #3332.

Cheers,
-- mb