### PR TITLE
Fixes #3526 - Request locale not retained in WebsocketUpgrade request.

### DIFF
--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/UpgradeHttpServletRequest.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/UpgradeHttpServletRequest.java
@@ -123,6 +123,12 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
             attributes.put(name, httpRequest.getAttribute(name));
         }
 
+        Enumeration<Locale> localeElements = httpRequest.getLocales();
+        while (localeElements.hasMoreElements())
+        {
+            locales.add(localeElements.nextElement());
+        }
+
         localAddress = InetSocketAddress.createUnresolved(httpRequest.getLocalAddr(), httpRequest.getLocalPort());
         localName = httpRequest.getLocalName();
         remoteAddress = InetSocketAddress.createUnresolved(httpRequest.getRemoteAddr(), httpRequest.getRemotePort());


### PR DESCRIPTION
#3526.

Trivial fix, the locale was not copied from the HTTP requets to the
WebSocket upgrade request.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>