### PR TITLE
Rejuvenate log levels

### DIFF
--- a/jetty-cdi/cdi-websocket/src/test/java/org/eclipse/jetty/cdi/websocket/cdiapp/InfoSocket.java
+++ b/jetty-cdi/cdi-websocket/src/test/java/org/eclipse/jetty/cdi/websocket/cdiapp/InfoSocket.java
@@ -53,14 +53,14 @@ public class InfoSocket
     @OnOpen
     public void onOpen(Session session)
     {
-        LOG.log(Level.INFO,"onOpen(): {0}",session);
+        LOG.log(Level.FINEST,"onOpen(): {0}",session);
         this.session = session;
     }
 
     @OnClose
     public void onClose(CloseReason close)
     {
-        LOG.log(Level.INFO,"onClose(): {}",close);
+        LOG.log(Level.FINEST,"onClose(): {}",close);
         this.session = null;
     }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
cdi-websocket | LOG.log(Level.INFO,"onClose():   {}",close) | INFO | FINEST | org.eclipse.jetty.cdi.websocket.cdiapp.InfoSocket | onClose(javax.websocket.CloseReason) | 0
cdi-websocket | LOG.log(Level.INFO,"onOpen(): {0}",session) | INFO | FINEST | org.eclipse.jetty.cdi.websocket.cdiapp.InfoSocket | onOpen(javax.websocket.Session) | 0




## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: 74fc49f

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
apache-jsp | [0.0, 1.8824999) | FINEST
apache-jsp | [1.8824999, 3.7649999) | FINER
apache-jsp | [3.7649999, 5.6475) | FINE
apache-jsp | [5.6475, 7.5299997) | INFO
apache-jstl | [0.0, 0.175) | FINEST
apache-jstl | [0.175, 0.35) | FINER
apache-jstl | [0.35, 0.525) | FINE
apache-jstl | [0.525, 0.7) | INFO
cdi-core | [0.0, 0.175) | FINEST
cdi-core | [0.175, 0.35) | FINER
cdi-core | [0.35, 0.525) | FINE
cdi-core | [0.525, 0.7) | INFO
cdi-servlet | [0.0, 0.175) | FINEST
cdi-servlet | [0.175, 0.35) | FINER
cdi-servlet | [0.35, 0.525) | FINE
cdi-servlet | [0.525, 0.7) | INFO
cdi-websocket | [0.0, 0.175) | FINEST
cdi-websocket | [0.175, 0.35) | FINER
cdi-websocket | [0.35, 0.525) | FINE
cdi-websocket | [0.525, 0.7) | INFO
example-jetty-embedded | [0.0, 0.78575) | FINEST
example-jetty-embedded | [0.78575, 1.5715) | FINER
example-jetty-embedded | [1.5715, 2.35725) | FINE
example-jetty-embedded | [2.35725, 3.143) | INFO
fcgi-client | [0.0, 2.4295) | FINEST
fcgi-client | [2.4295, 4.859) | FINER
fcgi-client | [4.859, 7.2885003) | FINE
fcgi-client | [7.2885003, 9.718) | INFO
fcgi-server | [0.0, 0.7985) | FINEST
fcgi-server | [0.7985, 1.597) | FINER
fcgi-server | [1.597, 2.3955) | FINE
fcgi-server | [2.3955, 3.194) | INFO
http2-alpn-tests | [0.0, 0.649) | FINEST
http2-alpn-tests | [0.649, 1.298) | FINER
http2-alpn-tests | [1.298, 1.947) | FINE
http2-alpn-tests | [1.947, 2.596) | INFO
http2-client | [0.0, 1.5879999) | FINEST
http2-client | [1.5879999, 3.1759999) | FINER
http2-client | [3.1759999, 4.764) | FINE
http2-client | [4.764, 6.3519998) | INFO
http2-common | [0.0, 5.4544997) | FINEST
http2-common | [5.4544997, 10.908999) | FINER
http2-common | [10.908999, 16.363499) | FINE
http2-common | [16.363499, 21.817999) | INFO
http2-hpack | [0.0, 3.982) | FINEST
http2-hpack | [3.982, 7.964) | FINER
http2-hpack | [7.964, 11.946) | FINE
http2-hpack | [11.946, 15.928) | INFO
http2-http-client-transport | [0.0, 1.4489999) | FINEST
http2-http-client-transport | [1.4489999, 2.8979998) | FINER
http2-http-client-transport | [2.8979998, 4.3469996) | FINE
http2-http-client-transport | [4.3469996, 5.7959995) | INFO
http2-server | [0.0, 1.3725) | FINEST
http2-server | [1.3725, 2.745) | FINER
http2-server | [2.745, 4.1175) | FINE
http2-server | [4.1175, 5.49) | INFO
javax-websocket-client-impl | [0.0, 1.5849999) | FINEST
javax-websocket-client-impl | [1.5849999, 3.1699998) | FINER
javax-websocket-client-impl | [3.1699998, 4.7549996) | FINE
javax-websocket-client-impl | [4.7549996, 6.3399997) | INFO
javax-websocket-server-impl | [0.0, 1.9612501) | FINEST
javax-websocket-server-impl | [1.9612501, 3.9225001) | FINER
javax-websocket-server-impl | [3.9225001, 5.88375) | FINE
javax-websocket-server-impl | [5.88375, 7.8450003) | INFO
jetty-alpn-client | [0.0, 0.175) | FINEST
jetty-alpn-client | [0.175, 0.35) | FINER
jetty-alpn-client | [0.35, 0.525) | FINE
jetty-alpn-client | [0.525, 0.7) | INFO
jetty-alpn-conscrypt-client | [0.0, 0.33725) | FINEST
jetty-alpn-conscrypt-client | [0.33725, 0.6745) | FINER
jetty-alpn-conscrypt-client | [0.6745, 1.01175) | FINE
jetty-alpn-conscrypt-client | [1.01175, 1.349) | INFO
jetty-alpn-conscrypt-server | [0.0, 1.5884999) | FINEST
jetty-alpn-conscrypt-server | [1.5884999, 3.1769998) | FINER
jetty-alpn-conscrypt-server | [3.1769998, 4.7654996) | FINE
jetty-alpn-conscrypt-server | [4.7654996, 6.3539996) | INFO
jetty-alpn-java-server | [0.0, 0.175) | FINEST
jetty-alpn-java-server | [0.175, 0.35) | FINER
jetty-alpn-java-server | [0.35, 0.525) | FINE
jetty-alpn-java-server | [0.525, 0.7) | INFO
jetty-alpn-server | [0.0, 0.34575) | FINEST
jetty-alpn-server | [0.34575, 0.6915) | FINER
jetty-alpn-server | [0.6915, 1.03725) | FINE
jetty-alpn-server | [1.03725, 1.383) | INFO
jetty-annotations | [0.0, 3.3987498) | FINEST
jetty-annotations | [3.3987498, 6.7974997) | FINER
jetty-annotations | [6.7974997, 10.196249) | FINE
jetty-annotations | [10.196249, 13.594999) | INFO
jetty-ant | [0.0, 0.5165) | FINEST
jetty-ant | [0.5165, 1.033) | FINER
jetty-ant | [1.033, 1.5495) | FINE
jetty-ant | [1.5495, 2.066) | INFO
jetty-client | [0.0, 2.8477497) | FINEST
jetty-client | [2.8477497, 5.6954994) | FINER
jetty-client | [5.6954994, 8.543249) | FINE
jetty-client | [8.543249, 11.390999) | INFO
jetty-deploy | [0.0, 0.5605) | FINEST
jetty-deploy | [0.5605, 1.121) | FINER
jetty-deploy | [1.121, 1.6815001) | FINE
jetty-deploy | [1.6815001, 2.242) | INFO
jetty-gcloud-session-manager | [0.0, 0.68724996) | FINEST
jetty-gcloud-session-manager | [0.68724996, 1.3744999) | FINER
jetty-gcloud-session-manager | [1.3744999, 2.06175) | FINE
jetty-gcloud-session-manager | [2.06175, 2.7489998) | INFO
jetty-hazelcast | [0.0, 0.65325) | FINEST
jetty-hazelcast | [0.65325, 1.3065) | FINER
jetty-hazelcast | [1.3065, 1.9597499) | FINE
jetty-hazelcast | [1.9597499, 2.613) | INFO
jetty-http | [0.0, 4.820999) | FINEST
jetty-http | [4.820999, 9.641998) | FINER
jetty-http | [9.641998, 14.462997) | FINE
jetty-http | [14.462997, 19.283997) | INFO
jetty-http-spi | [0.0, 0.95649993) | FINEST
jetty-http-spi | [0.95649993, 1.9129999) | FINER
jetty-http-spi | [1.9129999, 2.8694997) | FINE
jetty-http-spi | [2.8694997, 3.8259997) | INFO
jetty-infinispan | [0.0, 0.74325) | FINEST
jetty-infinispan | [0.74325, 1.4865) | FINER
jetty-infinispan | [1.4865, 2.2297502) | FINE
jetty-infinispan | [2.2297502, 2.973) | INFO
jetty-io | [0.0, 7.66875) | FINEST
jetty-io | [7.66875, 15.3375) | FINER
jetty-io | [15.3375, 23.006248) | FINE
jetty-io | [23.006248, 30.675) | INFO
jetty-jaas | [0.0, 1.55875) | FINEST
jetty-jaas | [1.55875, 3.1175) | FINER
jetty-jaas | [3.1175, 4.67625) | FINE
jetty-jaas | [4.67625, 6.235) | INFO
jetty-jaspi | [0.0, 0.6745) | FINEST
jetty-jaspi | [0.6745, 1.349) | FINER
jetty-jaspi | [1.349, 2.0235) | FINE
jetty-jaspi | [2.0235, 2.698) | INFO
jetty-jmh | [0.0, 0.37624997) | FINEST
jetty-jmh | [0.37624997, 0.75249994) | FINER
jetty-jmh | [0.75249994, 1.1287498) | FINE
jetty-jmh | [1.1287498, 1.5049999) | INFO
jetty-jmx | [0.0, 1.9344997) | FINEST
jetty-jmx | [1.9344997, 3.8689995) | FINER
jetty-jmx | [3.8689995, 5.803499) | FINE
jetty-jmx | [5.803499, 7.737999) | INFO
jetty-jndi | [0.0, 0.175) | FINEST
jetty-jndi | [0.175, 0.35) | FINER
jetty-jndi | [0.35, 0.525) | FINE
jetty-jndi | [0.525, 0.7) | INFO
jetty-jspc-maven-plugin | [0.0, 1.0159999) | FINEST
jetty-jspc-maven-plugin | [1.0159999, 2.0319998) | FINER
jetty-jspc-maven-plugin | [2.0319998, 3.0479999) | FINE
jetty-jspc-maven-plugin | [3.0479999, 4.0639997) | INFO
jetty-maven-plugin | [0.0, 2.0624998) | FINEST
jetty-maven-plugin | [2.0624998, 4.1249995) | FINER
jetty-maven-plugin | [4.1249995, 6.187499) | FINE
jetty-maven-plugin | [6.187499, 8.249999) | INFO
jetty-memcached-sessions | [0.0, 0.34149998) | FINEST
jetty-memcached-sessions | [0.34149998, 0.68299997) | FINER
jetty-memcached-sessions | [0.68299997, 1.0244999) | FINE
jetty-memcached-sessions | [1.0244999, 1.3659999) | INFO
jetty-nosql | [0.0, 1.874) | FINEST
jetty-nosql | [1.874, 3.748) | FINER
jetty-nosql | [3.748, 5.6219997) | FINE
jetty-nosql | [5.6219997, 7.496) | INFO
jetty-osgi-boot | [0.0, 1.31075) | FINEST
jetty-osgi-boot | [1.31075, 2.6215) | FINER
jetty-osgi-boot | [2.6215, 3.93225) | FINE
jetty-osgi-boot | [3.93225, 5.243) | INFO
jetty-osgi-boot-jsp | [0.0, 0.175) | FINEST
jetty-osgi-boot-jsp | [0.175, 0.35) | FINER
jetty-osgi-boot-jsp | [0.35, 0.525) | FINE
jetty-osgi-boot-jsp | [0.525, 0.7) | INFO
jetty-plus | [0.0, 0.49949998) | FINEST
jetty-plus | [0.49949998, 0.99899995) | FINER
jetty-plus | [0.99899995, 1.4984999) | FINE
jetty-plus | [1.4984999, 1.9979999) | INFO
jetty-proxy | [0.0, 2.4727504) | FINEST
jetty-proxy | [2.4727504, 4.945501) | FINER
jetty-proxy | [4.945501, 7.418251) | FINE
jetty-proxy | [7.418251, 9.891002) | INFO
jetty-quickstart | [0.0, 0.97774994) | FINEST
jetty-quickstart | [0.97774994, 1.9554999) | FINER
jetty-quickstart | [1.9554999, 2.93325) | FINE
jetty-quickstart | [2.93325, 3.9109998) | INFO
jetty-rewrite | [0.0, 0.9352499) | FINEST
jetty-rewrite | [0.9352499, 1.8704998) | FINER
jetty-rewrite | [1.8704998, 2.80575) | FINE
jetty-rewrite | [2.80575, 3.7409997) | INFO
jetty-runner | [0.0, 0.34575) | FINEST
jetty-runner | [0.34575, 0.6915) | FINER
jetty-runner | [0.6915, 1.03725) | FINE
jetty-runner | [1.03725, 1.383) | INFO
jetty-security | [0.0, 2.52025) | FINEST
jetty-security | [2.52025, 5.0405) | FINER
jetty-security | [5.0405, 7.56075) | FINE
jetty-security | [7.56075, 10.081) | INFO
jetty-server | [0.0, 4.994499) | FINEST
jetty-server | [4.994499, 9.988998) | FINER
jetty-server | [9.988998, 14.983498) | FINE
jetty-server | [14.983498, 19.977997) | INFO
jetty-servlet | [0.0, 1.4582498) | FINEST
jetty-servlet | [1.4582498, 2.9164996) | FINER
jetty-servlet | [2.9164996, 4.374749) | FINE
jetty-servlet | [4.374749, 5.832999) | INFO
jetty-servlets | [0.0, 0.99125004) | FINEST
jetty-servlets | [0.99125004, 1.9825001) | FINER
jetty-servlets | [1.9825001, 2.97375) | FINE
jetty-servlets | [2.97375, 3.9650002) | INFO
jetty-spring | [0.0, 0.175) | FINEST
jetty-spring | [0.175, 0.35) | FINER
jetty-spring | [0.35, 0.525) | FINE
jetty-spring | [0.525, 0.7) | INFO
jetty-start | [0.0, 1.9894999) | FINEST
jetty-start | [1.9894999, 3.9789999) | FINER
jetty-start | [3.9789999, 5.9684997) | FINE
jetty-start | [5.9684997, 7.9579997) | INFO
jetty-unixsocket | [0.0, 1.13575) | FINEST
jetty-unixsocket | [1.13575, 2.2715) | FINER
jetty-unixsocket | [2.2715, 3.4072502) | FINE
jetty-unixsocket | [3.4072502, 4.543) | INFO
jetty-util | [0.0, 3.3847497) | FINEST
jetty-util | [3.3847497, 6.7694993) | FINER
jetty-util | [6.7694993, 10.154249) | FINE
jetty-util | [10.154249, 13.538999) | INFO
jetty-util-ajax | [0.0, 0.43149996) | FINEST
jetty-util-ajax | [0.43149996, 0.8629999) | FINER
jetty-util-ajax | [0.8629999, 1.2944999) | FINE
jetty-util-ajax | [1.2944999, 1.7259998) | INFO
jetty-webapp | [0.0, 2.6809998) | FINEST
jetty-webapp | [2.6809998, 5.3619995) | FINER
jetty-webapp | [5.3619995, 8.042999) | FINE
jetty-webapp | [8.042999, 10.723999) | INFO
jetty-websocket-tests | [0.0, 1.4899999) | FINEST
jetty-websocket-tests | [1.4899999, 2.9799998) | FINER
jetty-websocket-tests | [2.9799998, 4.47) | FINE
jetty-websocket-tests | [4.47, 5.9599996) | INFO
jetty-xml | [0.0, 2.32675) | FINEST
jetty-xml | [2.32675, 4.6535) | FINER
jetty-xml | [4.6535, 6.9802504) | FINE
jetty-xml | [6.9802504, 9.307) | INFO
jmx-webapp-it | [0.0, 0.175) | FINEST
jmx-webapp-it | [0.175, 0.35) | FINER
jmx-webapp-it | [0.35, 0.525) | FINE
jmx-webapp-it | [0.525, 0.7) | INFO
test-container-initializer | [0.0, 0.175) | FINEST
test-container-initializer | [0.175, 0.35) | FINER
test-container-initializer | [0.35, 0.525) | FINE
test-container-initializer | [0.525, 0.7) | INFO
test-continuation | [0.0, 1.68275) | FINEST
test-continuation | [1.68275, 3.3655) | FINER
test-continuation | [3.3655, 5.04825) | FINE
test-continuation | [5.04825, 6.731) | INFO
test-distribution | [0.0, 4.77125) | FINEST
test-distribution | [4.77125, 9.5425) | FINER
test-distribution | [9.5425, 14.313749) | FINE
test-distribution | [14.313749, 19.085) | INFO
test-file-sessions | [0.0, 0.99899995) | FINEST
test-file-sessions | [0.99899995, 1.9979999) | FINER
test-file-sessions | [1.9979999, 2.9969997) | FINE
test-file-sessions | [2.9969997, 3.9959998) | INFO
test-gcloud-sessions | [0.0, 1.02025) | FINEST
test-gcloud-sessions | [1.02025, 2.0405) | FINER
test-gcloud-sessions | [2.0405, 3.06075) | FINE
test-gcloud-sessions | [3.06075, 4.081) | INFO
test-hazelcast-sessions | [0.0, 0.2905) | FINEST
test-hazelcast-sessions | [0.2905, 0.581) | FINER
test-hazelcast-sessions | [0.581, 0.87149996) | FINE
test-hazelcast-sessions | [0.87149996, 1.162) | INFO
test-http-client-transport | [0.0, 2.25275) | FINEST
test-http-client-transport | [2.25275, 4.5055) | FINER
test-http-client-transport | [4.5055, 6.7582498) | FINE
test-http-client-transport | [6.7582498, 9.011) | INFO
test-http2-webapp | [0.0, 0.175) | FINEST
test-http2-webapp | [0.175, 0.35) | FINER
test-http2-webapp | [0.35, 0.525) | FINE
test-http2-webapp | [0.525, 0.7) | INFO
test-infinispan-sessions | [0.0, 0.49949998) | FINEST
test-infinispan-sessions | [0.49949998, 0.99899995) | FINER
test-infinispan-sessions | [0.99899995, 1.4984999) | FINE
test-infinispan-sessions | [1.4984999, 1.9979999) | INFO
test-integration | [0.0, 1.1004999) | FINEST
test-integration | [1.1004999, 2.2009997) | FINER
test-integration | [2.2009997, 3.3014996) | FINE
test-integration | [3.3014996, 4.4019995) | INFO
test-jdbc-sessions | [0.0, 1.0244999) | FINEST
test-jdbc-sessions | [1.0244999, 2.0489998) | FINER
test-jdbc-sessions | [2.0489998, 3.0734997) | FINE
test-jdbc-sessions | [3.0734997, 4.0979996) | INFO
test-jetty-osgi | [0.0, 2.246) | FINEST
test-jetty-osgi | [2.246, 4.492) | FINER
test-jetty-osgi | [4.492, 6.738) | FINE
test-jetty-osgi | [6.738, 8.984) | INFO
test-jetty-osgi-server | [0.0, 0.175) | FINEST
test-jetty-osgi-server | [0.175, 0.35) | FINER
test-jetty-osgi-server | [0.35, 0.525) | FINE
test-jetty-osgi-server | [0.525, 0.7) | INFO
test-jetty-webapp | [0.0, 1.5324999) | FINEST
test-jetty-webapp | [1.5324999, 3.0649998) | FINER
test-jetty-webapp | [3.0649998, 4.5975) | FINE
test-jetty-webapp | [4.5975, 6.1299996) | INFO
test-jndi-webapp | [0.0, 0.175) | FINEST
test-jndi-webapp | [0.175, 0.35) | FINER
test-jndi-webapp | [0.35, 0.525) | FINE
test-jndi-webapp | [0.525, 0.7) | INFO
test-loginservice | [0.0, 0.175) | FINEST
test-loginservice | [0.175, 0.35) | FINER
test-loginservice | [0.35, 0.525) | FINE
test-loginservice | [0.525, 0.7) | INFO
test-memcached-sessions | [0.0, 0.175) | FINEST
test-memcached-sessions | [0.175, 0.35) | FINER
test-memcached-sessions | [0.35, 0.525) | FINE
test-memcached-sessions | [0.525, 0.7) | INFO
test-mongodb-sessions | [0.0, 0.84525) | FINEST
test-mongodb-sessions | [0.84525, 1.6905) | FINER
test-mongodb-sessions | [1.6905, 2.53575) | FINE
test-mongodb-sessions | [2.53575, 3.381) | INFO
test-quickstart | [0.0, 1.16625) | FINEST
test-quickstart | [1.16625, 2.3325) | FINER
test-quickstart | [2.3325, 3.49875) | FINE
test-quickstart | [3.49875, 4.665) | INFO
test-sessions-common | [0.0, 2.2772498) | FINEST
test-sessions-common | [2.2772498, 4.5544996) | FINER
test-sessions-common | [4.5544996, 6.8317494) | FINE
test-sessions-common | [6.8317494, 9.108999) | INFO
test-spec-webapp | [0.0, 0.175) | FINEST
test-spec-webapp | [0.175, 0.35) | FINER
test-spec-webapp | [0.35, 0.525) | FINE
test-spec-webapp | [0.525, 0.7) | INFO
websocket-api | [0.0, 0.64475) | FINEST
websocket-api | [0.64475, 1.2895) | FINER
websocket-api | [1.2895, 1.93425) | FINE
websocket-api | [1.93425, 2.579) | INFO
websocket-client | [0.0, 0.87299997) | FINEST
websocket-client | [0.87299997, 1.7459999) | FINER
websocket-client | [1.7459999, 2.619) | FINE
websocket-client | [2.619, 3.4919999) | INFO
websocket-common | [0.0, 1.1500003) | FINEST
websocket-common | [1.1500003, 2.3000007) | FINER
websocket-common | [2.3000007, 3.450001) | FINE
websocket-common | [3.450001, 4.6000013) | INFO
websocket-server | [0.0, 3.20325) | FINEST
websocket-server | [3.20325, 6.4065) | FINER
websocket-server | [6.4065, 9.60975) | FINE
websocket-server | [9.60975, 12.813) | INFO



