### PR TITLE
Rejuvenate log levels

### DIFF
--- a/jetty-cdi/cdi-websocket/src/test/java/org/eclipse/jetty/cdi/websocket/cdiapp/InfoSocket.java
+++ b/jetty-cdi/cdi-websocket/src/test/java/org/eclipse/jetty/cdi/websocket/cdiapp/InfoSocket.java
@@ -53,14 +53,14 @@ public class InfoSocket
     @OnOpen
     public void onOpen(Session session)
     {
-        LOG.log(Level.INFO,"onOpen(): {0}",session);
+        LOG.log(Level.FINEST,"onOpen(): {0}",session);
         this.session = session;
     }
 
     @OnClose
     public void onClose(CloseReason close)
     {
-        LOG.log(Level.INFO,"onClose(): {}",close);
+        LOG.log(Level.FINEST,"onClose(): {}",close);
         this.session = null;
     }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
LOG.log(Level.INFO,"onOpen():   {0}",session) | INFO | FINEST | org.eclipse.jetty.cdi.websocket.cdiapp.InfoSocket | onOpen(javax.websocket.Session) | 0
LOG.log(Level.INFO,"onClose():   {}",close) | INFO | FINEST | org.eclipse.jetty.cdi.websocket.cdiapp.InfoSocket | onClose(javax.websocket.CloseReason) | 0


## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: 65528f76c5ef6ddca11385f9721c8f0bc5f2eed7

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
apache-jsp | [0.0, 1.255) | FINEST
apache-jsp | [1.255, 2.51) | FINER
apache-jsp | [2.51, 3.7649999) | FINE
apache-jsp | [3.7649999, 5.02) | INFO
apache-jsp | [5.02, 6.275) | WARNING
apache-jsp | [6.275, 7.5299997) | SEVERE
apache-jstl | [0.0, 0.11666667) | FINEST
apache-jstl | [0.11666667, 0.23333333) | FINER
apache-jstl | [0.23333333, 0.35) | FINE
apache-jstl | [0.35, 0.46666667) | INFO
apache-jstl | [0.46666667, 0.5833333) | WARNING
apache-jstl | [0.5833333, 0.7) | SEVERE
cdi-core | [0.0, 0.11666667) | FINEST
cdi-core | [0.11666667, 0.23333333) | FINER
cdi-core | [0.23333333, 0.35) | FINE
cdi-core | [0.35, 0.46666667) | INFO
cdi-core | [0.46666667, 0.5833333) | WARNING
cdi-core | [0.5833333, 0.7) | SEVERE
cdi-servlet | [0.0, 0.11666667) | FINEST
cdi-servlet | [0.11666667, 0.23333333) | FINER
cdi-servlet | [0.23333333, 0.35) | FINE
cdi-servlet | [0.35, 0.46666667) | INFO
cdi-servlet | [0.46666667, 0.5833333) | WARNING
cdi-servlet | [0.5833333, 0.7) | SEVERE
cdi-websocket | [0.0, 0.11666667) | FINEST
cdi-websocket | [0.11666667, 0.23333333) | FINER
cdi-websocket | [0.23333333, 0.35) | FINE
cdi-websocket | [0.35, 0.46666667) | INFO
cdi-websocket | [0.46666667, 0.5833333) | WARNING
cdi-websocket | [0.5833333, 0.7) | SEVERE
example-jetty-embedded | [0.0, 0.52383333) | FINEST
example-jetty-embedded | [0.52383333, 1.0476667) | FINER
example-jetty-embedded | [1.0476667, 1.5715001) | FINE
example-jetty-embedded | [1.5715001, 2.0953333) | INFO
example-jetty-embedded | [2.0953333, 2.6191666) | WARNING
example-jetty-embedded | [2.6191666, 3.1430001) | SEVERE
fcgi-client | [0.0, 1.6196667) | FINEST
fcgi-client | [1.6196667, 3.2393334) | FINER
fcgi-client | [3.2393334, 4.859) | FINE
fcgi-client | [4.859, 6.478667) | INFO
fcgi-client | [6.478667, 8.098333) | WARNING
fcgi-client | [8.098333, 9.718) | SEVERE
fcgi-server | [0.0, 0.5323333) | FINEST
fcgi-server | [0.5323333, 1.0646666) | FINER
fcgi-server | [1.0646666, 1.5969999) | FINE
fcgi-server | [1.5969999, 2.1293333) | INFO
fcgi-server | [2.1293333, 2.6616666) | WARNING
fcgi-server | [2.6616666, 3.1939998) | SEVERE
http2-alpn-tests | [0.0, 0.45250002) | FINEST
http2-alpn-tests | [0.45250002, 0.90500003) | FINER
http2-alpn-tests | [0.90500003, 1.3575001) | FINE
http2-alpn-tests | [1.3575001, 1.8100001) | INFO
http2-alpn-tests | [1.8100001, 2.2625) | WARNING
http2-alpn-tests | [2.2625, 2.7150002) | SEVERE
http2-client | [0.0, 1.0586666) | FINEST
http2-client | [1.0586666, 2.1173332) | FINER
http2-client | [2.1173332, 3.1759996) | FINE
http2-client | [3.1759996, 4.2346663) | INFO
http2-client | [4.2346663, 5.293333) | WARNING
http2-client | [5.293333, 6.3519993) | SEVERE
http2-common | [0.0, 3.6363332) | FINEST
http2-common | [3.6363332, 7.2726665) | FINER
http2-common | [7.2726665, 10.908999) | FINE
http2-common | [10.908999, 14.545333) | INFO
http2-common | [14.545333, 18.181665) | WARNING
http2-common | [18.181665, 21.817999) | SEVERE
http2-hpack | [0.0, 2.6546667) | FINEST
http2-hpack | [2.6546667, 5.3093333) | FINER
http2-hpack | [5.3093333, 7.9639997) | FINE
http2-hpack | [7.9639997, 10.618667) | INFO
http2-hpack | [10.618667, 13.273334) | WARNING
http2-hpack | [13.273334, 15.9279995) | SEVERE
http2-http-client-transport | [0.0, 0.9659999) | FINEST
http2-http-client-transport | [0.9659999, 1.9319998) | FINER
http2-http-client-transport | [1.9319998, 2.8979998) | FINE
http2-http-client-transport | [2.8979998, 3.8639996) | INFO
http2-http-client-transport | [3.8639996, 4.8299994) | WARNING
http2-http-client-transport | [4.8299994, 5.7959995) | SEVERE
http2-server | [0.0, 0.91499996) | FINEST
http2-server | [0.91499996, 1.8299999) | FINER
http2-server | [1.8299999, 2.745) | FINE
http2-server | [2.745, 3.6599998) | INFO
http2-server | [3.6599998, 4.575) | WARNING
http2-server | [4.575, 5.49) | SEVERE
javax-websocket-client-impl | [0.0, 1.0566666) | FINEST
javax-websocket-client-impl | [1.0566666, 2.1133332) | FINER
javax-websocket-client-impl | [2.1133332, 3.1699998) | FINE
javax-websocket-client-impl | [3.1699998, 4.2266665) | INFO
javax-websocket-client-impl | [4.2266665, 5.283333) | WARNING
javax-websocket-client-impl | [5.283333, 6.3399997) | SEVERE
javax-websocket-server-impl | [0.0, 1.3075) | FINEST
javax-websocket-server-impl | [1.3075, 2.615) | FINER
javax-websocket-server-impl | [2.615, 3.9225001) | FINE
javax-websocket-server-impl | [3.9225001, 5.23) | INFO
javax-websocket-server-impl | [5.23, 6.5375) | WARNING
javax-websocket-server-impl | [6.5375, 7.8450003) | SEVERE
jetty-alpn-client | [0.0, 0.11666667) | FINEST
jetty-alpn-client | [0.11666667, 0.23333333) | FINER
jetty-alpn-client | [0.23333333, 0.35) | FINE
jetty-alpn-client | [0.35, 0.46666667) | INFO
jetty-alpn-client | [0.46666667, 0.5833333) | WARNING
jetty-alpn-client | [0.5833333, 0.7) | SEVERE
jetty-alpn-conscrypt-client | [0.0, 0.22483332) | FINEST
jetty-alpn-conscrypt-client | [0.22483332, 0.44966665) | FINER
jetty-alpn-conscrypt-client | [0.44966665, 0.6745) | FINE
jetty-alpn-conscrypt-client | [0.6745, 0.8993333) | INFO
jetty-alpn-conscrypt-client | [0.8993333, 1.1241666) | WARNING
jetty-alpn-conscrypt-client | [1.1241666, 1.349) | SEVERE
jetty-alpn-conscrypt-server | [0.0, 1.0589999) | FINEST
jetty-alpn-conscrypt-server | [1.0589999, 2.1179998) | FINER
jetty-alpn-conscrypt-server | [2.1179998, 3.1769996) | FINE
jetty-alpn-conscrypt-server | [3.1769996, 4.2359996) | INFO
jetty-alpn-conscrypt-server | [4.2359996, 5.2949996) | WARNING
jetty-alpn-conscrypt-server | [5.2949996, 6.353999) | SEVERE
jetty-alpn-java-server | [0.0, 0.11666667) | FINEST
jetty-alpn-java-server | [0.11666667, 0.23333333) | FINER
jetty-alpn-java-server | [0.23333333, 0.35) | FINE
jetty-alpn-java-server | [0.35, 0.46666667) | INFO
jetty-alpn-java-server | [0.46666667, 0.5833333) | WARNING
jetty-alpn-java-server | [0.5833333, 0.7) | SEVERE
jetty-alpn-server | [0.0, 0.2305) | FINEST
jetty-alpn-server | [0.2305, 0.461) | FINER
jetty-alpn-server | [0.461, 0.6915) | FINE
jetty-alpn-server | [0.6915, 0.922) | INFO
jetty-alpn-server | [0.922, 1.1525) | WARNING
jetty-alpn-server | [1.1525, 1.383) | SEVERE
jetty-annotations | [0.0, 2.2658331) | FINEST
jetty-annotations | [2.2658331, 4.5316663) | FINER
jetty-annotations | [4.5316663, 6.7974997) | FINE
jetty-annotations | [6.7974997, 9.063333) | INFO
jetty-annotations | [9.063333, 11.329165) | WARNING
jetty-annotations | [11.329165, 13.594999) | SEVERE
jetty-ant | [0.0, 0.34433332) | FINEST
jetty-ant | [0.34433332, 0.68866664) | FINER
jetty-ant | [0.68866664, 1.033) | FINE
jetty-ant | [1.033, 1.3773333) | INFO
jetty-ant | [1.3773333, 1.7216666) | WARNING
jetty-ant | [1.7216666, 2.066) | SEVERE
jetty-client | [0.0, 1.8984998) | FINEST
jetty-client | [1.8984998, 3.7969997) | FINER
jetty-client | [3.7969997, 5.6954994) | FINE
jetty-client | [5.6954994, 7.5939994) | INFO
jetty-client | [7.5939994, 9.492499) | WARNING
jetty-client | [9.492499, 11.390999) | SEVERE
jetty-deploy | [0.0, 0.37366667) | FINEST
jetty-deploy | [0.37366667, 0.74733335) | FINER
jetty-deploy | [0.74733335, 1.121) | FINE
jetty-deploy | [1.121, 1.4946667) | INFO
jetty-deploy | [1.4946667, 1.8683333) | WARNING
jetty-deploy | [1.8683333, 2.242) | SEVERE
jetty-gcloud-session-manager | [0.0, 0.45816663) | FINEST
jetty-gcloud-session-manager | [0.45816663, 0.91633326) | FINER
jetty-gcloud-session-manager | [0.91633326, 1.3744999) | FINE
jetty-gcloud-session-manager | [1.3744999, 1.8326665) | INFO
jetty-gcloud-session-manager | [1.8326665, 2.2908332) | WARNING
jetty-gcloud-session-manager | [2.2908332, 2.7489998) | SEVERE
jetty-hazelcast | [0.0, 0.4355) | FINEST
jetty-hazelcast | [0.4355, 0.871) | FINER
jetty-hazelcast | [0.871, 1.3065) | FINE
jetty-hazelcast | [1.3065, 1.742) | INFO
jetty-hazelcast | [1.742, 2.1775) | WARNING
jetty-hazelcast | [2.1775, 2.613) | SEVERE
jetty-http | [0.0, 3.2139995) | FINEST
jetty-http | [3.2139995, 6.427999) | FINER
jetty-http | [6.427999, 9.641998) | FINE
jetty-http | [9.641998, 12.855998) | INFO
jetty-http | [12.855998, 16.069998) | WARNING
jetty-http | [16.069998, 19.283997) | SEVERE
jetty-http-spi | [0.0, 0.63766664) | FINEST
jetty-http-spi | [0.63766664, 1.2753333) | FINER
jetty-http-spi | [1.2753333, 1.9129999) | FINE
jetty-http-spi | [1.9129999, 2.5506666) | INFO
jetty-http-spi | [2.5506666, 3.1883333) | WARNING
jetty-http-spi | [3.1883333, 3.8259997) | SEVERE
jetty-infinispan | [0.0, 0.4955) | FINEST
jetty-infinispan | [0.4955, 0.991) | FINER
jetty-infinispan | [0.991, 1.4865) | FINE
jetty-infinispan | [1.4865, 1.982) | INFO
jetty-infinispan | [1.982, 2.4775) | WARNING
jetty-infinispan | [2.4775, 2.973) | SEVERE
jetty-io | [0.0, 5.1124997) | FINEST
jetty-io | [5.1124997, 10.224999) | FINER
jetty-io | [10.224999, 15.3375) | FINE
jetty-io | [15.3375, 20.449999) | INFO
jetty-io | [20.449999, 25.562498) | WARNING
jetty-io | [25.562498, 30.675) | SEVERE
jetty-jaas | [0.0, 1.0391667) | FINEST
jetty-jaas | [1.0391667, 2.0783334) | FINER
jetty-jaas | [2.0783334, 3.1175) | FINE
jetty-jaas | [3.1175, 4.1566668) | INFO
jetty-jaas | [4.1566668, 5.195833) | WARNING
jetty-jaas | [5.195833, 6.235) | SEVERE
jetty-jaspi | [0.0, 0.44966665) | FINEST
jetty-jaspi | [0.44966665, 0.8993333) | FINER
jetty-jaspi | [0.8993333, 1.349) | FINE
jetty-jaspi | [1.349, 1.7986666) | INFO
jetty-jaspi | [1.7986666, 2.2483332) | WARNING
jetty-jaspi | [2.2483332, 2.698) | SEVERE
jetty-jmh | [0.0, 0.2508333) | FINEST
jetty-jmh | [0.2508333, 0.5016666) | FINER
jetty-jmh | [0.5016666, 0.75249994) | FINE
jetty-jmh | [0.75249994, 1.0033332) | INFO
jetty-jmh | [1.0033332, 1.2541665) | WARNING
jetty-jmh | [1.2541665, 1.5049999) | SEVERE
jetty-jmx | [0.0, 1.2896665) | FINEST
jetty-jmx | [1.2896665, 2.579333) | FINER
jetty-jmx | [2.579333, 3.8689995) | FINE
jetty-jmx | [3.8689995, 5.158666) | INFO
jetty-jmx | [5.158666, 6.448333) | WARNING
jetty-jmx | [6.448333, 7.737999) | SEVERE
jetty-jndi | [0.0, 0.11666667) | FINEST
jetty-jndi | [0.11666667, 0.23333333) | FINER
jetty-jndi | [0.23333333, 0.35) | FINE
jetty-jndi | [0.35, 0.46666667) | INFO
jetty-jndi | [0.46666667, 0.5833333) | WARNING
jetty-jndi | [0.5833333, 0.7) | SEVERE
jetty-jspc-maven-plugin | [0.0, 0.6773333) | FINEST
jetty-jspc-maven-plugin | [0.6773333, 1.3546666) | FINER
jetty-jspc-maven-plugin | [1.3546666, 2.0319998) | FINE
jetty-jspc-maven-plugin | [2.0319998, 2.7093332) | INFO
jetty-jspc-maven-plugin | [2.7093332, 3.3866665) | WARNING
jetty-jspc-maven-plugin | [3.3866665, 4.0639997) | SEVERE
jetty-maven-plugin | [0.0, 1.3749999) | FINEST
jetty-maven-plugin | [1.3749999, 2.7499998) | FINER
jetty-maven-plugin | [2.7499998, 4.1249995) | FINE
jetty-maven-plugin | [4.1249995, 5.4999995) | INFO
jetty-maven-plugin | [5.4999995, 6.8749995) | WARNING
jetty-maven-plugin | [6.8749995, 8.249999) | SEVERE
jetty-memcached-sessions | [0.0, 0.22766666) | FINEST
jetty-memcached-sessions | [0.22766666, 0.45533332) | FINER
jetty-memcached-sessions | [0.45533332, 0.68299997) | FINE
jetty-memcached-sessions | [0.68299997, 0.91066664) | INFO
jetty-memcached-sessions | [0.91066664, 1.1383333) | WARNING
jetty-memcached-sessions | [1.1383333, 1.3659999) | SEVERE
jetty-nosql | [0.0, 1.2493333) | FINEST
jetty-nosql | [1.2493333, 2.4986665) | FINER
jetty-nosql | [2.4986665, 3.7479997) | FINE
jetty-nosql | [3.7479997, 4.997333) | INFO
jetty-nosql | [4.997333, 6.2466664) | WARNING
jetty-nosql | [6.2466664, 7.4959993) | SEVERE
jetty-osgi-boot | [0.0, 0.87383336) | FINEST
jetty-osgi-boot | [0.87383336, 1.7476667) | FINER
jetty-osgi-boot | [1.7476667, 2.6215) | FINE
jetty-osgi-boot | [2.6215, 3.4953334) | INFO
jetty-osgi-boot | [3.4953334, 4.369167) | WARNING
jetty-osgi-boot | [4.369167, 5.243) | SEVERE
jetty-osgi-boot-jsp | [0.0, 0.11666667) | FINEST
jetty-osgi-boot-jsp | [0.11666667, 0.23333333) | FINER
jetty-osgi-boot-jsp | [0.23333333, 0.35) | FINE
jetty-osgi-boot-jsp | [0.35, 0.46666667) | INFO
jetty-osgi-boot-jsp | [0.46666667, 0.5833333) | WARNING
jetty-osgi-boot-jsp | [0.5833333, 0.7) | SEVERE
jetty-plus | [0.0, 0.33299997) | FINEST
jetty-plus | [0.33299997, 0.66599995) | FINER
jetty-plus | [0.66599995, 0.99899995) | FINE
jetty-plus | [0.99899995, 1.3319999) | INFO
jetty-plus | [1.3319999, 1.6649998) | WARNING
jetty-plus | [1.6649998, 1.9979999) | SEVERE
jetty-proxy | [0.0, 2.2318337) | FINEST
jetty-proxy | [2.2318337, 4.4636674) | FINER
jetty-proxy | [4.4636674, 6.6955013) | FINE
jetty-proxy | [6.6955013, 8.927335) | INFO
jetty-proxy | [8.927335, 11.159168) | WARNING
jetty-proxy | [11.159168, 13.391003) | SEVERE
jetty-quickstart | [0.0, 0.6518333) | FINEST
jetty-quickstart | [0.6518333, 1.3036666) | FINER
jetty-quickstart | [1.3036666, 1.9554999) | FINE
jetty-quickstart | [1.9554999, 2.6073332) | INFO
jetty-quickstart | [2.6073332, 3.2591665) | WARNING
jetty-quickstart | [3.2591665, 3.9109998) | SEVERE
jetty-rewrite | [0.0, 0.62349993) | FINEST
jetty-rewrite | [0.62349993, 1.2469999) | FINER
jetty-rewrite | [1.2469999, 1.8704998) | FINE
jetty-rewrite | [1.8704998, 2.4939997) | INFO
jetty-rewrite | [2.4939997, 3.1174996) | WARNING
jetty-rewrite | [3.1174996, 3.7409997) | SEVERE
jetty-runner | [0.0, 0.2305) | FINEST
jetty-runner | [0.2305, 0.461) | FINER
jetty-runner | [0.461, 0.6915) | FINE
jetty-runner | [0.6915, 0.922) | INFO
jetty-runner | [0.922, 1.1525) | WARNING
jetty-runner | [1.1525, 1.383) | SEVERE
jetty-security | [0.0, 1.6801667) | FINEST
jetty-security | [1.6801667, 3.3603334) | FINER
jetty-security | [3.3603334, 5.0405) | FINE
jetty-security | [5.0405, 6.720667) | INFO
jetty-security | [6.720667, 8.400833) | WARNING
jetty-security | [8.400833, 10.081) | SEVERE
jetty-server | [0.0, 3.3296661) | FINEST
jetty-server | [3.3296661, 6.6593323) | FINER
jetty-server | [6.6593323, 9.988998) | FINE
jetty-server | [9.988998, 13.318665) | INFO
jetty-server | [13.318665, 16.64833) | WARNING
jetty-server | [16.64833, 19.977997) | SEVERE
jetty-servlet | [0.0, 0.97216654) | FINEST
jetty-servlet | [0.97216654, 1.9443331) | FINER
jetty-servlet | [1.9443331, 2.9164996) | FINE
jetty-servlet | [2.9164996, 3.8886662) | INFO
jetty-servlet | [3.8886662, 4.8608327) | WARNING
jetty-servlet | [4.8608327, 5.832999) | SEVERE
jetty-servlets | [0.0, 0.66083336) | FINEST
jetty-servlets | [0.66083336, 1.3216667) | FINER
jetty-servlets | [1.3216667, 1.9825001) | FINE
jetty-servlets | [1.9825001, 2.6433334) | INFO
jetty-servlets | [2.6433334, 3.3041668) | WARNING
jetty-servlets | [3.3041668, 3.9650002) | SEVERE
jetty-spring | [0.0, 0.11666667) | FINEST
jetty-spring | [0.11666667, 0.23333333) | FINER
jetty-spring | [0.23333333, 0.35) | FINE
jetty-spring | [0.35, 0.46666667) | INFO
jetty-spring | [0.46666667, 0.5833333) | WARNING
jetty-spring | [0.5833333, 0.7) | SEVERE
jetty-start | [0.0, 1.3263333) | FINEST
jetty-start | [1.3263333, 2.6526666) | FINER
jetty-start | [2.6526666, 3.9789999) | FINE
jetty-start | [3.9789999, 5.305333) | INFO
jetty-start | [5.305333, 6.631666) | WARNING
jetty-start | [6.631666, 7.9579997) | SEVERE
jetty-unixsocket | [0.0, 0.7571667) | FINEST
jetty-unixsocket | [0.7571667, 1.5143334) | FINER
jetty-unixsocket | [1.5143334, 2.2715) | FINE
jetty-unixsocket | [2.2715, 3.0286667) | INFO
jetty-unixsocket | [3.0286667, 3.7858334) | WARNING
jetty-unixsocket | [3.7858334, 4.543) | SEVERE
jetty-util | [0.0, 2.2564998) | FINEST
jetty-util | [2.2564998, 4.5129995) | FINER
jetty-util | [4.5129995, 6.7694993) | FINE
jetty-util | [6.7694993, 9.025999) | INFO
jetty-util | [9.025999, 11.282499) | WARNING
jetty-util | [11.282499, 13.538999) | SEVERE
jetty-util-ajax | [0.0, 0.28766665) | FINEST
jetty-util-ajax | [0.28766665, 0.5753333) | FINER
jetty-util-ajax | [0.5753333, 0.8629999) | FINE
jetty-util-ajax | [0.8629999, 1.1506666) | INFO
jetty-util-ajax | [1.1506666, 1.4383333) | WARNING
jetty-util-ajax | [1.4383333, 1.7259998) | SEVERE
jetty-webapp | [0.0, 1.7873331) | FINEST
jetty-webapp | [1.7873331, 3.5746663) | FINER
jetty-webapp | [3.5746663, 5.3619995) | FINE
jetty-webapp | [5.3619995, 7.1493325) | INFO
jetty-webapp | [7.1493325, 8.936666) | WARNING
jetty-webapp | [8.936666, 10.723999) | SEVERE
jetty-websocket-tests | [0.0, 0.9933333) | FINEST
jetty-websocket-tests | [0.9933333, 1.9866666) | FINER
jetty-websocket-tests | [1.9866666, 2.9799998) | FINE
jetty-websocket-tests | [2.9799998, 3.9733331) | INFO
jetty-websocket-tests | [3.9733331, 4.966666) | WARNING
jetty-websocket-tests | [4.966666, 5.9599996) | SEVERE
jetty-xml | [0.0, 1.5511667) | FINEST
jetty-xml | [1.5511667, 3.1023333) | FINER
jetty-xml | [3.1023333, 4.6535) | FINE
jetty-xml | [4.6535, 6.2046666) | INFO
jetty-xml | [6.2046666, 7.755833) | WARNING
jetty-xml | [7.755833, 9.307) | SEVERE
jmx-webapp-it | [0.0, 0.11666667) | FINEST
jmx-webapp-it | [0.11666667, 0.23333333) | FINER
jmx-webapp-it | [0.23333333, 0.35) | FINE
jmx-webapp-it | [0.35, 0.46666667) | INFO
jmx-webapp-it | [0.46666667, 0.5833333) | WARNING
jmx-webapp-it | [0.5833333, 0.7) | SEVERE
test-container-initializer | [0.0, 0.11666667) | FINEST
test-container-initializer | [0.11666667, 0.23333333) | FINER
test-container-initializer | [0.23333333, 0.35) | FINE
test-container-initializer | [0.35, 0.46666667) | INFO
test-container-initializer | [0.46666667, 0.5833333) | WARNING
test-container-initializer | [0.5833333, 0.7) | SEVERE
test-continuation | [0.0, 1.1218333) | FINEST
test-continuation | [1.1218333, 2.2436666) | FINER
test-continuation | [2.2436666, 3.3655) | FINE
test-continuation | [3.3655, 4.4873333) | INFO
test-continuation | [4.4873333, 5.6091666) | WARNING
test-continuation | [5.6091666, 6.731) | SEVERE
test-distribution | [0.0, 3.180833) | FINEST
test-distribution | [3.180833, 6.361666) | FINER
test-distribution | [6.361666, 9.5425) | FINE
test-distribution | [9.5425, 12.723332) | INFO
test-distribution | [12.723332, 15.904165) | WARNING
test-distribution | [15.904165, 19.085) | SEVERE
test-file-sessions | [0.0, 0.66599995) | FINEST
test-file-sessions | [0.66599995, 1.3319999) | FINER
test-file-sessions | [1.3319999, 1.9979999) | FINE
test-file-sessions | [1.9979999, 2.6639998) | INFO
test-file-sessions | [2.6639998, 3.3299997) | WARNING
test-file-sessions | [3.3299997, 3.9959998) | SEVERE
test-gcloud-sessions | [0.0, 0.68016666) | FINEST
test-gcloud-sessions | [0.68016666, 1.3603333) | FINER
test-gcloud-sessions | [1.3603333, 2.0405) | FINE
test-gcloud-sessions | [2.0405, 2.7206666) | INFO
test-gcloud-sessions | [2.7206666, 3.4008334) | WARNING
test-gcloud-sessions | [3.4008334, 4.081) | SEVERE
test-hazelcast-sessions | [0.0, 0.19366665) | FINEST
test-hazelcast-sessions | [0.19366665, 0.3873333) | FINER
test-hazelcast-sessions | [0.3873333, 0.581) | FINE
test-hazelcast-sessions | [0.581, 0.7746666) | INFO
test-hazelcast-sessions | [0.7746666, 0.96833324) | WARNING
test-hazelcast-sessions | [0.96833324, 1.162) | SEVERE
test-http-client-transport | [0.0, 2.6685) | FINEST
test-http-client-transport | [2.6685, 5.337) | FINER
test-http-client-transport | [5.337, 8.0055) | FINE
test-http-client-transport | [8.0055, 10.674) | INFO
test-http-client-transport | [10.674, 13.3425) | WARNING
test-http-client-transport | [13.3425, 16.011) | SEVERE
test-http2-webapp | [0.0, 0.11666667) | FINEST
test-http2-webapp | [0.11666667, 0.23333333) | FINER
test-http2-webapp | [0.23333333, 0.35) | FINE
test-http2-webapp | [0.35, 0.46666667) | INFO
test-http2-webapp | [0.46666667, 0.5833333) | WARNING
test-http2-webapp | [0.5833333, 0.7) | SEVERE
test-infinispan-sessions | [0.0, 0.33299997) | FINEST
test-infinispan-sessions | [0.33299997, 0.66599995) | FINER
test-infinispan-sessions | [0.66599995, 0.99899995) | FINE
test-infinispan-sessions | [0.99899995, 1.3319999) | INFO
test-infinispan-sessions | [1.3319999, 1.6649998) | WARNING
test-infinispan-sessions | [1.6649998, 1.9979999) | SEVERE
test-integration | [0.0, 0.7336666) | FINEST
test-integration | [0.7336666, 1.4673332) | FINER
test-integration | [1.4673332, 2.2009997) | FINE
test-integration | [2.2009997, 2.9346664) | INFO
test-integration | [2.9346664, 3.668333) | WARNING
test-integration | [3.668333, 4.4019995) | SEVERE
test-jdbc-sessions | [0.0, 0.6829999) | FINEST
test-jdbc-sessions | [0.6829999, 1.3659998) | FINER
test-jdbc-sessions | [1.3659998, 2.0489998) | FINE
test-jdbc-sessions | [2.0489998, 2.7319996) | INFO
test-jdbc-sessions | [2.7319996, 3.4149995) | WARNING
test-jdbc-sessions | [3.4149995, 4.0979996) | SEVERE
test-jetty-osgi | [0.0, 1.4973334) | FINEST
test-jetty-osgi | [1.4973334, 2.9946668) | FINER
test-jetty-osgi | [2.9946668, 4.492) | FINE
test-jetty-osgi | [4.492, 5.9893336) | INFO
test-jetty-osgi | [5.9893336, 7.486667) | WARNING
test-jetty-osgi | [7.486667, 8.984) | SEVERE
test-jetty-osgi-server | [0.0, 0.11666667) | FINEST
test-jetty-osgi-server | [0.11666667, 0.23333333) | FINER
test-jetty-osgi-server | [0.23333333, 0.35) | FINE
test-jetty-osgi-server | [0.35, 0.46666667) | INFO
test-jetty-osgi-server | [0.46666667, 0.5833333) | WARNING
test-jetty-osgi-server | [0.5833333, 0.7) | SEVERE
test-jetty-webapp | [0.0, 1.0216666) | FINEST
test-jetty-webapp | [1.0216666, 2.0433333) | FINER
test-jetty-webapp | [2.0433333, 3.065) | FINE
test-jetty-webapp | [3.065, 4.0866666) | INFO
test-jetty-webapp | [4.0866666, 5.108333) | WARNING
test-jetty-webapp | [5.108333, 6.13) | SEVERE
test-jndi-webapp | [0.0, 0.11666667) | FINEST
test-jndi-webapp | [0.11666667, 0.23333333) | FINER
test-jndi-webapp | [0.23333333, 0.35) | FINE
test-jndi-webapp | [0.35, 0.46666667) | INFO
test-jndi-webapp | [0.46666667, 0.5833333) | WARNING
test-jndi-webapp | [0.5833333, 0.7) | SEVERE
test-loginservice | [0.0, 0.11666667) | FINEST
test-loginservice | [0.11666667, 0.23333333) | FINER
test-loginservice | [0.23333333, 0.35) | FINE
test-loginservice | [0.35, 0.46666667) | INFO
test-loginservice | [0.46666667, 0.5833333) | WARNING
test-loginservice | [0.5833333, 0.7) | SEVERE
test-memcached-sessions | [0.0, 0.11666667) | FINEST
test-memcached-sessions | [0.11666667, 0.23333333) | FINER
test-memcached-sessions | [0.23333333, 0.35) | FINE
test-memcached-sessions | [0.35, 0.46666667) | INFO
test-memcached-sessions | [0.46666667, 0.5833333) | WARNING
test-memcached-sessions | [0.5833333, 0.7) | SEVERE
test-mongodb-sessions | [0.0, 0.5635) | FINEST
test-mongodb-sessions | [0.5635, 1.127) | FINER
test-mongodb-sessions | [1.127, 1.6905) | FINE
test-mongodb-sessions | [1.6905, 2.254) | INFO
test-mongodb-sessions | [2.254, 2.8174999) | WARNING
test-mongodb-sessions | [2.8174999, 3.381) | SEVERE
test-quickstart | [0.0, 0.7775) | FINEST
test-quickstart | [0.7775, 1.555) | FINER
test-quickstart | [1.555, 2.3325) | FINE
test-quickstart | [2.3325, 3.11) | INFO
test-quickstart | [3.11, 3.8874998) | WARNING
test-quickstart | [3.8874998, 4.665) | SEVERE
test-sessions-common | [0.0, 1.5181665) | FINEST
test-sessions-common | [1.5181665, 3.036333) | FINER
test-sessions-common | [3.036333, 4.5544996) | FINE
test-sessions-common | [4.5544996, 6.072666) | INFO
test-sessions-common | [6.072666, 7.5908327) | WARNING
test-sessions-common | [7.5908327, 9.108999) | SEVERE
test-spec-webapp | [0.0, 0.11666667) | FINEST
test-spec-webapp | [0.11666667, 0.23333333) | FINER
test-spec-webapp | [0.23333333, 0.35) | FINE
test-spec-webapp | [0.35, 0.46666667) | INFO
test-spec-webapp | [0.46666667, 0.5833333) | WARNING
test-spec-webapp | [0.5833333, 0.7) | SEVERE
websocket-api | [0.0, 0.42983332) | FINEST
websocket-api | [0.42983332, 0.85966665) | FINER
websocket-api | [0.85966665, 1.2895) | FINE
websocket-api | [1.2895, 1.7193333) | INFO
websocket-api | [1.7193333, 2.1491666) | WARNING
websocket-api | [2.1491666, 2.579) | SEVERE
websocket-client | [0.0, 0.58199996) | FINEST
websocket-client | [0.58199996, 1.1639999) | FINER
websocket-client | [1.1639999, 1.7459998) | FINE
websocket-client | [1.7459998, 2.3279998) | INFO
websocket-client | [2.3279998, 2.9099998) | WARNING
websocket-client | [2.9099998, 3.4919996) | SEVERE
websocket-common | [0.0, 0.7666669) | FINEST
websocket-common | [0.7666669, 1.5333338) | FINER
websocket-common | [1.5333338, 2.3000007) | FINE
websocket-common | [2.3000007, 3.0666676) | INFO
websocket-common | [3.0666676, 3.8333344) | WARNING
websocket-common | [3.8333344, 4.6000013) | SEVERE
websocket-server | [0.0, 2.1355) | FINEST
websocket-server | [2.1355, 4.271) | FINER
websocket-server | [4.271, 6.4065) | FINE
websocket-server | [6.4065, 8.542) | INFO
websocket-server | [8.542, 10.6775) | WARNING
websocket-server | [10.6775, 12.813) | SEVERE



