### PR TITLE
Address issue #3562 - InetAccessHandler should be able to only be applied to a specific set of connector names

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-http.xml
+++ b/jetty-server/src/main/config/etc/jetty-http.xml
@@ -42,6 +42,7 @@
         <Get name="SelectorManager">
           <Set name="connectTimeout"><Property name="jetty.http.connectTimeout" default="15000"/></Set>
         </Get>
+        <Set name="name">http</Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/etc/jetty-https.xml
+++ b/jetty-server/src/main/config/etc/jetty-https.xml
@@ -25,5 +25,7 @@
       </New>
     </Arg>
   </Call>
-  
+
+  <Call name="setName"><Arg>https</Arg></Call>
+
 </Configure>

--- a/jetty-server/src/main/config/etc/jetty-inetaccess.xml
+++ b/jetty-server/src/main/config/etc/jetty-inetaccess.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="insertHandler">
+        <Arg>
+            <New id="InetAccessHandler" class="org.eclipse.jetty.server.handler.InetAccessHandler">
+                <Call name="include"><Arg>127.0.0.1-127.0.0.255</Arg></Call>
+                <Call name="exclude"><Arg>127.0.0.128-127.0.0.129</Arg></Call>
+                <Call name="includeConnectorName"><Arg>http</Arg></Call>
+                <Call name="excludeConnectorName"><Arg>https</Arg></Call>
+            </New>
+        </Arg>
+    </Call>
+</Configure>

--- a/jetty-server/src/main/config/modules/inetaccess.mod
+++ b/jetty-server/src/main/config/modules/inetaccess.mod
@@ -1,0 +1,14 @@
+DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Enable the InetAccessHandler to apply a include/exclude
+control of the remote IP of requests.
+
+[tags]
+handler
+
+[depend]
+server
+
+[xml]
+etc/jetty-inetaccess.xml

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
@@ -219,6 +219,13 @@ public class IPAccessHandler extends HandlerWrapper
         this._whiteListByPath = whiteListByPath;
     }
 
+    /* ------------------------------------------------------------ */
+    /**
+     * If not empty, this will make the IP access filter only apply if the server
+     * port matches one of these ports.
+     *
+     * @param onlyAppliesToPorts matching mode
+     */
     public void setOnlyAppliesToPorts(int[] onlyAppliesToPorts) {
         _onlyAppliesToPorts = new HashSet<Integer>();
         for (Integer port : onlyAppliesToPorts) {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
@@ -102,6 +102,11 @@ import java.util.Set;
  * to define a range of the internet addresses (e.g. 127., 10.10., 172.16.1.).
  * They also used the first "/" character of the URI pattern to separate it from the
  * internet address. Both of these features have been deprecated in the current version.
+ * <p>
+ * Additionally, there may be times when you want to only apply this handler to a subset
+ * of your connectors. For example maybe you want to have HTTPS wide open but have HTTP
+ * restricted. In this situation you can use <b>connectorNames</b> to specify the connector
+ * names that you want this IP access filter to apply to.
  * @deprecated
  * @see InetAccessHandler
  */

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -54,7 +54,7 @@ public class InetAccessHandler extends HandlerWrapper
     private static final Logger LOG = Log.getLogger(InetAccessHandler.class);
 
     private final IncludeExcludeSet<String, InetAddress> _set = new IncludeExcludeSet<>(InetAddressSet.class);
-    private final IncludeExclude<String> _names = new IncludeExclude<>();
+    private final IncludeExclude<String> _connectorNames = new IncludeExclude<>();
 
     /**
      * Includes an InetAddress pattern
@@ -105,8 +105,8 @@ public class InetAccessHandler extends HandlerWrapper
      *
      * @param name Connector name to include in this handler
      */
-     public void includeName(String name) {
-         _names.include(name);
+     public void includeConnectorName(String name) {
+         _connectorNames.include(name);
      }
 
      /**
@@ -114,8 +114,8 @@ public class InetAccessHandler extends HandlerWrapper
      *
      * @param name Connector name to exclude in this handler.
      */
-     public void excludeName(String name) {
-         _names.exclude(name);
+     public void excludeConnectorName(String name) {
+         _connectorNames.exclude(name);
      }
 
     /**
@@ -155,7 +155,9 @@ public class InetAccessHandler extends HandlerWrapper
     protected boolean isAllowed(InetAddress address, Request baseRequest, HttpServletRequest request)
     {
         String connectorName = baseRequest.getHttpChannel().getConnector().getName();
-        boolean allowed = _set.test(address) && _names.test(connectorName);
+
+        boolean allowed = _set.test(address) && (connectorName == null || _connectorNames.test(connectorName));
+        LOG.info("Connector name {} is included? {}", connectorName, _connectorNames.test(connectorName));
         if (LOG.isDebugEnabled())
             LOG.debug("{} {} {} for {}", this, allowed ? "allowed" : "denied", address, request);
         return allowed;
@@ -164,6 +166,6 @@ public class InetAccessHandler extends HandlerWrapper
     @Override
     public void dump(Appendable out, String indent) throws IOException
     {
-        dumpBeans(out, indent, _set.getIncluded(), _set.getExcluded(), _names.getIncluded(), _names.getExcluded());
+        dumpBeans(out, indent, _set.getIncluded(), _set.getExcluded(), _connectorNames.getIncluded(), _connectorNames.getExcluded());
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -156,8 +156,9 @@ public class InetAccessHandler extends HandlerWrapper
     {
         String connectorName = baseRequest.getHttpChannel().getConnector().getName();
 
-        boolean allowed = _set.test(address) && (connectorName == null || _connectorNames.test(connectorName));
-        LOG.info("Connector name {} is included? {}", connectorName, _connectorNames.test(connectorName));
+        boolean allowed = (connectorName != null &&
+          (!_connectorNames.getIncluded().isEmpty() || !_connectorNames.getExcluded().isEmpty()) &&
+          !_connectorNames.test(connectorName)) || _set.test(address);
         if (LOG.isDebugEnabled())
             LOG.debug("{} {} {} for {}", this, allowed ? "allowed" : "denied", address, request);
         return allowed;


### PR DESCRIPTION
Addresses #3562 

Allows you to specify a list of connector names that the ip access filter applies to.

This allows you to do things like have an open HTTPS connector but a whitelist restricted HTTP. 

Example:

`etc/jetty-inetaccess.xml`

```
<?xml version="1.0"?>
<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">

<!-- =============================================================== -->
<!-- The IP Access Handler                                           -->
<!-- =============================================================== -->

<Configure id="Server" class="org.eclipse.jetty.server.Server">
  <Call name="insertHandler">
    <Arg>
      <New id="IPAccessHandler" class="org.eclipse.jetty.server.handler.IPAccessHandler">
  <Set name="connectorNames">
    <Array type="String">
	    <Item>http</Item>
	  </Array>
  </Set>
	<Set name="white">
	  <Array type="String">
	    <Item>127.0.0.1</Item>
	    <Item>127.0.1.1</Item>
	    <Item>192.168.1.229</Item>
	    <Item>192.168.1.199</Item>
	  </Array>
	</Set>
	<Set name="black">
	  <Array type="String">
	  </Array>
	</Set>
	<Set name="whiteListByPath">false</Set>
      </New>
    </Arg>
  </Call>
</Configure>

```
