### PR TITLE
Issue #3382 - improve testing for WS suspend and fix demand on resume

### DIFF
--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -436,17 +436,18 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         if (delayedFrame != null)
             delayedFrame.run();
         else
-            demand();
+            session.getCoreSession().demand(1);
     }
 
     private void demand()
     {
+        boolean demand = false;
         synchronized (this)
         {
             switch(state)
             {
                 case DEMANDING:
-                    session.getCoreSession().demand(1);
+                    demand = true;
                     break;
 
                 case SUSPENDED:
@@ -460,6 +461,9 @@ public class JettyWebSocketFrameHandler implements FrameHandler
                     throw new IllegalStateException();
             }
         }
+
+        if (demand)
+            session.getCoreSession().demand(1);
     }
 
     static Throwable convertCause(Throwable cause)

--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -435,6 +435,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
 
         if (delayedFrame != null)
             delayedFrame.run();
+        else
+            demand();
     }
 
     private void demand()

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.websocket.tests;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +29,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.SuspendToken;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
@@ -43,6 +45,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SuspendResumeTest
 {
+    @WebSocket
+    public static class SuspendSocket extends EventSocket
+    {
+        volatile SuspendToken suspendToken = null;
+
+        @Override
+        public void onMessage(String message) throws IOException
+        {
+            if ("suspend".equals(message))
+                suspendToken = session.suspend();
+            super.onMessage(message);
+        }
+    }
+
     public class UpgradeServlet extends JettyWebSocketServlet
     {
         @Override
@@ -54,20 +70,19 @@ public class SuspendResumeTest
 
     private Server server = new Server();
     private WebSocketClient client = new WebSocketClient();
-    private EventSocket serverSocket = new EventSocket();
+    private SuspendSocket serverSocket = new SuspendSocket();
     private ServerConnector connector;
 
     @BeforeEach
     public void start() throws Exception
     {
         connector = new ServerConnector(server);
-        connector.setPort(0);
         server.addConnector(connector);
 
         ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         contextHandler.setContextPath("/");
         server.setHandler(contextHandler);
-        contextHandler.addServlet(new ServletHolder(new UpgradeServlet()), "/test");
+        contextHandler.addServlet(new ServletHolder(new UpgradeServlet()), "/suspend");
 
         JettyWebSocketServletContainerInitializer.configureContext(contextHandler);
 
@@ -83,27 +98,60 @@ public class SuspendResumeTest
     }
 
     @Test
-    public void testSuspendResume() throws Exception
+    public void testSuspendWhenProcessingFrame() throws Exception
     {
-        URI uri = new URI("ws://localhost:"+connector.getLocalPort()+"/test");
+        URI uri = new URI("ws://localhost:"+connector.getLocalPort()+"/suspend");
+        EventSocket clientSocket = new EventSocket();
+        Future<Session> connect = client.connect(clientSocket, uri);
+        connect.get(5, TimeUnit.SECONDS);
+
+        clientSocket.session.getRemote().sendString("suspend");
+        clientSocket.session.getRemote().sendString("suspend");
+        clientSocket.session.getRemote().sendString("hello world");
+
+        assertThat(serverSocket.messageQueue.poll(5, TimeUnit.SECONDS), is("suspend"));
+        assertNull(serverSocket.messageQueue.poll(1, TimeUnit.SECONDS));
+
+        serverSocket.suspendToken.resume();
+        assertThat(serverSocket.messageQueue.poll(5, TimeUnit.SECONDS), is("suspend"));
+        assertNull(serverSocket.messageQueue.poll(1, TimeUnit.SECONDS));
+
+        serverSocket.suspendToken.resume();
+        assertThat(serverSocket.messageQueue.poll(5, TimeUnit.SECONDS), is("hello world"));
+        assertNull(serverSocket.messageQueue.poll(1, TimeUnit.SECONDS));
+
+        // make sure both sides are closed
+        clientSocket.session.close();
+        assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(serverSocket.closeLatch.await(5, TimeUnit.SECONDS));
+
+        // check no errors occurred
+        assertNull(clientSocket.error);
+        assertNull(serverSocket.error);
+    }
+
+    @Test
+    public void testExternalSuspend() throws Exception
+    {
+        URI uri = new URI("ws://localhost:"+connector.getLocalPort()+"/suspend");
         EventSocket clientSocket = new EventSocket();
         Future<Session> connect = client.connect(clientSocket, uri);
         connect.get(5, TimeUnit.SECONDS);
 
         // verify connection by sending a message from server to client
         assertTrue(serverSocket.openLatch.await(5, TimeUnit.SECONDS));
-        serverSocket.session.getRemote().sendStringByFuture("verification");
+        serverSocket.session.getRemote().sendString("verification");
         assertThat(clientSocket.messageQueue.poll(5, TimeUnit.SECONDS), is("verification"));
 
         // suspend the client so that no read events occur
         SuspendToken suspendToken = clientSocket.session.suspend();
 
         // verify client can still send messages
-        clientSocket.session.getRemote().sendStringByFuture("message-from-client");
+        clientSocket.session.getRemote().sendString("message-from-client");
         assertThat(serverSocket.messageQueue.poll(5, TimeUnit.SECONDS), is("message-from-client"));
 
         // the message is not received as it is suspended
-        serverSocket.session.getRemote().sendStringByFuture("message-from-server");
+        serverSocket.session.getRemote().sendString("message-from-server");
         assertNull(clientSocket.messageQueue.poll(2, TimeUnit.SECONDS));
 
         // client should receive message after it resumes


### PR DESCRIPTION
new test case demonstrates an issue with websocket suspend when suspending while processing a frame

fixed this by demanding in `session.resume()`