### PR TITLE
Issue #3481 unflushed TLS close notify

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -389,9 +389,9 @@ abstract public class WriteFlusher
         boolean progress = true;
         while (progress && buffers != null)
         {
-            long before = remaining(buffers);
+            long before = BufferUtil.remaining(buffers);
             boolean flushed = _endPoint.flush(buffers);
-            long after = remaining(buffers);
+            long after = BufferUtil.remaining(buffers);
             long written = before - after;
 
             if (LOG.isDebugEnabled())
@@ -439,16 +439,6 @@ abstract public class WriteFlusher
         // This is probably SSL being unable to flush the encrypted buffer, so return EMPTY_BUFFERS
         // and that will keep this WriteFlusher pending.
         return buffers == null ? EMPTY_BUFFERS : buffers;
-    }
-
-    private long remaining(ByteBuffer[] buffers)
-    {
-        if (buffers == null)
-            return 0;
-        long result = 0;
-        for (ByteBuffer buffer : buffers)
-            result += buffer.remaining();
-        return result;
     }
 
     /**

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -946,8 +946,13 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
                                     if (!flushed)
                                         return result = false;
+
                                     if (isEmpty)
-                                        return result = true;
+                                    {
+                                        if (wrapResult.getHandshakeStatus() != HandshakeStatus.NEED_WRAP ||
+                                                wrapResult.bytesProduced() == 0)
+                                            return result = true;
+                                    }
                                     break;
 
                                 default:
@@ -1110,7 +1115,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                         // and continue as if we are closed. The assumption here is that
                         // the encrypted buffer will contain the entire close handshake
                         // and that a call to flush(EMPTY_BUFFER) is not needed.
-                        endp.write(Callback.from(()->{}, t-> endp.close()), _encryptedOutput);
+                        endp.write(Callback.from(() -> {}, t -> endp.close()), _encryptedOutput);
                     }
                 }
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1102,9 +1102,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
                 if (flush)
                 {
-                    if (flush(BufferUtil.EMPTY_BUFFER))
-                        endp.shutdownOutput();
-                    else if (!close)
+                    if (!flush(BufferUtil.EMPTY_BUFFER) && !close)
                     {
                         Thread.yield();
                         // if we still can't flush, but we are not closing the endpoint,
@@ -1112,7 +1110,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                         // and continue as if we are closed. The assumption here is that
                         // the encrypted buffer will contain the entire close handshake
                         // and that a call to flush(EMPTY_BUFFER) is not needed.
-                        endp.write(Callback.from(endp::shutdownOutput, t-> endp.close()), _encryptedOutput);
+                        endp.write(Callback.from(()->{}, t-> endp.close()), _encryptedOutput);
                     }
                 }
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -870,7 +871,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                         if (filled < 0)
                                             throw new IOException("Broken pipe");
                                     }
-                                    return result = appOuts.length==1 && BufferUtil.isEmpty(appOuts[0]);
+                                    return result = BufferUtil.isEmpty(_encryptedOutput) &&
+                                            Arrays.stream(appOuts).mapToInt(ByteBuffer::remaining).sum()==0;
 
                                 default:
                                     throw new IllegalStateException("Unexpected HandshakeStatus " + status);

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1098,19 +1098,15 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
                 if (flush && !flush(BufferUtil.EMPTY_BUFFER))
                 {
-                    // We failed to flush. Try a few times more after short delay just in case progress can be made
-                    // TODO configure this loops?
-                    int retry = 10;
-                    for (;retry-->0;)
+                    // We failed to flush. Try a one more after short delay just in case progress can be made
+                    Thread.yield();
+                    if (!getEndPoint().flush(_encryptedOutput) && !close)
                     {
-                        Thread.yield();
-                        if (flush(BufferUtil.EMPTY_BUFFER))
-                            break;
+                        // if we still can't flush, and we are not closing,
+                        // let's just flush the encrypted output in the background.
+                        // and continue as if we are closed
+                        getEndPoint().write(Callback.NOOP, _encryptedOutput);
                     }
-
-                    // if we still can't flush, and we are not closing, let's just flush the encrypted output in the background.
-                    if (retry==0 && !close)
-                        getEndPoint().write(Callback.NOOP,_encryptedOutput);
                 }
 
                 if (close)

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/SslConnectionTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/SslConnectionTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
@@ -31,7 +32,9 @@ import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -46,10 +49,13 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.TimerScheduler;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -63,6 +69,8 @@ public class SslConnectionTest
     private final SslContextFactory _sslCtxFactory =new SslContextFactory();
     protected volatile EndPoint _lastEndp;
     private volatile boolean _testFill=true;
+    private volatile boolean _onXWriteThenShutdown=false;
+
     private volatile FutureCallback _writeCallback;
     protected ServerSocketChannel _connector;
     final AtomicInteger _dispatches = new AtomicInteger();
@@ -105,6 +113,7 @@ public class SslConnectionTest
 
     static final AtomicInteger __startBlocking = new AtomicInteger();
     static final AtomicInteger __blockFor = new AtomicInteger();
+    static final AtomicBoolean __onIncompleteFlush = new AtomicBoolean();
     private static class TestEP extends SocketChannelEndPoint
     {
         public TestEP(SelectableChannel channel, ManagedSelector selector, SelectionKey key, Scheduler scheduler)
@@ -115,13 +124,15 @@ public class SslConnectionTest
         @Override
         protected void onIncompleteFlush()
         {
-            super.onIncompleteFlush();
+            __onIncompleteFlush.set(true);
+            // super.onIncompleteFlush();
         }
         
 
         @Override
         public boolean flush(ByteBuffer... buffers) throws IOException
         {
+            __onIncompleteFlush.set(false);
             if (__startBlocking.get()==0 || __startBlocking.decrementAndGet()==0)
             {
                 if (__blockFor.get()>0 && __blockFor.getAndDecrement()>0)
@@ -227,20 +238,23 @@ public class SslConnectionTest
                         filled=endp.fill(_in);
                     }
 
+                    boolean shutdown = _onXWriteThenShutdown && BufferUtil.toString(_in).contains("X");
+
                     // Write everything
                     int l=_in.remaining();
                     if (l>0)
                     {
                         FutureCallback blockingWrite= new FutureCallback();
+
                         endp.write(blockingWrite,_in);
                         blockingWrite.get();
+                        if (shutdown)
+                            endp.shutdownOutput();
                     }
 
                     // are we done?
-                    if (endp.isInputShutdown())
-                    {
+                    if (endp.isInputShutdown() || shutdown)
                         endp.shutdownOutput();
-                    }
                 }
             }
             catch(InterruptedException|EofException e)
@@ -426,7 +440,7 @@ public class SslConnectionTest
     public void testBlockedWrite() throws Exception
     {
         startSSL();
-        try (Socket client = newClient())
+        try (SSLSocket client = newClient())
         {
             client.setSoTimeout(5000);
             try (SocketChannel server = _connector.accept())
@@ -434,24 +448,84 @@ public class SslConnectionTest
                 server.configureBlocking(false);
                 _manager.accept(server);
 
-                __startBlocking.set(5);
-                __blockFor.set(3);
 
                 client.getOutputStream().write("Hello".getBytes(StandardCharsets.UTF_8));
                 byte[] buffer = new byte[1024];
                 int len = client.getInputStream().read(buffer);
-                assertEquals(5, len);
                 assertEquals("Hello", new String(buffer, 0, len, StandardCharsets.UTF_8));
 
+                __startBlocking.set(0);
+                __blockFor.set(2);
                 _dispatches.set(0);
                 client.getOutputStream().write("World".getBytes(StandardCharsets.UTF_8));
-                len = 5;
-                while (len > 0)
-                    len -= client.getInputStream().read(buffer);
-                assertEquals(0, len);
+
+                try
+                {
+                    client.setSoTimeout(500);
+                    client.getInputStream().read(buffer);
+                    throw new IllegalStateException();
+                }
+                catch(SocketTimeoutException e)
+                {
+                }
+
+
+                assertTrue(__onIncompleteFlush.get());
+                ((TestEP)_lastEndp).getWriteFlusher().completeWrite();
+
+                len = client.getInputStream().read(buffer);
+                assertEquals("World", new String(buffer, 0, len, StandardCharsets.UTF_8));
             }
         }
     }
+
+
+    @Test
+    public void testBlockedClose() throws Exception
+    {
+        startSSL();
+        try (SSLSocket client = newClient())
+        {
+            client.setSoTimeout(5000);
+            try (SocketChannel server = _connector.accept())
+            {
+                server.configureBlocking(false);
+                _manager.accept(server);
+
+                //__startBlocking.set(5);
+                //__blockFor.set(3);
+
+                client.getOutputStream().write("Short".getBytes(StandardCharsets.UTF_8));
+                byte[] buffer = new byte[1024];
+                int len = client.getInputStream().read(buffer);
+                assertEquals("Short", new String(buffer, 0, len, StandardCharsets.UTF_8));
+
+                _onXWriteThenShutdown=true;
+                __startBlocking.set(2); // block on the close handshake flush
+                __blockFor.set(Integer.MAX_VALUE); // > retry loops in SslConnection + 1
+                client.getOutputStream().write("This is a much longer example with X".getBytes(StandardCharsets.UTF_8));
+                len = client.getInputStream().read(buffer);
+                assertEquals("This is a much longer example with X", new String(buffer, 0, len, StandardCharsets.UTF_8));
+
+                try
+                {
+                    client.setSoTimeout(500);
+                    client.getInputStream().read(buffer);
+                    throw new IllegalStateException();
+                }
+                catch(SocketTimeoutException e)
+                {
+                }
+
+                __blockFor.set(0);
+                assertTrue(__onIncompleteFlush.get());
+                ((TestEP)_lastEndp).getWriteFlusher().completeWrite();
+                len = client.getInputStream().read(buffer);
+                assertThat(len, is(len));
+            }
+        }
+    }
+
 
     @Test
     public void testManyLines() throws Exception
@@ -478,7 +552,6 @@ public class SslConnectionTest
                             String line = in.readLine();
                             if (line == null)
                                 break;
-                            // System.err.println(line);
                             count.countDown();
                         }
                     }
@@ -491,7 +564,6 @@ public class SslConnectionTest
                 for (int i = 0; i < LINES; i++)
                 {
                     client.getOutputStream().write(("HelloWorld " + i + "\n").getBytes(StandardCharsets.UTF_8));
-                    // System.err.println("wrote");
                     if (i % 1000 == 0)
                     {
                         client.getOutputStream().flush();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -237,6 +237,7 @@ public class BufferUtil
         }
     }
 
+    /* ------------------------------------------------------------ */
     /**
      * @param buf the buffer to check
      * @return true if buf is equal to EMPTY_BUFFER
@@ -256,6 +257,36 @@ public class BufferUtil
     public static boolean isEmpty(ByteBuffer buf)
     {
         return buf == null || buf.remaining() == 0;
+    }
+
+    /* ------------------------------------------------------------ */
+    /** Check for an empty or null buffers.
+     * @param buf the buffer to check
+     * @return true if the buffer is null or empty.
+     */
+    public static boolean isEmpty(ByteBuffer[] buf)
+    {
+        if (buf==null || buf.length==0)
+            return true;
+        for (ByteBuffer b : buf)
+            if (b!=null && b.hasRemaining())
+                return false;
+        return true;
+    }
+
+    /* ------------------------------------------------------------ */
+    /** Get the remaining bytes in 0 or more buffers.
+     * @param buf the buffers to check
+     * @return number of bytes remaining in all buffers.
+     */
+    public static long remaining(ByteBuffer... buf)
+    {
+        long remaining = 0;
+        if (buf!=null)
+        for (ByteBuffer b : buf)
+            if (b!=null)
+                remaining += b.remaining();
+        return remaining;
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.util;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import org.eclipse.jetty.util.thread.Invocable;
 
@@ -110,7 +111,130 @@ public interface Callback extends Invocable
         };
     }
 
-    class Nested implements Callback
+    /**
+     * Create a callback from the passed success and failure
+     * @param success Called when the callback succeeds
+     * @param failure Called when the callback fails
+     * @return a new Callback
+     */
+    static Callback from(Runnable success, Consumer<Throwable> failure)
+    {
+        return new Callback()
+        {
+            @Override
+            public void succeeded()
+            {
+                success.run();
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                failure.accept(x);
+            }
+        };
+    }
+
+    /** Creaste a callback that runs completed when it succeeds or fails
+     * @param completed The completion to run on success or failure
+     * @return a new callback
+     */
+    static Callback from(Runnable completed)
+    {
+        return new Completing()
+        {
+            public void completed()
+            {
+                completed.run();
+            }
+        };
+    }
+
+    /**
+     * Create a nested callback that runs completed after
+     * completing the nested callback.
+     * @param callback The nested callback
+     * @param completed The completion to run after the nested callback is completed
+     * @return a new callback.
+     */
+    static Callback from(Callback callback, Runnable completed)
+    {
+        return new Nested(callback)
+        {
+            public void completed()
+            {
+                completed.run();
+            }
+        };
+    }
+
+    /**
+     * Create a nested callback that runs completed before
+     * completing the nested callback.
+     * @param callback The nested callback
+     * @param completed The completion to run before the nested callback is completed. Any exceptions thrown
+     *                  from completed will result in a callback failure.
+     * @return a new callback.
+     */
+    static Callback from(Runnable completed, Callback callback)
+    {
+        return new Callback()
+        {
+            @Override
+            public void succeeded()
+            {
+                try
+                {
+                    completed.run();
+                    callback.succeeded();
+                }
+                catch(Throwable t)
+                {
+                    callback.failed(t);
+                }
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                try
+                {
+                    completed.run();
+                }
+                catch(Throwable t)
+                {
+                    x.addSuppressed(t);
+                }
+                callback.failed(x);
+            }
+        };
+    }
+
+
+    class Completing implements Callback
+    {
+        @Override
+        public void succeeded()
+        {
+            completed();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            completed();
+        }
+
+        public void completed()
+        {
+        }
+    }
+
+    /**
+     * Nested Completing Callback that completes after
+     * completing the nested callback
+     */
+    class Nested extends Completing
     {
         private final Callback callback;
 
@@ -132,13 +256,27 @@ public interface Callback extends Invocable
         @Override
         public void succeeded()
         {
-            callback.succeeded();
+            try
+            {
+                callback.succeeded();
+            }
+            finally
+            {
+                completed();
+            }
         }
 
         @Override
         public void failed(Throwable x)
         {
-            callback.failed(x);
+            try
+            {
+                callback.failed(x);
+            }
+            finally
+            {
+                completed();
+            }
         }
 
         @Override
@@ -147,6 +285,7 @@ public interface Callback extends Invocable
             return callback.getInvocationType();
         }
     }
+
     /**
      * <p>A CompletableFuture that is also a Callback.</p>
      */


### PR DESCRIPTION
Fixes #3481 by:
 + if the close notify is not flushed then try again after a thread yield
 + if the retry does not flush then:
    - if close is true, don't bother with the flush and just proceed to close the encrypted
    - if close is false, schedule an async write to do the flush and proceed as if the decrypted endpoint is closed

Added a test harness with a modified encrypted endpoint to test this behaviour.

Signed-off-by: Greg Wilkins <gregw@webtide.com>