### PR TITLE
Only include hazelcast test-jar in test scope

### DIFF
--- a/jetty-hazelcast/pom.xml
+++ b/jetty-hazelcast/pom.xml
@@ -22,6 +22,7 @@
       <artifactId>hazelcast</artifactId>
       <version>${hazelcast.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
This looks like a simple oversight, but forces the hazelcast test-jar onto users of `jetty-hazelcast`.