### PR TITLE
Issue #3412 - WebSocket CoreSession Customizer

### DIFF
--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 
 public final class WebSocketConstants
 {
@@ -33,7 +32,6 @@ public final class WebSocketConstants
     public static final int DEFAULT_INPUT_BUFFER_SIZE = 4 * 1024;
     public static final int DEFAULT_OUTPUT_BUFFER_SIZE = 4 * 1024;
     public static final boolean DEFAULT_AUTO_FRAGMENT = true;
-    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ZERO;
 
     /**
      * Globally Unique Identifier for use in WebSocket handshake within {@code Sec-WebSocket-Accept} and <code>Sec-WebSocket-Key</code> http headers.

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 public final class WebSocketConstants
 {
@@ -32,6 +33,7 @@ public final class WebSocketConstants
     public static final int DEFAULT_INPUT_BUFFER_SIZE = 4 * 1024;
     public static final int DEFAULT_OUTPUT_BUFFER_SIZE = 4 * 1024;
     public static final boolean DEFAULT_AUTO_FRAGMENT = true;
+    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ZERO;
 
     /**
      * Globally Unique Identifier for use in WebSocket handshake within {@code Sec-WebSocket-Accept} and <code>Sec-WebSocket-Key</code> http headers.

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -338,6 +338,8 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
             WebSocketConstants.SPEC_VERSION_STRING);
 
         WebSocketChannel wsChannel = newWebSocketChannel(frameHandler, negotiated);
+        wsClient.customize(wsChannel);
+
         WebSocketConnection wsConnection = newWebSocketConnection(endp, httpClient.getExecutor(), httpClient.getByteBufferPool(), wsChannel);
 
         for (Connection.Listener listener : wsClient.getBeans(Connection.Listener.class))
@@ -345,7 +347,6 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
 
         wsChannel.setWebSocketConnection(wsConnection);
 
-        wsClient.customize(wsChannel);
         notifyUpgradeListeners((listener) -> listener.onHandshakeResponse(this, response));
 
         // Now swap out the connection

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -77,6 +77,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     private int outputBufferSize = WebSocketConstants.DEFAULT_OUTPUT_BUFFER_SIZE;
     private long maxBinaryMessageSize = WebSocketConstants.DEFAULT_MAX_BINARY_MESSAGE_SIZE;
     private long maxTextMessageSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
+    private Duration idleTimeout = WebSocketConstants.DEFAULT_IDLE_TIMEOUT;
 
     public WebSocketChannel(FrameHandler handler,
         Behavior behavior,
@@ -222,13 +223,19 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     @Override
     public Duration getIdleTimeout()
     {
-        return Duration.ofMillis(getConnection().getEndPoint().getIdleTimeout());
+        if (getConnection() == null)
+            return idleTimeout;
+        else
+            return Duration.ofMillis(getConnection().getEndPoint().getIdleTimeout());
     }
 
     @Override
     public void setIdleTimeout(Duration timeout)
     {
-        getConnection().getEndPoint().setIdleTimeout(timeout == null?0:timeout.toMillis());
+        if (getConnection() == null)
+            idleTimeout = timeout;
+        else
+            getConnection().getEndPoint().setIdleTimeout(timeout.toMillis());
     }
 
     public SocketAddress getLocalAddress()
@@ -255,6 +262,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     public void setWebSocketConnection(WebSocketConnection connection)
     {
         this.connection = connection;
+        getConnection().getEndPoint().setIdleTimeout(idleTimeout.toMillis());
     }
 
     /**

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -77,7 +77,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     private int outputBufferSize = WebSocketConstants.DEFAULT_OUTPUT_BUFFER_SIZE;
     private long maxBinaryMessageSize = WebSocketConstants.DEFAULT_MAX_BINARY_MESSAGE_SIZE;
     private long maxTextMessageSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
-    private Duration idleTimeout = WebSocketConstants.DEFAULT_IDLE_TIMEOUT;
+    private Duration idleTimeout;
 
     public WebSocketChannel(FrameHandler handler,
         Behavior behavior,
@@ -262,7 +262,11 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     public void setWebSocketConnection(WebSocketConnection connection)
     {
         this.connection = connection;
-        getConnection().getEndPoint().setIdleTimeout(idleTimeout.toMillis());
+        if (idleTimeout != null)
+        {
+            getConnection().getEndPoint().setIdleTimeout(idleTimeout.toMillis());
+            idleTimeout = null;
+        }
     }
 
     /**

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.websocket.core.server.internal;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -181,6 +182,10 @@ public final class RFC6455Handshaker implements Handshaker
 
         // Create the Channel
         WebSocketChannel channel = newWebSocketChannel(handler, negotiated);
+        if (defaultCustomizer!=null)
+            defaultCustomizer.customize(channel);
+        negotiator.customize(channel);
+
         if (LOG.isDebugEnabled())
             LOG.debug("channel {}", channel);
 
@@ -198,9 +203,6 @@ public final class RFC6455Handshaker implements Handshaker
             connection.addListener(listener);
 
         channel.setWebSocketConnection(connection);
-        if (defaultCustomizer!=null)
-            defaultCustomizer.customize(channel);
-        negotiator.customize(channel);
 
         // send upgrade response
         Response baseResponse = baseRequest.getResponse();

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServlet.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServlet.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.websocket.servlet;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.time.Duration;
+
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -158,10 +159,7 @@ public abstract class WebSocketServlet extends HttpServlet
     protected void service(HttpServletRequest req, HttpServletResponse resp)
         throws ServletException, IOException
     {
-        // Often this servlet is used together with the WebSocketUpgradeFilter,
-        // so upgrade requests will normally be upgraded by the filter.  But we
-        // can do it here as well if for some reason the filter did not match.
-        if (mapping.upgrade(req, resp, null))
+        if (mapping.upgrade(req, resp, customizer))
             return;
 
         // If we reach this point, it means we had an incoming request to upgrade


### PR DESCRIPTION
Issue #3412
the autoFragment boolean was never being set on the `Parser` as it was only able to be set on the constructor of `WebSocketConnection` which is called before the point where the channel is customized to set autoFragment