### PR TITLE
Jetty 9.4.x 3550 queued thread pool stalled

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -604,7 +604,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
             String knownMethod = "";
             for (StackTraceElement t : trace)
             {
-                if ("idleJobPoll".equals(t.getMethodName()) && t.getClassName().endsWith("QueuedThreadPool$Runner"))
+                if ("idleJobPoll".equals(t.getMethodName()) && t.getClassName().equals(Runner.class.getName()))
                 {
                     knownMethod = "IDLE ";
                     break;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -474,7 +474,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
         else
         {
             // Make sure there is at least one thread executing the job.
-            if (getThreads() == 0)
+            if (getQueueSize() > 0 && getIdleThreads() == 0)
                 startThreads(1);
         }
     }
@@ -781,8 +781,11 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
                         }
 
                         job = idleJobPoll();
-                        if (job==SHRINK)
+                        if (job == SHRINK)
+                        {
+                            LOG.warn("shrinking {}", this);
                             break;
+                        }
                     }
 
                     // run job

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -783,7 +783,8 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
                         job = idleJobPoll();
                         if (job == SHRINK)
                         {
-                            LOG.warn("shrinking {}", this);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("shrinking {}", this);
                             break;
                         }
                     }
@@ -829,7 +830,9 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
 
                 removeThread(Thread.currentThread());
 
-                if (_threadsStarted.decrementAndGet() < getMinThreads())
+                int threads = _threadsStarted.decrementAndGet();
+                // We should start a new thread if threads are now less than min threads or we have queued jobs
+                if (threads < getMinThreads() || getQueueSize()>0)
                     startThreads(1);
             }
         }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
@@ -135,7 +136,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
     @Override
     protected void doStart() throws Exception
     {
-        _tryExecutor = new ReservedThreadExecutor(this,_reservedThreads);
+        _tryExecutor = _reservedThreads==0 ? NO_TRY : new ReservedThreadExecutor(this,_reservedThreads);
         addBean(_tryExecutor);
         
         super.doStart();
@@ -603,7 +604,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
             String knownMethod = "";
             for (StackTraceElement t : trace)
             {
-                if ("idleJobPoll".equals(t.getMethodName()) && t.getClassName().endsWith("QueuedThreadPool"))
+                if ("idleJobPoll".equals(t.getMethodName()) && t.getClassName().endsWith("QueuedThreadPool$Runner"))
                 {
                     knownMethod = "IDLE ";
                     break;
@@ -636,11 +637,10 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
                     @Override
                     public void dump(Appendable out, String indent) throws IOException
                     {
-                        String s = thread.getId()+" "+thread.getName()+" "+thread.getState()+" "+thread.getPriority();
-                        if (known.length()==0)
-                            Dumpable.dumpObjects(out, indent, s, (Object[])trace);
+                        if (StringUtil.isBlank(known))
+                            Dumpable.dumpObjects(out, indent, String.format("%s %s %s %d", thread.getId(), thread.getName(), thread.getState(), thread.getPriority()), (Object[])trace);
                         else
-                            Dumpable.dumpObjects(out, indent, s);
+                            Dumpable.dumpObjects(out, indent, String.format("%s %s %s %s %d", thread.getId(), thread.getName(), known, thread.getState(), thread.getPriority()));
                     }
 
                     @Override
@@ -671,7 +671,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
     @Override
     public String toString()
     {
-        return String.format("%s[%s]@%x{%s,%d<=%d<=%d,i=%d,q=%d}[%s]",
+        return String.format("%s[%s]@%x{%s,%d<=%d<=%d,i=%d,r=%d,q=%d}[%s]",
             getClass().getSimpleName(),
             _name,
             hashCode(),
@@ -680,100 +680,12 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
             getThreads(),
             getMaxThreads(),
             getIdleThreads(),
+            getReservedThreads(),
             _jobs.size(),
             _tryExecutor);
     }
 
-    private Runnable _runnable = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            boolean idle = false;
-
-            try
-            {
-                Runnable job = _jobs.poll();
-                if (job != null && _threadsIdle.get() == 0)
-                    startThreads(1);
-
-                while (true)
-                {
-                    if (job == null)
-                    {
-                        if (!idle)
-                        {
-                            idle = true;
-                            _threadsIdle.incrementAndGet();
-                        }
-
-                        if (_idleTimeout <= 0)
-                            job = _jobs.take();
-                        else
-                        {
-                            // maybe we should shrink?
-                            int size = _threadsStarted.get();
-                            if (size > _minThreads)
-                            {
-                                long last = _lastShrink.get();
-                                long now = System.nanoTime();
-                                if (last == 0 || (now - last) > TimeUnit.MILLISECONDS.toNanos(_idleTimeout))
-                                {
-                                    if (_lastShrink.compareAndSet(last, now))
-                                        break;
-                                }
-                            }
-
-                            job = _jobs.poll(_idleTimeout, TimeUnit.MILLISECONDS);
-                        }
-                    }
-
-                    // run job
-                    if (job != null)
-                    {
-                        if (idle)
-                        {
-                            idle = false;
-                            if (_threadsIdle.decrementAndGet() == 0)
-                                startThreads(1);
-                        }
-
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("run {}", job);
-                        runJob(job);
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("ran {}", job);
-
-                        // Clear interrupted status
-                        Thread.interrupted();
-                    }
-
-                    if (!isRunning())
-                        break;
-
-                    job = _jobs.poll();
-                }
-            }
-            catch (InterruptedException e)
-            {
-                LOG.ignore(e);
-            }
-            catch (Throwable e)
-            {
-                LOG.warn(String.format("Unexpected thread death: %s in %s", this, QueuedThreadPool.this), e);
-            }
-            finally
-            {
-                if (idle)
-                    _threadsIdle.decrementAndGet();
-
-                removeThread(Thread.currentThread());
-
-                if (_threadsStarted.decrementAndGet() < getMinThreads())
-                    startThreads(1);
-            }
-        }
-    };
+    private final Runnable _runnable = new Runner();
 
     /**
      * <p>Runs the given job in the {@link Thread#currentThread() current thread}.</p>
@@ -842,5 +754,102 @@ public class QueuedThreadPool extends ContainerLifeCycle implements SizedThreadP
             }
         }
         return null;
+    }
+
+    private static Runnable SHRINK = ()->{};
+    private class Runner implements Runnable
+    {
+        @Override
+        public void run()
+        {
+            boolean idle = false;
+
+            try
+            {
+                Runnable job = _jobs.poll();
+                if (job != null && _threadsIdle.get() == 0)
+                    startThreads(1);
+
+                while (true)
+                {
+                    if (job == null)
+                    {
+                        if (!idle)
+                        {
+                            idle = true;
+                            _threadsIdle.incrementAndGet();
+                        }
+
+                        job = idleJobPoll();
+                        if (job==SHRINK)
+                            break;
+                    }
+
+                    // run job
+                    if (job != null)
+                    {
+                        if (idle)
+                        {
+                            idle = false;
+                            if (_threadsIdle.decrementAndGet() == 0)
+                                startThreads(1);
+                        }
+
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("run {}", job);
+                        runJob(job);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("ran {}", job);
+
+                        // Clear interrupted status
+                        Thread.interrupted();
+                    }
+
+                    if (!isRunning())
+                        break;
+
+                    job = _jobs.poll();
+                }
+            }
+            catch (InterruptedException e)
+            {
+                LOG.ignore(e);
+            }
+            catch (Throwable e)
+            {
+                LOG.warn(String.format("Unexpected thread death: %s in %s", this, QueuedThreadPool.this), e);
+            }
+            finally
+            {
+                if (idle)
+                    _threadsIdle.decrementAndGet();
+
+                removeThread(Thread.currentThread());
+
+                if (_threadsStarted.decrementAndGet() < getMinThreads())
+                    startThreads(1);
+            }
+        }
+
+        private Runnable idleJobPoll() throws InterruptedException
+        {
+            if (_idleTimeout <= 0)
+                return _jobs.take();
+
+            // maybe we should shrink?
+            int size = _threadsStarted.get();
+            if (size > _minThreads)
+            {
+                long last = _lastShrink.get();
+                long now = System.nanoTime();
+                if (last == 0 || (now - last) > TimeUnit.MILLISECONDS.toNanos(_idleTimeout))
+                {
+                    if (_lastShrink.compareAndSet(last, now))
+                        return SHRINK;
+                }
+            }
+
+            return _jobs.poll(_idleTimeout, TimeUnit.MILLISECONDS);
+        }
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/TryExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/TryExecutor.java
@@ -75,5 +75,19 @@ public interface TryExecutor extends Executor
         }
     }
 
-    public static final TryExecutor NO_TRY = task -> false;
+    TryExecutor NO_TRY = new TryExecutor()
+    {
+        @Override
+        public boolean tryExecute(Runnable task)
+        {
+            return false;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "NO_TRY";
+        }
+    };
+
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -168,6 +168,39 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
     }
 
     @Test
+    public void testExecuteNoIdleThreads() throws Exception
+    {
+        QueuedThreadPool tp= new QueuedThreadPool();
+        tp.setDetailedDump(true);
+        tp.setMinThreads(3);
+        tp.setMaxThreads(10);
+        tp.setIdleTimeout(500);
+
+        tp.start();
+
+        RunningJob job1 = new RunningJob();
+        tp.execute(job1);
+
+        RunningJob job2 = new RunningJob();
+        tp.execute(job2);
+
+        RunningJob job3 = new RunningJob();
+        tp.execute(job3);
+
+        // make sure these jobs have started running
+        assertTrue(job1._run.await(5, TimeUnit.SECONDS));
+        assertTrue(job2._run.await(5, TimeUnit.SECONDS));
+        assertTrue(job3._run.await(5, TimeUnit.SECONDS));
+
+        waitForThreads(tp, 4);
+        waitForThreads(tp, 3);
+
+        RunningJob job4 = new RunningJob();
+        tp.execute(job4);
+        assertTrue(job4._run.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void testLifeCycleStop() throws Exception
     {
         QueuedThreadPool tp= new QueuedThreadPool();


### PR DESCRIPTION
This fixes #3550 by ensure that a new thread is always started when:
 + a task is executed, the queue is not empty and there are no idle threads available (this may race, but will only start addition threads)
 + if a thread exits and the queue is not empty