### PR TITLE
Issue #3627 Only renew session id when spnego authentication is fully complete

### DIFF
--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/ConfigurableSpnegoAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/ConfigurableSpnegoAuthenticator.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.security.SpnegoUserPrincipal;
 import org.eclipse.jetty.security.UserAuthentication;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Authentication.User;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -98,6 +99,25 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
     {
         _authenticationDuration = authenticationDuration;
     }
+    
+    
+
+    /**
+     * Only renew the session id if the user has been fully authenticated, don't
+     * renew the session for any of the intermediate request/response handshakes.
+     */
+    @Override
+    public UserIdentity login(String username, Object password, ServletRequest servletRequest)
+    {
+        SpnegoUserIdentity user = (SpnegoUserIdentity)_loginService.login(username, password, servletRequest);
+        if (user != null && user.isEstablished())
+        {
+            Request request = Request.getBaseRequest(servletRequest);
+            renewSession(request, request == null ? null : request.getResponse());
+        }
+        return user;
+    }
+    
 
     @Override
     public Authentication validateRequest(ServletRequest req, ServletResponse res, boolean mandatory) throws ServerAuthException

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/ConfigurableSpnegoAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/ConfigurableSpnegoAuthenticator.java
@@ -99,8 +99,6 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
     {
         _authenticationDuration = authenticationDuration;
     }
-    
-    
 
     /**
      * Only renew the session id if the user has been fully authenticated, don't

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -33,14 +33,7 @@ import org.eclipse.jetty.server.session.Session;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
-/**
- * @author janb
- *
- */
-/**
- * @author janb
- *
- */
+
 public abstract class LoginAuthenticator implements Authenticator
 {
     private static final Logger LOG = Log.getLogger(LoginAuthenticator.class);
@@ -62,7 +55,7 @@ public abstract class LoginAuthenticator implements Authenticator
     }
 
     /**
-     * If the UserIdentity is not null after this method calls LoginService.login, it
+     * If the UserIdentity is not null after this method calls {@link LoginService#login(String,Object,ServletRequest)}, it
      * is assumed that the user is fully authenticated and we need to change the session id to prevent
      * session fixation vulnerability. If the UserIdentity is not necessarily fully
      * authenticated, then subclasses must override this method and
@@ -75,7 +68,6 @@ public abstract class LoginAuthenticator implements Authenticator
      */
     public UserIdentity login(String username, Object password, ServletRequest servletRequest)
     {
-
         UserIdentity user = _loginService.login(username, password, servletRequest);
         if (user != null)
         {

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -33,6 +33,14 @@ import org.eclipse.jetty.server.session.Session;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
+/**
+ * @author janb
+ *
+ */
+/**
+ * @author janb
+ *
+ */
 public abstract class LoginAuthenticator implements Authenticator
 {
     private static final Logger LOG = Log.getLogger(LoginAuthenticator.class);
@@ -53,8 +61,21 @@ public abstract class LoginAuthenticator implements Authenticator
         //empty implementation as the default
     }
 
+    /**
+     * If the UserIdentity is not null after this method calls LoginService.login, it
+     * is assumed that the user is fully authenticated and we need to change the session id to prevent
+     * session fixation vulnerability. If the UserIdentity is not necessarily fully
+     * authenticated, then subclasses must override this method and
+     * determine when the UserIdentity IS fully authenticated and renew the session id.
+     * 
+     * @param username the username of the client to be authenticated
+     * @param password the user's credential
+     * @param servletRequest the inbound request that needs authentication
+     * @return
+     */
     public UserIdentity login(String username, Object password, ServletRequest servletRequest)
     {
+
         UserIdentity user = _loginService.login(username, password, servletRequest);
         if (user != null)
         {


### PR DESCRIPTION
#3627

Spnego authentication can have multiple client/server round trips, during which time the server needs to keep some info about the in-flight authentication process. This info is kept in a http session. Prior to this PR, after the first client/server round trip we would change the session id and mark it as being secure.  Thus, whilst changing the session id is good, it should not happen until the last request of the authentication sequence is processed when the user is actually authenticated.