### PR TITLE
Issue #3399 jetty.webapps.uri should be the parent of the webapp

### DIFF
--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -153,7 +153,7 @@ public class XmlConfiguration
                 Path webappPath = webapp.getFile().toPath().toAbsolutePath();
                 getProperties().put("jetty.webapp", webappPath.toString());
                 getProperties().put("jetty.webapps", webappPath.getParent().toString());
-                getProperties().put("jetty.webapps.uri", normalizeURI(webapp.getURI().toString()));
+                getProperties().put("jetty.webapps.uri", normalizeURI(webappPath.getParent().toUri().toString()));
             }
         }
         catch(Exception e)

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -22,10 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -980,5 +984,25 @@ public class XmlConfigurationTest
             assertThat(propName, tc.getTestString(), is(notNullValue()));
             assertThat(propName, tc.getTestString(), startsWith("file:"));
         }
+    }
+    
+    @Test
+    public void testJettyStandardIdsAndProperties_JettyWebappsUri() throws Exception
+    {
+    	Path war = MavenTestingUtils.getTargetPath("no.war");
+    	XmlConfiguration configuration =
+                new XmlConfiguration("" +
+                        "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+                        "  <Set name=\"TestString\">" +
+                        "    <Property name=\"" + "jetty.webapps.uri" + "\"/>" +
+                        "  </Set>" +
+                        "</Configure>");
+
+        configuration.setJettyStandardIdsAndProperties(null, Resource.newResource(war));
+
+        TestConfiguration tc = new TestConfiguration();
+        configuration.configure(tc);
+
+        assertThat("jetty.webapps.uri", tc.getTestString(), is(XmlConfiguration.normalizeURI(war.getParent().toUri().toString())));
     }
 }


### PR DESCRIPTION
Issue #3399

The XmlConfiguration property jetty.webapps.uri should be the uri of the parent of the webapp, but is currently the uri of the webapp itself.  Fixed in jetty-10.0.x to not disturb any users in jetty-9 who are currently relying on the (incorrect) value.