### PR TITLE
Issue #3159 - permessage-deflate continuation frame with RSV1 set

### DIFF
--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.websocket.core.internal.Negotiated;
 import org.eclipse.jetty.websocket.core.internal.Parser;
 import org.eclipse.jetty.websocket.core.internal.WebSocketChannel;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -95,7 +96,7 @@ public class ExtensionTool
                     Frame frame = parser.parse(buffer);
                     if (frame == null)
                         break;
-                    ext.onFrame(frame, Callback.NOOP);
+                    ext.onFrame(frame, Callback.from(()->{}, Assertions::fail));
                 }
             }
         }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/FragmentExtensionTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/FragmentExtensionTest.java
@@ -35,6 +35,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -126,10 +129,10 @@ public class FragmentExtensionTest extends AbstractExtensionTest
     /**
      * Verify that outgoing text frames are fragmented by the maxLength configuration.
      *
-     * @throws IOException on test failure
+     * @throws Exception on test failure
      */
     @Test
-    public void testOutgoingFramesByMaxLength() throws IOException
+    public void testOutgoingFramesByMaxLength() throws Exception
     {
         OutgoingFramesCapture capture = new OutgoingFramesCapture();
 
@@ -169,11 +172,11 @@ public class FragmentExtensionTest extends AbstractExtensionTest
         capture.assertFrameCount(len);
 
         String prefix;
-        LinkedList<Frame> frames = new LinkedList<>(capture.frames);
+        BlockingQueue<Frame> frames = capture.frames;
         for (int i = 0; i < len; i++)
         {
             prefix = "Frame[" + i + "]";
-            Frame actualFrame = frames.get(i);
+            Frame actualFrame = frames.poll(1, TimeUnit.SECONDS);
             Frame expectedFrame = expectedFrames.get(i);
 
             // System.out.printf("actual: %s%n",actualFrame);
@@ -198,10 +201,10 @@ public class FragmentExtensionTest extends AbstractExtensionTest
     /**
      * Verify that outgoing text frames are fragmented by default configuration
      *
-     * @throws IOException on test failure
+     * @throws Exception on test failure
      */
     @Test
-    public void testOutgoingFramesDefaultConfig() throws IOException
+    public void testOutgoingFramesDefaultConfig() throws Exception
     {
         OutgoingFramesCapture capture = new OutgoingFramesCapture();
 
@@ -236,11 +239,11 @@ public class FragmentExtensionTest extends AbstractExtensionTest
         capture.assertFrameCount(len);
 
         String prefix;
-        LinkedList<Frame> frames = new LinkedList<>(capture.frames);
+        BlockingQueue<Frame> frames = capture.frames;
         for (int i = 0; i < len; i++)
         {
             prefix = "Frame[" + i + "]";
-            Frame actualFrame = frames.get(i);
+            Frame actualFrame = frames.poll(1, TimeUnit.SECONDS);
             Frame expectedFrame = expectedFrames.get(i);
 
             // Validate Frame


### PR DESCRIPTION
For the permessage-deflate extension the `RSV1` bit should be set on only the first frame of a compressed message.

Our current implementation will ignore the `RSV1` bit if it is set on a `CONTINUATION` frame.

We should warn or trigger a `ProtocolException` if the `RSV1` bit is set on any `CONTINUATION` frame.