### PR TITLE
Fixes #3605 - IdleTimeout with Jetty HTTP/2 and InputStreamResponseListener

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -51,6 +51,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicInteger sweeps = new AtomicInteger();
     private final Session session;
+    private boolean recycleHttpChannels;
 
     public HttpConnectionOverHTTP2(HttpDestination destination, Session session)
     {
@@ -61,6 +62,16 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     public Session getSession()
     {
         return session;
+    }
+
+    public boolean isRecycleHttpChannels()
+    {
+        return recycleHttpChannels;
+    }
+
+    public void setRecycleHttpChannels(boolean recycleHttpChannels)
+    {
+        this.recycleHttpChannels = recycleHttpChannels;
     }
 
     @Override
@@ -99,7 +110,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             // Recycle only non-failed channels.
             if (channel.isFailed())
                 channel.destroy();
-            else
+            else if (isRecycleHttpChannels())
                 idleChannels.offer(channel);
         }
         else


### PR DESCRIPTION
#3605.

Now properly resetting HttpReceiverOverHTTP2.ContentNotifier by overriding
reset() and making sure fields are cleared from previous values.
Also, disable channel recycling by default - needs to be benchmarked
whether it's beneficial or not.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>