### PR TITLE
Issue #3374 - WebSocket write timeouts

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -33,6 +32,7 @@ import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -731,5 +731,23 @@ public class TypeUtil
             LOG.debug(e);
         }
         return null;
+    }
+
+    public static <T> Iterator<T> concat(Iterator<T> i1, Iterator<T> i2)
+    {
+        return new Iterator<>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return i1.hasNext() || i2.hasNext();
+            }
+
+            @Override
+            public T next()
+            {
+                return i1.hasNext() ? i1.next() : i2.next();
+            }
+        };
     }
 }

--- a/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketAsyncRemote.java
+++ b/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketAsyncRemote.java
@@ -18,6 +18,15 @@
 
 package org.eclipse.jetty.websocket.javax.common;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Future;
+
+import javax.websocket.EncodeException;
+import javax.websocket.Encoder;
+import javax.websocket.SendHandler;
+import javax.websocket.SendResult;
+
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.log.Log;
@@ -28,14 +37,6 @@ import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.javax.common.messages.MessageOutputStream;
 import org.eclipse.jetty.websocket.javax.common.messages.MessageWriter;
 import org.eclipse.jetty.websocket.javax.common.util.TextUtil;
-
-import javax.websocket.EncodeException;
-import javax.websocket.Encoder;
-import javax.websocket.SendHandler;
-import javax.websocket.SendResult;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.concurrent.Future;
 
 public class JavaxWebSocketAsyncRemote extends JavaxWebSocketRemoteEndpoint implements javax.websocket.RemoteEndpoint.Async
 {
@@ -49,15 +50,13 @@ public class JavaxWebSocketAsyncRemote extends JavaxWebSocketRemoteEndpoint impl
     @Override
     public long getSendTimeout()
     {
-        // TODO: verify that JSR356 "send timeout" means the same as connection idle timeout
-        return getIdleTimeout();
+        return getWriteIdleTimeout();
     }
 
     @Override
     public void setSendTimeout(long timeoutmillis)
     {
-        // TODO: verify that JSR356 "send timeout" means the same as connection idle timeout
-        setIdleTimeout(timeoutmillis);
+        setWriteIdleTimeout(timeoutmillis);
     }
 
     @Override

--- a/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketRemoteEndpoint.java
+++ b/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketRemoteEndpoint.java
@@ -18,6 +18,14 @@
 
 package org.eclipse.jetty.websocket.javax.common;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+
+import javax.websocket.EncodeException;
+import javax.websocket.Encoder;
+import javax.websocket.SendHandler;
+
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.SharedBlockingCallback;
@@ -30,13 +38,6 @@ import org.eclipse.jetty.websocket.core.OutgoingFrames;
 import org.eclipse.jetty.websocket.core.WebSocketException;
 import org.eclipse.jetty.websocket.javax.common.messages.MessageOutputStream;
 import org.eclipse.jetty.websocket.javax.common.messages.MessageWriter;
-
-import javax.websocket.EncodeException;
-import javax.websocket.Encoder;
-import javax.websocket.SendHandler;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.time.Duration;
 
 public class JavaxWebSocketRemoteEndpoint implements javax.websocket.RemoteEndpoint, OutgoingFrames
 {
@@ -94,6 +95,16 @@ public class JavaxWebSocketRemoteEndpoint implements javax.websocket.RemoteEndpo
     public void setIdleTimeout(long ms)
     {
         channel.setIdleTimeout(Duration.ofMillis(ms));
+    }
+
+    public long getWriteIdleTimeout()
+    {
+        return channel.getWriteIdleTimeout().toMillis();
+    }
+
+    public void setWriteIdleTimeout(long ms)
+    {
+        channel.setWriteIdleTimeout(Duration.ofMillis(ms));
     }
 
     @Override

--- a/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketRemoteEndpoint.java
+++ b/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketRemoteEndpoint.java
@@ -99,12 +99,12 @@ public class JavaxWebSocketRemoteEndpoint implements javax.websocket.RemoteEndpo
 
     public long getWriteIdleTimeout()
     {
-        return channel.getWriteIdleTimeout().toMillis();
+        return channel.getWriteTimeout().toMillis();
     }
 
     public void setWriteIdleTimeout(long ms)
     {
-        channel.setWriteIdleTimeout(Duration.ofMillis(ms));
+        channel.setWriteTimeout(Duration.ofMillis(ms));
     }
 
     @Override

--- a/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/WriteTimeoutTest.java
+++ b/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/WriteTimeoutTest.java
@@ -1,0 +1,121 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.tests.client;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.websocket.ContainerProvider;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import javax.websocket.server.ServerEndpoint;
+
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.websocket.core.WebSocketWriteTimeoutException;
+import org.eclipse.jetty.websocket.javax.tests.LocalServer;
+import org.eclipse.jetty.websocket.javax.tests.WSEndpointTracker;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WriteTimeoutTest
+{
+    private static LocalServer server;
+
+    @BeforeAll
+    public static void startServer() throws Exception
+    {
+        server = new LocalServer();
+        server.start();
+        server.getServerContainer().addEndpoint(LoggingSocket.class);
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception
+    {
+        server.stop();
+    }
+
+    public static class ClientEndpoint extends WSEndpointTracker implements MessageHandler.Whole<String>
+    {
+        @Override
+        public void onOpen(Session session, EndpointConfig config)
+        {
+            super.onOpen(session, config);
+            session.addMessageHandler(this);
+        }
+
+        @Override
+        public void onMessage(String message)
+        {
+            super.onWsText(message);
+        }
+    }
+
+    @Test
+    public void testEchoInstance() throws Exception
+    {
+        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+        ClientEndpoint clientEndpoint = new ClientEndpoint();
+        assertThat(clientEndpoint, Matchers.instanceOf(javax.websocket.Endpoint.class));
+        Session session = container.connectToServer(clientEndpoint, server.getWsUri().resolve("/logSocket"));
+
+        session.getAsyncRemote().setSendTimeout(5);
+
+        session.setMaxTextMessageBufferSize(1000000);
+        String string = "xxxxxxx";
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < session.getMaxTextMessageBufferSize() - string.length())
+            sb.append(string);
+        string = sb.toString();
+
+        while (session.isOpen())
+            session.getAsyncRemote().sendText(string);
+
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientEndpoint.error.get(), instanceOf(WebSocketWriteTimeoutException.class));
+    }
+
+    @ServerEndpoint("/logSocket")
+    public static class LoggingSocket
+    {
+        private final Logger LOG = Log.getLogger(LoggingSocket.class);
+
+        @OnMessage
+        public void onMessage(String msg)
+        {
+            LOG.debug("onMessage(): {}", msg);
+        }
+
+        @OnError
+        public void onError(Throwable t)
+        {
+            LOG.debug("onError(): {}", t);
+        }
+    }
+}

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
@@ -141,16 +141,26 @@ public interface FrameHandler extends IncomingFrames
          */
         Duration getIdleTimeout();
 
-        Duration getWriteIdleTimeout();
+        /**
+         * Get the Write Timeout
+         *
+         * @return the write timeout
+         */
+        Duration getWriteTimeout();
 
         /**
          * Set the Idle Timeout.
          *
-         * @param timeout the timeout duration
+         * @param timeout the timeout duration (timeout &lt;= 0 implies an infinite timeout)
          */
         void setIdleTimeout(Duration timeout);
 
-        void setWriteIdleTimeout(Duration timeout);
+        /**
+         * Set the Write Timeout.
+         *
+         * @param timeout the timeout duration (timeout &lt;= 0 implies an infinite timeout)
+         */
+        void setWriteTimeout(Duration timeout);
 
         boolean isAutoFragment();
 
@@ -396,7 +406,7 @@ public interface FrameHandler extends IncomingFrames
             }
 
             @Override
-            public Duration getWriteIdleTimeout()
+            public Duration getWriteTimeout()
             {
                 return Duration.ZERO;
             }
@@ -407,7 +417,7 @@ public interface FrameHandler extends IncomingFrames
             }
 
             @Override
-            public void setWriteIdleTimeout(Duration timeout)
+            public void setWriteTimeout(Duration timeout)
             {
             }
 
@@ -511,7 +521,7 @@ public interface FrameHandler extends IncomingFrames
 
     class ConfigurationCustomizer implements Customizer, Configuration
     {
-        private Duration timeout;
+        private Duration idleTimeout;
         private Duration writeTimeout;
         private Boolean autoFragment;
         private Long maxFrameSize;
@@ -523,25 +533,25 @@ public interface FrameHandler extends IncomingFrames
         @Override
         public Duration getIdleTimeout()
         {
-            return timeout==null ? Duration.ZERO : timeout;
+            return idleTimeout;
         }
 
         @Override
-        public Duration getWriteIdleTimeout()
+        public Duration getWriteTimeout()
         {
-            return timeout==null ? Duration.ZERO : timeout;
+            return writeTimeout;
         }
 
         @Override
         public void setIdleTimeout(Duration timeout)
         {
-            this.timeout = timeout;
+            this.idleTimeout = timeout==null ? Duration.ZERO : timeout;
         }
 
         @Override
-        public void setWriteIdleTimeout(Duration timeout)
+        public void setWriteTimeout(Duration timeout)
         {
-            this.writeTimeout = timeout;
+            this.writeTimeout = timeout==null ? Duration.ZERO : timeout;
         }
 
         @Override
@@ -619,10 +629,10 @@ public interface FrameHandler extends IncomingFrames
         @Override
         public void customize(CoreSession session)
         {
-            if (timeout!=null)
-                session.setIdleTimeout(timeout);
+            if (idleTimeout !=null)
+                session.setIdleTimeout(idleTimeout);
             if (writeTimeout!=null)
-                session.setWriteIdleTimeout(timeout);
+                session.setWriteTimeout(idleTimeout);
             if (autoFragment!=null)
                 session.setAutoFragment(autoFragment);
             if (maxFrameSize!=null)

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
@@ -141,12 +141,16 @@ public interface FrameHandler extends IncomingFrames
          */
         Duration getIdleTimeout();
 
+        Duration getWriteIdleTimeout();
+
         /**
          * Set the Idle Timeout.
          *
          * @param timeout the timeout duration
          */
         void setIdleTimeout(Duration timeout);
+
+        void setWriteIdleTimeout(Duration timeout);
 
         boolean isAutoFragment();
 
@@ -392,8 +396,20 @@ public interface FrameHandler extends IncomingFrames
             }
 
             @Override
+            public Duration getWriteIdleTimeout()
+            {
+                return Duration.ZERO;
+            }
+
+            @Override
             public void setIdleTimeout(Duration timeout)
             {
+            }
+
+            @Override
+            public void setWriteIdleTimeout(Duration timeout)
+            {
+
             }
 
             @Override
@@ -497,6 +513,7 @@ public interface FrameHandler extends IncomingFrames
     class ConfigurationCustomizer implements Customizer, Configuration
     {
         private Duration timeout;
+        private Duration writeTimeout;
         private Boolean autoFragment;
         private Long maxFrameSize;
         private Integer outputBufferSize;
@@ -511,9 +528,21 @@ public interface FrameHandler extends IncomingFrames
         }
 
         @Override
+        public Duration getWriteIdleTimeout()
+        {
+            return timeout==null ? Duration.ZERO : timeout;
+        }
+
+        @Override
         public void setIdleTimeout(Duration timeout)
         {
             this.timeout = timeout;
+        }
+
+        @Override
+        public void setWriteIdleTimeout(Duration timeout)
+        {
+            this.writeTimeout = timeout;
         }
 
         @Override
@@ -593,6 +622,8 @@ public interface FrameHandler extends IncomingFrames
         {
             if (timeout!=null)
                 session.setIdleTimeout(timeout);
+            if (writeTimeout!=null)
+                session.setWriteIdleTimeout(timeout);
             if (autoFragment!=null)
                 session.setAutoFragment(autoFragment);
             if (maxFrameSize!=null)

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
@@ -409,7 +409,6 @@ public interface FrameHandler extends IncomingFrames
             @Override
             public void setWriteIdleTimeout(Duration timeout)
             {
-
             }
 
             @Override

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketWriteTimeoutException.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketWriteTimeoutException.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.websocket.core;
 
 public class WebSocketWriteTimeoutException extends WebSocketTimeoutException

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketWriteTimeoutException.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketWriteTimeoutException.java
@@ -1,0 +1,9 @@
+package org.eclipse.jetty.websocket.core;
+
+public class WebSocketWriteTimeoutException extends WebSocketTimeoutException
+{
+    public WebSocketWriteTimeoutException(String message)
+    {
+        super(message);
+    }
+}

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/ClientUpgradeRequest.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.FrameHandler;
@@ -349,7 +350,7 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
         WebSocketChannel wsChannel = newWebSocketChannel(frameHandler, negotiated);
         wsClient.customize(wsChannel);
 
-        WebSocketConnection wsConnection = newWebSocketConnection(endp, httpClient.getExecutor(), httpClient.getByteBufferPool(), wsChannel);
+        WebSocketConnection wsConnection = newWebSocketConnection(endp, httpClient.getExecutor(), httpClient.getScheduler(), httpClient.getByteBufferPool(), wsChannel);
 
         for (Connection.Listener listener : wsClient.getBeans(Connection.Listener.class))
             wsConnection.addListener(listener);
@@ -379,9 +380,9 @@ public abstract class ClientUpgradeRequest extends HttpRequest implements Respon
     {
     }
 
-    protected WebSocketConnection newWebSocketConnection(EndPoint endp, Executor executor, ByteBufferPool byteBufferPool, WebSocketChannel wsChannel)
+    protected WebSocketConnection newWebSocketConnection(EndPoint endp, Executor executor, Scheduler scheduler, ByteBufferPool byteBufferPool, WebSocketChannel wsChannel)
     {
-        return new WebSocketConnection(endp, executor, byteBufferPool, wsChannel);
+        return new WebSocketConnection(endp, executor, scheduler, byteBufferPool, wsChannel);
     }
 
     protected WebSocketChannel newWebSocketChannel(FrameHandler handler, Negotiated negotiated)

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketChannel.java
@@ -241,7 +241,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     }
 
     @Override
-    public Duration getWriteIdleTimeout()
+    public Duration getWriteTimeout()
     {
         if (getConnection() == null)
             return idleWriteTimeout;
@@ -250,7 +250,7 @@ public class WebSocketChannel implements IncomingFrames, FrameHandler.CoreSessio
     }
 
     @Override
-    public void setWriteIdleTimeout(Duration timeout)
+    public void setWriteTimeout(Duration timeout)
     {
         if (getConnection() == null)
             idleWriteTimeout = timeout;

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -546,6 +546,11 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         setInitialBuffer(prefilled);
     }
 
+    public FrameFlusher getFrameFlusher()
+    {
+        return flusher;
+    }
+
     @Override
     public long getMessagesIn()
     {

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.MessageTooLargeException;
@@ -79,10 +80,11 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
      */
     public WebSocketConnection(EndPoint endp,
         Executor executor,
+        Scheduler scheduler,
         ByteBufferPool bufferPool,
         WebSocketChannel channel)
     {
-        this(endp, executor, bufferPool, channel, true);
+        this(endp, executor, scheduler, bufferPool, channel, true);
     }
 
     /**
@@ -94,6 +96,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
      */
     public WebSocketConnection(EndPoint endp,
         Executor executor,
+        Scheduler scheduler,
         ByteBufferPool bufferPool,
         WebSocketChannel channel,
         boolean validating)
@@ -122,7 +125,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
         };
 
-        this.flusher = new Flusher(channel.getOutputBufferSize(), generator, endp);
+        this.flusher = new Flusher(scheduler, channel.getOutputBufferSize(), generator, endp);
         this.setInputBufferSize(channel.getInputBufferSize());
 
         this.random = this.channel.getBehavior() == Behavior.CLIENT?new Random(endp.hashCode()):null;
@@ -596,9 +599,9 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private class Flusher extends FrameFlusher
     {
-        private Flusher(int bufferSize, Generator generator, EndPoint endpoint)
+        private Flusher(Scheduler scheduler, int bufferSize, Generator generator, EndPoint endpoint)
         {
-            super(bufferPool, generator, endpoint, bufferSize, 8);
+            super(bufferPool, scheduler, generator, endpoint, bufferSize, 8);
         }
 
         @Override

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
@@ -43,6 +43,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.FrameHandler;
@@ -201,7 +202,7 @@ public final class RFC6455Handshaker implements Handshaker
             LOG.debug("channel {}", channel);
 
         // Create a connection
-        WebSocketConnection connection = newWebSocketConnection(httpChannel.getEndPoint(), connector.getExecutor(), connector.getByteBufferPool(), channel);
+        WebSocketConnection connection = newWebSocketConnection(httpChannel.getEndPoint(), connector.getExecutor(), connector.getScheduler(), connector.getByteBufferPool(), channel);
         if (LOG.isDebugEnabled())
             LOG.debug("connection {}", connection);
         if (connection == null)
@@ -241,9 +242,9 @@ public final class RFC6455Handshaker implements Handshaker
         return new WebSocketChannel(handler, Behavior.SERVER, negotiated);
     }
 
-    protected WebSocketConnection newWebSocketConnection(EndPoint endPoint, Executor executor, ByteBufferPool byteBufferPool, WebSocketChannel wsChannel)
+    protected WebSocketConnection newWebSocketConnection(EndPoint endPoint, Executor executor, Scheduler scheduler, ByteBufferPool byteBufferPool, WebSocketChannel wsChannel)
     {
-        return new WebSocketConnection(endPoint, executor, byteBufferPool, wsChannel);
+        return new WebSocketConnection(endPoint, executor, scheduler, byteBufferPool, wsChannel);
     }
 
     private boolean getSendServerVersion(Connector connector)

--- a/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
+++ b/jetty-websocket/websocket-core/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
@@ -24,19 +24,24 @@ import java.nio.channels.WritePendingException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FutureCallback;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
+import org.eclipse.jetty.websocket.core.WebSocketWriteTimeoutException;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -134,6 +139,39 @@ public class FrameFlusherTest
         serverTask.get();
     }
 
+    @Test
+    public void testWriteTimeout() throws Exception
+    {
+        Generator generator = new Generator(bufferPool);
+        BlockingEndpoint endPoint = new BlockingEndpoint(bufferPool);
+        int bufferSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
+        int maxGather = 8;
+
+
+        CountDownLatch flusherFailure = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, generator, endPoint, bufferSize, maxGather)
+        {
+            @Override
+            public void onCompleteFailure(Throwable failure)
+            {
+                error.set(failure);
+                flusherFailure.countDown();
+                super.onCompleteFailure(failure);
+            }
+        };
+
+        frameFlusher.setIdleTimeout(150);
+        endPoint.setBlockTime(200);
+
+        Frame frame = new Frame(OpCode.TEXT).setPayload("message").setFin(true);
+        frameFlusher.enqueue(frame, Callback.NOOP, false);
+        frameFlusher.iterate();
+
+        assertTrue(flusherFailure.await(2, TimeUnit.SECONDS));
+        assertThat(error.get(), instanceOf(WebSocketWriteTimeoutException.class));
+    }
+
     public static class CapturingEndPoint extends MockEndpoint
     {
         public Parser parser;
@@ -174,6 +212,45 @@ public class FrameFlusherTest
             {
                 callback.failed(t);
             }
+        }
+    }
+
+    public static class BlockingEndpoint extends CapturingEndPoint
+    {
+        private static final Logger LOG = Log.getLogger(BlockingEndpoint.class);
+
+        private long blockTime = 0;
+        public CountDownLatch closeLatch = new CountDownLatch(1);
+        public volatile Throwable error;
+
+        public void setBlockTime(int time)
+        {
+            blockTime = time;
+        }
+
+        public BlockingEndpoint(ByteBufferPool bufferPool)
+        {
+            super(bufferPool);
+        }
+
+        @Override
+        public void write(Callback callback, ByteBuffer... buffers) throws WritePendingException
+        {
+            try
+            {
+                Thread.sleep(blockTime);
+                super.write(callback, buffers);
+            }
+            catch (InterruptedException e)
+            {
+                callback.failed(e);
+            }
+        }
+
+        @Override
+        public void close(Throwable cause)
+        {
+            //ignore
         }
     }
 }

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServletFactory.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServletFactory.java
@@ -36,6 +36,12 @@ public interface WebSocketServletFactory extends FrameHandler.Configuration
     void setIdleTimeout(Duration duration);
 
     @Override
+    Duration getWriteTimeout();
+
+    @Override
+    void setWriteTimeout(Duration duration);
+
+    @Override
     int getInputBufferSize();
 
     @Override


### PR DESCRIPTION
addition of websocket write timeouts in websocket-core in order to implement JSR356 `RemoteEndpoint.Async.setSendTimeout()` for issue #3374 