### PR TITLE
Issue #3597 Fix session persistence classloading for deep structures

### DIFF
--- a/jetty-documentation/src/main/asciidoc/reference/architecture/jetty-classloading.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/architecture/jetty-classloading.adoc
@@ -162,6 +162,10 @@ You can do so directly to the API via a context XML file such as the following:
 
 If none of the alternatives already described meet your needs, you can always provide a custom classloader for your webapp.
 We recommend, but do not require, that your custom loader subclasses link:{JDURL}/org/eclipse/jetty/webapp/WebAppClassLoader.html[WebAppClassLoader].
+
+If you do not subclass WebAppClassLoader, we recommend that you implement the link:{JDURL}/org/eclipse/jetty/util/ClassVisibilityChecker.html[ClassVisibilityChecker] interface.
+Without this interface, session persistence will be slower.
+
 You configure the classloader for the webapp like so:
 
 [source, java, subs="{sub-order}"]

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ClassVisibilityChecker.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ClassVisibilityChecker.java
@@ -1,0 +1,51 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+
+package org.eclipse.jetty.util;
+
+/**
+ * ClassVisibilityChecker
+ * 
+ * Interface to be implemented by classes capable of checking class visibility
+ * for a context.
+ *
+ */
+public interface ClassVisibilityChecker
+{
+    /* ------------------------------------------------------------ */
+    /** Is the class a System Class.
+     * A System class is a class that is visible to a webapplication,
+     * but that cannot be overridden by the contents of WEB-INF/lib or
+     * WEB-INF/classes 
+     * @param clazz The fully qualified name of the class.
+     * @return True if the class is a system class.
+     */
+    boolean isSystemClass(Class<?> clazz);
+
+    /* ------------------------------------------------------------ */
+    /** Is the class a Server Class.
+     * A Server class is a class that is part of the implementation of 
+     * the server and is NIT visible to a webapplication. The web
+     * application may provide it's own implementation of the class,
+     * to be loaded from WEB-INF/lib or WEB-INF/classes 
+     * @param clazz The fully qualified name of the class.
+     * @return True if the class is a server class.
+     */
+    boolean isServerClass(Class<?> clazz);
+}

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppClassLoader.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jetty.util.ClassVisibilityChecker;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.log.Log;
@@ -65,7 +66,7 @@ import org.eclipse.jetty.util.resource.ResourceCollection;
  * context classloader will be used.  If that is null then the 
  * classloader that loaded this class is used as the parent.
  */
-public class WebAppClassLoader extends URLClassLoader
+public class WebAppClassLoader extends URLClassLoader implements ClassVisibilityChecker
 {
     static
     {
@@ -85,7 +86,7 @@ public class WebAppClassLoader extends URLClassLoader
     /* ------------------------------------------------------------ */
     /** The Context in which the classloader operates.
      */
-    public interface Context
+    public interface Context extends ClassVisibilityChecker
     {
         /* ------------------------------------------------------------ */
         /** Convert a URL or path to a Resource.
@@ -103,26 +104,6 @@ public class WebAppClassLoader extends URLClassLoader
          */
         PermissionCollection getPermissions();
         
-        /* ------------------------------------------------------------ */
-        /** Is the class a System Class.
-         * A System class is a class that is visible to a webapplication,
-         * but that cannot be overridden by the contents of WEB-INF/lib or
-         * WEB-INF/classes 
-         * @param clazz The fully qualified name of the class.
-         * @return True if the class is a system class.
-         */
-        boolean isSystemClass(Class<?> clazz);
-
-        /* ------------------------------------------------------------ */
-        /** Is the class a Server Class.
-         * A Server class is a class that is part of the implementation of 
-         * the server and is NIT visible to a webapplication. The web
-         * application may provide it's own implementation of the class,
-         * to be loaded from WEB-INF/lib or WEB-INF/classes 
-         * @param clazz The fully qualified name of the class.
-         * @return True if the class is a server class.
-         */
-        boolean isServerClass(Class<?> clazz);
 
         /* ------------------------------------------------------------ */
         /**
@@ -743,6 +724,18 @@ public class WebAppClassLoader extends URLClassLoader
     public String toString()
     {
         return "WebAppClassLoader=" + _name+"@"+Long.toHexString(hashCode());
+    }
+
+    @Override
+    public boolean isSystemClass(Class<?> clazz)
+    {
+        return _context.isSystemClass(clazz);
+    }
+
+    @Override
+    public boolean isServerClass(Class<?> clazz)
+    {
+       return _context.isServerClass(clazz);
     }
     
 }


### PR DESCRIPTION
#3597 

Fix for session persistence when using deep structures, especially deep structures based off java.util Collection classes like ArrayList etc.  The problem can be seen if the attribute that is stored is an java.util.ArrayList, containing elements that are classes only known to the webapp:  if the server classloader is used to try and deserialize the elements (because that is the  classloader of ArrayList), this will fail, because the classes of the list elements can only be loaded by the webapp classloader.  The solution  is to check if the class of the attribute, eg the ArrayList, can be seen by the weapp classloader, and if so to use that classloader to deserialize.