### PR TITLE
Fixing IllegalStateException when websocket Session.suspend gets called multiple times

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -628,8 +628,14 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
     @Override
     public SuspendToken suspend()
     {
-        readState.suspending();
-        return this;
+        if (readState.suspending())
+        {
+            return this;
+        }
+        else
+        {
+            return null;
+        }
     }
 
     @Override

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
@@ -51,6 +51,8 @@ class ReadState
                     if (state.compareAndSet(current, State.SUSPENDING))
                         return true;
                     break;
+                case SUSPENDING:
+                    return false;
                 case EOF:
                     return false;
                 default:


### PR DESCRIPTION
If `OnWebSocketMessage` handler has a code that calls `org.eclipse.jetty.websocket.api.Session.suspend` and multiple messages arrive roughly at the same time, then each would call `suspend`, causing `IllegalStateException` to be thrown.

Signed-off-by: Volodymyr Sorokin <sorrro@gmail.com>