### PR TITLE
Issue #3494 - flaky tests in jetty-websocket-tests ClientCloseTest

### DIFF
--- a/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketAdapter.java
+++ b/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketAdapter.java
@@ -59,8 +59,7 @@ public class WebSocketAdapter implements WebSocketListener
     @Override
     public void onWebSocketClose(int statusCode, String reason)
     {
-        this.session = null;
-        this.remote = null;
+        /* do nothing */
     }
 
     @Override

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
@@ -179,7 +179,7 @@ public class WebSocketStatsTest
         ClientSocket socket = new ClientSocket();
         CompletableFuture<Session> connect = client.connect(socket, uri);
 
-        final long numMessages = 10000;
+        final long numMessages = 1000;
         final String msgText = "hello world";
 
         long upgradeSentBytes;

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -237,7 +237,7 @@ public class ClientCloseTest
     public void testRemoteDisconnect() throws Exception
     {
         // Set client timeout
-        final int clientTimeout = 1000;
+        final int clientTimeout = 3000;
         client.setIdleTimeout(Duration.ofMillis(clientTimeout));
 
         ClientOpenSessionTracker clientSessionTracker = new ClientOpenSessionTracker(1);
@@ -248,20 +248,18 @@ public class ClientCloseTest
         CloseTrackingEndpoint clientSocket = new CloseTrackingEndpoint();
         Future<Session> clientConnectFuture = client.connect(clientSocket, wsUri);
 
-        try (Session ignored = confirmConnection(clientSocket, clientConnectFuture))
-        {
-            // client confirms connection via echo
+        // client confirms connection via echo
+        confirmConnection(clientSocket, clientConnectFuture);
 
-            // client sends close frame (triggering server connection abort)
-            final String origCloseReason = "abort";
-            clientSocket.getSession().close(StatusCode.NORMAL, origCloseReason);
+        // client sends close frame (triggering server connection abort)
+        final String origCloseReason = "abort";
+        clientSocket.getSession().close(StatusCode.NORMAL, origCloseReason);
 
-            // client reads -1 (EOF)
-            // client triggers close event on client ws-endpoint
-            clientSocket.assertReceivedCloseEvent(clientTimeout * 2,
-                    is(StatusCode.ABNORMAL),
-                    containsString("Channel Closed"));
-        }
+        // client reads -1 (EOF)
+        // client triggers close event on client ws-endpoint
+        clientSocket.assertReceivedCloseEvent(2000,
+                is(StatusCode.ABNORMAL),
+                containsString("Channel Closed"));
 
         clientSessionTracker.assertClosedProperly(client);
     }
@@ -286,7 +284,7 @@ public class ClientCloseTest
             // client confirms connection via echo
 
             // client sends close frame
-            final String origCloseReason = "sleep|5000";
+            final String origCloseReason = "sleep|2500";
             clientSocket.getSession().close(StatusCode.NORMAL, origCloseReason);
 
             // client close should occur

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.io.ByteBufferPool;
-import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.Utf8Appendable;
@@ -363,29 +362,6 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
                 callback.failed(e);
             }
         }
-
-
-    }
-
-    AbnormalCloseStatus abnormalCloseStatusFor(Throwable cause)
-    {
-        int code;
-        if (cause instanceof ProtocolException)
-            code = CloseStatus.PROTOCOL;
-        else if (cause instanceof CloseException)
-            code = ((CloseException)cause).getStatusCode();
-        else if (cause instanceof Utf8Appendable.NotUtf8Exception)
-            code = CloseStatus.BAD_PAYLOAD;
-        else if (cause instanceof WebSocketTimeoutException || cause instanceof TimeoutException || cause instanceof SocketTimeoutException)
-            code = CloseStatus.SHUTDOWN;
-        else if (cause instanceof EofException)
-            code = CloseStatus.NO_CLOSE;
-        else if (behavior == Behavior.CLIENT)
-            code = CloseStatus.POLICY_VIOLATION;
-        else
-            code = CloseStatus.SERVER_ERROR;
-
-        return new AbnormalCloseStatus(code, cause);
     }
 
     /**
@@ -401,14 +377,24 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         if (LOG.isDebugEnabled())
             LOG.debug("processConnectionError {} {}", this, cause);
 
-        CloseStatus closeStatus = abnormalCloseStatusFor(cause);
-
-        if (closeStatus.getCode() == CloseStatus.PROTOCOL)
-            close(closeStatus, callback);
-        else if (channelState.onClosed(closeStatus))
-            closeConnection(cause, closeStatus, callback);
+        int code;
+        if (cause instanceof CloseException)
+            code = ((CloseException)cause).getStatusCode();
+        else if (cause instanceof Utf8Appendable.NotUtf8Exception)
+            code = CloseStatus.BAD_PAYLOAD;
+        else if (cause instanceof WebSocketTimeoutException || cause instanceof TimeoutException || cause instanceof SocketTimeoutException)
+            code = CloseStatus.SHUTDOWN;
         else
-            callback.failed(cause);
+            code = CloseStatus.NO_CLOSE;
+
+        AbnormalCloseStatus closeStatus = new AbnormalCloseStatus(code, cause);
+        if (CloseStatus.isTransmittableStatusCode(code))
+            close(closeStatus, callback);
+        else
+        {
+            if (channelState.onClosed(closeStatus))
+                closeConnection(cause, closeStatus, callback);
+        }
     }
 
     /**
@@ -423,7 +409,19 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         if (LOG.isDebugEnabled())
             LOG.debug("processHandlerError {} {}", this, cause);
 
-        close(abnormalCloseStatusFor(cause), callback);
+        int code;
+        if (cause instanceof CloseException)
+            code = ((CloseException)cause).getStatusCode();
+        else if (cause instanceof Utf8Appendable.NotUtf8Exception)
+            code = CloseStatus.BAD_PAYLOAD;
+        else if (cause instanceof WebSocketTimeoutException || cause instanceof TimeoutException || cause instanceof SocketTimeoutException)
+            code = CloseStatus.SHUTDOWN;
+        else if (behavior == Behavior.CLIENT)
+            code = CloseStatus.POLICY_VIOLATION;
+        else
+            code = CloseStatus.SERVER_ERROR;
+
+        close(new AbnormalCloseStatus(code, cause), callback);
     }
 
     /**
@@ -515,6 +513,9 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         }
         catch (Throwable t)
         {
+            if (LOG.isDebugEnabled())
+                LOG.warn("Invalid outgoing frame: {}", frame);
+
             callback.failed(t);
             return;
         }
@@ -523,10 +524,10 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         {
             synchronized(flusher)
             {
-                boolean closeConnection = channelState.onOutgoingFrame(frame);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("sendFrame({}, {}, {}) {}", frame, callback, batch, closeConnection);
+                    LOG.debug("sendFrame({}, {}, {})", frame, callback, batch);
 
+                boolean closeConnection = channelState.onOutgoingFrame(frame);
                 if (closeConnection)
                 {
                     Throwable cause = AbnormalCloseStatus.getCause(CloseStatus.getCloseStatus(frame));
@@ -546,6 +547,9 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
         }
         catch (Throwable t)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Failed sendFrame()", t);
+
             if (frame.getOpCode() == OpCode.CLOSE)
             {
                 CloseStatus closeStatus = CloseStatus.getCloseStatus(frame);

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -599,8 +599,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         @Override
         public void onCompleteFailure(Throwable x)
         {
-            super.onCompleteFailure(x);
             channel.processConnectionError(x, NOOP);
+            super.onCompleteFailure(x);
         }
     }
 }

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.net.Socket;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -315,21 +317,22 @@ public class WebSocketCloseTest extends WebSocketTester
         client.close();
         assertFalse(server.handler.closed.await(250, TimeUnit.MILLISECONDS));
 
-        while(true)
-        {
-            if (!server.isOpen())
-                break;
-
-            server.sendFrame(new Frame(OpCode.TEXT, BufferUtil.toBuffer("frame after close")), Callback.NOOP);
-        }
+        assertTimeoutPreemptively(Duration.ofSeconds(1), ()->{
+            while(true)
+            {
+                if (!server.isOpen())
+                    break;
+                server.sendFrame(new Frame(OpCode.TEXT, BufferUtil.toBuffer("frame after close")), Callback.NOOP);
+                Thread.sleep(100);
+            }
+        });
 
         assertTrue(server.handler.closed.await(5, TimeUnit.SECONDS));
         assertNotNull(server.handler.error);
-        assertThat(server.handler.closeStatus.getCode(), is(CloseStatus.SERVER_ERROR));
+        assertThat(server.handler.closeStatus.getCode(), is(CloseStatus.NO_CLOSE));
 
         Callback callback = server.handler.receivedCallback.poll(5, TimeUnit.SECONDS);
         callback.succeeded();
-        assertThat(server.handler.closeStatus.getCode(), is(CloseStatus.SERVER_ERROR));
     }
 
     @ParameterizedTest
@@ -433,7 +436,7 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onOpen(CoreSession coreSession)
         {
-            LOG.info("onOpen {}", coreSession);
+            LOG.debug("onOpen {}", coreSession);
             session = coreSession;
             state = session.toString();
             opened.countDown();
@@ -442,7 +445,7 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onFrame(Frame frame, Callback callback)
         {
-            LOG.info("onFrame: " + BufferUtil.toDetailString(frame.getPayload()));
+            LOG.debug("onFrame: " + BufferUtil.toDetailString(frame.getPayload()));
             state = session.toString();
             receivedCallback.offer(callback);
             receivedFrames.offer(Frame.copy(frame));
@@ -454,7 +457,7 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onClosed(CloseStatus closeStatus)
         {
-            LOG.info("onClosed {}", closeStatus);
+            LOG.debug("onClosed {}", closeStatus);
             state = session.toString();
             this.closeStatus = closeStatus;
             closed.countDown();
@@ -463,7 +466,7 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onError(Throwable cause)
         {
-            LOG.info("onError {} ", cause == null?null:cause.toString());
+            LOG.debug("onError {} ", cause);
             error = cause;
             state = session.toString();
         }


### PR DESCRIPTION
#3494 

Nulling out values in `WebSocketAdapter` causes race conditions when trying to access session and endpoint externally which was causing errors in the tests, if you call `adapter.getSession().close()` the socket could receive a close just before null out the session and then you get a NPE

There was a race condition in `WebSocketChannel.Flusher.onCompleteFailure()`, where `processConnectionError()` should be called before `super.onCompleteFailure()` to ensure that the
correct close reason is processed before the channel is closed.

In `testWriteException` when the output was shutdown there was a race condition between the client detecting the write failure and the server detecting a read failure and sending a failure response.
We now send a message to block the server from reading so that it will not detect the failure and respond.