### PR TITLE
WebSocketChannel bug fixes, cleanup and javadoc updates for FrameHandler

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
@@ -210,6 +210,31 @@ public interface Callback extends Invocable
         };
     }
 
+    /**
+     * Create a nested callback which always fails the nested callback on completion.
+     * @param callback The nested callback
+     * @param cause The cause to fail the nested callback, if the new callback is failed the reason
+     *             will be added to this cause as a suppressed exception.
+     * @return a new callback.
+     */
+    static Callback from(Callback callback, Throwable cause)
+    {
+        return new Callback()
+        {
+            @Override
+            public void succeeded()
+            {
+                callback.failed(cause);
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                cause.addSuppressed(x);
+                callback.failed(cause);
+            }
+        };
+    }
 
     class Completing implements Callback
     {

--- a/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -135,7 +135,8 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     public CompletableFuture<Session> connect(Object websocket, URI toUri, UpgradeRequest request, UpgradeListener listener) throws IOException
     {
         JettyClientUpgradeRequest upgradeRequest = new JettyClientUpgradeRequest(this, coreClient, request, toUri, websocket);
-        upgradeRequest.addListener(listener);
+        if (listener != null)
+            upgradeRequest.addListener(listener);
         coreClient.connect(upgradeRequest);
         return upgradeRequest.getFutureSession();
     }


### PR DESCRIPTION
these are the changes from #3365 which are not related to the `WebSocketProxy`

- update javadoc of `FrameHandler`

- pass the cause from the `AbnormalCloseStatus` to closeConnection in
WSChannel

- If `onOpen()` throws we now throw a runtime exception in addition to
failing the callback, this is to fail the `CompletableFuture` in the
`ClientUpgradeRequest`.

- new utility method in `Callback` used in WSChannel and will be used in `WebSocketProxy` as well