### PR TITLE
Fixes #3411 - HttpClient does not timeout during multiple redirection.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -217,6 +218,8 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                     path = request.getPath();
                 }
                 Request newRequest = client.copyRequest(request, requestURI);
+                // Disable the timeout so that only the one from the initial request applies.
+                newRequest.timeout(0, TimeUnit.MILLISECONDS);
                 if (path != null)
                     newRequest.path(path);
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -928,7 +928,7 @@ public class HttpClient extends ContainerLifeCycle
     }
 
     /**
-     * @return the max number of HTTP redirects that are followed
+     * @return the max number of HTTP redirects that are followed in a conversation
      * @see #setMaxRedirects(int)
      */
     public int getMaxRedirects()
@@ -937,7 +937,7 @@ public class HttpClient extends ContainerLifeCycle
     }
 
     /**
-     * @param maxRedirects the max number of HTTP redirects that are followed
+     * @param maxRedirects the max number of HTTP redirects that are followed in a conversation, or -1 for unlimited redirects
      * @see #setFollowRedirects(boolean)
      */
     public void setMaxRedirects(int maxRedirects)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.client;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -63,10 +62,10 @@ public class HttpRedirector
 {
     private static final Logger LOG = Log.getLogger(HttpRedirector.class);
     private static final String SCHEME_REGEXP = "(^https?)";
-    private static final String AUTHORITY_REGEXP = "([^/\\?#]+)";
+    private static final String AUTHORITY_REGEXP = "([^/?#]+)";
     // The location may be relative so the scheme://authority part may be missing
     private static final String DESTINATION_REGEXP = "(" + SCHEME_REGEXP + "://" + AUTHORITY_REGEXP + ")?";
-    private static final String PATH_REGEXP = "([^\\?#]*)";
+    private static final String PATH_REGEXP = "([^?#]*)";
     private static final String QUERY_REGEXP = "([^#]*)";
     private static final String FRAGMENT_REGEXP = "(.*)";
     private static final Pattern URI_PATTERN = Pattern.compile(DESTINATION_REGEXP + PATH_REGEXP + QUERY_REGEXP + FRAGMENT_REGEXP);
@@ -159,14 +158,6 @@ public class HttpRedirector
             URI newURI = extractRedirectURI(response);
             if (newURI != null)
             {
-                boolean absolute = newURI.isAbsolute();
-                URI uri = request.getURI();
-                if (absolute && newURI.equals(uri) ||
-                        !absolute && Objects.equals(newURI.getPath(), uri.getPath()))
-                {
-                    fail(request, response, new HttpResponseException("Redirect to same URI: " + location, response));
-                    return null;
-                }
                 if (LOG.isDebugEnabled())
                     LOG.debug("Redirecting to {} (Location: {})", newURI, location);
                 return redirect(request, response, listener, newURI);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -261,12 +261,14 @@ public interface Request
     Request idleTimeout(long timeout, TimeUnit unit);
 
     /**
-     * @return the total timeout for this request, in milliseconds
+     * @return the total timeout for this request, in milliseconds;
+     * zero or negative if the timeout is disabled
      */
     long getTimeout();
 
     /**
-     * @param timeout the total timeout for the request/response conversation
+     * @param timeout the total timeout for the request/response conversation;
+     *                use zero or a negative value to disable the timeout
      * @param unit the timeout unit
      * @return this request object
      */

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
@@ -483,13 +483,9 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
         });
 
         ExecutionException x = assertThrows(ExecutionException.class, () ->
-        {
-            client.setMaxRedirects(-1);
-            client.newRequest("localhost", connector.getLocalPort())
-                    .scheme(scenario.getScheme())
-                    .timeout(5, TimeUnit.SECONDS)
-                    .send();
-        });
+                client.newRequest("localhost", connector.getLocalPort())
+                        .scheme(scenario.getScheme())
+                        .send());
         assertThat(x.getCause(), Matchers.instanceOf(HttpResponseException.class));
     }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
@@ -18,14 +18,6 @@
 
 package org.eclipse.jetty.client;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
@@ -34,7 +26,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -48,12 +42,19 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.toolchain.test.IO;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpClientRedirectTest extends AbstractHttpClientServerTest
 {
@@ -128,14 +129,13 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
     {
         start(scenario, new RedirectHandler());
 
-        ExecutionException x = assertThrows(ExecutionException.class, ()->{
-            client.newRequest("localhost", connector.getLocalPort())
-                    .scheme(scenario.getScheme())
-                    .method(HttpMethod.DELETE)
-                    .path("/301/localhost/done")
-                    .timeout(5, TimeUnit.SECONDS)
-                    .send();
-        });
+        ExecutionException x = assertThrows(ExecutionException.class, () ->
+                client.newRequest("localhost", connector.getLocalPort())
+                        .scheme(scenario.getScheme())
+                        .method(HttpMethod.DELETE)
+                        .path("/301/localhost/done")
+                        .timeout(5, TimeUnit.SECONDS)
+                        .send());
         HttpResponseException xx = (HttpResponseException)x.getCause();
         Response response = xx.getResponse();
         assertNotNull(response);
@@ -170,13 +170,12 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
         start(scenario, new RedirectHandler());
         client.setMaxRedirects(1);
 
-        ExecutionException x = assertThrows(ExecutionException.class, ()->{
-            client.newRequest("localhost", connector.getLocalPort())
-                    .scheme(scenario.getScheme())
-                    .path("/303/localhost/302/localhost/done")
-                    .timeout(5, TimeUnit.SECONDS)
-                    .send();
-        });
+        ExecutionException x = assertThrows(ExecutionException.class, () ->
+                client.newRequest("localhost", connector.getLocalPort())
+                        .scheme(scenario.getScheme())
+                        .path("/303/localhost/302/localhost/done")
+                        .timeout(5, TimeUnit.SECONDS)
+                        .send());
         HttpResponseException xx = (HttpResponseException)x.getCause();
         Response response = xx.getResponse();
         assertNotNull(response);
@@ -269,12 +268,11 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
     @ArgumentsSource(ScenarioProvider.class)
     public void testRedirectWithWrongScheme(Scenario scenario) throws Exception
     {
-        start(scenario, new AbstractHandler()
+        start(scenario, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                baseRequest.setHandled(true);
                 response.setStatus(303);
                 response.setHeader("Location", "ssh://localhost:" + connector.getLocalPort() + "/path");
             }
@@ -439,12 +437,11 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
     public void testRedirectWithCorruptedBody(Scenario scenario) throws Exception
     {
         byte[] bytes = "ok".getBytes(StandardCharsets.UTF_8);
-        start(scenario, new AbstractHandler()
+        start(scenario, new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                baseRequest.setHandled(true);
                 if (target.startsWith("/redirect"))
                 {
                     response.setStatus(HttpStatus.SEE_OTHER_303);
@@ -469,6 +466,64 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
 
         assertEquals(200, response.getStatus());
         assertArrayEquals(bytes, response.getContent());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testRedirectToSameURL(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                response.setStatus(HttpStatus.SEE_OTHER_303);
+                response.setHeader(HttpHeader.LOCATION.asString(), request.getRequestURI());
+            }
+        });
+
+        ExecutionException x = assertThrows(ExecutionException.class, () ->
+        {
+            client.setMaxRedirects(-1);
+            client.newRequest("localhost", connector.getLocalPort())
+                    .scheme(scenario.getScheme())
+                    .timeout(5, TimeUnit.SECONDS)
+                    .send();
+        });
+        assertThat(x.getCause(), Matchers.instanceOf(HttpResponseException.class));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testInfiniteRedirectLoopMustTimeout(Scenario scenario) throws Exception
+    {
+        AtomicLong counter = new AtomicLong();
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                try
+                {
+                    Thread.sleep(200);
+                    response.setStatus(HttpStatus.SEE_OTHER_303);
+                    response.setHeader(HttpHeader.LOCATION.asString(), "/" + counter.getAndIncrement());
+                }
+                catch (InterruptedException x)
+                {
+                    throw new RuntimeException(x);
+                }
+            }
+        });
+
+        assertThrows(TimeoutException.class, () ->
+        {
+            client.setMaxRedirects(-1);
+            client.newRequest("localhost", connector.getLocalPort())
+                    .scheme(scenario.getScheme())
+                    .timeout(1, TimeUnit.SECONDS)
+                    .send();
+        });
     }
 
     private void testSameMethodRedirect(final Scenario scenario, final HttpMethod method, int redirectCode) throws Exception
@@ -519,10 +574,10 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
         assertEquals(200, response.getStatus());
     }
 
-    private class RedirectHandler extends AbstractHandler
+    private class RedirectHandler extends EmptyServerHandler
     {
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+        protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
         {
             try
             {
@@ -550,10 +605,6 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
                 response.setStatus(200);
                 // Echo content back
                 IO.copy(request.getInputStream(), response.getOutputStream());
-            }
-            finally
-            {
-                baseRequest.setHandled(true);
             }
         }
     }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -18,16 +18,6 @@
 
 package org.eclipse.jetty.client;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -105,6 +95,16 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 public class HttpClientTest extends AbstractHttpClientServerTest


### PR DESCRIPTION
#3411.
Removed timeout after copying the request in case of redirects
(and authentications), to avoid that the timeout listener is
notified of intermediate exchanges and resets the timeout.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>