### PR TITLE
Issue #3465 - WebSocket Extension Negotiation

### DIFF
--- a/jetty-websocket/javax-websocket-client/src/main/java/org/eclipse/jetty/websocket/javax/client/JavaxWebSocketClientContainer.java
+++ b/jetty-websocket/javax-websocket-client/src/main/java/org/eclipse/jetty/websocket/javax/client/JavaxWebSocketClientContainer.java
@@ -156,18 +156,10 @@ public class JavaxWebSocketClientContainer extends JavaxWebSocketContainer imple
             upgradeRequest.addListener(jsrUpgradeListener);
 
             for (Extension ext : clientEndpointConfig.getExtensions())
-            {
-                if (!getExtensionRegistry().isAvailable(ext.getName()))
-                {
-                    throw new IllegalArgumentException("Requested extension [" + ext.getName() + "] is not installed");
-                }
                 upgradeRequest.addExtensions(new JavaxWebSocketExtensionConfig(ext));
-            }
 
             if (clientEndpointConfig.getPreferredSubprotocols().size() > 0)
-            {
                 upgradeRequest.setSubProtocols(clientEndpointConfig.getPreferredSubprotocols());
-            }
         }
 
         try

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
@@ -1,0 +1,115 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.log.StacklessLogging;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.UpgradeRequest;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JettyWebSocketNegotiationTest
+{
+    Server server;
+    WebSocketClient client;
+    ServletContextHandler contextHandler;
+
+    @BeforeEach
+    public void start() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(8080);
+        server.addConnector(connector);
+
+        contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+
+        server.start();
+        client = new WebSocketClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testBadRequest() throws Exception
+    {
+        JettyWebSocketServerContainer container = JettyWebSocketServletContainerInitializer.configureContext(contextHandler);
+        container.addMapping("/", (req, resp)->new EventSocket.EchoSocket());
+
+        URI uri = URI.create("ws://localhost:8080/filterPath");
+        EventSocket socket = new EventSocket();
+
+        UpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        upgradeRequest.addExtensions("permessage-deflate;invalidParameter");
+
+        CompletableFuture<Session> connect = client.connect(socket, uri, upgradeRequest);
+        Throwable t = assertThrows(ExecutionException.class, () -> connect.get(5, TimeUnit.SECONDS));
+        assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
+        assertThat(t.getMessage(), containsString("400 Bad Request"));
+    }
+
+
+    @Test
+    public void testServerError() throws Exception
+    {
+        JettyWebSocketServerContainer container = JettyWebSocketServletContainerInitializer.configureContext(contextHandler);
+        container.addMapping("/", (req, resp)->
+        {
+            resp.setAcceptedSubProtocol("errorSubProtocol");
+            return new EventSocket.EchoSocket();
+        });
+
+        URI uri = URI.create("ws://localhost:8080/filterPath");
+        EventSocket socket = new EventSocket();
+
+        try (StacklessLogging stacklessLogging = new StacklessLogging(HttpChannel.class))
+        {
+            CompletableFuture<Session> connect = client.connect(socket, uri);
+            Throwable t = assertThrows(ExecutionException.class, () -> connect.get(5, TimeUnit.SECONDS));
+            assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
+            assertThat(t.getMessage(), containsString("500 Server Error"));
+        }
+    }
+}

--- a/jetty-websocket/jetty-websocket-tests/src/test/resources/jetty-logging.properties
+++ b/jetty-websocket/jetty-websocket-tests/src/test/resources/jetty-logging.properties
@@ -20,7 +20,7 @@
 # org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
 org.eclipse.jetty.LEVEL=WARN
-org.eclipse.jetty.websocket.tests.LEVEL=DEBUG
+# org.eclipse.jetty.websocket.tests.LEVEL=DEBUG
 # org.eclipse.jetty.util.log.stderr.LONG=true
 # org.eclipse.jetty.server.AbstractConnector.LEVEL=DEBUG
 # org.eclipse.jetty.io.WriteFlusher.LEVEL=DEBUG

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketExtensionRegistry.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketExtensionRegistry.java
@@ -18,15 +18,16 @@
 
 package org.eclipse.jetty.websocket.core;
 
-import org.eclipse.jetty.io.ByteBufferPool;
-import org.eclipse.jetty.util.DecoratedObjectFactory;
-import org.eclipse.jetty.util.StringUtil;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.util.DecoratedObjectFactory;
+import org.eclipse.jetty.util.StringUtil;
 
 public class WebSocketExtensionRegistry implements Iterable<Class<? extends Extension>>
 {
@@ -100,7 +101,7 @@ public class WebSocketExtensionRegistry implements Iterable<Class<? extends Exte
         }
         catch (Throwable t)
         {
-            throw new WebSocketException("Cannot instantiate extension: " + extClass, t);
+            throw new BadMessageException("Cannot instantiate extension: " + extClass, t);
         }
     }
 

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -282,6 +282,9 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
         List<ExtensionConfig> offeredExtensions = getExtensions();
         for (ExtensionConfig config : extensions)
         {
+            if (config.getName().startsWith("@"))
+                continue;
+
             long numMatch = offeredExtensions.stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
             if (numMatch < 1)
                 throw new WebSocketException("Upgrade failed: Sec-WebSocket-Extensions contained extension not requested");

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -296,7 +296,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
 
         // Negotiate the extension stack
         HttpClient httpClient = wsClient.getHttpClient();
-        ExtensionStack extensionStack = new ExtensionStack(wsClient.getExtensionRegistry());
+        ExtensionStack extensionStack = new ExtensionStack(wsClient.getExtensionRegistry(), Behavior.CLIENT);
         extensionStack.negotiate(wsClient.getObjectFactory(), httpClient.getByteBufferPool(), offeredExtensions, negotiatedExtensions);
 
         // Get the negotiated subprotocol

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -260,7 +260,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
             throw new HttpResponseException("Invalid Sec-WebSocket-Accept hash (was:" + respHash + ", expected:" + expectedHash + ")", response);
 
         // Parse the Negotiated Extensions
-        List<ExtensionConfig> extensions = new ArrayList<>();
+        List<ExtensionConfig> negotiatedExtensions = new ArrayList<>();
         HttpField extField = response.getHeaders().getField(HttpHeader.SEC_WEBSOCKET_EXTENSIONS);
         if (extField != null)
         {
@@ -272,7 +272,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
                     QuotedStringTokenizer tok = new QuotedStringTokenizer(extVal, ",");
                     while (tok.hasMoreTokens())
                     {
-                        extensions.add(ExtensionConfig.parse(tok.nextToken()));
+                        negotiatedExtensions.add(ExtensionConfig.parse(tok.nextToken()));
                     }
                 }
             }
@@ -280,7 +280,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
 
         // Verify the Negotiated Extensions
         List<ExtensionConfig> offeredExtensions = getExtensions();
-        for (ExtensionConfig config : extensions)
+        for (ExtensionConfig config : negotiatedExtensions)
         {
             if (config.getName().startsWith("@"))
                 continue;
@@ -289,7 +289,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
             if (numMatch < 1)
                 throw new WebSocketException("Upgrade failed: Sec-WebSocket-Extensions contained extension not requested");
 
-            numMatch = extensions.stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
+            numMatch = negotiatedExtensions.stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
             if (numMatch > 1)
                 throw new WebSocketException("Upgrade failed: Sec-WebSocket-Extensions contained more than one extension of the same name");
         }
@@ -297,7 +297,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
         // Negotiate the extension stack
         HttpClient httpClient = wsClient.getHttpClient();
         ExtensionStack extensionStack = new ExtensionStack(wsClient.getExtensionRegistry());
-        extensionStack.negotiate(wsClient.getObjectFactory(), httpClient.getByteBufferPool(), extensions);
+        extensionStack.negotiate(wsClient.getObjectFactory(), httpClient.getByteBufferPool(), offeredExtensions, negotiatedExtensions);
 
         // Get the negotiated subprotocol
         String negotiatedSubProtocol = null;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -285,6 +285,8 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
             long numMatch = offeredExtensions.stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
             if (numMatch < 1)
                 throw new WebSocketException("Upgrade failed: Sec-WebSocket-Extensions contained extension not requested");
+
+            numMatch = extensions.stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
             if (numMatch > 1)
                 throw new WebSocketException("Upgrade failed: Sec-WebSocket-Extensions contained more than one extension of the same name");
         }

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/WebSocketCoreClient.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/WebSocketCoreClient.java
@@ -87,11 +87,7 @@ public class WebSocketCoreClient extends ContainerLifeCycle implements FrameHand
     public CompletableFuture<FrameHandler.CoreSession> connect(ClientUpgradeRequest request) throws IOException
     {
         if (!isStarted())
-        {
             throw new IllegalStateException(WebSocketCoreClient.class.getSimpleName() + "@" + this.hashCode() + " is not started");
-        }
-
-        // TODO: add HttpClient delayed/on-demand start - See Issue #1516
 
         // Validate Requested Extensions
         for (ExtensionConfig reqExt : request.getExtensions())

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/compress/PerMessageDeflateExtension.java
@@ -169,7 +169,7 @@ public class PerMessageDeflateExtension extends CompressExtension
                 }
                 case "server_no_context_takeover":
                 {
-                    params_negotiated.put("client_no_context_takeover", null);
+                    params_negotiated.put("server_no_context_takeover", null);
                     outgoingContextTakeover = false;
                     break;
                 }

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/Negotiation.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/Negotiation.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.http.QuotedCSV;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
+import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.WebSocketExtensionRegistry;
 import org.eclipse.jetty.websocket.core.internal.ExtensionStack;
@@ -227,7 +228,7 @@ public class Negotiation
         if (extensionStack == null)
         {
             // Extension stack can decide to drop any of these extensions or their parameters
-            extensionStack = new ExtensionStack(registry);
+            extensionStack = new ExtensionStack(registry, Behavior.SERVER);
             extensionStack.negotiate(objectFactory, bufferPool, offeredExtensions, negotiatedExtensions);
             negotiatedExtensions = extensionStack.getNegotiatedExtensions();
 

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/Negotiation.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/Negotiation.java
@@ -130,7 +130,7 @@ public class Negotiation
             ?Collections.emptyList()
             :extensions.getValues().stream()
             .map(ExtensionConfig::parse)
-            .filter(ec -> available.contains(ec.getName().toLowerCase()))
+            .filter(ec -> available.contains(ec.getName().toLowerCase()) && !ec.getName().startsWith("@"))
             .collect(Collectors.toList());
 
         offeredSubprotocols = subprotocols == null

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
@@ -170,6 +170,9 @@ public final class RFC6455Handshaker implements Handshaker
         // validate negotiated extensions
         for (ExtensionConfig config : negotiation.getNegotiatedExtensions())
         {
+            if (config.getName().startsWith("@"))
+                continue;
+
             long matches = negotiation.getOfferedExtensions().stream().filter(c -> config.getName().equalsIgnoreCase(c.getName())).count();
             if (matches < 1)
                 throw new WebSocketException("Upgrade failed: negotiated extension not requested");

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorFrameFlagsTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorFrameFlagsTest.java
@@ -63,7 +63,7 @@ public class GeneratorFrameFlagsTest
 
     public void setup(Frame invalidFrame)
     {
-        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
         exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         this.channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.CLIENT, Negotiated.from(exStack));
     }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorFrameFlagsTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorFrameFlagsTest.java
@@ -18,6 +18,10 @@
 
 package org.eclipse.jetty.websocket.core;
 
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.stream.Stream;
+
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
@@ -28,10 +32,6 @@ import org.eclipse.jetty.websocket.core.internal.WebSocketChannel;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.nio.ByteBuffer;
-import java.util.LinkedList;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -64,7 +64,7 @@ public class GeneratorFrameFlagsTest
     public void setup(Frame invalidFrame)
     {
         ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
-        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         this.channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.CLIENT, Negotiated.from(exStack));
     }
 

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
@@ -56,7 +56,7 @@ public class GeneratorTest
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
         ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
-        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         return new WebSocketChannel(new AbstractTestFrameHandler(), behavior, Negotiated.from(exStack));
     }
 

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
@@ -55,7 +55,7 @@ public class GeneratorTest
     private static WebSocketChannel newChannel(Behavior behavior)
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
-        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
         exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         return new WebSocketChannel(new AbstractTestFrameHandler(), behavior, Negotiated.from(exStack));
     }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/ParserCapture.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/ParserCapture.java
@@ -59,7 +59,7 @@ public class ParserCapture
 
         ByteBufferPool bufferPool = new MappedByteBufferPool();
         ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
-        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         this.channel = new WebSocketChannel(new AbstractTestFrameHandler(), behavior, Negotiated.from(exStack));
     }
 

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/ParserCapture.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/ParserCapture.java
@@ -58,7 +58,7 @@ public class ParserCapture
         this.copy = copy;
 
         ByteBufferPool bufferPool = new MappedByteBufferPool();
-        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
         exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         this.channel = new WebSocketChannel(new AbstractTestFrameHandler(), behavior, Negotiated.from(exStack));
     }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/TestWebSocketNegotiator.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/TestWebSocketNegotiator.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.websocket.core;
 import java.io.IOException;
 import java.util.List;
 
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
@@ -44,7 +43,7 @@ public class TestWebSocketNegotiator implements WebSocketNegotiator
     }
 
     public TestWebSocketNegotiator(DecoratedObjectFactory objectFactory, WebSocketExtensionRegistry extensionRegistry, ByteBufferPool bufferPool,
-        FrameHandler frameHandler)
+                                   FrameHandler frameHandler)
     {
         this.objectFactory = objectFactory;
         this.extensionRegistry = extensionRegistry;
@@ -56,13 +55,9 @@ public class TestWebSocketNegotiator implements WebSocketNegotiator
     public FrameHandler negotiate(Negotiation negotiation) throws IOException
     {
         List<String> offeredSubprotocols = negotiation.getOfferedSubprotocols();
-        if (!offeredSubprotocols.contains("test"))
-            return null;
-        negotiation.setSubprotocol("test");
+        if (!offeredSubprotocols.isEmpty())
+            negotiation.setSubprotocol(offeredSubprotocols.get(0));
 
-        // TODO better to call negotiation.setNegotiatedExtensions();
-        negotiation.getResponse().addHeader(HttpHeader.SEC_WEBSOCKET_EXTENSIONS.asString(),
-            "@validation; outgoing-sequence; incoming-sequence; outgoing-frame; incoming-frame; incoming-utf8; outgoing-utf8");
         return frameHandler;
     }
 

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.core;
 
 import java.io.IOException;

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
@@ -1,0 +1,287 @@
+package org.eclipse.jetty.websocket.core;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.HttpResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.log.StacklessLogging;
+import org.eclipse.jetty.websocket.core.FrameHandler.CoreSession;
+import org.eclipse.jetty.websocket.core.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.core.client.UpgradeListener;
+import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
+import org.eclipse.jetty.websocket.core.server.Negotiation;
+import org.eclipse.jetty.websocket.core.server.WebSocketNegotiator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WebSocketNegotiationTest
+{
+    public static class EchoFrameHandler extends TestFrameHandler
+    {
+        @Override
+        public void onFrame(Frame frame)
+        {
+            super.onFrame(frame);
+            Frame echo = new Frame(frame.getOpCode(), frame.getPayloadAsUTF8());
+            getCoreSession().sendFrame(echo, Callback.NOOP, false);
+        }
+    }
+
+    private WebSocketServer server;
+    private WebSocketCoreClient client;
+
+    @BeforeEach
+    public void startup() throws Exception
+    {
+        WebSocketNegotiator negotiator = new WebSocketNegotiator.AbstractNegotiator()
+        {
+            @Override
+            public FrameHandler negotiate(Negotiation negotiation) throws IOException
+            {
+                if (negotiation.getOfferedSubprotocols().isEmpty())
+                {
+                    negotiation.setSubprotocol("NotOffered");
+                    return new EchoFrameHandler();
+                }
+
+
+                String subprotocol = negotiation.getOfferedSubprotocols().get(0);
+                negotiation.setSubprotocol(subprotocol);
+                switch (subprotocol)
+                {
+                    case "testExtensionSelection":
+                        negotiation.setNegotiatedExtensions(List.of(ExtensionConfig.parse("permessage-deflate;client_no_context_takeover")));
+                        break;
+
+                    case "testNotOfferedParameter":
+                        negotiation.setNegotiatedExtensions(List.of(ExtensionConfig.parse("permessage-deflate;server_no_context_takeover")));
+                        break;
+
+                    case "testInvalidExtensionParameter":
+                        break;
+
+                    case "testAcceptTwoExtensionsOfSameName":
+                        // We should automatically be selecting just one extension out of these two
+                        break;
+
+                    case "testNotAcceptingExtensions":
+                        negotiation.setNegotiatedExtensions(Collections.EMPTY_LIST);
+                        break;
+
+                    case "testNoSubProtocolSelected":
+                        negotiation.setSubprotocol(null);
+                        break;
+
+                    default:
+                        return null;
+                }
+
+                return new EchoFrameHandler();
+            }
+        };
+
+        server = new WebSocketServer(negotiator);
+        client = new WebSocketCoreClient();
+
+        server.start();
+        client.start();
+    }
+
+    @AfterEach
+    public void shutdown() throws Exception
+    {
+        server.start();
+        client.start();
+    }
+
+    @Test
+    public void testExtensionSelection() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testExtensionSelection");
+        upgradeRequest.addExtensions("permessage-deflate;server_no_context_takeover", "permessage-deflate;client_no_context_takeover");
+
+        CompletableFuture<String> extensionHeader = new CompletableFuture<>();
+        upgradeRequest.addListener(new UpgradeListener()
+        {
+            @Override
+            public void onHandshakeResponse(HttpRequest request, HttpResponse response)
+            {
+                extensionHeader.complete(response.getHeaders().get(HttpHeader.SEC_WEBSOCKET_EXTENSIONS));
+            }
+        });
+
+        CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+        connect.get(5, TimeUnit.SECONDS);
+
+        clientHandler.sendText("hello world");
+        clientHandler.sendClose();
+        assertTrue(clientHandler.closed.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler.receivedFrames.size(), is(2));
+        assertNull(clientHandler.getError());
+
+        assertThat(extensionHeader.get(5, TimeUnit.SECONDS), is("permessage-deflate;client_no_context_takeover"));
+    }
+
+    @Test
+    public void testNotOfferedParameter() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testNotOfferedParameter");
+        upgradeRequest.addExtensions("permessage-deflate;client_no_context_takeover");
+
+        CompletableFuture<String> extensionHeader = new CompletableFuture<>();
+        upgradeRequest.addListener(new UpgradeListener()
+        {
+            @Override
+            public void onHandshakeResponse(HttpRequest request, HttpResponse response)
+            {
+                extensionHeader.complete(response.getHeaders().get(HttpHeader.SEC_WEBSOCKET_EXTENSIONS));
+            }
+        });
+
+        CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+        connect.get(5, TimeUnit.SECONDS);
+        clientHandler.sendText("hello world");
+        clientHandler.sendClose();
+        assertTrue(clientHandler.closed.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler.receivedFrames.size(), is(2));
+        assertNull(clientHandler.getError());
+
+        assertThat(extensionHeader.get(5, TimeUnit.SECONDS), is("permessage-deflate;server_no_context_takeover"));
+    }
+
+
+    @Test
+    public void testInvalidExtensionParameter() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testInvalidExtensionParameter");
+        upgradeRequest.addExtensions("permessage-deflate;invalid_parameter");
+
+        CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+
+        Throwable t = assertThrows(ExecutionException.class, ()->connect.get(5, TimeUnit.SECONDS));
+        assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
+        assertThat(t.getMessage(), containsString("400 Bad Request"));
+    }
+
+
+    @Test
+    public void testNotAcceptingExtensions() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testNotAcceptingExtensions");
+        upgradeRequest.addExtensions("permessage-deflate;server_no_context_takeover", "permessage-deflate;client_no_context_takeover");
+
+        CompletableFuture<String> extensionHeader = new CompletableFuture<>();
+        upgradeRequest.addListener(new UpgradeListener()
+        {
+            @Override
+            public void onHandshakeResponse(HttpRequest request, HttpResponse response)
+            {
+                extensionHeader.complete(response.getHeaders().get(HttpHeader.SEC_WEBSOCKET_EXTENSIONS));
+            }
+        });
+
+        CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+        connect.get(5, TimeUnit.SECONDS);
+
+        clientHandler.sendText("hello world");
+        clientHandler.sendClose();
+        assertTrue(clientHandler.closed.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler.receivedFrames.size(), is(2));
+        assertNull(clientHandler.getError());
+
+        assertNull(extensionHeader.get(5, TimeUnit.SECONDS));
+    }
+
+
+    @Test
+    public void testAcceptTwoExtensionsOfSameName() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testAcceptTwoExtensionsOfSameName");
+        upgradeRequest.addExtensions("permessage-deflate;server_no_context_takeover", "permessage-deflate;client_no_context_takeover");
+
+        CompletableFuture<String> extensionHeader = new CompletableFuture<>();
+        upgradeRequest.addListener(new UpgradeListener()
+        {
+            @Override
+            public void onHandshakeResponse(HttpRequest request, HttpResponse response)
+            {
+                extensionHeader.complete(response.getHeaders().get(HttpHeader.SEC_WEBSOCKET_EXTENSIONS));
+            }
+        });
+
+        CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+        connect.get(5, TimeUnit.SECONDS);
+
+        clientHandler.sendText("hello world");
+        clientHandler.sendClose();
+        assertTrue(clientHandler.closed.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler.receivedFrames.size(), is(2));
+        assertNull(clientHandler.getError());
+
+        assertThat(extensionHeader.get(5, TimeUnit.SECONDS), is("permessage-deflate;server_no_context_takeover"));
+    }
+
+    @Test
+    public void testSubProtocolNotOffered() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+
+        try (StacklessLogging stacklessLogging = new StacklessLogging(HttpChannel.class))
+        {
+            CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+            Throwable t = assertThrows(ExecutionException.class, () -> connect.get(5, TimeUnit.SECONDS));
+            assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
+            assertThat(t.getMessage(), containsString("500 Server Error"));
+        }
+    }
+
+    @Test
+    public void testNoSubProtocolSelected() throws Exception
+    {
+        TestFrameHandler clientHandler = new TestFrameHandler();
+
+        ClientUpgradeRequest upgradeRequest = ClientUpgradeRequest.from(client, server.getUri(), clientHandler);
+        upgradeRequest.setSubProtocols("testNoSubProtocolSelected");
+
+        try (StacklessLogging stacklessLogging = new StacklessLogging(HttpChannel.class))
+        {
+            CompletableFuture<CoreSession> connect = client.connect(upgradeRequest);
+            Throwable t = assertThrows(ExecutionException.class, () -> connect.get(5, TimeUnit.SECONDS));
+            assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
+            assertThat(t.getMessage(), containsString("500 Server Error"));
+        }
+    }
+}

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketServer.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketServer.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 import org.eclipse.jetty.server.NetworkConnector;
@@ -35,10 +36,12 @@ public class WebSocketServer
 {
     private static Logger LOG = Log.getLogger(WebSocketServer.class);
     private final Server server;
+    private URI serverUri;
 
     public void start() throws Exception
     {
         server.start();
+        serverUri = new URI("ws://localhost:" + getLocalPort());
     }
 
     public void stop() throws Exception
@@ -56,12 +59,12 @@ public class WebSocketServer
         return server;
     }
 
-    public WebSocketServer(FrameHandler frameHandler)
+    public WebSocketServer(FrameHandler frameHandler) throws Exception
     {
         this(new DefaultNegotiator(frameHandler));
     }
 
-    public WebSocketServer(WebSocketNegotiator negotiator)
+    public WebSocketServer(WebSocketNegotiator negotiator) throws Exception
     {
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
@@ -73,6 +76,11 @@ public class WebSocketServer
 
         WebSocketUpgradeHandler upgradeHandler = new WebSocketUpgradeHandler(negotiator);
         context.setHandler(upgradeHandler);
+    }
+
+    public URI getUri()
+    {
+        return serverUri;
     }
 
     private static class DefaultNegotiator extends WebSocketNegotiator.AbstractNegotiator

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
@@ -420,7 +420,7 @@ public class DeflateFrameExtensionTest extends AbstractExtensionTest
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
         ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
-        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
 
         WebSocketChannel channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.SERVER, Negotiated.from(exStack));
         channel.setMaxFrameSize(maxMessageSize);

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/DeflateFrameExtensionTest.java
@@ -419,7 +419,7 @@ public class DeflateFrameExtensionTest extends AbstractExtensionTest
     private WebSocketChannel channelWithMaxMessageSize(int maxMessageSize)
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
-        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
         exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
 
         WebSocketChannel channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.SERVER, Negotiated.from(exStack));

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
@@ -75,7 +75,7 @@ public class ExtensionStackTest
         // 1 extension
         List<ExtensionConfig> configs = new ArrayList<>();
         configs.add(ExtensionConfig.parse("identity"));
-        stack.negotiate(objectFactory, bufferPool, configs);
+        stack.negotiate(objectFactory, bufferPool, configs, configs);
 
         // Setup Listeners
         IncomingFrames session = new IncomingFramesCapture();
@@ -99,7 +99,7 @@ public class ExtensionStackTest
         List<ExtensionConfig> configs = new ArrayList<>();
         configs.add(ExtensionConfig.parse("identity; id=A"));
         configs.add(ExtensionConfig.parse("identity; id=B"));
-        stack.negotiate(objectFactory, bufferPool, configs);
+        stack.negotiate(objectFactory, bufferPool, configs, configs);
 
         // Setup Listeners
         IncomingFrames session = new IncomingFramesCapture();
@@ -130,7 +130,7 @@ public class ExtensionStackTest
     {
         String chromeRequest = "permessage-deflate; client_max_window_bits, x-webkit-deflate-frame";
         List<ExtensionConfig> requestedConfigs = ExtensionConfig.parseList(chromeRequest);
-        stack.negotiate(objectFactory, bufferPool, requestedConfigs);
+        stack.negotiate(objectFactory, bufferPool, requestedConfigs, requestedConfigs);
 
         List<ExtensionConfig> negotiated = stack.getNegotiatedExtensions();
         String response = ExtensionConfig.toHeaderValue(negotiated);

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.Extension;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.IncomingFrames;
@@ -55,7 +56,7 @@ public class ExtensionStackTest
     {
         objectFactory = new DecoratedObjectFactory();
         bufferPool = new MappedByteBufferPool();
-        stack = new ExtensionStack(new WebSocketExtensionRegistry());
+        stack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
     }
 
     @SuppressWarnings("unchecked")

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
@@ -154,7 +154,7 @@ public class ExtensionTool
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
         ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
-        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>());
+        exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         WebSocketChannel channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.SERVER, Negotiated.from(exStack));
         return channel;
     }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionTool.java
@@ -153,7 +153,7 @@ public class ExtensionTool
     private WebSocketChannel newWebsocketChannel()
     {
         ByteBufferPool bufferPool = new MappedByteBufferPool();
-        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry());
+        ExtensionStack exStack = new ExtensionStack(new WebSocketExtensionRegistry(), Behavior.SERVER);
         exStack.negotiate(new DecoratedObjectFactory(), bufferPool, new LinkedList<>(), new LinkedList<>());
         WebSocketChannel channel = new WebSocketChannel(new AbstractTestFrameHandler(), Behavior.SERVER, Negotiated.from(exStack));
         return channel;

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ValidationExtensionTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/extensions/ValidationExtensionTest.java
@@ -18,17 +18,23 @@
 
 package org.eclipse.jetty.websocket.core.extensions;
 
+import java.io.IOException;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.websocket.core.CloseStatus;
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.RawFrameBuilder;
 import org.eclipse.jetty.websocket.core.TestFrameHandler;
 import org.eclipse.jetty.websocket.core.TestWebSocketNegotiator;
 import org.eclipse.jetty.websocket.core.WebSocketServer;
 import org.eclipse.jetty.websocket.core.WebSocketTester;
+import org.eclipse.jetty.websocket.core.server.Negotiation;
 import org.eclipse.jetty.websocket.core.server.WebSocketNegotiator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +54,19 @@ public class ValidationExtensionTest extends WebSocketTester
     public void start() throws Exception
     {
         serverHandler = new TestFrameHandler();
-        WebSocketNegotiator negotiator = new TestWebSocketNegotiator(serverHandler);
+        WebSocketNegotiator negotiator = new TestWebSocketNegotiator(serverHandler)
+        {
+            @Override
+            public FrameHandler negotiate(Negotiation negotiation) throws IOException
+            {
+                List<ExtensionConfig> negotiatedExtensions = new ArrayList<>();
+                negotiatedExtensions.add(ExtensionConfig.parse(
+                        "@validation; outgoing-sequence; incoming-sequence; outgoing-frame; incoming-frame; incoming-utf8; outgoing-utf8"));
+                negotiation.setNegotiatedExtensions(negotiatedExtensions);
+
+                return super.negotiate(negotiation);
+            }
+        };
         server = new WebSocketServer(negotiator);
         server.start();
     }

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
@@ -170,6 +170,9 @@ public class ServletUpgradeResponse
         // This validation is also done later in RFC6455Handshaker but it is better to fail earlier
         for (ExtensionConfig config : configs)
         {
+            if (config.getName().startsWith("@"))
+                continue;
+
             long matches = negotiation.getOfferedExtensions().stream().filter(e -> e.getName().equals(config.getName())).count();
             if (matches < 1)
                 throw new IllegalArgumentException("Extension not a requested extension");

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java
@@ -170,18 +170,13 @@ public class ServletUpgradeResponse
         // This validation is also done later in RFC6455Handshaker but it is better to fail earlier
         for (ExtensionConfig config : configs)
         {
-            int matches = (int)negotiation.getOfferedExtensions().stream()
-                    .filter(e -> e.getName().equals(config.getName())).count();
+            long matches = negotiation.getOfferedExtensions().stream().filter(e -> e.getName().equals(config.getName())).count();
+            if (matches < 1)
+                throw new IllegalArgumentException("Extension not a requested extension");
 
-            switch (matches)
-            {
-                case 0:
-                    throw new IllegalArgumentException("Extension not a requested extension");
-                case 1:
-                    continue;
-                default:
-                    throw new IllegalArgumentException("Multiple extensions of the same name");
-            }
+            matches = negotiation.getNegotiatedExtensions().stream().filter(e -> e.getName().equals(config.getName())).count();
+            if (matches > 1)
+                throw new IllegalArgumentException("Multiple extensions of the same name");
         }
 
         negotiation.setNegotiatedExtensions(configs);

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketMapping.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketMapping.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.websocket.servlet;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.function.Consumer;
 
 import javax.servlet.ServletContext;
@@ -32,7 +31,6 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.http.pathmap.RegexPathSpec;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.http.pathmap.UriTemplatePathSpec;
-import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -217,7 +215,7 @@ public class WebSocketMapping implements Dumpable, LifeCycle.Listener
         return mapping.getResource();
     }
 
-    public boolean upgrade(HttpServletRequest request, HttpServletResponse response, FrameHandler.Customizer defaultCustomizer)
+    public boolean upgrade(HttpServletRequest request, HttpServletResponse response, FrameHandler.Customizer defaultCustomizer) throws IOException
     {
         // Since this may be a filter, we need to be smart about determining the target path.
         // We should rely on the Container for stripping path parameters and its ilk before
@@ -240,14 +238,7 @@ public class WebSocketMapping implements Dumpable, LifeCycle.Listener
             LOG.debug("WebSocket Negotiated detected on {} for endpoint {}", target, negotiator);
 
         // We have an upgrade request
-        try
-        {
-            return handshaker.upgradeRequest(negotiator, request, response, defaultCustomizer);
-        }
-        catch (IOException e)
-        {
-            throw new WebSocketException(e);
-        }
+        return handshaker.upgradeRequest(negotiator, request, response, defaultCustomizer);
     }
 
     private class Negotiator extends WebSocketNegotiator.AbstractNegotiator
@@ -269,7 +260,7 @@ public class WebSocketMapping implements Dumpable, LifeCycle.Listener
 
 
         @Override
-        public FrameHandler negotiate(Negotiation negotiation)
+        public FrameHandler negotiate(Negotiation negotiation) throws IOException
         {
             ServletContext servletContext = negotiation.getRequest().getServletContext();
             if (servletContext == null)
@@ -303,14 +294,6 @@ public class WebSocketMapping implements Dumpable, LifeCycle.Listener
                     return frameHandler;
 
                 return null;
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeIOException(e);
-            }
-            catch (URISyntaxException e)
-            {
-                throw new RuntimeIOException("Unable to negotiate websocket due to mangled request URI", e);
             }
             finally
             {


### PR DESCRIPTION
#3465

- Negotiated now excludes duplicate extension names when setting the negotiated extensions from offered extensions

- do not allow internal extensions to be offered by the client and do not validate internal extensions when set

- Throw exception on websocket errors so the proper status code can be reported back to the client
- WebSocketMapping no longer catches the exceptions and warns but allows them to be caught at a higher level so the appropriate response can be returned

- added tests in core and jetty-websocket to test the negotiation
