### PR TITLE
demand before succeeding callback in JettyWebSocketFrameHandler

### DIFF
--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -204,8 +204,17 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         // Demand after succeeding any received frame
         Callback demandingCallback = Callback.from(()->
                 {
+                    try
+                    {
+                        demand();
+                    }
+                    catch (Throwable t)
+                    {
+                        callback.failed(t);
+                        return;
+                    }
+
                     callback.succeeded();
-                    demand();
                 },
                 callback::failed
         );

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.websocket.tests.client;
 
 
-import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -442,14 +441,10 @@ public class ClientCloseTest
                     session.getRemote().sendString(message);
                 }
             }
-            catch (InterruptedException e)
+            catch (Throwable t)
             {
-                LOG.debug("unblocked");
-                throw new IllegalStateException(e);
-            }
-            catch (IOException ignore)
-            {
-                LOG.debug(ignore);
+                LOG.debug(t);
+                throw new RuntimeException(t);
             }
         }
 


### PR DESCRIPTION
demand has the potential to throw so make sure that the callback in `JettyWebSocketFrameHandler.onFrame()` is either succeeded or failed but not both