### PR TITLE
Issue #3458 - jetty websocket upgrades without using websocket-servlet classes

### DIFF
--- a/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
+++ b/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
@@ -18,236 +18,70 @@
 
 package org.eclipse.jetty.websocket.api.extensions;
 
-import org.eclipse.jetty.websocket.api.util.QuoteUtil;
-
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 /**
  * Represents an Extension Configuration, as seen during the connection Handshake process.
  */
-public class ExtensionConfig
+public interface ExtensionConfig
 {
-    /**
-     * Parse a single parameterized name.
-     *
-     * @param parameterizedName the parameterized name
-     * @return the ExtensionConfig
-     */
-    public static ExtensionConfig parse(String parameterizedName)
+    interface Parser
     {
-        return new ExtensionConfig(parameterizedName);
+        ExtensionConfig parse(String parameterizedName);
+        List<ExtensionConfig> parseEnum(Enumeration<String> valuesEnum);
+        List<ExtensionConfig> parseList(String... rawSecWebSocketExtensions);
+        String toHeaderValue(List<ExtensionConfig> configs);
     }
 
-    /**
-     * Parse enumeration of {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
-     *
-     * @param valuesEnum the raw header values enum
-     * @return the list of extension configs
-     */
-    public static List<ExtensionConfig> parseEnum(Enumeration<String> valuesEnum)
+    private static ExtensionConfig.Parser getParser()
     {
-        List<ExtensionConfig> configs = new ArrayList<>();
-
-        if (valuesEnum != null)
-        {
-            while (valuesEnum.hasMoreElements())
-            {
-                Iterator<String> extTokenIter = QuoteUtil.splitAt(valuesEnum.nextElement(), ",");
-                while (extTokenIter.hasNext())
-                {
-                    String extToken = extTokenIter.next();
-                    configs.add(ExtensionConfig.parse(extToken));
-                }
-            }
-        }
-
-        return configs;
+        return ServiceLoader.load(ExtensionConfig.Parser.class).findFirst().get();
     }
 
-    /**
-     * Parse 1 or more raw {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
-     *
-     * @param rawSecWebSocketExtensions the raw header values
-     * @return the list of extension configs
-     */
-    public static List<ExtensionConfig> parseList(String... rawSecWebSocketExtensions)
+    static ExtensionConfig parse(String parameterizedName)
     {
-        List<ExtensionConfig> configs = new ArrayList<>();
-
-        for (String rawValue : rawSecWebSocketExtensions)
-        {
-            Iterator<String> extTokenIter = QuoteUtil.splitAt(rawValue, ",");
-            while (extTokenIter.hasNext())
-            {
-                String extToken = extTokenIter.next();
-                configs.add(ExtensionConfig.parse(extToken));
-            }
-        }
-
-        return configs;
+        return getParser().parse(parameterizedName);
     }
 
-    /**
-     * Convert a list of {@code ExtensionConfig} to a header value
-     *
-     * @param configs the list of extension configs
-     * @return the header value (null if no configs present)
-     */
-    public static String toHeaderValue(List<ExtensionConfig> configs)
+    static List<ExtensionConfig> parseEnum(Enumeration<String> valuesEnum)
     {
-        if ((configs == null) || (configs.isEmpty()))
-        {
-            return null;
-        }
-        StringBuilder parameters = new StringBuilder();
-        boolean needsDelim = false;
-        for (ExtensionConfig ext : configs)
-        {
-            if (needsDelim)
-            {
-                parameters.append(", ");
-            }
-            parameters.append(ext.getParameterizedName());
-            needsDelim = true;
-        }
-        return parameters.toString();
+        return getParser().parseEnum(valuesEnum);
     }
 
-    private final String name;
-    private final Map<String, String> parameters;
-
-    /**
-     * Copy constructor
-     *
-     * @param copy the extension config to copy
-     */
-    public ExtensionConfig(ExtensionConfig copy)
+    static List<ExtensionConfig> parseList(String... rawSecWebSocketExtensions)
     {
-        this.name = copy.name;
-        this.parameters = new HashMap<>();
-        this.parameters.putAll(copy.parameters);
+        return getParser().parseList(rawSecWebSocketExtensions);
     }
 
-    public ExtensionConfig(String parameterizedName)
+    static String toHeaderValue(List<ExtensionConfig> configs)
     {
-        Iterator<String> extListIter = QuoteUtil.splitAt(parameterizedName, ";");
-        this.name = extListIter.next();
-        this.parameters = new HashMap<>();
-
-        // now for parameters
-        while (extListIter.hasNext())
-        {
-            String extParam = extListIter.next();
-            Iterator<String> extParamIter = QuoteUtil.splitAt(extParam, "=");
-            String key = extParamIter.next().trim();
-            String value = null;
-            if (extParamIter.hasNext())
-            {
-                value = extParamIter.next();
-            }
-            parameters.put(key, value);
-        }
+        return getParser().toHeaderValue(configs);
     }
 
-    public ExtensionConfig(String name, Map<String, String> parameters)
-    {
-        this.name = name;
-        this.parameters = parameters;
-    }
+    String getName();
 
-    public String getName()
-    {
-        return name;
-    }
+    int getParameter(String key, int defValue);
 
-    public final int getParameter(String key, int defValue)
-    {
-        String val = parameters.get(key);
-        if (val == null)
-        {
-            return defValue;
-        }
-        return Integer.parseInt(val);
-    }
+    String getParameter(String key, String defValue);
 
-    public final String getParameter(String key, String defValue)
-    {
-        String val = parameters.get(key);
-        if (val == null)
-        {
-            return defValue;
-        }
-        return val;
-    }
+    String getParameterizedName();
 
-    public final String getParameterizedName()
-    {
-        StringBuilder str = new StringBuilder();
-        str.append(name);
-        for (String param : parameters.keySet())
-        {
-            str.append(';');
-            str.append(param);
-            String value = parameters.get(param);
-            if (value != null)
-            {
-                str.append('=');
-                QuoteUtil.quoteIfNeeded(str, value, ";=");
-            }
-        }
-        return str.toString();
-    }
-
-    public final Set<String> getParameterKeys()
-    {
-        return parameters.keySet();
-    }
+    Set<String> getParameterKeys();
 
     /**
      * Return parameters found in request URI.
      *
      * @return the parameter map
      */
-    public final Map<String, String> getParameters()
-    {
-        return parameters;
-    }
+    Map<String, String> getParameters();
 
-    /**
-     * Initialize the parameters on this config from the other configuration.
-     *
-     * @param other the other configuration.
-     */
-    public final void init(ExtensionConfig other)
-    {
-        this.parameters.clear();
-        this.parameters.putAll(other.parameters);
-    }
+    void setParameter(String key);
 
-    public final void setParameter(String key)
-    {
-        parameters.put(key, null);
-    }
+    void setParameter(String key, int value);
 
-    public final void setParameter(String key, int value)
-    {
-        parameters.put(key, Integer.toString(value));
-    }
-
-    public final void setParameter(String key, String value)
-    {
-        parameters.put(key, value);
-    }
-
-    @Override
-    public String toString()
-    {
-        return getParameterizedName();
-    }
+    void setParameter(String key, String value);
 }

--- a/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
+++ b/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/extensions/ExtensionConfig.java
@@ -18,8 +18,6 @@
 
 package org.eclipse.jetty.websocket.api.extensions;
 
-import java.util.Enumeration;
-import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -32,9 +30,6 @@ public interface ExtensionConfig
     interface Parser
     {
         ExtensionConfig parse(String parameterizedName);
-        List<ExtensionConfig> parseEnum(Enumeration<String> valuesEnum);
-        List<ExtensionConfig> parseList(String... rawSecWebSocketExtensions);
-        String toHeaderValue(List<ExtensionConfig> configs);
     }
 
     private static ExtensionConfig.Parser getParser()
@@ -45,21 +40,6 @@ public interface ExtensionConfig
     static ExtensionConfig parse(String parameterizedName)
     {
         return getParser().parse(parameterizedName);
-    }
-
-    static List<ExtensionConfig> parseEnum(Enumeration<String> valuesEnum)
-    {
-        return getParser().parseEnum(valuesEnum);
-    }
-
-    static List<ExtensionConfig> parseList(String... rawSecWebSocketExtensions)
-    {
-        return getParser().parseList(rawSecWebSocketExtensions);
-    }
-
-    static String toHeaderValue(List<ExtensionConfig> configs)
-    {
-        return getParser().toHeaderValue(configs);
     }
 
     String getName();

--- a/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/JettyUpgradeListener.java
+++ b/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/JettyUpgradeListener.java
@@ -1,0 +1,42 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.client;
+
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.HttpResponse;
+
+public interface JettyUpgradeListener
+{
+    /**
+     * Event that triggers before the Handshake request is sent.
+     *
+     * @param request the request
+     */
+    default void onHandshakeRequest(HttpRequest request)
+    {}
+
+    /**
+     * Event that triggers after the Handshake response has been received.
+     *
+     * @param request  the request that was used
+     * @param response the response that was received
+     */
+    default void onHandshakeResponse(HttpRequest request, HttpResponse response)
+    {}
+}

--- a/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/impl/JettyClientUpgradeRequest.java
+++ b/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/impl/JettyClientUpgradeRequest.java
@@ -22,6 +22,7 @@ import java.net.HttpCookie;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.client.HttpResponse;
 import org.eclipse.jetty.http.HttpFields;
@@ -33,6 +34,7 @@ import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.common.JettyWebSocketFrameHandler;
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
@@ -74,9 +76,9 @@ public class JettyClientUpgradeRequest extends ClientUpgradeRequest
             setSubProtocols(request.getSubProtocols());
 
             // Copy extensions
-            /* TODO or not?
-            setExtensions(request.getExtensions());
-            */
+            setExtensions(request.getExtensions().stream()
+                    .map(c -> new ExtensionConfig(c.getName(), c.getParameters()))
+                    .collect(Collectors.toList()));
 
             // Copy method from upgradeRequest object
             if (request.getMethod() != null)

--- a/jetty-websocket/jetty-websocket-common/src/main/java/module-info.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/module-info.java
@@ -16,6 +16,9 @@
 //  ========================================================================
 //
 
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.common.ExtensionConfigParser;
+
 module org.eclipse.jetty.websocket.jetty.common
 {
     exports org.eclipse.jetty.websocket.common;
@@ -27,4 +30,6 @@ module org.eclipse.jetty.websocket.jetty.common
     requires org.eclipse.jetty.util;
     requires org.eclipse.jetty.websocket.core;
     requires org.eclipse.jetty.websocket.jetty.api;
+
+    provides ExtensionConfig.Parser with ExtensionConfigParser;
 }

--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/ExtensionConfigParser.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/ExtensionConfigParser.java
@@ -1,0 +1,85 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.common;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
+
+public class ExtensionConfigParser implements org.eclipse.jetty.websocket.api.extensions.ExtensionConfig.Parser
+{
+    /**
+     * Parse a single parameterized name.
+     *
+     * @param parameterizedName the parameterized name
+     * @return the ExtensionConfig
+     */
+    @Override
+    public JettyExtensionConfig parse(String parameterizedName)
+    {
+        return new JettyExtensionConfig(ExtensionConfig.parse(parameterizedName));
+    }
+
+    /**
+     * Parse enumeration of {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
+     *
+     * @param valuesEnum the raw header values enum
+     * @return the list of extension configs
+     */
+    @Override
+    public List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> parseEnum(Enumeration<String> valuesEnum)
+    {
+        List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs = new ArrayList<>();
+        for (ExtensionConfig config : ExtensionConfig.parseEnum(valuesEnum))
+            configs.add(new JettyExtensionConfig(config));
+        return configs;
+    }
+
+    /**
+     * Parse 1 or more raw {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
+     *
+     * @param rawSecWebSocketExtensions the raw header values
+     * @return the list of extension configs
+     */
+    @Override
+    public List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> parseList(String... rawSecWebSocketExtensions)
+    {
+        List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs = new ArrayList<>();
+        for (ExtensionConfig config : ExtensionConfig.parseList(rawSecWebSocketExtensions))
+            configs.add(new JettyExtensionConfig(config));
+        return configs;
+    }
+
+    /**
+     * Convert a list of {@code ExtensionConfig} to a header value
+     *
+     * @param configs the list of extension configs
+     * @return the header value (null if no configs present)
+     */
+    @Override
+    public String toHeaderValue(List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs)
+    {
+        return ExtensionConfig.toHeaderValue(configs.stream()
+                .map(c->new ExtensionConfig(c.getName(), c.getParameters()))
+                .collect(Collectors.toList()));
+    }
+}

--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/ExtensionConfigParser.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/ExtensionConfigParser.java
@@ -18,11 +18,6 @@
 
 package org.eclipse.jetty.websocket.common;
 
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 
 public class ExtensionConfigParser implements org.eclipse.jetty.websocket.api.extensions.ExtensionConfig.Parser
@@ -37,49 +32,5 @@ public class ExtensionConfigParser implements org.eclipse.jetty.websocket.api.ex
     public JettyExtensionConfig parse(String parameterizedName)
     {
         return new JettyExtensionConfig(ExtensionConfig.parse(parameterizedName));
-    }
-
-    /**
-     * Parse enumeration of {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
-     *
-     * @param valuesEnum the raw header values enum
-     * @return the list of extension configs
-     */
-    @Override
-    public List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> parseEnum(Enumeration<String> valuesEnum)
-    {
-        List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs = new ArrayList<>();
-        for (ExtensionConfig config : ExtensionConfig.parseEnum(valuesEnum))
-            configs.add(new JettyExtensionConfig(config));
-        return configs;
-    }
-
-    /**
-     * Parse 1 or more raw {@code Sec-WebSocket-Extensions} header values into a {@code ExtensionConfig} list
-     *
-     * @param rawSecWebSocketExtensions the raw header values
-     * @return the list of extension configs
-     */
-    @Override
-    public List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> parseList(String... rawSecWebSocketExtensions)
-    {
-        List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs = new ArrayList<>();
-        for (ExtensionConfig config : ExtensionConfig.parseList(rawSecWebSocketExtensions))
-            configs.add(new JettyExtensionConfig(config));
-        return configs;
-    }
-
-    /**
-     * Convert a list of {@code ExtensionConfig} to a header value
-     *
-     * @param configs the list of extension configs
-     * @return the header value (null if no configs present)
-     */
-    @Override
-    public String toHeaderValue(List<org.eclipse.jetty.websocket.api.extensions.ExtensionConfig> configs)
-    {
-        return ExtensionConfig.toHeaderValue(configs.stream()
-                .map(c->new ExtensionConfig(c.getName(), c.getParameters()))
-                .collect(Collectors.toList()));
     }
 }

--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyExtensionConfig.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyExtensionConfig.java
@@ -1,0 +1,128 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.common;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
+
+/**
+ * Represents an Extension Configuration, as seen during the connection Handshake process.
+ */
+public class JettyExtensionConfig implements org.eclipse.jetty.websocket.api.extensions.ExtensionConfig
+{
+
+    private final ExtensionConfig config;
+
+    /**
+     * Copy constructor
+     *
+     * @param copy the extension config to copy
+     */
+    public JettyExtensionConfig(JettyExtensionConfig copy)
+    {
+        this(copy.config);
+    }
+
+    public JettyExtensionConfig(ExtensionConfig config)
+    {
+        this.config = config;
+    }
+
+    public JettyExtensionConfig(String parameterizedName)
+    {
+        this.config = new ExtensionConfig(parameterizedName);
+    }
+
+    public JettyExtensionConfig(String name, Map<String, String> parameters)
+    {
+        this.config = new ExtensionConfig(name, parameters);
+    }
+
+    public ExtensionConfig getCoreConfig()
+    {
+        return config;
+    }
+
+    @Override
+    public String getName()
+    {
+        return config.getName();
+    }
+
+    @Override
+    public final int getParameter(String key, int defValue)
+    {
+        return config.getParameter(key, defValue);
+    }
+
+    @Override
+    public final String getParameter(String key, String defValue)
+    {
+        return config.getParameter(key, defValue);
+    }
+
+    @Override
+    public final String getParameterizedName()
+    {
+        return config.getParameterizedName();
+    }
+
+    @Override
+    public final Set<String> getParameterKeys()
+    {
+        return config.getParameterKeys();
+    }
+
+    /**
+     * Return parameters found in request URI.
+     *
+     * @return the parameter map
+     */
+    @Override
+    public final Map<String, String> getParameters()
+    {
+        return config.getParameters();
+    }
+
+    @Override
+    public final void setParameter(String key)
+    {
+        config.setParameter(key);
+    }
+
+    @Override
+    public final void setParameter(String key, int value)
+    {
+        config.setParameter(key, value);
+    }
+
+    @Override
+    public final void setParameter(String key, String value)
+    {
+        config.setParameter(key, value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return config.toString();
+    }
+}

--- a/jetty-websocket/jetty-websocket-common/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.api.extensions.ExtensionConfig$Parser
+++ b/jetty-websocket/jetty-websocket-common/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.api.extensions.ExtensionConfig$Parser
@@ -1,0 +1,1 @@
+org.eclipse.jetty.websocket.common.ExtensionConfigParser

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeRequest.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeRequest.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.server;
 
 import java.net.HttpCookie;

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeRequest.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeRequest.java
@@ -1,0 +1,310 @@
+package org.eclipse.jetty.websocket.server;
+
+import java.net.HttpCookie;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
+import org.eclipse.jetty.websocket.core.server.Negotiation;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+
+public class JettyServerUpgradeRequest
+{
+    private ServletUpgradeRequest upgradeRequest;
+
+    public JettyServerUpgradeRequest(ServletUpgradeRequest request)
+    {
+        upgradeRequest = request;
+    }
+
+    /**
+     * @return The {@link X509Certificate} instance at request attribute "javax.servlet.request.X509Certificate" or null.
+     */
+    public X509Certificate[] getCertificates()
+    {
+        return upgradeRequest.getCertificates();
+    }
+
+    /**
+     * @see HttpServletRequest#getCookies()
+     * @return Request cookies
+     */
+    public List<HttpCookie> getCookies()
+    {
+        return upgradeRequest.getCookies();
+    }
+
+    /**
+     * @return The extensions offered
+     * @see Negotiation#getOfferedExtensions()
+     */
+    public List<ExtensionConfig> getExtensions()
+    {
+        return upgradeRequest.getExtensions().stream().map(JettyExtensionConfig::new).collect(Collectors.toList());
+    }
+
+    /**
+     * @param name Header name
+     * @return Header value or null
+     * @see HttpServletRequest#getHeader(String)
+     */
+    public String getHeader(String name)
+    {
+        return upgradeRequest.getHeader(name);
+    }
+
+    /**
+     * @param name Header name
+     * @return Header value as integer or -1
+     * @see HttpServletRequest#getHeader(String)
+     */
+    public int getHeaderInt(String name)
+    {
+        return upgradeRequest.getHeaderInt(name);
+    }
+
+    /**
+     * @return Map of headers
+     */
+    public Map<String, List<String>> getHeadersMap()
+    {
+        return upgradeRequest.getHeadersMap();
+    }
+
+    /**
+     * @param name Header name
+     * @return List of header values or null
+     */
+    public List<String> getHeaders(String name)
+    {
+        return upgradeRequest.getHeaders(name);
+    }
+
+    /**
+     * @return The requested host
+     * @see HttpServletRequest#getRequestURL()
+     */
+    public String getHost()
+    {
+        return upgradeRequest.getHost();
+    }
+
+    /**
+     * @return Immutable version of {@link HttpServletRequest}
+     */
+    public HttpServletRequest getHttpServletRequest()
+    {
+        return upgradeRequest.getHttpServletRequest();
+    }
+
+    /**
+     * @return The HTTP protocol version
+     * @see HttpServletRequest#getProtocol()
+     */
+    public String getHttpVersion()
+    {
+        return upgradeRequest.getHttpVersion();
+    }
+
+    /**
+     * @return The requested Locale
+     * @see HttpServletRequest#getLocale()
+     */
+    public Locale getLocale()
+    {
+        return upgradeRequest.getLocale();
+    }
+
+    /**
+     * @return The requested Locales
+     * @see HttpServletRequest#getLocales()
+     */
+    public Enumeration<Locale> getLocales()
+    {
+        return upgradeRequest.getLocales();
+    }
+
+    /**
+     * @return The local requested address, which is typically an {@link InetSocketAddress}, but may be another derivation of {@link SocketAddress}
+     * @see ServletRequest#getLocalAddr()
+     * @see ServletRequest#getLocalPort()
+     */
+    public SocketAddress getLocalSocketAddress()
+    {
+        return upgradeRequest.getLocalSocketAddress();
+    }
+
+    /**
+     * @return The requested method
+     * @see HttpServletRequest#getMethod()
+     */
+    public String getMethod()
+    {
+        return upgradeRequest.getMethod();
+    }
+
+    /**
+     * @return The origin header value
+     */
+    public String getOrigin()
+    {
+        return upgradeRequest.getOrigin();
+    }
+
+    /**
+     * @return The request parameter map
+     * @see ServletRequest#getParameterMap()
+     */
+    public Map<String, List<String>> getParameterMap()
+    {
+        return upgradeRequest.getParameterMap();
+    }
+
+    /**
+     * @return WebSocket protocol version from "Sec-WebSocket-Version" header
+     */
+    public String getProtocolVersion()
+    {
+        return upgradeRequest.getProtocolVersion();
+    }
+
+    /**
+     * @return The request query string
+     * @see HttpServletRequest#getQueryString()
+     */
+    public String getQueryString()
+    {
+        return upgradeRequest.getQueryString();
+    }
+
+    /**
+     * @return The remote request address, which is typically an {@link InetSocketAddress}, but may be another derivation of {@link SocketAddress}
+     * @see ServletRequest#getRemoteAddr()
+     * @see ServletRequest#getRemotePort()
+     */
+    public SocketAddress getRemoteSocketAddress()
+    {
+        return upgradeRequest.getRemoteSocketAddress();
+    }
+
+    /**
+     * @return The request URI path within the context
+     */
+    public String getRequestPath()
+    {
+        return upgradeRequest.getRequestPath();
+    }
+
+    /**
+     * @return The request URI
+     * @see HttpServletRequest#getRequestURL()
+     */
+    public URI getRequestURI()
+    {
+        return upgradeRequest.getRequestURI();
+    }
+
+    /**
+     * @param name Attribute name
+     * @return Attribute value or null
+     * @see ServletRequest#getAttribute(String)
+     */
+    public Object getServletAttribute(String name)
+    {
+        return upgradeRequest.getServletAttribute(name);
+    }
+
+    /**
+     * @return Request attribute map
+     */
+    public Map<String, Object> getServletAttributes()
+    {
+        return upgradeRequest.getServletAttributes();
+    }
+
+    /**
+     * @return Request parameters
+     * @see ServletRequest#getParameterMap()
+     */
+    public Map<String, List<String>> getServletParameters()
+    {
+        return upgradeRequest.getServletParameters();
+    }
+
+    /**
+     * @return The HttpSession, which may be null or invalidated
+     * @see HttpServletRequest#getSession(boolean)
+     */
+    public HttpSession getSession()
+    {
+        return upgradeRequest.getSession();
+    }
+
+    /**
+     * @return Get WebSocket negotiation offered sub protocols
+     */
+    public List<String> getSubProtocols()
+    {
+        return upgradeRequest.getSubProtocols();
+    }
+
+    /**
+     * @return The User's {@link Principal} or null
+     * @see HttpServletRequest#getUserPrincipal()
+     */
+    public Principal getUserPrincipal()
+    {
+        return upgradeRequest.getUserPrincipal();
+    }
+
+    /**
+     * @param subprotocol A sub protocol name
+     * @return True if the sub protocol was offered
+     */
+    public boolean hasSubProtocol(String subprotocol)
+    {
+        return upgradeRequest.hasSubProtocol(subprotocol);
+    }
+
+    /**
+     * @return True if the request is secure
+     * @see ServletRequest#isSecure()
+     */
+    public boolean isSecure()
+    {
+        return upgradeRequest.isSecure();
+    }
+
+    /**
+     * @param role The user role
+     * @return True if the requests user has the role
+     * @see HttpServletRequest#isUserInRole(String)
+     */
+    public boolean isUserInRole(String role)
+    {
+        return upgradeRequest.isUserInRole(role);
+    }
+
+    /**
+     * @param name Attribute name
+     * @param value Attribute value to set
+     * @see ServletRequest#setAttribute(String, Object)
+     */
+    public void setServletAttribute(String name, Object value)
+    {
+        upgradeRequest.setServletAttribute(name, value);
+    }
+}

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeResponse.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeResponse.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.server;
 
 import java.io.IOException;

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeResponse.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerUpgradeResponse.java
@@ -1,0 +1,103 @@
+package org.eclipse.jetty.websocket.server;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+
+public class JettyServerUpgradeResponse
+{
+    private ServletUpgradeResponse upgradeResponse;
+
+    public JettyServerUpgradeResponse(ServletUpgradeResponse response)
+    {
+        upgradeResponse = response;
+    }
+
+    public void addHeader(String name, String value)
+    {
+        upgradeResponse.addHeader(name, value);
+    }
+
+    public void setHeader(String name, String value)
+    {
+        upgradeResponse.setHeader(name, value);
+    }
+
+    public void setHeader(String name, List<String> values)
+    {
+        upgradeResponse.setHeader(name, values);
+    }
+
+    public String getAcceptedSubProtocol()
+    {
+        return upgradeResponse.getAcceptedSubProtocol();
+    }
+
+    public List<ExtensionConfig> getExtensions()
+    {
+        return upgradeResponse.getExtensions().stream().map(JettyExtensionConfig::new).collect(Collectors.toList());
+    }
+
+    public String getHeader(String name)
+    {
+        return upgradeResponse.getHeader(name);
+    }
+
+    public Set<String> getHeaderNames()
+    {
+        return upgradeResponse.getHeaderNames();
+    }
+
+    public Map<String, List<String>> getHeadersMap()
+    {
+        return upgradeResponse.getHeadersMap();
+    }
+
+    public List<String> getHeaders(String name)
+    {
+        return upgradeResponse.getHeaders(name);
+    }
+
+    public int getStatusCode()
+    {
+        return upgradeResponse.getStatusCode();
+    }
+
+    public boolean isCommitted()
+    {
+        return upgradeResponse.isCommitted();
+    }
+
+    public void sendError(int statusCode, String message) throws IOException
+    {
+        upgradeResponse.sendError(statusCode, message);
+    }
+
+    public void sendForbidden(String message) throws IOException
+    {
+        upgradeResponse.sendForbidden(message);
+    }
+
+    public void setAcceptedSubProtocol(String protocol)
+    {
+        upgradeResponse.setAcceptedSubProtocol(protocol);
+    }
+
+    public void setExtensions(List<ExtensionConfig> configs)
+    {
+        upgradeResponse.setExtensions(configs.stream()
+                .map(c->new org.eclipse.jetty.websocket.core.ExtensionConfig(c.getName(), c.getParameters()))
+                .collect(Collectors.toList()));
+    }
+
+    public void setStatusCode(int statusCode)
+    {
+        upgradeResponse.setStatusCode(statusCode);
+    }
+}

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketCreator.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketCreator.java
@@ -1,0 +1,21 @@
+package org.eclipse.jetty.websocket.server;
+
+
+/**
+ * Abstract WebSocket creator interface.
+ * <p>
+ * Should you desire filtering of the WebSocket object creation due to criteria such as origin or sub-protocol, then you will be required to implement a custom
+ * WebSocketCreator implementation.
+ * </p>
+ */
+public interface JettyWebSocketCreator
+{
+    /**
+     * Create a websocket from the incoming request.
+     *
+     * @param req  the request details
+     * @param resp the response details
+     * @return a websocket object to use, or null if no websocket should be created from this request.
+     */
+    Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp);
+}

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketCreator.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketCreator.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.server;
 
 

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServerContainer.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import javax.servlet.ServletContext;
 
 import org.eclipse.jetty.http.pathmap.PathSpec;
-import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -44,7 +43,6 @@ import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
 import org.eclipse.jetty.websocket.core.WebSocketException;
 import org.eclipse.jetty.websocket.servlet.FrameHandlerFactory;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketMapping;
 
 public class JettyWebSocketServerContainer extends ContainerLifeCycle implements WebSocketContainer, WebSocketPolicy, LifeCycle.Listener
@@ -114,13 +112,15 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
         addSessionListener(sessionTracker);
     }
 
-    public void addMapping(String pathSpec, WebSocketCreator creator)
+    public void addMapping(String pathSpec, JettyWebSocketCreator creator)
     {
         PathSpec ps = WebSocketMapping.parsePathSpec(pathSpec);
         if (webSocketMapping.getMapping(ps) != null)
             throw new WebSocketException("Duplicate WebSocket Mapping for PathSpec");
 
-        webSocketMapping.addMapping(ps, creator, frameHandlerFactory, customizer);
+        webSocketMapping.addMapping(ps,
+                (req, resp)-> creator.createWebSocket(new JettyServerUpgradeRequest(req), new JettyServerUpgradeResponse(resp)),
+                frameHandlerFactory, customizer);
     }
 
     @Override

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/internal/DelegatedJettyServletUpgradeRequest.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/internal/DelegatedJettyServletUpgradeRequest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 
 public class DelegatedJettyServletUpgradeRequest implements UpgradeRequest
@@ -60,7 +61,7 @@ public class DelegatedJettyServletUpgradeRequest implements UpgradeRequest
     public List<ExtensionConfig> getExtensions()
     {
         return this.servletRequest.getExtensions().stream()
-            .map((ext) -> new org.eclipse.jetty.websocket.api.extensions.ExtensionConfig(ext.getName(), ext.getParameters()))
+            .map((ext) -> new JettyExtensionConfig(ext.getName(), ext.getParameters()))
             .collect(Collectors.toList());
     }
 

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseAdapter.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseAdapter.java
@@ -18,15 +18,16 @@
 
 package org.eclipse.jetty.websocket.server.internal;
 
-import org.eclipse.jetty.websocket.api.UpgradeResponse;
-import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.eclipse.jetty.websocket.api.UpgradeResponse;
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 
 public class UpgradeResponseAdapter implements UpgradeResponse
 {
@@ -53,7 +54,7 @@ public class UpgradeResponseAdapter implements UpgradeResponse
     public List<ExtensionConfig> getExtensions()
     {
         return this.servletResponse.getExtensions().stream()
-            .map((ext) -> new org.eclipse.jetty.websocket.api.extensions.ExtensionConfig(ext.getName(), ext.getParameters()))
+            .map((ext) -> new JettyExtensionConfig(ext.getName(), ext.getParameters()))
             .collect(Collectors.toList());
     }
 

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
@@ -1,0 +1,136 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.HttpResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.UpgradeRequest;
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.client.UpgradeListener;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JettyWebSocketExtensionConfigTest
+{
+    Server server;
+    WebSocketClient client;
+
+    @BeforeEach
+    public void start() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(8080);
+        server.addConnector(connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+
+        JettyWebSocketServerContainer container = JettyWebSocketServletContainerInitializer.configureContext(contextHandler);
+        container.addMapping("/", (req, resp)->
+        {
+            assertEquals(req.getExtensions().stream().filter(e -> e.getName().equals("permessage-deflate")).count(), 1);
+            assertEquals(resp.getExtensions().stream().filter(e -> e.getName().equals("permessage-deflate")).count(), 1);
+
+            ExtensionConfig nonRequestedExtension = ExtensionConfig.parse("identity");
+            assertNotNull(nonRequestedExtension);
+
+            assertThrows(IllegalArgumentException.class,
+                    ()->resp.setExtensions(List.of(nonRequestedExtension)),
+                    "should not allow extensions not requested");
+
+            // Check identity extension was not added because it was not requested
+            assertEquals(resp.getExtensions().stream().filter(config -> config.getName().equals("identity")).count(), 0);
+            assertEquals(resp.getExtensions().stream().filter(e -> e.getName().equals("permessage-deflate")).count(), 1);
+
+            return new EchoSocket();
+        });
+        server.start();
+
+        client = new WebSocketClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testJettyExtensionConfig() throws Exception
+    {
+        URI uri = URI.create("ws://localhost:8080/filterPath");
+        EventSocket socket = new EventSocket();
+
+        UpgradeRequest request = new ClientUpgradeRequest();
+        request.addExtensions(ExtensionConfig.parse("permessage-deflate"));
+
+        CountDownLatch correctResponseExtensions = new CountDownLatch(1);
+        UpgradeListener listener = new UpgradeListener()
+        {
+            @Override
+            public void onHandshakeResponse(HttpRequest request, HttpResponse response)
+            {
+
+                String extensions = response.getHeaders().get(HttpHeader.SEC_WEBSOCKET_EXTENSIONS);
+                if("permessage-deflate".equals(extensions))
+                    correctResponseExtensions.countDown();
+                else
+                    throw new IllegalStateException("Unexpected Negotiated Extensions: " + extensions);
+            }
+        };
+
+        CompletableFuture<Session> connect = client.connect(socket, uri, request, listener);
+        try(Session session = connect.get(5, TimeUnit.SECONDS))
+        {
+            session.getRemote().sendString("hello world");
+        }
+        assertTrue(socket.closed.await(5, TimeUnit.SECONDS));
+        assertTrue(correctResponseExtensions.await(5, TimeUnit.SECONDS));
+
+        String msg = socket.receivedMessages.poll();
+        assertThat(msg, is("hello world"));
+    }
+}

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
@@ -34,8 +34,8 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.JettyUpgradeListener;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.eclipse.jetty.websocket.core.client.UpgradeListener;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
 import org.junit.jupiter.api.AfterEach;
@@ -108,7 +108,7 @@ public class JettyWebSocketExtensionConfigTest
         request.addExtensions(ExtensionConfig.parse("permessage-deflate"));
 
         CountDownLatch correctResponseExtensions = new CountDownLatch(1);
-        UpgradeListener listener = new UpgradeListener()
+        JettyUpgradeListener listener = new JettyUpgradeListener()
         {
             @Override
             public void onHandshakeResponse(HttpRequest request, HttpResponse response)

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/extensions/ExtensionConfigTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/extensions/ExtensionConfigTest.java
@@ -16,12 +16,13 @@
 //  ========================================================================
 //
 
-package org.eclipse.jetty.websocket.api.extensions;
-
-import org.junit.jupiter.api.Test;
+package org.eclipse.jetty.websocket.tests.extensions;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/QuoteUtilTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/QuoteUtilTest.java
@@ -16,12 +16,13 @@
 //  ========================================================================
 //
 
-package org.eclipse.jetty.websocket.api.util;
-
-import org.junit.jupiter.api.Test;
+package org.eclipse.jetty.websocket.tests.util;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import org.eclipse.jetty.websocket.api.util.QuoteUtil;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/QuoteUtil_QuoteTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/QuoteUtil_QuoteTest.java
@@ -16,15 +16,16 @@
 //  ========================================================================
 //
 
-package org.eclipse.jetty.websocket.api.util;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+package org.eclipse.jetty.websocket.tests.util;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+
+import org.eclipse.jetty.websocket.api.util.QuoteUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/WSURITest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/util/WSURITest.java
@@ -16,12 +16,13 @@
 //  ========================================================================
 //
 
-package org.eclipse.jetty.websocket.api.util;
-
-import org.junit.jupiter.api.Test;
+package org.eclipse.jetty.websocket.tests.util;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import org.eclipse.jetty.websocket.api.util.WSURI;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/UpgradeListener.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/UpgradeListener.java
@@ -28,7 +28,8 @@ public interface UpgradeListener
      *
      * @param request the request
      */
-    void onHandshakeRequest(HttpRequest request);
+    default void onHandshakeRequest(HttpRequest request)
+    {}
 
     /**
      * Event that triggers after the Handshake response has been received.
@@ -36,5 +37,6 @@ public interface UpgradeListener
      * @param request  the request that was used
      * @param response the response that was received
      */
-    void onHandshakeResponse(HttpRequest request, HttpResponse response);
+    default void onHandshakeResponse(HttpRequest request, HttpResponse response)
+    {}
 }

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
@@ -18,11 +18,6 @@
 
 package org.eclipse.jetty.websocket.servlet;
 
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.websocket.core.ExtensionConfig;
-import org.eclipse.jetty.websocket.core.server.Negotiation;
-
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +27,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
+import org.eclipse.jetty.websocket.core.server.Negotiation;
 
 /**
  * Servlet Specific UpgradeResponse implementation.
@@ -166,6 +167,20 @@ public class ServletUpgradeResponse
 
     public void setExtensions(List<ExtensionConfig> configs)
     {
+        for (ExtensionConfig config : configs)
+        {
+            List<ExtensionConfig> collect = negotiation.getOfferedExtensions().stream()
+                    .filter(e -> e.getName().equals(config.getName()))
+                    .collect(Collectors.toList());
+
+            if (collect.size() == 1)
+                continue;
+            else if (collect.size() == 0)
+                throw new IllegalArgumentException("Extension not a requested extension");
+            else if (collect.size() > 1)
+                throw new IllegalArgumentException("Multiple extensions of the same name");
+        }
+
         negotiation.setNegotiatedExtensions(configs);
     }
 


### PR DESCRIPTION
#3458 

remove the dependence on jetty-servlet to use websocket server with the jetty-websocket-api
jetty-servlet exposes core classes as it is used by both the javax and jetty sides
a jetty-server `WebSocketCreator` can now be made and be mapped to a pathspec in `JettyWebSocketServerContainer`

jetty-websocket-api now defines interface `ExtensionConfig` which is implemented by `JettyExtensionConfig` in jetty-websocket-common which delegates to the core version, this is to not reimplement this in API and to also not expose the core classes