### PR TITLE
Address issue #3562 - InetAccessHandler should be able to only be applied to a specific set of connector names

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-inetaccess.xml
+++ b/jetty-server/src/main/config/etc/jetty-inetaccess.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="insertHandler">
+        <Arg>
+            <New id="InetAccessHandler" class="org.eclipse.jetty.server.handler.InetAccessHandler">
+
+                <!-- include - Inclusive list of Inet address range to allow through. -->
+                <!--<Call name="include"><Arg>127.0.0.1-127.0.0.255</Arg></Call>-->
+
+                <!-- exclude - Exclusive list of Inet address ranges to block. -->
+                <!--<Call name="exclude"><Arg>127.0.0.128-127.0.0.129</Arg></Call>-->
+
+                <!-- includeConnectorName - This access handler will only apply to these connector names. -->
+                <!--<Call name="includeConnectorName"><Arg>http</Arg></Call>-->
+
+                <!-- excludeConnectorName - This access handler will not apply to these connector names. -->
+                <!--<Call name="excludeConnectorName"><Arg>tls</Arg></Call>-->
+            </New>
+        </Arg>
+    </Call>
+</Configure>

--- a/jetty-server/src/main/config/modules/inetaccess.mod
+++ b/jetty-server/src/main/config/modules/inetaccess.mod
@@ -1,0 +1,14 @@
+DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Enable the InetAccessHandler to apply a include/exclude
+control of the remote IP of requests.
+
+[tags]
+handler
+
+[depend]
+server
+
+[xml]
+etc/jetty-inetaccess.xml

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IPAccessHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.IPAddressMap;
+import org.eclipse.jetty.util.component.DumpableCollection;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -347,40 +348,11 @@ public class IPAccessHandler extends HandlerWrapper
     /**
      * Dump the handler configuration
      */
-    @Override
-    public String dump()
+    public void dump(Appendable out, String indent) throws IOException
     {
-        StringBuilder buf = new StringBuilder();
-
-        buf.append(toString());
-        buf.append(" WHITELIST:\n");
-        dump(buf, _white);
-        buf.append(toString());
-        buf.append(" BLACKLIST:\n");
-        dump(buf, _black);
-
-        return buf.toString();
-    }
-
-    /* ------------------------------------------------------------ */
-    /**
-     * Dump a pattern map into a StringBuilder buffer
-     *
-     * @param buf buffer
-     * @param patternMap pattern map to dump
-     */
-    protected void dump(StringBuilder buf, PathMap<IPAddressMap<Boolean>> patternMap)
-    {
-        for (String path: patternMap.keySet())
-        {
-            for (String addr: patternMap.get(path).keySet())
-            {
-                buf.append("# ");
-                buf.append(addr);
-                buf.append("|");
-                buf.append(path);
-                buf.append("\n");
-            }
-        }
+        dumpObjects(out, indent,
+          DumpableCollection.from("white", _white),
+          DumpableCollection.from("black", _black),
+          DumpableCollection.from("whiteListByPath", _whiteListByPath));
     }
  }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/InetHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/InetHandlerTest.java
@@ -1,0 +1,273 @@
+package org.eclipse.jetty.server.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class InetHandlerTest
+{
+    private static Server _server;
+    private static ServerConnector _connector;
+    private static InetAccessHandler _handler;
+
+    @BeforeAll
+    public static void setUp() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _connector.setName("http");
+        _server.setConnectors(new Connector[] { _connector });
+
+        _handler = new InetAccessHandler();
+        _handler.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request,
+                    HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                response.setStatus(HttpStatus.OK_200);
+            }
+        });
+        _server.setHandler(_handler);
+        _server.start();
+    }
+
+    /* ------------------------------------------------------------ */
+    @AfterAll
+    public static void tearDown() throws Exception
+    {
+        _server.stop();
+    }
+
+    /* ------------------------------------------------------------ */
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testHandler(String include, String exclude, String includeConnectors, String excludeConnectors,
+            String host, String uri, String code) throws Exception
+    {
+        _handler.clear();
+        for (String inc : include.split(";", -1)) {
+            if (inc.length() > 0) {
+                _handler.include(inc);
+            }
+        }
+        for (String exc : exclude.split(";", -1)) {
+            if (exc.length() > 0) {
+                _handler.exclude(exc);
+            }
+        }
+        for (String inc : includeConnectors.split(";", -1)) {
+            if (inc.length() > 0) {
+                _handler.includeConnectorName(inc);
+            }
+        }
+        for (String exc : excludeConnectors.split(";", -1)) {
+            if (exc.length() > 0) {
+                _handler.excludeConnectorName(exc);
+            }
+        }
+        String request = "GET " + uri + " HTTP/1.1\n" + "Host: " + host + "\n\n";
+        Socket socket = new Socket("127.0.0.1", _connector.getLocalPort());
+        socket.setSoTimeout(5000);
+        try {
+            OutputStream output = socket.getOutputStream();
+            BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            Response response = readResponse(input);
+            Object[] params = new Object[] { "Request WBHUC", include, exclude, includeConnectors, excludeConnectors,
+                    host, uri, code, "Response", response.getCode() };
+            assertEquals(code, response.getCode(), Arrays.deepToString(params));
+        } finally {
+            socket.close();
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+    protected Response readResponse(BufferedReader reader) throws IOException
+    {
+        // Simplified parser for HTTP responses
+        String line = reader.readLine();
+        if (line == null)
+            throw new EOFException();
+        Matcher responseLine = Pattern.compile("HTTP/1\\.1\\s+(\\d+)").matcher(line);
+        assertTrue(responseLine.lookingAt());
+        String code = responseLine.group(1);
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        while ((line = reader.readLine()) != null) {
+            if (line.trim().length() == 0)
+                break;
+
+            Matcher header = Pattern.compile("([^:]+):\\s*(.*)").matcher(line);
+            assertTrue(header.lookingAt());
+            String headerName = header.group(1);
+            String headerValue = header.group(2);
+            headers.put(headerName.toLowerCase(Locale.ENGLISH), headerValue.toLowerCase(Locale.ENGLISH));
+        }
+
+        StringBuilder body = new StringBuilder();
+        if (headers.containsKey("content-length")) {
+            int length = Integer.parseInt(headers.get("content-length"));
+            for (int i = 0; i < length; ++i) {
+                char c = (char) reader.read();
+                body.append(c);
+            }
+        } else if ("chunked".equals(headers.get("transfer-encoding"))) {
+            while ((line = reader.readLine()) != null) {
+                if ("0".equals(line)) {
+                    line = reader.readLine();
+                    assertEquals("", line);
+                    break;
+                }
+
+                int length = Integer.parseInt(line, 16);
+                for (int i = 0; i < length; ++i) {
+                    char c = (char) reader.read();
+                    body.append(c);
+                }
+                line = reader.readLine();
+                assertEquals("", line);
+            }
+        }
+
+        return new Response(code, headers, body.toString().trim());
+    }
+
+    /* ------------------------------------------------------------ */
+    protected class Response
+    {
+        private final String code;
+        private final Map<String, String> headers;
+        private final String body;
+
+        /* ------------------------------------------------------------ */
+        private Response(String code, Map<String, String> headers, String body)
+        {
+            this.code = code;
+            this.headers = headers;
+            this.body = body;
+        }
+
+        /* ------------------------------------------------------------ */
+        public String getCode()
+        {
+            return code;
+        }
+
+        /* ------------------------------------------------------------ */
+        public Map<String, String> getHeaders()
+        {
+            return headers;
+        }
+
+        /* ------------------------------------------------------------ */
+        public String getBody()
+        {
+            return body;
+        }
+
+        /* ------------------------------------------------------------ */
+        @Override
+        public String toString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.append(code).append("\r\n");
+            for (Map.Entry<String, String> entry : headers.entrySet())
+                builder.append(entry.getKey()).append(": ").append(entry.getValue()).append("\r\n");
+            builder.append("\r\n");
+            builder.append(body);
+            return builder.toString();
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+    public static Stream<Arguments> data()
+    {
+        Object[][] data = new Object[][] {
+                // Empty lists
+                { "", "", "", "", "127.0.0.1", "/", "200" }, { "", "", "", "", "127.0.0.1", "/dump/info", "200" },
+
+                // test simple filters
+                { "127.0.0.1", "", "", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1", "", "", "", "127.0.0.1", "/dump/info", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1", "", "", "", "127.0.0.1", "/", "403" },
+                { "192.0.0.1", "", "", "", "127.0.0.1", "/dump/info", "403" },
+                { "192.0.0.1-192.0.0.254", "", "", "", "127.0.0.1", "/", "403" },
+                { "192.0.0.1-192.0.0.254", "", "", "", "127.0.0.1", "/dump/info", "403" },
+
+                // test connector name filters
+                { "127.0.0.1", "", "http", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1", "", "http", "", "127.0.0.1", "/dump/info", "200" },
+                { "127.0.0.1-127.0.0.254", "", "http", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1-127.0.0.254", "", "http", "", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1", "", "http", "", "127.0.0.1", "/", "403" },
+                { "192.0.0.1", "", "http", "", "127.0.0.1", "/dump/info", "403" },
+                { "192.0.0.1-192.0.0.254", "", "http", "", "127.0.0.1", "/", "403" },
+                { "192.0.0.1-192.0.0.254", "", "http", "", "127.0.0.1", "/dump/info", "403" },
+
+                { "127.0.0.1", "", "nothttp", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1", "", "nothttp", "", "127.0.0.1", "/dump/info", "200" },
+                { "127.0.0.1-127.0.0.254", "", "nothttp", "", "127.0.0.1", "/", "200" },
+                { "127.0.0.1-127.0.0.254", "", "nothttp", "", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1", "", "nothttp", "", "127.0.0.1", "/", "200" },
+                { "192.0.0.1", "", "nothttp", "", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1-192.0.0.254", "", "nothttp", "", "127.0.0.1", "/", "200" },
+                { "192.0.0.1-192.0.0.254", "", "nothttp", "", "127.0.0.1", "/dump/info", "200" },
+
+                { "127.0.0.1", "", "", "http", "127.0.0.1", "/", "200" },
+                { "127.0.0.1", "", "", "http", "127.0.0.1", "/dump/info", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "http", "127.0.0.1", "/", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "http", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1", "", "", "http", "127.0.0.1", "/", "200" },
+                { "192.0.0.1", "", "", "http", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1-192.0.0.254", "", "", "http", "127.0.0.1", "/", "200" },
+                { "192.0.0.1-192.0.0.254", "", "", "http", "127.0.0.1", "/dump/info", "200" },
+
+                { "127.0.0.1", "", "", "nothttp", "127.0.0.1", "/", "200" },
+                { "127.0.0.1", "", "", "nothttp", "127.0.0.1", "/dump/info", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "nothttp", "127.0.0.1", "/", "200" },
+                { "127.0.0.1-127.0.0.254", "", "", "nothttp", "127.0.0.1", "/dump/info", "200" },
+                { "192.0.0.1", "", "", "nothttp", "127.0.0.1", "/", "403" },
+                { "192.0.0.1", "", "", "nothttp", "127.0.0.1", "/dump/info", "403" },
+                { "192.0.0.1-192.0.0.254", "", "", "nothttp", "127.0.0.1", "/", "403" },
+                { "192.0.0.1-192.0.0.254", "", "", "nothttp", "127.0.0.1", "/dump/info", "403" },
+
+        };
+        return Arrays.asList(data).stream().map(Arguments::of);
+    }
+}

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/InetHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/InetHandlerTest.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.server.handler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,14 +63,15 @@ public class InetHandlerTest
         _server = new Server();
         _connector = new ServerConnector(_server);
         _connector.setName("http");
-        _server.setConnectors(new Connector[] { _connector });
+        _server.setConnectors(new Connector[]
+        { _connector });
 
         _handler = new InetAccessHandler();
         _handler.setHandler(new AbstractHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request,
-                    HttpServletResponse response) throws IOException, ServletException
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+                    throws IOException, ServletException
             {
                 baseRequest.setHandled(true);
                 response.setStatus(HttpStatus.OK_200);
@@ -72,34 +91,43 @@ public class InetHandlerTest
     /* ------------------------------------------------------------ */
     @ParameterizedTest
     @MethodSource("data")
-    public void testHandler(String include, String exclude, String includeConnectors, String excludeConnectors,
-            String host, String uri, String code) throws Exception
+    public void testHandler(String include, String exclude, String includeConnectors, String excludeConnectors, String host, String uri, String code)
+            throws Exception
     {
         _handler.clear();
-        for (String inc : include.split(";", -1)) {
-            if (inc.length() > 0) {
+        for (String inc : include.split(";", -1))
+        {
+            if (inc.length() > 0)
+            {
                 _handler.include(inc);
             }
         }
-        for (String exc : exclude.split(";", -1)) {
-            if (exc.length() > 0) {
+        for (String exc : exclude.split(";", -1))
+        {
+            if (exc.length() > 0)
+            {
                 _handler.exclude(exc);
             }
         }
-        for (String inc : includeConnectors.split(";", -1)) {
-            if (inc.length() > 0) {
+        for (String inc : includeConnectors.split(";", -1))
+        {
+            if (inc.length() > 0)
+            {
                 _handler.includeConnectorName(inc);
             }
         }
-        for (String exc : excludeConnectors.split(";", -1)) {
-            if (exc.length() > 0) {
+        for (String exc : excludeConnectors.split(";", -1))
+        {
+            if (exc.length() > 0)
+            {
                 _handler.excludeConnectorName(exc);
             }
         }
         String request = "GET " + uri + " HTTP/1.1\n" + "Host: " + host + "\n\n";
         Socket socket = new Socket("127.0.0.1", _connector.getLocalPort());
         socket.setSoTimeout(5000);
-        try {
+        try
+        {
             OutputStream output = socket.getOutputStream();
             BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 
@@ -107,10 +135,11 @@ public class InetHandlerTest
             output.flush();
 
             Response response = readResponse(input);
-            Object[] params = new Object[] { "Request WBHUC", include, exclude, includeConnectors, excludeConnectors,
-                    host, uri, code, "Response", response.getCode() };
+            Object[] params = new Object[]
+            { "Request WBHUC", include, exclude, includeConnectors, excludeConnectors, host, uri, code, "Response", response.getCode() };
             assertEquals(code, response.getCode(), Arrays.deepToString(params));
-        } finally {
+        } finally
+        {
             socket.close();
         }
     }
@@ -127,7 +156,8 @@ public class InetHandlerTest
         String code = responseLine.group(1);
 
         Map<String, String> headers = new LinkedHashMap<>();
-        while ((line = reader.readLine()) != null) {
+        while ((line = reader.readLine()) != null)
+        {
             if (line.trim().length() == 0)
                 break;
 
@@ -139,22 +169,28 @@ public class InetHandlerTest
         }
 
         StringBuilder body = new StringBuilder();
-        if (headers.containsKey("content-length")) {
+        if (headers.containsKey("content-length"))
+        {
             int length = Integer.parseInt(headers.get("content-length"));
-            for (int i = 0; i < length; ++i) {
+            for (int i = 0; i < length; ++i)
+            {
                 char c = (char) reader.read();
                 body.append(c);
             }
-        } else if ("chunked".equals(headers.get("transfer-encoding"))) {
-            while ((line = reader.readLine()) != null) {
-                if ("0".equals(line)) {
+        } else if ("chunked".equals(headers.get("transfer-encoding")))
+        {
+            while ((line = reader.readLine()) != null)
+            {
+                if ("0".equals(line))
+                {
                     line = reader.readLine();
                     assertEquals("", line);
                     break;
                 }
 
                 int length = Integer.parseInt(line, 16);
-                for (int i = 0; i < length; ++i) {
+                for (int i = 0; i < length; ++i)
+                {
                     char c = (char) reader.read();
                     body.append(c);
                 }
@@ -216,9 +252,11 @@ public class InetHandlerTest
     /* ------------------------------------------------------------ */
     public static Stream<Arguments> data()
     {
-        Object[][] data = new Object[][] {
+        Object[][] data = new Object[][]
+        {
                 // Empty lists
-                { "", "", "", "", "127.0.0.1", "/", "200" }, { "", "", "", "", "127.0.0.1", "/dump/info", "200" },
+                { "", "", "", "", "127.0.0.1", "/", "200" },
+                { "", "", "", "", "127.0.0.1", "/dump/info", "200" },
 
                 // test simple filters
                 { "127.0.0.1", "", "", "", "127.0.0.1", "/", "200" },


### PR DESCRIPTION
Addresses #3562 

## Ports the `ipaccess` being added as a module from jetty 10

you can now do `java -jar start.jar --add-to-start=inetaccess` to add the inetaccess handler to your jetty config.

## Allows you to specify a list of connector names that the `InetAccessHandler` applies to

This is important for those who run jetty using `start.jar` to make it possible to do things like have an open HTTPS connector but a whitelist restricted HTTP connector. 

Example:

`etc/jetty-inetaccess.xml`

```
<?xml version="1.0"?>
<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">

<Configure id="Server" class="org.eclipse.jetty.server.Server">
    <Call name="insertHandler">
        <Arg>
            <New id="InetAccessHandler" class="org.eclipse.jetty.server.handler.InetAccessHandler">
                <Call name="exclude"><Arg>127.0.0.128-127.0.0.129</Arg></Call>
                <Call name="includeConnectorName"><Arg>http</Arg></Call>
            </New>
        </Arg>
    </Call>
</Configure>
```

You can now 
`java -jar start.jar --add-to-start=https`
and
`java -jar start.jar --add-to-start=inetaccess`

And you can now choose what inetaccess handler rules apply to http versus https.

## Adds a basic `InetAccessHandler` Unit Test

Cover a few of the basic features of InetAccessHandler so it can have some coverage.