### PR TITLE
Issue #3422 - WebSocket wss CLOSE_WAIT on aborted client connection

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/CloseTrackingEndpoint.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/CloseTrackingEndpoint.java
@@ -38,7 +38,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CloseTrackingEndpoint extends WebSocketAdapter
 {
@@ -66,11 +65,7 @@ public class CloseTrackingEndpoint extends WebSocketAdapter
         assertThat("Client Close Event Occurred", closeLatch.await(clientTimeoutMs, TimeUnit.MILLISECONDS), is(true));
         assertThat("Client Close Event Count", closeCount.get(), is(1));
         assertThat("Client Close Event Status Code", closeCode, statusCodeMatcher);
-        if (reasonMatcher == null)
-        {
-            assertThat("Client Close Event Reason", closeReason, nullValue());
-        }
-        else
+        if (reasonMatcher != null)
         {
             assertThat("Client Close Event Reason", closeReason, reasonMatcher);
         }

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -249,9 +249,8 @@ public class ClientCloseTest
 
             // client reads -1 (EOF)
             // client triggers close event on client ws-endpoint
-            clientSocket.assertReceivedCloseEvent(clientTimeout * 2,
-                    is(StatusCode.SHUTDOWN),
-                    containsString("timeout"));
+            // assert - close code==1006 (abnormal) or code==1001 (shutdown)
+            clientSocket.assertReceivedCloseEvent(clientTimeout * 2, anyOf(is(StatusCode.SHUTDOWN), is(StatusCode.ABNORMAL)));
         }
 
         clientSessionTracker.assertClosedProperly(client);

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -446,6 +446,10 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
         if (readMode == ReadMode.EOF)
         {
             readState.eof();
+
+            // Handle case where the remote connection was abruptly terminated without a close frame
+            CloseInfo close = new CloseInfo(StatusCode.SHUTDOWN);
+            close(close, new DisconnectCallback(this));
         }
         else if (!readState.suspend())
         {

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketServerFactory.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketServerFactory.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -627,7 +628,10 @@ public class WebSocketServerFactory extends ContainerLifeCycle implements WebSoc
         
         // Setup websocket connection
         AbstractWebSocketConnection wsConnection = new WebSocketServerConnection(endp, executor, scheduler, driver.getPolicy(), bufferPool);
-        
+
+        for (Connection.Listener listener : connector.getBeans(Connection.Listener.class))
+            wsConnection.addListener(listener);
+
         extensionStack.setPolicy(driver.getPolicy());
         extensionStack.configure(wsConnection.getParser());
         extensionStack.configure(wsConnection.getGenerator());


### PR DESCRIPTION
+ Adding testcase to replicate
+ Fixing CLOSE_WAIT by issuing wsclose + disconnect on eof

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>