### PR TITLE
Issue #3247 Generate jetty-maven-plugin website

### DIFF
--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -122,16 +122,42 @@
         <reportSets>
           <reportSet>
             <reports>
-              <report>project-team</report>
-              <report>mailing-list</report>
-              <report>cim</report>
-              <report>issue-tracking</report>
-              <report>license</report>
+              <report>team</report>
+              <report>mailing-lists</report>
+              <report>ci-management</report>
+              <report>issue-management</report>
+              <report>licenses</report>
               <report>scm</report>
             </reports>
           </reportSet>
         </reportSets>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+      </plugin>
     </plugins>
   </reporting>
+  <profiles>
+    <profile>
+      <id>eclipse-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>site-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/jetty-jspc-maven-plugin/src/site/markdown/index.md
+++ b/jetty-jspc-maven-plugin/src/site/markdown/index.md
@@ -1,0 +1,4 @@
+Eclipse Jetty Jspc Maven Plugin
+========================
+
+This plugin will help you pre-compile your jsps and works in conjunction with the Maven war plugin to put them inside an assembled war.

--- a/jetty-jspc-maven-plugin/src/site/site.xml
+++ b/jetty-jspc-maven-plugin/src/site/site.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+
+  <bannerLeft>
+    <name>${project.name}</name>
+    <src>https://www.eclipse.org/jetty/images/jetty-logo-80x22.png</src>
+    <href>https://eclipse.org/jetty/</href>
+  </bannerLeft>
+  <bannerRight>
+    <src>https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-426x100.png</src>
+  </bannerRight>
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.7</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>true</topBarEnabled>
+      <sideBarEnabled>true</sideBarEnabled>
+      <googleSearch>
+        <sitesearch>${project.url}</sitesearch>
+      </googleSearch>
+      <gitHub>
+        <projectId>eclipse/jetty.project</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>gray</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+    <menu ref="reports" inherit="bottom"/>
+
+  </body>
+</project>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -244,16 +244,42 @@
         <reportSets>
           <reportSet>
             <reports>
-              <report>project-team</report>
-              <report>mailing-list</report>
-              <report>cim</report>
-              <report>issue-tracking</report>
-              <report>license</report>
+              <report>team</report>
+              <report>mailing-lists</report>
+              <report>ci-management</report>
+              <report>issue-management</report>
+              <report>licenses</report>
               <report>scm</report>
             </reports>
           </reportSet>
         </reportSets>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+      </plugin>
     </plugins>
   </reporting>
+  <profiles>
+    <profile>
+      <id>site-jar</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>site-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -262,7 +262,7 @@
   </reporting>
   <profiles>
     <profile>
-      <id>site-jar</id>
+      <id>eclipse-release</id>
       <build>
         <plugins>
           <plugin>

--- a/jetty-maven-plugin/src/site/markdown/index.md
+++ b/jetty-maven-plugin/src/site/markdown/index.md
@@ -1,0 +1,4 @@
+Eclipse Jetty Maven Plugin
+========================
+
+Bla Bla bla Bla Bla bla Bla Bla bla  

--- a/jetty-maven-plugin/src/site/markdown/index.md
+++ b/jetty-maven-plugin/src/site/markdown/index.md
@@ -1,4 +1,10 @@
 Eclipse Jetty Maven Plugin
 ========================
 
-Bla Bla bla Bla Bla bla Bla Bla bla  
+The Jetty Maven plugin is useful for rapid development and testing.
+
+You can add it to any webapp project that is structured according to the Maven defaults.
+
+The plugin can then periodically scan your project for changes and automatically redeploy the webapp if any are found.
+
+This makes the development cycle more productive by eliminating the build and deploy steps: you use your IDE to make changes to the project, and the running web container automatically picks them up, allowing you to test them straight away.  

--- a/jetty-maven-plugin/src/site/site.xml
+++ b/jetty-maven-plugin/src/site/site.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+
+  <bannerLeft>
+    <name>${project.name}</name>
+    <src>https://www.eclipse.org/jetty/images/jetty-logo-80x22.png</src>
+    <href>https://eclipse.org/jetty/</href>
+  </bannerLeft>
+  <bannerRight>
+    <src>https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-426x100.png</src>
+  </bannerRight>
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.7</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>true</topBarEnabled>
+      <sideBarEnabled>true</sideBarEnabled>
+      <googleSearch>
+        <sitesearch>${project.url}</sitesearch>
+      </googleSearch>
+      <gitHub>
+        <projectId>eclipse/jetty.project</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>gray</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+    <menu ref="reports" inherit="bottom"/>
+
+  </body>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1222,6 +1222,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Signed-off-by: olivier lamy <oliver.lamy@gmail.com>
@jmcc0nn3ll @WalkerWatch  it's really WIP (I'm not really a UI person :) ) and similar change probably need to go as well to jetty-jspc-maven-plugin
Use `mvn clean package -DskipTets -Psite-jar -pl :jetty-maven-plugin`
jar file is available in jetty-maven-plugin/target/jetty-maven-plugin-9.4.15-SNAPSHOT-site.jar
