### PR TITLE
Issue #3165 - javax-websocket-server tests

### DIFF
--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -50,6 +50,8 @@
         <configuration>
           <argLine>
             @{argLine} ${jetty.surefire.argLine}
+            --add-opens org.eclipse.jetty.websocket.javax.server/org.eclipse.jetty.websocket.javax.server.examples=org.eclipse.jetty.websocket.javax.common
+            --add-reads org.eclipse.jetty.websocket.javax.server=org.eclipse.jetty.security
             --add-reads org.eclipse.jetty.websocket.javax.common=org.eclipse.jetty.websocket.javax.server
           </argLine>
         </configuration>

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/WebSocketServerExamplesTest.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/WebSocketServerExamplesTest.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.javax.server;
 
 import java.net.URI;
@@ -16,9 +34,6 @@ import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 import javax.websocket.server.ServerContainer;
 
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.AuthenticationStore;
-import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
@@ -30,9 +45,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Credential;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
-import org.eclipse.jetty.websocket.javax.client.JavaxWebSocketClientContainer;
 import org.eclipse.jetty.websocket.javax.server.examples.GetHttpSessionSocket;
 import org.eclipse.jetty.websocket.javax.server.examples.MyAuthedSocket;
 import org.eclipse.jetty.websocket.javax.server.examples.StreamingEchoSocket;
@@ -136,12 +148,9 @@ public class WebSocketServerExamplesTest
     @Test
     public void testMyAuthedSocket() throws Exception
     {
+        //HttpClient is configured for BasicAuthentication with the XmlHttpClientProvider
         URI uri = URI.create("ws://localhost:8080/secured/socket");
-        HttpClient client = new HttpClient(new SslContextFactory()); // TODO: use HttpClientProvider from issue #3341
-        AuthenticationStore authenticationStore = client.getAuthenticationStore();
-        authenticationStore.addAuthentication(new BasicAuthentication(uri, "testRealm", "user", "password"));
-        JavaxWebSocketClientContainer clientContainer = new JavaxWebSocketClientContainer(new WebSocketCoreClient(client));
-        clientContainer.start(); // TODO: use container provider
+        WebSocketContainer clientContainer = ContainerProvider.getWebSocketContainer();
 
         ClientSocket clientEndpoint = new ClientSocket();
         try(Session session = clientContainer.connectToServer(clientEndpoint, uri))
@@ -152,8 +161,6 @@ public class WebSocketServerExamplesTest
 
         String msg = clientEndpoint.messageQueue.poll(5, TimeUnit.SECONDS);
         assertThat(msg, is("hello world"));
-
-        clientContainer.stop();
     }
 
     @Test

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/WebSocketServerExamplesTest.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/WebSocketServerExamplesTest.java
@@ -1,0 +1,192 @@
+package org.eclipse.jetty.websocket.javax.server;
+
+import java.net.URI;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import javax.websocket.server.ServerContainer;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.client.util.BasicAuthentication;
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.security.authentication.BasicAuthenticator;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.security.Credential;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
+import org.eclipse.jetty.websocket.javax.client.JavaxWebSocketClientContainer;
+import org.eclipse.jetty.websocket.javax.server.examples.GetHttpSessionSocket;
+import org.eclipse.jetty.websocket.javax.server.examples.MyAuthedSocket;
+import org.eclipse.jetty.websocket.javax.server.examples.StreamingEchoSocket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class WebSocketServerExamplesTest
+{
+    @ClientEndpoint
+    public static class ClientSocket
+    {
+        CountDownLatch closed = new CountDownLatch(1);
+        ArrayBlockingQueue<String> messageQueue = new ArrayBlockingQueue<>(2);
+
+        @OnOpen
+        public void onOpen(Session sess)
+        {
+            System.err.println("ClientSocket Connected: " + sess);
+        }
+
+        @OnMessage
+        public void onMessage(String message)
+        {
+            messageQueue.offer(message);
+            System.err.println("Received TEXT message: " + message);
+        }
+
+        @OnClose
+        public void onClose(CloseReason closeReason)
+        {
+            System.err.println("ClientSocket Closed: " + closeReason);
+            closed.countDown();
+        }
+
+        @OnError
+        public void onError(Throwable cause)
+        {
+            cause.printStackTrace(System.err);
+        }
+    }
+
+    static Server _server;
+    static ServletContextHandler _context;
+
+    @BeforeAll
+    public static void setup() throws Exception
+    {
+        _server = new Server();
+        ServerConnector connector = new ServerConnector(_server);
+        connector.setPort(8080);
+        _server.addConnector(connector);
+
+        _context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        _context.setContextPath("/");
+        _context.setSecurityHandler(getSecurityHandler("user", "password", "testRealm"));
+        _server.setHandler(_context);
+
+        ServerContainer serverContainer = JavaxWebSocketServletContainerInitializer.configureContext(_context);
+        serverContainer.addEndpoint(MyAuthedSocket.class);
+        serverContainer.addEndpoint(StreamingEchoSocket.class);
+        serverContainer.addEndpoint(GetHttpSessionSocket.class);
+
+        _server.start();
+    }
+
+    @AfterAll
+    public static void stop() throws Exception
+    {
+        _server.stop();
+    }
+
+    private static SecurityHandler getSecurityHandler(String username, String password, String realm) {
+
+        HashLoginService loginService = new HashLoginService();
+        UserStore userStore = new UserStore();
+        userStore.addUser(username, Credential.getCredential(password), new String[] {"websocket"});
+        loginService.setUserStore(userStore);
+        loginService.setName(realm);
+
+        Constraint constraint = new Constraint();
+        constraint.setName("auth");
+        constraint.setAuthenticate(true);
+        constraint.setRoles(new String[]{"**"});
+
+        ConstraintMapping mapping = new ConstraintMapping();
+        mapping.setPathSpec("/secured/socket/*");
+        mapping.setConstraint(constraint);
+
+        ConstraintSecurityHandler security = new ConstraintSecurityHandler();
+        security.addConstraintMapping(mapping);
+        security.setAuthenticator(new BasicAuthenticator());
+        security.setLoginService(loginService);
+
+        return security;
+    }
+
+    @Test
+    public void testMyAuthedSocket() throws Exception
+    {
+        URI uri = URI.create("ws://localhost:8080/secured/socket");
+        HttpClient client = new HttpClient(new SslContextFactory()); // TODO: use HttpClientProvider from issue #3341
+        AuthenticationStore authenticationStore = client.getAuthenticationStore();
+        authenticationStore.addAuthentication(new BasicAuthentication(uri, "testRealm", "user", "password"));
+        JavaxWebSocketClientContainer clientContainer = new JavaxWebSocketClientContainer(new WebSocketCoreClient(client));
+        clientContainer.start(); // TODO: use container provider
+
+        ClientSocket clientEndpoint = new ClientSocket();
+        try(Session session = clientContainer.connectToServer(clientEndpoint, uri))
+        {
+            session.getBasicRemote().sendText("hello world");
+        }
+        clientEndpoint.closed.await(5, TimeUnit.SECONDS);
+
+        String msg = clientEndpoint.messageQueue.poll(5, TimeUnit.SECONDS);
+        assertThat(msg, is("hello world"));
+
+        clientContainer.stop();
+    }
+
+    @Test
+    public void testStreamingEchoSocket() throws Exception
+    {
+        URI uri = URI.create("ws://localhost:8080/echo");
+        WebSocketContainer clientContainer = ContainerProvider.getWebSocketContainer();
+
+        ClientSocket clientEndpoint = new ClientSocket();
+        try(Session session = clientContainer.connectToServer(clientEndpoint, uri))
+        {
+            session.getBasicRemote().sendText("hello world");
+        }
+        clientEndpoint.closed.await(5, TimeUnit.SECONDS);
+
+        String msg = clientEndpoint.messageQueue.poll(5, TimeUnit.SECONDS);
+        assertThat(msg, is("hello world"));
+    }
+
+    @Test
+    public void testGetHttpSessionSocket() throws Exception
+    {
+        URI uri = URI.create("ws://localhost:8080/example");
+        WebSocketContainer clientContainer = ContainerProvider.getWebSocketContainer();
+
+        ClientSocket clientEndpoint = new ClientSocket();
+        try(Session session = clientContainer.connectToServer(clientEndpoint, uri))
+        {
+            session.getBasicRemote().sendText("hello world");
+        }
+        clientEndpoint.closed.await(5, TimeUnit.SECONDS);
+
+        String msg = clientEndpoint.messageQueue.poll(5, TimeUnit.SECONDS);
+        assertThat(msg, is("hello world"));
+    }
+}

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserConfigurator.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserConfigurator.java
@@ -16,32 +16,37 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.browser;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.websocket.Extension;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;
-import java.security.Principal;
 
-public class MyAuthedConfigurator extends ServerEndpointConfig.Configurator
+import org.eclipse.jetty.http.QuotedCSV;
+
+public class JsrBrowserConfigurator extends ServerEndpointConfig.Configurator
 {
     @Override
     public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
     {
-        // Is Authenticated?
-        Principal principal = request.getUserPrincipal();
-        if (principal == null)
-        {
-            throw new RuntimeException("Not authenticated");
-        }
-
-        // Is Authorized?
-        if (!request.isUserInRole("websocket"))
-        {
-            throw new RuntimeException("Not authorized");
-        }
-
-        // normal operation
         super.modifyHandshake(sec, request, response);
+        sec.getUserProperties().put("userAgent", getHeaderValue(request, "User-Agent"));
+        sec.getUserProperties().put("requestedExtensions", getHeaderValue(request, "Sec-WebSocket-Extensions"));
+    }
+
+    private String getHeaderValue(HandshakeRequest request, String key)
+    {
+        List<String> values = request.getHeaders().get(key);
+        return QuotedCSV.join(values);
+    }
+
+    @Override
+    public List<Extension> getNegotiatedExtensions(List<Extension> installed, List<Extension> requested)
+    {
+        return Collections.emptyList();
     }
 }

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserDebugTool.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserDebugTool.java
@@ -16,7 +16,7 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.browser;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserSocket.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/browser/JsrBrowserSocket.java
@@ -16,11 +16,14 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.browser;
 
-import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
 
 import javax.websocket.CloseReason;
 import javax.websocket.OnClose;
@@ -29,12 +32,10 @@ import javax.websocket.OnOpen;
 import javax.websocket.RemoteEndpoint.Async;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Locale;
-import java.util.Random;
-import java.util.Set;
+
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 
 @ServerEndpoint(value = "/", subprotocols = { "tool" }, configurator = JsrBrowserConfigurator.class)
 public class JsrBrowserSocket

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/GetHttpSessionConfigurator.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/GetHttpSessionConfigurator.java
@@ -16,33 +16,19 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.examples;
 
 import javax.servlet.http.HttpSession;
-import javax.websocket.EndpointConfig;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
-import java.io.IOException;
+import javax.websocket.HandshakeResponse;
+import javax.websocket.server.HandshakeRequest;
+import javax.websocket.server.ServerEndpointConfig;
 
-@ServerEndpoint(value = "/example", configurator = GetHttpSessionConfigurator.class)
-public class GetHttpSessionSocket
+public class GetHttpSessionConfigurator extends ServerEndpointConfig.Configurator
 {
-    private Session wsSession;
-    @SuppressWarnings("unused")
-    private HttpSession httpSession;
-
-    @OnOpen
-    public void open(Session session, EndpointConfig config)
+    @Override
+    public void modifyHandshake(ServerEndpointConfig config, HandshakeRequest request, HandshakeResponse response)
     {
-        this.wsSession = session;
-        this.httpSession = (HttpSession)config.getUserProperties().get(HttpSession.class.getName());
-    }
-
-    @OnMessage
-    public void echo(String msg) throws IOException
-    {
-        wsSession.getBasicRemote().sendText(msg);
+        HttpSession httpSession = (HttpSession)request.getHttpSession();
+        config.getUserProperties().put(HttpSession.class.getName(), httpSession);
     }
 }

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/GetHttpSessionSocket.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/GetHttpSessionSocket.java
@@ -16,18 +16,34 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.examples;
 
+import java.io.IOException;
+
+import javax.servlet.http.HttpSession;
+import javax.websocket.EndpointConfig;
 import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
-@ServerEndpoint(value = "/secured/socket", configurator = MyAuthedConfigurator.class)
-public class MyAuthedSocket
+@ServerEndpoint(value = "/example", configurator = GetHttpSessionConfigurator.class)
+public class GetHttpSessionSocket
 {
-    @OnMessage
-    public String onMessage(String msg)
+    private Session wsSession;
+    @SuppressWarnings("unused")
+    private HttpSession httpSession;
+
+    @OnOpen
+    public void open(Session session, EndpointConfig config)
     {
-        // echo the message back to the remote
-        return msg;
+        this.wsSession = session;
+        this.httpSession = (HttpSession)config.getUserProperties().get(HttpSession.class.getName());
+    }
+
+    @OnMessage
+    public void echo(String msg) throws IOException
+    {
+        wsSession.getBasicRemote().sendText(msg);
     }
 }

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/MyAuthedConfigurator.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/MyAuthedConfigurator.java
@@ -16,36 +16,33 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.examples;
 
-import org.eclipse.jetty.http.QuotedCSV;
+import java.security.Principal;
 
-import javax.websocket.Extension;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;
-import java.util.Collections;
-import java.util.List;
 
-public class JsrBrowserConfigurator extends ServerEndpointConfig.Configurator
+public class MyAuthedConfigurator extends ServerEndpointConfig.Configurator
 {
     @Override
     public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
     {
+        // Is Authenticated?
+        Principal principal = request.getUserPrincipal();
+        if (principal == null)
+        {
+            throw new RuntimeException("Not authenticated");
+        }
+
+        // Is Authorized?
+        if (!request.isUserInRole("websocket"))
+        {
+            throw new RuntimeException("Not authorized");
+        }
+
+        // normal operation
         super.modifyHandshake(sec, request, response);
-        sec.getUserProperties().put("userAgent", getHeaderValue(request, "User-Agent"));
-        sec.getUserProperties().put("requestedExtensions", getHeaderValue(request, "Sec-WebSocket-Extensions"));
-    }
-
-    private String getHeaderValue(HandshakeRequest request, String key)
-    {
-        List<String> values = request.getHeaders().get(key);
-        return QuotedCSV.join(values);
-    }
-
-    @Override
-    public List<Extension> getNegotiatedExtensions(List<Extension> installed, List<Extension> requested)
-    {
-        return Collections.emptyList();
     }
 }

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/MyAuthedSocket.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/MyAuthedSocket.java
@@ -16,19 +16,18 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.examples;
 
-import javax.servlet.http.HttpSession;
-import javax.websocket.HandshakeResponse;
-import javax.websocket.server.HandshakeRequest;
-import javax.websocket.server.ServerEndpointConfig;
+import javax.websocket.OnMessage;
+import javax.websocket.server.ServerEndpoint;
 
-public class GetHttpSessionConfigurator extends ServerEndpointConfig.Configurator
+@ServerEndpoint(value = "/secured/socket", configurator = MyAuthedConfigurator.class)
+public class MyAuthedSocket
 {
-    @Override
-    public void modifyHandshake(ServerEndpointConfig config, HandshakeRequest request, HandshakeResponse response)
+    @OnMessage
+    public String onMessage(String msg)
     {
-        HttpSession httpSession = (HttpSession)request.getHttpSession();
-        config.getUserProperties().put(HttpSession.class.getName(), httpSession);
+        // echo the message back to the remote
+        return msg;
     }
 }

--- a/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/StreamingEchoSocket.java
+++ b/jetty-websocket/javax-websocket-server/src/test/java/org/eclipse/jetty/websocket/javax/server/examples/StreamingEchoSocket.java
@@ -16,16 +16,17 @@
 //  ========================================================================
 //
 
-package examples;
+package org.eclipse.jetty.websocket.javax.server.examples;
 
-import org.eclipse.jetty.util.IO;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 
 import javax.websocket.OnMessage;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
+
+import org.eclipse.jetty.util.IO;
 
 @ServerEndpoint("/echo")
 public class StreamingEchoSocket

--- a/jetty-websocket/javax-websocket-server/src/test/resources/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/javax-websocket-server/src/test/resources/jetty-websocket-httpclient.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configure class="org.eclipse.jetty.client.HttpClient">
+  <Arg>
+    <New class="org.eclipse.jetty.util.ssl.SslContextFactory"/>
+  </Arg>
+  <Call name="getAuthenticationStore">
+    <Call name="addAuthentication">
+      <Arg>
+        <New class="org.eclipse.jetty.client.util.BasicAuthentication">
+          <Arg>
+            <New class="java.net.URI" arg="ws://localhost:8080/secured/socket"/>
+          </Arg>
+          <Arg>testRealm</Arg>
+          <Arg>user</Arg>
+          <Arg>password</Arg>
+        </New>
+      </Arg>
+    </Call>
+  </Call>
+</Configure>


### PR DESCRIPTION
Issue #3165 

Includes changes to the HttpClientProvider done in #3357 as these are waiting to be merged.

- Moved all JsrBrowser classes into package `org.eclipse.jetty.websocket.javax.server.browser`
- Moved Example Classes into package `org.eclipse.jetty.websocket.javax.server.examples`
- Created `WebSocketServerExamplesTest` to run all the examples