### PR TITLE
Issue #3484 - making WebSocketServlet generic

### DIFF
--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/WebSocketServer.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/WebSocketServer.java
@@ -24,10 +24,8 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.core.FrameHandler;
-import org.eclipse.jetty.websocket.servlet.WebSocketMapping;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 /**
  * Example of setting up a Jetty WebSocket server
@@ -53,10 +51,10 @@ public class WebSocketServer
      * Servlet layer
      */
     @SuppressWarnings("serial")
-    public static class EchoServlet extends WebSocketServlet
+    public static class EchoServlet extends JettyWebSocketServlet
     {
         @Override
-        public void configure(WebSocketServletFactory factory)
+        public void configure(JettyWebSocketServletFactory factory)
         {
             factory.addMapping(factory.parsePathSpec("/"), (req,res)->new EchoSocket());
         }

--- a/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/LocalServer.java
+++ b/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/LocalServer.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.websocket.javax.tests;
 import java.net.URI;
 import java.util.Map;
 import java.util.function.BiConsumer;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.OnMessage;
@@ -48,7 +49,10 @@ import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.core.internal.Parser;
+import org.eclipse.jetty.websocket.javax.server.JavaxWebSocketServerContainer;
+import org.eclipse.jetty.websocket.javax.server.JavaxWebSocketServerFrameHandlerFactory;
 import org.eclipse.jetty.websocket.javax.server.JavaxWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.servlet.FrameHandlerFactory;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
@@ -256,11 +260,19 @@ public class LocalServer extends ContainerLifeCycle implements LocalFuzzer.Provi
     {
         ServletHolder holder = new ServletHolder(new WebSocketServlet()
         {
+            JavaxWebSocketServerFrameHandlerFactory factory = new JavaxWebSocketServerFrameHandlerFactory(JavaxWebSocketServerContainer.ensureContainer(getServletContext()));
+
             @Override
             public void configure(WebSocketServletFactory factory)
             {
                 PathSpec pathSpec = factory.parsePathSpec("/");
                 factory.addMapping(pathSpec, creator);
+            }
+
+            @Override
+            public FrameHandlerFactory getFactory()
+            {
+                return factory;
             }
         });
         servletContextHandler.addServlet(holder, urlPattern);

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerFrameHandlerFactory.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyServerFrameHandlerFactory.java
@@ -38,6 +38,12 @@ public class JettyServerFrameHandlerFactory
     extends JettyWebSocketFrameHandlerFactory
     implements FrameHandlerFactory, LifeCycle.Listener
 {
+    public static JettyServerFrameHandlerFactory getFactory(ServletContext context)
+    {
+        ServletContextHandler contextHandler = ServletContextHandler.getServletContextHandler(context, "JettyServerFrameHandlerFactory");
+        return contextHandler.getBean(JettyServerFrameHandlerFactory.class);
+    }
+
     public JettyServerFrameHandlerFactory(WebSocketContainer container)
     {
         super(container);

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketConfiguration.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketConfiguration.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.websocket.server;
 
+import java.util.ServiceLoader;
+
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -28,8 +30,6 @@ import org.eclipse.jetty.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.webapp.WebAppConfiguration;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
-
-import java.util.ServiceLoader;
 
 /**
  * <p>Websocket Configuration</p>
@@ -58,9 +58,7 @@ public class JettyWebSocketConfiguration extends AbstractConfiguration
 
         protectAndExpose(
             "org.eclipse.jetty.websocket.api.",
-            "org.eclipse.jetty.websocket.common.",
-            "org.eclipse.jetty.websocket.client.",
-            "org.eclipse.jetty.websocket.server.");
+                "org.eclipse.jetty.websocket.server.");
     }
 
     @Override

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServlet.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServlet.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.server;
 
 import org.eclipse.jetty.websocket.servlet.FrameHandlerFactory;

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServlet.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServlet.java
@@ -1,0 +1,27 @@
+package org.eclipse.jetty.websocket.server;
+
+import org.eclipse.jetty.websocket.servlet.FrameHandlerFactory;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+
+public abstract class JettyWebSocketServlet extends WebSocketServlet
+{
+    protected abstract void configure(JettyWebSocketServletFactory factory);
+
+    @Override
+    protected final void configure(WebSocketServletFactory factory)
+    {
+        configure(new JettyWebSocketServletFactory(factory));
+    }
+
+    @Override
+    public FrameHandlerFactory getFactory()
+    {
+        JettyServerFrameHandlerFactory frameHandlerFactory = JettyServerFrameHandlerFactory.getFactory(getServletContext());
+
+        if (frameHandlerFactory==null)
+            throw new IllegalStateException("JettyServerFrameHandlerFactory not found");
+
+        return frameHandlerFactory;
+    }
+}

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServletFactory.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServletFactory.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.server;
 
 import java.time.Duration;

--- a/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServletFactory.java
+++ b/jetty-websocket/jetty-websocket-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServletFactory.java
@@ -1,0 +1,224 @@
+package org.eclipse.jetty.websocket.server;
+
+import java.time.Duration;
+import java.util.Set;
+
+import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+
+
+public class JettyWebSocketServletFactory
+{
+    private WebSocketServletFactory factory;
+
+    public JettyWebSocketServletFactory(WebSocketServletFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public Set<String> getAvailableExtensionNames()
+    {
+        return factory.getExtensionRegistry().getAvailableExtensionNames();
+    }
+
+    public Duration getIdleTimeout()
+    {
+        return factory.getIdleTimeout();
+    }
+
+    public void setIdleTimeout(Duration duration)
+    {
+        factory.setIdleTimeout(duration);
+    }
+
+    public int getInputBufferSize()
+    {
+        return factory.getInputBufferSize();
+    }
+
+    public void setInputBufferSize(int bufferSize)
+    {
+        factory.setInputBufferSize(bufferSize);
+    }
+
+    public long getMaxFrameSize()
+    {
+        return factory.getMaxFrameSize();
+    }
+
+    public void setMaxFrameSize(long maxFrameSize)
+    {
+        factory.setMaxFrameSize(maxFrameSize);
+    }
+
+    public long getMaxBinaryMessageSize()
+    {
+        return factory.getMaxFrameSize();
+    }
+
+    public void setMaxBinaryMessageSize(long bufferSize)
+    {
+        factory.setMaxBinaryMessageSize(bufferSize);
+    }
+
+    public long getMaxTextMessageSize()
+    {
+        return factory.getMaxTextMessageSize();
+    }
+
+    public void setMaxTextMessageSize(long bufferSize)
+    {
+        factory.setMaxBinaryMessageSize(bufferSize);
+    }
+
+    public int getOutputBufferSize()
+    {
+        return factory.getOutputBufferSize();
+    }
+
+    public void setOutputBufferSize(int bufferSize)
+    {
+        factory.setOutputBufferSize(bufferSize);
+    }
+
+    public boolean isAutoFragment()
+    {
+        return factory.isAutoFragment();
+    }
+
+    public void setAutoFragment(boolean autoFragment)
+    {
+        factory.setAutoFragment(autoFragment);
+    }
+
+    public void addMapping(String pathSpec, JettyWebSocketCreator creator)
+    {
+        factory.addMapping(pathSpec, new WrappedCreator(creator));
+    }
+
+    /**
+     * add a WebSocket mapping to a provided {@link JettyWebSocketCreator}.
+     * <p>
+     * If mapping is added before this configuration is started, then it is persisted through
+     * stop/start of this configuration's lifecycle.  Otherwise it will be removed when
+     * this configuration is stopped.
+     * </p>
+     *
+     * @param pathSpec the pathspec to respond on
+     * @param creator  the WebSocketCreator to use
+     * @since 10.0
+     */
+    public void addMapping(PathSpec pathSpec, JettyWebSocketCreator creator)
+    {
+        factory.addMapping(pathSpec, new WrappedCreator(creator));
+    }
+
+    /**
+     * Add a WebSocket mapping at PathSpec "/" for a creator which creates the endpointClass
+     *
+     * @param endpointClass the WebSocket class to use
+     */
+    public void register(Class<?> endpointClass)
+    {
+        factory.register(endpointClass);
+    }
+
+    /**
+     * Add a WebSocket mapping at PathSpec "/" for a creator
+     *
+     * @param creator the WebSocketCreator to use
+     */
+    public void setCreator(JettyWebSocketCreator creator)
+    {
+        factory.setCreator(new WrappedCreator(creator));
+    }
+
+    /**
+     * Returns the creator for the given path spec.
+     *
+     * @param pathSpec the pathspec to respond on
+     * @return the websocket creator if path spec exists, or null
+     */
+    public JettyWebSocketCreator getMapping(PathSpec pathSpec)
+    {
+        WebSocketCreator creator = factory.getMapping(pathSpec);
+        if (creator instanceof WrappedCreator)
+            return ((WrappedCreator)creator).getCreator();
+
+        return null;
+    }
+
+    /**
+     * Get the MappedResource for the given target path.
+     *
+     * @param target the target path
+     * @return the MappedResource if matched, or null if not matched.
+     */
+    public JettyWebSocketCreator getMatch(String target)
+    {
+        WebSocketCreator creator = factory.getMatch(target);
+        if (creator instanceof WrappedCreator)
+            return ((WrappedCreator)creator).getCreator();
+
+        return null;
+    }
+
+
+    /**
+     * Parse a PathSpec string into a PathSpec instance.
+     * <p>
+     * Recognized Path Spec syntaxes:
+     * </p>
+     * <dl>
+     * <dt><code>/path/to</code> or <code>/</code> or <code>*.ext</code> or <code>servlet|{spec}</code></dt>
+     * <dd>Servlet Syntax</dd>
+     * <dt><code>^{spec}</code> or <code>regex|{spec}</code></dt>
+     * <dd>Regex Syntax</dd>
+     * <dt><code>uri-template|{spec}</code></dt>
+     * <dd>URI Template (see JSR356 and RFC6570 level 1)</dd>
+     * </dl>
+     *
+     * @param rawSpec the raw path spec as String to parse.
+     * @return the {@link PathSpec} implementation for the rawSpec
+     */
+    public PathSpec parsePathSpec(String rawSpec)
+    {
+        return factory.parsePathSpec(rawSpec);
+    }
+
+    /**
+     * Removes the mapping based on the given path spec.
+     *
+     * @param pathSpec the pathspec to respond on
+     * @return true if underlying mapping were altered, false otherwise
+     */
+    public boolean removeMapping(PathSpec pathSpec)
+    {
+        return factory.removeMapping(pathSpec);
+    }
+
+
+    private static class WrappedCreator implements WebSocketCreator
+    {
+        private JettyWebSocketCreator creator;
+
+        private WrappedCreator(JettyWebSocketCreator creator)
+        {
+            this.creator = creator;
+        }
+
+        public JettyWebSocketCreator getCreator()
+        {
+            return creator;
+        }
+
+        @Override
+        public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+        {
+            return creator.createWebSocket(new JettyServerUpgradeRequest(req), new JettyServerUpgradeResponse(resp));
+        }
+    }
+}

--- a/jetty-websocket/jetty-websocket-server/src/test/java/org/eclipse/jetty/websocket/server/browser/BrowserDebugTool.java
+++ b/jetty-websocket/jetty-websocket-server/src/test/java/org/eclipse/jetty/websocket/server/browser/BrowserDebugTool.java
@@ -42,13 +42,13 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.websocket.core.ExtensionConfig;
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 /**
  * Tool to help debug websocket circumstances reported around browsers.
@@ -137,10 +137,10 @@ public class BrowserDebugTool
         server.stop();
     }
 
-    public static class BrowserSocketServlet extends WebSocketServlet
+    public static class BrowserSocketServlet extends JettyWebSocketServlet
     {
         @Override
-        public void configure(WebSocketServletFactory factory) {
+        public void configure(JettyWebSocketServletFactory factory) {
             LOG.debug("Configuring WebSocketServerFactory ...");
 
             // Setup the desired Socket to use for all incoming upgrade requests
@@ -160,10 +160,10 @@ public class BrowserDebugTool
         }
     }
 
-    public static class BrowserSocketCreator implements WebSocketCreator
+    public static class BrowserSocketCreator implements JettyWebSocketCreator
     {
         @Override
-        public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+        public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
         {
             LOG.debug("Creating BrowserSocket");
 
@@ -182,7 +182,7 @@ public class BrowserDebugTool
             // manually negotiate extensions
             List<ExtensionConfig> negotiated = new ArrayList<>();
             // adding frame debug
-            negotiated.add(new ExtensionConfig("@frame-capture; output-dir=target"));
+            negotiated.add(ExtensionConfig.parse("@frame-capture; output-dir=target"));
             for (ExtensionConfig config : req.getExtensions())
             {
                 if (config.getName().equals("permessage-deflate"))

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/EchoCreator.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/EchoCreator.java
@@ -18,14 +18,14 @@
 
 package org.eclipse.jetty.websocket.tests;
 
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
 
-public class EchoCreator implements WebSocketCreator
+public class EchoCreator implements JettyWebSocketCreator
 {
     @Override
-    public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+    public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
     {
         if (req.hasSubProtocol("echo"))
         {

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketServletTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketServletTest.java
@@ -27,9 +27,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,10 +40,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JettyWebSocketServletTest
 {
-    public static class MyWebSocketServlet extends WebSocketServlet
+    public static class MyWebSocketServlet extends JettyWebSocketServlet
     {
         @Override
-        public void configure(WebSocketServletFactory factory)
+        public void configure(JettyWebSocketServletFactory factory)
         {
             factory.addMapping("/",(req, resp)->new EventSocket.EchoSocket());
         }

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
@@ -45,9 +45,9 @@ import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.Generator;
 import org.eclipse.jetty.websocket.core.internal.WebSocketConnection;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,10 +103,10 @@ public class WebSocketStatsTest
         }
     }
 
-    public static class MyWebSocketServlet extends WebSocketServlet
+    public static class MyWebSocketServlet extends JettyWebSocketServlet
     {
         @Override
-        public void configure(WebSocketServletFactory factory)
+        public void configure(JettyWebSocketServletFactory factory)
         {
             factory.setAutoFragment(false);
             factory.addMapping("/",(req, resp)->new EchoSocket());

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/BadNetworkTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/BadNetworkTest.java
@@ -37,9 +37,9 @@ import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.api.util.WSURI;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,10 +75,10 @@ public class BadNetworkTest
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
-        ServletHolder holder = new ServletHolder(new WebSocketServlet()
+        ServletHolder holder = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.setIdleTimeout(Duration.ofSeconds(10));
                 factory.setMaxTextMessageSize(1024 * 1024 * 2);

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -38,7 +38,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.websocket.api.CloseException;
 import org.eclipse.jetty.websocket.api.Frame;
 import org.eclipse.jetty.websocket.api.MessageTooLargeException;
 import org.eclipse.jetty.websocket.api.Session;
@@ -50,9 +49,9 @@ import org.eclipse.jetty.websocket.api.util.WSURI;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,10 +120,10 @@ public class ClientCloseTest
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
-        ServletHolder holder = new ServletHolder(new WebSocketServlet()
+        ServletHolder holder = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.setIdleTimeout(Duration.ofSeconds(10));
                 factory.setMaxTextMessageSize(1024 * 1024 * 2);

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
@@ -39,9 +39,9 @@ import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.common.WebSocketSession;
 import org.eclipse.jetty.websocket.common.WebSocketSessionListener;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.eclipse.jetty.websocket.tests.EchoCreator;
 import org.junit.jupiter.api.AfterEach;
@@ -69,10 +69,10 @@ public class ClientSessionsTest
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
-        ServletHolder holder = new ServletHolder(new WebSocketServlet()
+        ServletHolder holder = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.setIdleTimeout(Duration.ofSeconds(10));
                 factory.setMaxTextMessageSize(1024 * 1024 * 2);

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/SlowClientTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/SlowClientTest.java
@@ -32,9 +32,9 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.util.WSURI;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.eclipse.jetty.websocket.tests.EchoSocket;
 import org.junit.jupiter.api.AfterEach;
@@ -72,10 +72,10 @@ public class SlowClientTest
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
-        ServletHolder websocket = new ServletHolder(new WebSocketServlet()
+        ServletHolder websocket = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.register(EchoSocket.class);
             }

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAdvancedEchoCreator.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAdvancedEchoCreator.java
@@ -18,11 +18,11 @@
 
 package org.eclipse.jetty.websocket.tests.examples;
 
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
 
-public class MyAdvancedEchoCreator implements WebSocketCreator
+public class MyAdvancedEchoCreator implements JettyWebSocketCreator
 {
     private MyBinaryEchoSocket binaryEcho;
     private MyEchoSocket textEcho;
@@ -35,7 +35,7 @@ public class MyAdvancedEchoCreator implements WebSocketCreator
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+    public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
     {
         for (String subprotocol : req.getSubProtocols())
         {

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAdvancedEchoServlet.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAdvancedEchoServlet.java
@@ -22,15 +22,15 @@ import java.time.Duration;
 
 import javax.servlet.annotation.WebServlet;
 
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 @SuppressWarnings("serial")
 @WebServlet(name = "MyAdvanced Echo WebSocket Servlet", urlPatterns = { "/advecho" })
-public class MyAdvancedEchoServlet extends WebSocketServlet
+public class MyAdvancedEchoServlet extends JettyWebSocketServlet
 {
     @Override
-    public void configure(WebSocketServletFactory factory)
+    public void configure(JettyWebSocketServletFactory factory)
     {
         // set a 10 second timeout
         factory.setIdleTimeout(Duration.ofSeconds(10));

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAuthedCreator.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAuthedCreator.java
@@ -21,14 +21,14 @@ package org.eclipse.jetty.websocket.tests.examples;
 import java.io.IOException;
 import java.security.Principal;
 
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
 
-public class MyAuthedCreator implements WebSocketCreator
+public class MyAuthedCreator implements JettyWebSocketCreator
 {
     @Override
-    public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+    public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
     {
         try
         {

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAuthedServlet.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyAuthedServlet.java
@@ -18,14 +18,14 @@
 
 package org.eclipse.jetty.websocket.tests.examples;
 
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 @SuppressWarnings("serial")
-public class MyAuthedServlet extends WebSocketServlet
+public class MyAuthedServlet extends JettyWebSocketServlet
 {
     @Override
-    public void configure(WebSocketServletFactory factory)
+    public void configure(JettyWebSocketServletFactory factory)
     {
         factory.setCreator(new MyAuthedCreator());
     }

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyEchoServlet.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/examples/MyEchoServlet.java
@@ -22,15 +22,15 @@ import java.time.Duration;
 
 import javax.servlet.annotation.WebServlet;
 
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 @SuppressWarnings("serial")
 @WebServlet(name = "MyEcho WebSocket Servlet", urlPatterns = { "/echo" })
-public class MyEchoServlet extends WebSocketServlet
+public class MyEchoServlet extends JettyWebSocketServlet
 {
     @Override
-    public void configure(WebSocketServletFactory factory)
+    public void configure(JettyWebSocketServletFactory factory)
     {
         // set a 10 second timeout
         factory.setIdleTimeout(Duration.ofSeconds(10));

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseCreator.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseCreator.java
@@ -19,29 +19,30 @@
 package org.eclipse.jetty.websocket.tests.server;
 
 import java.util.concurrent.LinkedBlockingQueue;
+
 import javax.servlet.ServletContext;
 
 import org.eclipse.jetty.websocket.common.WebSocketContainer;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.EchoSocket;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class ServerCloseCreator implements WebSocketCreator
+public class ServerCloseCreator implements JettyWebSocketCreator
 {
-    private final WebSocketServletFactory serverFactory;
+    private final JettyWebSocketServletFactory serverFactory;
     private LinkedBlockingQueue<AbstractCloseEndpoint> createdSocketQueue = new LinkedBlockingQueue<>();
 
-    public ServerCloseCreator(WebSocketServletFactory serverFactory)
+    public ServerCloseCreator(JettyWebSocketServletFactory serverFactory)
     {
         this.serverFactory = serverFactory;
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+    public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
     {
         AbstractCloseEndpoint closeSocket = null;
 

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseTest.java
@@ -37,9 +37,9 @@ import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.common.WebSocketSession;
 import org.eclipse.jetty.websocket.core.internal.WebSocketChannel;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,10 +73,10 @@ public class ServerCloseTest
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
 
-        ServletHolder closeEndpoint = new ServletHolder(new WebSocketServlet()
+        ServletHolder closeEndpoint = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.setIdleTimeout(Duration.ofSeconds(2));
                 serverEndpointCreator = new ServerCloseCreator(factory);

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/SlowServerTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/SlowServerTest.java
@@ -32,9 +32,9 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.util.WSURI;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,10 +72,10 @@ public class SlowServerTest
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
 
-        ServletHolder websocket = new ServletHolder(new WebSocketServlet()
+        ServletHolder websocket = new ServletHolder(new JettyWebSocketServlet()
         {
             @Override
-            public void configure(WebSocketServletFactory factory)
+            public void configure(JettyWebSocketServletFactory factory)
             {
                 factory.register(SlowServerEndpoint.class);
             }

--- a/tests/test-webapps/test-jetty-webapp/pom.xml
+++ b/tests/test-webapps/test-jetty-webapp/pom.xml
@@ -207,19 +207,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-servlet</artifactId>
+      <artifactId>jetty-websocket-server</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>jetty-websocket-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/WebSocketChatServlet.java
+++ b/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/WebSocketChatServlet.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -32,16 +33,14 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.core.FrameHandler;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import org.eclipse.jetty.websocket.servlet.WebSocketMapping;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 
 @SuppressWarnings("serial")
-public class WebSocketChatServlet extends WebSocketServlet implements WebSocketCreator
+public class WebSocketChatServlet extends JettyWebSocketServlet implements JettyWebSocketCreator
 {
     /** Holds active sockets to other members of the chat */
     private final List<ChatWebSocket> members = new CopyOnWriteArrayList<ChatWebSocket>();
@@ -53,7 +52,7 @@ public class WebSocketChatServlet extends WebSocketServlet implements WebSocketC
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
+    public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
     {
         if (req.hasSubProtocol("chat"))
         {
@@ -64,7 +63,7 @@ public class WebSocketChatServlet extends WebSocketServlet implements WebSocketC
     }
 
     @Override
-    public void configure(WebSocketServletFactory factory)
+    public void configure(JettyWebSocketServletFactory factory)
     {
         factory.addMapping(factory.parsePathSpec("/"), this);
     }


### PR DESCRIPTION
make `WebSocketServlet` part of jetty-websocket-server as it is code specific to the jetty-websocket-api, and should not be exposing core classes to the user

Edit: no longer moving to jetty-websocket-server, now making `WebSocketServlet` generic and extending it in jetty-websocket-server with the class `JettyWebSocketServlet` where the new abstract method `WebSocketServlet.getFactory()` is implemented to get the specific instance of the `JettyServerFrameHandlerFactory`