### PR TITLE
Issue #1861 - Limit total bytes pooled by ByteBufferPools.

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
@@ -1,0 +1,93 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.ManagedOperation;
+
+@ManagedObject
+abstract class AbstractByteBufferPool implements ByteBufferPool
+{
+    private final int _factor;
+    private final int _maxQueueLength;
+    private final long _maxHeapMemory;
+    private final AtomicLong _heapMemory = new AtomicLong();
+    private final long _maxDirectMemory;
+    private final AtomicLong _directMemory = new AtomicLong();
+
+    protected AbstractByteBufferPool(int factor, int maxQueueLength, long maxHeapMemory, long maxDirectMemory)
+    {
+        _factor = factor <= 0 ? 1024 : factor;
+        _maxQueueLength = maxQueueLength;
+        _maxHeapMemory = maxHeapMemory;
+        _maxDirectMemory = maxDirectMemory;
+    }
+
+    protected int getCapacityFactor()
+    {
+        return _factor;
+    }
+
+    protected int getMaxQueueLength()
+    {
+        return _maxQueueLength;
+    }
+
+    protected void decrementMemory(ByteBuffer buffer)
+    {
+        AtomicLong memory = buffer.isDirect() ? _directMemory : _heapMemory;
+        memory.addAndGet(-buffer.capacity());
+    }
+
+    protected boolean incrementMemory(ByteBuffer buffer)
+    {
+        boolean direct = buffer.isDirect();
+        int capacity = buffer.capacity();
+        long maxMemory = direct ? _maxDirectMemory : _maxHeapMemory;
+        AtomicLong memory = direct ? _directMemory : _heapMemory;
+        if (maxMemory <= 0)
+            return true;
+        while (true)
+        {
+            long current = memory.get();
+            long value = current + capacity;
+            if (value > maxMemory)
+                return false;
+            if (memory.compareAndSet(current, value))
+                return true;
+        }
+    }
+
+    @ManagedOperation(value = "Returns the memory occupied by this ByteBufferPool in bytes", impact = "INFO")
+    public long getMemory(boolean direct)
+    {
+        AtomicLong memory = direct ? _directMemory : _heapMemory;
+        return memory.get();
+    }
+
+    @ManagedOperation(value = "Clears this ByteBufferPool", impact = "ACTION")
+    public void clear()
+    {
+        _heapMemory.set(0);
+        _directMemory.set(0);
+    }
+}

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
 
@@ -80,7 +81,18 @@ abstract class AbstractByteBufferPool implements ByteBufferPool
         }
     }
 
-    @ManagedOperation(value = "Returns the memory occupied by this ByteBufferPool in bytes", impact = "INFO")
+    @ManagedAttribute("The bytes retained by direct ByteBuffers")
+    public long getDirectMemory()
+    {
+        return getMemory(true);
+    }
+
+    @ManagedAttribute("The bytes retained by heap ByteBuffers")
+    public long getHeapMemory()
+    {
+        return getMemory(false);
+    }
+
     public long getMemory(boolean direct)
     {
         AtomicLong memory = direct ? _directMemory : _heapMemory;

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractByteBufferPool.java
@@ -64,13 +64,11 @@ abstract class AbstractByteBufferPool implements ByteBufferPool
         int capacity = buffer.capacity();
         long maxMemory = direct ? _maxDirectMemory : _maxHeapMemory;
         AtomicLong memory = direct ? _directMemory : _heapMemory;
-        if (maxMemory <= 0)
-            return true;
         while (true)
         {
             long current = memory.get();
             long value = current + capacity;
-            if (value > maxMemory)
+            if (maxMemory > 0 && value > maxMemory)
                 return false;
             if (memory.compareAndSet(current, value))
                 return true;

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -100,13 +100,13 @@ public class ArrayByteBufferPool extends AbstractByteBufferPool
     @Override
     public ByteBuffer acquire(int size, boolean direct)
     {
+        int capacity = size < _minCapacity ? size : (bucketFor(size) + 1) * getCapacityFactor();
         ByteBufferPool.Bucket bucket = bucketFor(size, direct, null);
         if (bucket == null)
-        {
-            int capacity = size < _minCapacity ? size : (bucketFor(size) + 1) * getCapacityFactor();
             return newByteBuffer(capacity, direct);
-        }
-        ByteBuffer buffer = bucket.acquire(direct);
+        ByteBuffer buffer = bucket.acquire();
+        if (buffer == null)
+            return newByteBuffer(capacity, direct);
         decrementMemory(buffer);
         return buffer;
     }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -19,8 +19,11 @@
 package org.eclipse.jetty.io;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.IntFunction;
 
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
 /**
@@ -194,6 +197,26 @@ public class ArrayByteBufferPool extends AbstractByteBufferPool
         if (bucket == null && newBucket != null)
             buckets[b] = bucket = newBucket.apply(b + 1);
         return bucket;
+    }
+
+    @ManagedAttribute("The number of pooled direct ByteBuffers")
+    public long getDirectByteBufferCount()
+    {
+        return getByteBufferCount(true);
+    }
+
+    @ManagedAttribute("The number of pooled heap ByteBuffers")
+    public long getHeapByteBufferCount()
+    {
+        return getByteBufferCount(false);
+    }
+
+    private long getByteBufferCount(boolean direct)
+    {
+        return Arrays.stream(bucketsFor(direct))
+                .filter(Objects::nonNull)
+                .mapToLong(Bucket::size)
+                .sum();
     }
 
     // Package local for testing

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -153,19 +153,18 @@ public class ArrayByteBufferPool extends AbstractByteBufferPool
 
     private void clearOldestBucket(boolean direct)
     {
-        long oldest = 0;
+        long oldest = Long.MAX_VALUE;
         int index = -1;
         Bucket[] buckets = bucketsFor(direct);
-        long now = System.nanoTime();
         for (int i = 0; i < buckets.length; ++i)
         {
             Bucket bucket = buckets[i];
             if (bucket == null)
                 continue;
-            long age = now - bucket.getLastUpdate();
-            if (age > oldest)
+            long lastUpdate = bucket.getLastUpdate();
+            if (lastUpdate < oldest)
             {
-                oldest = age;
+                oldest = lastUpdate;
                 index = i;
             }
         }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -139,7 +139,7 @@ public interface ByteBufferPool
         private final int _capacity;
         private final int _maxSize;
         private final AtomicInteger _size;
-        private long _lastUpdate;
+        private long _lastUpdate = System.nanoTime();
 
         public Bucket(ByteBufferPool pool, int capacity, int maxSize)
         {

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -131,7 +131,7 @@ public interface ByteBufferPool
         }
     }
 
-    class Bucket
+    public static class Bucket
     {
         private final Deque<ByteBuffer> _queue = new ConcurrentLinkedDeque<>();
         private final ByteBufferPool _pool;

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.eclipse.jetty.util.BufferUtil;
 
@@ -60,7 +61,7 @@ public interface ByteBufferPool
      * <p>Creates a new ByteBuffer of the given capacity and the given directness.</p>
      *
      * @param capacity the ByteBuffer capacity
-     * @param direct the ByteBuffer directness
+     * @param direct   the ByteBuffer directness
      * @return a newly allocated ByteBuffer
      */
     default ByteBuffer newByteBuffer(int capacity, boolean direct)
@@ -136,13 +137,16 @@ public interface ByteBufferPool
         private final Deque<ByteBuffer> _queue = new ConcurrentLinkedDeque<>();
         private final ByteBufferPool _pool;
         private final int _capacity;
-        private final AtomicInteger _space;
+        private final int _maxSize;
+        private final AtomicInteger _size;
+        private long _lastUpdate;
 
         public Bucket(ByteBufferPool pool, int capacity, int maxSize)
         {
             _pool = pool;
             _capacity = capacity;
-            _space = maxSize > 0 ? new AtomicInteger(maxSize) : null;
+            _maxSize = maxSize;
+            _size = maxSize > 0 ? new AtomicInteger() : null;
         }
 
         public ByteBuffer acquire()
@@ -150,8 +154,8 @@ public interface ByteBufferPool
             ByteBuffer buffer = queuePoll();
             if (buffer == null)
                 return null;
-            if (_space != null)
-                _space.incrementAndGet();
+            if (_size != null)
+                _size.decrementAndGet();
             return buffer;
         }
 
@@ -166,35 +170,42 @@ public interface ByteBufferPool
             ByteBuffer buffer = queuePoll();
             if (buffer == null)
                 return _pool.newByteBuffer(_capacity, direct);
-            if (_space != null)
-                _space.incrementAndGet();
+            if (_size != null)
+                _size.decrementAndGet();
             return buffer;
         }
 
         public void release(ByteBuffer buffer)
         {
+            _lastUpdate = System.nanoTime();
             BufferUtil.clear(buffer);
-            if (_space == null)
+            if (_size == null)
                 queueOffer(buffer);
-            else if (_space.decrementAndGet() >= 0)
+            else if (_size.incrementAndGet() <= _maxSize)
                 queueOffer(buffer);
             else
-                _space.incrementAndGet();
+                _size.decrementAndGet();
         }
 
         public void clear()
         {
-            if (_space == null)
+            clear(null);
+        }
+
+        void clear(Consumer<ByteBuffer> memoryFn)
+        {
+            int size = _size == null ? 0 : _size.get() - 1;
+            while (size >= 0)
             {
-                queueClear();
-            }
-            else
-            {
-                int s = _space.getAndSet(0);
-                while (s-- > 0)
+                ByteBuffer buffer = queuePoll();
+                if (buffer == null)
+                    break;
+                if (memoryFn != null)
+                    memoryFn.accept(buffer);
+                if (_size != null)
                 {
-                    if (queuePoll() == null)
-                        _space.incrementAndGet();
+                    _size.decrementAndGet();
+                    --size;
                 }
             }
         }
@@ -209,11 +220,6 @@ public interface ByteBufferPool
             return _queue.poll();
         }
 
-        private void queueClear()
-        {
-            _queue.clear();
-        }
-
         boolean isEmpty()
         {
             return _queue.isEmpty();
@@ -224,10 +230,15 @@ public interface ByteBufferPool
             return _queue.size();
         }
 
+        long getLastUpdate()
+        {
+            return _lastUpdate;
+        }
+
         @Override
         public String toString()
         {
-            return String.format("%s@%x{%d/%d}", getClass().getSimpleName(), hashCode(), size(), _capacity);
+            return String.format("%s@%x{%d/%d@%d}", getClass().getSimpleName(), hashCode(), size(), _maxSize, _capacity);
         }
     }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -145,6 +145,22 @@ public interface ByteBufferPool
             _space = maxSize > 0 ? new AtomicInteger(maxSize) : null;
         }
 
+        public ByteBuffer acquire()
+        {
+            ByteBuffer buffer = queuePoll();
+            if (buffer == null)
+                return null;
+            if (_space != null)
+                _space.incrementAndGet();
+            return buffer;
+        }
+
+        /**
+         * @param direct whether to create a direct buffer when none is available
+         * @return a ByteBuffer
+         * @deprecated use {@link #acquire()} instead
+         */
+        @Deprecated
         public ByteBuffer acquire(boolean direct)
         {
             ByteBuffer buffer = queuePoll();

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
@@ -105,11 +105,14 @@ public class MappedByteBufferPool extends AbstractByteBufferPool
     public ByteBuffer acquire(int size, boolean direct)
     {
         int b = bucketFor(size);
+        int capacity = b * getCapacityFactor();
         ConcurrentMap<Integer, Bucket> buffers = bucketsFor(direct);
         Bucket bucket = buffers.get(b);
         if (bucket == null)
-            return newByteBuffer(b * getCapacityFactor(), direct);
-        ByteBuffer buffer = bucket.acquire(direct);
+            return newByteBuffer(capacity, direct);
+        ByteBuffer buffer = bucket.acquire();
+        if (buffer == null)
+            return newByteBuffer(capacity, direct);
         decrementMemory(buffer);
         return buffer;
     }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
@@ -150,17 +150,16 @@ public class MappedByteBufferPool extends AbstractByteBufferPool
 
     private void clearOldestBucket(boolean direct)
     {
-        long oldest = 0;
+        long oldest = Long.MAX_VALUE;
         int index = -1;
         ConcurrentMap<Integer, Bucket> buckets = bucketsFor(direct);
-        long now = System.nanoTime();
         for (Map.Entry<Integer, Bucket> entry : buckets.entrySet())
         {
             Bucket bucket = entry.getValue();
-            long age = now - bucket.getLastUpdate();
-            if (age > oldest)
+            long lastUpdate = bucket.getLastUpdate();
+            if (lastUpdate < oldest)
             {
-                oldest = age;
+                oldest = lastUpdate;
                 index = entry.getKey();
             }
         }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/MappedByteBufferPool.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
 /**
@@ -180,6 +181,25 @@ public class MappedByteBufferPool extends AbstractByteBufferPool
         if (bucket * factor != size)
             ++bucket;
         return bucket;
+    }
+
+    @ManagedAttribute("The number of pooled direct ByteBuffers")
+    public long getDirectByteBufferCount()
+    {
+        return getByteBufferCount(true);
+    }
+
+    @ManagedAttribute("The number of pooled heap ByteBuffers")
+    public long getHeapByteBufferCount()
+    {
+        return getByteBufferCount(false);
+    }
+
+    private long getByteBufferCount(boolean direct)
+    {
+        return bucketsFor(direct).values().stream()
+                .mapToLong(Bucket::size)
+                .sum();
     }
 
     // Package local for testing

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -20,12 +20,17 @@ package org.eclipse.jetty.io;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.io.ByteBufferPool.Bucket;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -46,12 +51,18 @@ public class ArrayByteBufferPoolTest
             assertTrue(buffer.isDirect());
             assertEquals(size, buffer.capacity());
             for (ByteBufferPool.Bucket bucket : buckets)
-                assertTrue(bucket.isEmpty());
+            {
+                if (bucket != null)
+                    assertTrue(bucket.isEmpty());
+            }
 
             bufferPool.release(buffer);
 
             for (ByteBufferPool.Bucket bucket : buckets)
-                assertTrue(bucket.isEmpty());
+            {
+                if (bucket != null)
+                    assertTrue(bucket.isEmpty());
+            }
         }
     }
 
@@ -69,15 +80,17 @@ public class ArrayByteBufferPoolTest
             assertTrue(buffer.isDirect());
             assertThat(buffer.capacity(), greaterThanOrEqualTo(size));
             for (ByteBufferPool.Bucket bucket : buckets)
-                assertTrue(bucket.isEmpty());
+            {
+                if (bucket != null)
+                    assertTrue(bucket.isEmpty());
+            }
 
             bufferPool.release(buffer);
 
-            int pooled = 0;
-            for (ByteBufferPool.Bucket bucket : buckets)
-            {
-                pooled += bucket.size();
-            }
+            int pooled = Arrays.stream(buckets)
+                    .filter(Objects::nonNull)
+                    .mapToInt(Bucket::size)
+                    .sum();
             assertEquals(size <= 1000, 1 == pooled);
         }
     }
@@ -96,20 +109,17 @@ public class ArrayByteBufferPoolTest
             assertTrue(buffer.isDirect());
             assertThat(buffer.capacity(), greaterThanOrEqualTo(size));
             for (ByteBufferPool.Bucket bucket : buckets)
-                assertTrue(bucket.isEmpty());
+            {
+                if (bucket != null)
+                    assertTrue(bucket.isEmpty());
+            }
 
             bufferPool.release(buffer);
 
-            int pooled = 0;
-            for (ByteBufferPool.Bucket bucket : buckets)
-            {
-                if (!bucket.isEmpty())
-                {
-                    pooled += bucket.size();
-                    // TODO assertThat(bucket._bufferSize,greaterThanOrEqualTo(size));
-                    // TODO assertThat(bucket._bufferSize,Matchers.lessThan(size+100));
-                }
-            }
+            int pooled = Arrays.stream(buckets)
+                    .filter(Objects::nonNull)
+                    .mapToInt(Bucket::size)
+                    .sum();
             assertEquals(1, pooled);
         }
     }
@@ -130,16 +140,10 @@ public class ArrayByteBufferPoolTest
             ByteBuffer buffer3 = bufferPool.acquire(size, false);
             bufferPool.release(buffer3);
 
-            int pooled = 0;
-            for (ByteBufferPool.Bucket bucket : buckets)
-            {
-                if (!bucket.isEmpty())
-                {
-                    pooled += bucket.size();
-                    // TODO assertThat(bucket._bufferSize,greaterThanOrEqualTo(size));
-                    // TODO assertThat(bucket._bufferSize,Matchers.lessThan(size+100));
-                }
-            }
+            int pooled = Arrays.stream(buckets)
+                    .filter(Objects::nonNull)
+                    .mapToInt(Bucket::size)
+                    .sum();
             assertEquals(1, pooled);
 
             assertSame(buffer1, buffer2);
@@ -157,10 +161,16 @@ public class ArrayByteBufferPoolTest
         ByteBuffer buffer3 = bufferPool.acquire(512, false);
 
         Bucket[] buckets = bufferPool.bucketsFor(false);
-        Arrays.asList(buckets).forEach(b -> assertEquals(0, b.size()));
+        Arrays.stream(buckets)
+                .filter(Objects::nonNull)
+                .forEach(b -> assertEquals(0, b.size()));
 
         bufferPool.release(buffer1);
-        Bucket bucket = Arrays.stream(buckets).filter(b -> b.size() > 0).findFirst().get();
+        Bucket bucket = Arrays.stream(buckets)
+                .filter(Objects::nonNull)
+                .filter(b -> b.size() > 0)
+                .findFirst()
+                .orElseThrow(AssertionError::new);
         assertEquals(1, bucket.size());
 
         bufferPool.release(buffer2);
@@ -168,5 +178,42 @@ public class ArrayByteBufferPoolTest
 
         bufferPool.release(buffer3);
         assertEquals(2, bucket.size());
+    }
+
+    @Test
+    public void testMaxMemory()
+    {
+        int factor = 1024;
+        int maxMemory = 10 * 1024;
+        ArrayByteBufferPool bufferPool = new ArrayByteBufferPool(-1, factor, -1, -1, -1, maxMemory);
+
+        int capacity = 3 * 1024;
+        ByteBuffer[] buffers = new ByteBuffer[maxMemory / capacity + 1];
+        for (int i = 0; i < buffers.length; ++i)
+            buffers[i] = bufferPool.acquire(capacity, true);
+
+        // Return all the buffers, but only some is retained by the pool.
+        for (ByteBuffer buffer : buffers)
+            bufferPool.release(buffer);
+
+        List<Bucket> directBuckets = Arrays.stream(bufferPool.bucketsFor(true))
+                .filter(Objects::nonNull)
+                .filter(b -> !b.isEmpty())
+                .collect(Collectors.toList());
+        assertEquals(1, directBuckets.size());
+
+        Bucket bucket = directBuckets.get(0);
+        assertEquals(buffers.length - 1, bucket.size());
+
+        long memory1 = bufferPool.getMemory(true);
+        assertThat(memory1, lessThanOrEqualTo((long)maxMemory));
+
+        ByteBuffer buffer = bufferPool.acquire(capacity, true);
+        long memory2 = bufferPool.getMemory(true);
+        assertThat(memory2, lessThan(memory1));
+
+        bufferPool.release(buffer);
+        long memory3 = bufferPool.getMemory(true);
+        assertEquals(memory1, memory3);
     }
 }

--- a/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure>
+  <New id="byteBufferPool" class="org.eclipse.jetty.io.ArrayByteBufferPool">
+    <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.factor" default="1024"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.maxCapacity" default="65536"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.maxQueueLength" default="-1"/></Arg>
+    <Arg type="long"><Property name="jetty.byteBufferPool.maxHeapMemory" default="-1"/></Arg>
+    <Arg type="long"><Property name="jetty.byteBufferPool.maxDirectMemory" default="-1"/></Arg>
+  </New>
+</Configure>

--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -26,6 +26,10 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <Arg name="threadpool"><Ref refid="threadPool"/></Arg>
 
+    <Call name="addBean">
+      <Arg><Ref refid="byteBufferPool"/></Arg>
+    </Call>
+
     <!-- =========================================================== -->
     <!-- Add shared Scheduler instance                               -->
     <!-- =========================================================== -->

--- a/jetty-server/src/main/config/modules/bytebufferpool.mod
+++ b/jetty-server/src/main/config/modules/bytebufferpool.mod
@@ -1,0 +1,27 @@
+DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Configures the ByteBufferPool used by ServerConnectors.
+
+[xml]
+etc/jetty-bytebufferpool.xml
+
+[ini-template]
+### Server ByteBufferPool Configuration
+## Minimum capacity to pool ByteBuffers
+#jetty.byteBufferPool.minCapacity=0
+
+## Maximum capacity to pool ByteBuffers
+#jetty.byteBufferPool.maxCapacity=65536
+
+## Capacity factor
+#jetty.byteBufferPool.factor=1024
+
+## Maximum queue length for each bucket (-1 for unbounded)
+#jetty.byteBufferPool.maxQueueLength=-1
+
+## Maximum heap memory retainable by the pool (-1 for unlimited)
+#jetty.byteBufferPool.maxHeapMemory=-1
+
+## Maximum direct memory retainable by the pool (-1 for unlimited)
+#jetty.byteBufferPool.maxDirectMemory=-1

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -11,6 +11,7 @@ logging
 
 [depend]
 threadpool
+bytebufferpool
 
 [lib]
 lib/servlet-api-3.1.jar


### PR DESCRIPTION
#1861
Implemented a limit for the total memory retained by the
ByteBufferPool for both direct and heap buffers.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>