### PR TITLE
Issue #3630 Forwarded-Port

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
@@ -22,9 +22,9 @@ package org.eclipse.jetty.http;
 import org.eclipse.jetty.util.HostPort;
 
 
-
-/* ------------------------------------------------------------ */
 /**
+ * A HttpField holding a preparsed Host and port number
+ * @see HostPort
  */
 public class HostPortHttpField extends HttpField
 {
@@ -35,7 +35,6 @@ public class HostPortHttpField extends HttpField
         this(HttpHeader.HOST,HttpHeader.HOST.asString(),authority);
     }
 
-    /* ------------------------------------------------------------ */
     protected HostPortHttpField(HttpHeader header, String name, String authority)
     {
         super(header,name,authority);
@@ -49,20 +48,17 @@ public class HostPortHttpField extends HttpField
         }
     }
 
-    /* ------------------------------------------------------------ */
     public HostPortHttpField(String host, int port)
     {
         this(new HostPort(host, port));
     }
 
-    /* ------------------------------------------------------------ */
-    protected HostPortHttpField(HostPort hostport)
+    public HostPortHttpField(HostPort hostport)
     {
         super(HttpHeader.HOST,HttpHeader.HOST.asString(),hostport.toString());
         _hostPort = hostport;
     }
 
-    /* ------------------------------------------------------------ */
     /** Get the host.
      * @return the host
      */
@@ -71,7 +67,6 @@ public class HostPortHttpField extends HttpField
         return _hostPort.getHost();
     }
 
-    /* ------------------------------------------------------------ */
     /** Get the port.
      * @return the port
      */
@@ -80,7 +75,6 @@ public class HostPortHttpField extends HttpField
         return _hostPort.getPort();
     }
     
-    /* ------------------------------------------------------------ */
     /** Get the port.
      * @param defaultPort The default port to return if no port set
      * @return the port
@@ -88,5 +82,10 @@ public class HostPortHttpField extends HttpField
     public int getPort(int defaultPort)
     {
         return _hostPort.getPort(defaultPort);
+    }
+
+    public HostPort getHostPort()
+    {
+        return _hostPort;
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
@@ -50,6 +50,19 @@ public class HostPortHttpField extends HttpField
     }
 
     /* ------------------------------------------------------------ */
+    public HostPortHttpField(String host, int port)
+    {
+        this(new HostPort(host, port));
+    }
+
+    /* ------------------------------------------------------------ */
+    protected HostPortHttpField(HostPort hostport)
+    {
+        super(HttpHeader.HOST,HttpHeader.HOST.asString(),hostport.toString());
+        _hostPort = hostport;
+    }
+
+    /* ------------------------------------------------------------ */
     /** Get the host.
      * @return the host
      */

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpHeader.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpHeader.java
@@ -82,6 +82,7 @@ public enum HttpHeader
     TE("TE"),
     USER_AGENT("User-Agent"),
     X_FORWARDED_FOR("X-Forwarded-For"),
+    X_FORWARDED_PORT("X-Forwarded-Port"),
     X_FORWARDED_PROTO("X-Forwarded-Proto"),
     X_FORWARDED_SERVER("X-Forwarded-Server"),
     X_FORWARDED_HOST("X-Forwarded-Host"),

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
@@ -22,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.jetty.util.QuotedStringTokenizer;
-
 /* ------------------------------------------------------------ */
 /**
  * Implements a quoted comma separated list of values
@@ -32,226 +30,26 @@ import org.eclipse.jetty.util.QuotedStringTokenizer;
  * @see "https://tools.ietf.org/html/rfc7230#section-3.2.6"
  * @see "https://tools.ietf.org/html/rfc7230#section-7"
  */
-public class QuotedCSV implements Iterable<String>
-{    
-    private enum State { VALUE, PARAM_NAME, PARAM_VALUE};
-    
+public class QuotedCSV extends QuotedCSVParser implements Iterable<String>
+{
     protected final List<String> _values = new ArrayList<>();
-    protected final boolean _keepQuotes;
-    
-    /* ------------------------------------------------------------ */
+
     public QuotedCSV(String... values)
     {
         this(true,values);
     }
     
-    /* ------------------------------------------------------------ */
     public QuotedCSV(boolean keepQuotes,String... values)
     {
-        _keepQuotes=keepQuotes;
+        super(keepQuotes);
         for (String v:values)
             addValue(v);
     }
-    
-    /* ------------------------------------------------------------ */
-    /** Add and parse a value string(s) 
-     * @param value A value that may contain one or more Quoted CSV items.
-     */
-    public void addValue(String value)
+
+    @Override
+    protected void parsedValueAndParams(StringBuffer buffer)
     {
-        if (value == null)
-            return;
-        
-        StringBuffer buffer = new StringBuffer();
-        
-        int l=value.length();
-        State state=State.VALUE;
-        boolean quoted=false;
-        boolean sloshed=false;
-        int nws_length=0;
-        int last_length=0;
-        int value_length=-1;
-        int param_name=-1;
-        int param_value=-1;
-        
-        for (int i=0;i<=l;i++)
-        {
-            char c=i==l?0:value.charAt(i);
-            
-            // Handle quoting https://tools.ietf.org/html/rfc7230#section-3.2.6
-            if (quoted && c!=0)
-            {
-                if (sloshed)
-                    sloshed=false;
-                else
-                {
-                    switch(c)
-                    {
-                        case '\\':
-                            sloshed=true;
-                            if (!_keepQuotes)
-                                continue;
-                            break;
-                        case '"':
-                            quoted=false;
-                            if (!_keepQuotes)
-                                continue;
-                            break;
-                    }
-                }
-
-                buffer.append(c);
-                nws_length=buffer.length();
-                continue;
-            }
-            
-            // Handle common cases
-            switch(c)
-            {
-                case ' ':
-                case '\t':
-                    if (buffer.length()>last_length) // not leading OWS
-                        buffer.append(c);
-                    continue;
-
-                case '"':
-                    quoted=true;
-                    if (_keepQuotes)
-                    {
-                        if (state==State.PARAM_VALUE && param_value<0)
-                            param_value=nws_length;
-                        buffer.append(c);
-                    }
-                    else if (state==State.PARAM_VALUE && param_value<0)
-                        param_value=nws_length;
-                    nws_length=buffer.length();
-                    continue;
-                    
-                case ';':                    
-                    buffer.setLength(nws_length); // trim following OWS
-                    if (state==State.VALUE)
-                    {
-                        parsedValue(buffer);
-                        value_length=buffer.length();
-                    }
-                    else
-                        parsedParam(buffer,value_length,param_name,param_value);
-                    nws_length=buffer.length();
-                    param_name=param_value=-1;
-                    buffer.append(c);
-                    last_length=++nws_length;
-                    state=State.PARAM_NAME;
-                    continue;
-                    
-                case ',':
-                case 0:
-                    if (nws_length>0)
-                    {
-                        buffer.setLength(nws_length); // trim following OWS
-                        switch(state)
-                        {
-                            case VALUE:
-                                parsedValue(buffer);
-                                value_length=buffer.length();
-                                break;
-                            case PARAM_NAME:
-                            case PARAM_VALUE:
-                                parsedParam(buffer,value_length,param_name,param_value);
-                                break;
-                        }
-                        _values.add(buffer.toString());
-                    }
-                    buffer.setLength(0);
-                    last_length=0;
-                    nws_length=0;
-                    value_length=param_name=param_value=-1;
-                    state=State.VALUE;
-                    continue;
-
-                case '=':
-                    switch (state)
-                    {
-                        case VALUE:
-                            // It wasn't really a value, it was a param name
-                            value_length=param_name=0;
-                            buffer.setLength(nws_length); // trim following OWS
-                            String param = buffer.toString();
-                            buffer.setLength(0);
-                            parsedValue(buffer);
-                            value_length=buffer.length();
-                            buffer.append(param);
-                            buffer.append(c);
-                            last_length=++nws_length;
-                            state=State.PARAM_VALUE;
-                            continue;
-
-                        case PARAM_NAME:
-                            buffer.setLength(nws_length); // trim following OWS
-                            buffer.append(c);
-                            last_length=++nws_length;
-                            state=State.PARAM_VALUE;
-                            continue;
-
-                        case PARAM_VALUE:
-                            if (param_value<0)
-                                param_value=nws_length;
-                            buffer.append(c);
-                            nws_length=buffer.length();
-                            continue;
-                    }
-                    continue;
-                    
-                default:
-                {
-                    switch (state)
-                    {
-                        case VALUE:
-                        {
-                            buffer.append(c);
-                            nws_length=buffer.length();
-                            continue;
-                        }
-
-                        case PARAM_NAME:
-                        {
-                            if (param_name<0)
-                                param_name=nws_length;
-                            buffer.append(c);
-                            nws_length=buffer.length();
-                            continue;
-                        }
-
-                        case PARAM_VALUE:
-                        {
-                            if (param_value<0)
-                                param_value=nws_length;
-                            buffer.append(c);
-                            nws_length=buffer.length();
-                            continue;
-                        }
-                    }
-                }
-            }  
-        }
-    }
-
-    /**
-     * Called when a value has been parsed
-     * @param buffer Containing the trimmed value, which may be mutated
-     */
-    protected void parsedValue(StringBuffer buffer)
-    {
-    }
-
-    /**
-     * Called when a parameter has been parsed
-     * @param buffer Containing the trimmed value and all parameters, which may be mutated
-     * @param valueLength The length of the value
-     * @param paramName The index of the start of the parameter just parsed
-     * @param paramValue The index of the start of the parameter value just parsed, or -1
-     */
-    protected void parsedParam(StringBuffer buffer, int valueLength, int paramName, int paramValue)
-    {
+        _values.add(buffer.toString());
     }
 
     public int size()
@@ -274,55 +72,7 @@ public class QuotedCSV implements Iterable<String>
     {
         return _values.iterator();
     }
-    
-    public static String unquote(String s)
-    {
-        // handle trivial cases
-        int l=s.length();
-        if (s==null || l==0)
-            return s;
-        
-        // Look for any quotes
-        int i=0;
-        for (;i<l;i++)
-        {
-            char c=s.charAt(i);
-            if (c=='"')
-                break;
-        }
-        if (i==l)
-            return s;
 
-        boolean quoted=true;
-        boolean sloshed=false;
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(s,0,i);
-        i++;
-        for (;i<l;i++)
-        {
-            char c=s.charAt(i);
-            if (quoted)
-            {
-                if (sloshed)
-                {
-                    buffer.append(c);
-                    sloshed=false;
-                }
-                else if (c=='"')
-                    quoted=false;
-                else if (c=='\\')
-                    sloshed=true;
-                else
-                    buffer.append(c);
-            }
-            else if (c=='"')
-                quoted=true;
-            else
-                buffer.append(c);
-        }
-        return buffer.toString();
-    }
-    
     @Override
     public String toString()
     {

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSVParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSVParser.java
@@ -1,0 +1,288 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+public abstract class QuotedCSVParser
+{
+    private enum State { VALUE, PARAM_NAME, PARAM_VALUE}
+
+    protected final boolean _keepQuotes;
+
+    public QuotedCSVParser(boolean keepQuotes)
+    {
+        _keepQuotes=keepQuotes;
+    }
+
+    public static String unquote(String s)
+    {
+        // handle trivial cases
+        int l=s.length();
+        if (s==null || l==0)
+            return s;
+
+        // Look for any quotes
+        int i=0;
+        for (;i<l;i++)
+        {
+            char c=s.charAt(i);
+            if (c=='"')
+                break;
+        }
+        if (i==l)
+            return s;
+
+        boolean quoted=true;
+        boolean sloshed=false;
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(s,0,i);
+        i++;
+        for (;i<l;i++)
+        {
+            char c=s.charAt(i);
+            if (quoted)
+            {
+                if (sloshed)
+                {
+                    buffer.append(c);
+                    sloshed=false;
+                }
+                else if (c=='"')
+                    quoted=false;
+                else if (c=='\\')
+                    sloshed=true;
+                else
+                    buffer.append(c);
+            }
+            else if (c=='"')
+                quoted=true;
+            else
+                buffer.append(c);
+        }
+        return buffer.toString();
+    }
+
+    /** Add and parse a value string(s)
+     * @param value A value that may contain one or more Quoted CSV items.
+     */
+    public void addValue(String value)
+    {
+        if (value == null)
+            return;
+
+        StringBuffer buffer = new StringBuffer();
+
+        int l=value.length();
+        State state=State.VALUE;
+        boolean quoted=false;
+        boolean sloshed=false;
+        int nws_length=0;
+        int last_length=0;
+        int value_length=-1;
+        int param_name=-1;
+        int param_value=-1;
+
+        for (int i=0;i<=l;i++)
+        {
+            char c=i==l?0:value.charAt(i);
+
+            // Handle quoting https://tools.ietf.org/html/rfc7230#section-3.2.6
+            if (quoted && c!=0)
+            {
+                if (sloshed)
+                    sloshed=false;
+                else
+                {
+                    switch(c)
+                    {
+                        case '\\':
+                            sloshed=true;
+                            if (!_keepQuotes)
+                                continue;
+                            break;
+                        case '"':
+                            quoted=false;
+                            if (!_keepQuotes)
+                                continue;
+                            break;
+                    }
+                }
+
+                buffer.append(c);
+                nws_length=buffer.length();
+                continue;
+            }
+
+            // Handle common cases
+            switch(c)
+            {
+                case ' ':
+                case '\t':
+                    if (buffer.length()>last_length) // not leading OWS
+                        buffer.append(c);
+                    continue;
+
+                case '"':
+                    quoted=true;
+                    if (_keepQuotes)
+                    {
+                        if (state==State.PARAM_VALUE && param_value<0)
+                            param_value=nws_length;
+                        buffer.append(c);
+                    }
+                    else if (state==State.PARAM_VALUE && param_value<0)
+                        param_value=nws_length;
+                    nws_length=buffer.length();
+                    continue;
+
+                case ';':
+                    buffer.setLength(nws_length); // trim following OWS
+                    if (state==State.VALUE)
+                    {
+                        parsedValue(buffer);
+                        value_length=buffer.length();
+                    }
+                    else
+                        parsedParam(buffer,value_length,param_name,param_value);
+                    nws_length=buffer.length();
+                    param_name=param_value=-1;
+                    buffer.append(c);
+                    last_length=++nws_length;
+                    state=State.PARAM_NAME;
+                    continue;
+
+                case ',':
+                case 0:
+                    if (nws_length>0)
+                    {
+                        buffer.setLength(nws_length); // trim following OWS
+                        switch(state)
+                        {
+                            case VALUE:
+                                parsedValue(buffer);
+                                value_length=buffer.length();
+                                break;
+                            case PARAM_NAME:
+                            case PARAM_VALUE:
+                                parsedParam(buffer,value_length,param_name,param_value);
+                                break;
+                        }
+                        parsedValueAndParams(buffer);
+                    }
+                    buffer.setLength(0);
+                    last_length=0;
+                    nws_length=0;
+                    value_length=param_name=param_value=-1;
+                    state=State.VALUE;
+                    continue;
+
+                case '=':
+                    switch (state)
+                    {
+                        case VALUE:
+                            // It wasn't really a value, it was a param name
+                            value_length=param_name=0;
+                            buffer.setLength(nws_length); // trim following OWS
+                            String param = buffer.toString();
+                            buffer.setLength(0);
+                            parsedValue(buffer);
+                            value_length=buffer.length();
+                            buffer.append(param);
+                            buffer.append(c);
+                            last_length=++nws_length;
+                            state=State.PARAM_VALUE;
+                            continue;
+
+                        case PARAM_NAME:
+                            buffer.setLength(nws_length); // trim following OWS
+                            buffer.append(c);
+                            last_length=++nws_length;
+                            state=State.PARAM_VALUE;
+                            continue;
+
+                        case PARAM_VALUE:
+                            if (param_value<0)
+                                param_value=nws_length;
+                            buffer.append(c);
+                            nws_length=buffer.length();
+                            continue;
+                    }
+                    continue;
+
+                default:
+                {
+                    switch (state)
+                    {
+                        case VALUE:
+                        {
+                            buffer.append(c);
+                            nws_length=buffer.length();
+                            continue;
+                        }
+
+                        case PARAM_NAME:
+                        {
+                            if (param_name<0)
+                                param_name=nws_length;
+                            buffer.append(c);
+                            nws_length=buffer.length();
+                            continue;
+                        }
+
+                        case PARAM_VALUE:
+                        {
+                            if (param_value<0)
+                                param_value=nws_length;
+                            buffer.append(c);
+                            nws_length=buffer.length();
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when a value and it's parameters has been parsed
+     * @param buffer Containing the trimmed value and parameters
+     */
+    protected void parsedValueAndParams(StringBuffer buffer)
+    {
+    }
+
+    /**
+     * Called when a value has been parsed (prior to any parameters)
+     * @param buffer Containing the trimmed value, which may be mutated
+     */
+    protected void parsedValue(StringBuffer buffer)
+    {
+    }
+
+    /**
+     * Called when a parameter has been parsed
+     * @param buffer Containing the trimmed value and all parameters, which may be mutated
+     * @param valueLength The length of the value
+     * @param paramName The index of the start of the parameter just parsed
+     * @param paramValue The index of the start of the parameter value just parsed, or -1
+     */
+    protected void parsedParam(StringBuffer buffer, int valueLength, int paramName, int paramValue)
+    {
+    }
+
+}

--- a/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/ForwardBenchmark.java
+++ b/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/ForwardBenchmark.java
@@ -1,0 +1,196 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.jmh;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.ArrayTrie;
+import org.eclipse.jetty.util.Trie;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.foldArguments;
+import static java.lang.invoke.MethodType.methodType;
+
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class ForwardBenchmark
+{
+    static HttpFields __fields = new HttpFields();
+    static
+    {
+        Arrays.stream(new String[][]
+            {
+                {"accept", "*/*"},
+                {"accept-encoding", "gzip, deflate, br"},
+                {"accept-language", "en,en-AU;q=0.9,it;q=0.8"},
+                {"content-length", "0"},
+                {"content-type", "text/plain;charset=UTF-8"},
+                {"cookie", "S=maestro=cH6W-eZ0JweknIgCwBxWD4FxQk647Uru:sso=HEiTd0qT5KdU7X6eL1m8snK1jNHwVJ9d"},
+                {"origin", "https://www.google.com"},
+                {"referer", "https://www.google.com/"},
+                {"user-agent", "Mozilla/5.0"},
+                {"x-client-data", "CLK1yQEIkLbJAQiltskBCKmdygEIoZ7KAQioo8oBCL+nygEI4qjKAQ=="},
+                {"Forwarded", "for=192.0.2.43,for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com"}
+            }).map(a->new HttpField(a[0],a[1])).forEach(__fields::add);
+    }
+
+    public ForwardBenchmark()
+    {
+    }
+
+
+
+    @Benchmark
+    @BenchmarkMode({ Mode.Throughput})
+    public String testStringCompare()
+    {
+        String forwardedFor = null;
+        String forwardedHost = null;
+        String forwardedServer = null;
+        String forwarded = null;
+
+        for (HttpField field : __fields)
+        {
+            String name = field.getName();
+            if (HttpHeader.X_FORWARDED_FOR.asString().equalsIgnoreCase(name))
+                forwardedFor = field.getValue();
+            else if (HttpHeader.X_FORWARDED_HOST.asString().equalsIgnoreCase(name))
+                forwardedHost = field.getValue();
+            else if (HttpHeader.X_FORWARDED_SERVER.asString().equalsIgnoreCase(name))
+                forwardedServer = field.getValue();
+            else if (HttpHeader.FORWARDED.asString().equalsIgnoreCase(name))
+                forwardedServer = field.getValue();
+        }
+
+        if (forwardedFor!=null)
+            return forwardedFor;
+        if (forwardedHost!=null)
+            return forwardedHost;
+        if (forwardedServer!=null)
+            return forwardedServer;
+        return forwarded;
+    }
+
+
+
+    static class Forwarded
+    {
+        String host;
+
+        public void getHost(HttpField field)
+        {
+            if (host==null)
+                host = field.getValue();
+        }
+    }
+
+    static Trie<MethodHandle> __handles = new ArrayTrie<>(1024);
+    static
+    {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType type = methodType(Void.TYPE, HttpField.class);
+
+        try
+        {
+            __handles.put(HttpHeader.X_FORWARDED_FOR.asString(), lookup.findVirtual(Forwarded.class, "getHost", type));
+            __handles.put(HttpHeader.X_FORWARDED_HOST.asString(), lookup.findVirtual(Forwarded.class, "getHost", type));
+            __handles.put(HttpHeader.X_FORWARDED_SERVER.asString(), lookup.findVirtual(Forwarded.class, "getHost", type));
+            __handles.put(HttpHeader.FORWARDED.asString(), lookup.findVirtual(Forwarded.class, "getHost", type));
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Benchmark
+    @BenchmarkMode({ Mode.Throughput})
+    public String testTrieMethodHandle()
+    {
+        Forwarded forwarded = new Forwarded();
+
+        try
+        {
+            for (HttpField field : __fields)
+            {
+                MethodHandle handle = __handles.get(field.getName());
+                if (handle != null)
+                    handle.invoke(forwarded, field);
+            }
+        }
+        catch (Throwable e)
+        {
+            e.printStackTrace();
+        }
+
+        return forwarded.host;
+    }
+
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(ForwardBenchmark.class.getSimpleName())
+            .warmupIterations(20)
+            .measurementIterations(10)
+            .addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(100)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
+++ b/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
@@ -11,6 +11,7 @@
         <Set name="forwardedServerHeader"><Property name="jetty.httpConfig.forwardedServerHeader" default="X-Forwarded-Server"/></Set>
         <Set name="forwardedProtoHeader"><Property name="jetty.httpConfig.forwardedProtoHeader" default="X-Forwarded-Proto"/></Set>
         <Set name="forwardedForHeader"><Property name="jetty.httpConfig.forwardedForHeader" default="X-Forwarded-For"/></Set>
+        <Set name="forwardedPortHeader"><Property name="jetty.httpConfig.forwardedPortHeader" default="X-Forwarded-Port"/></Set>
         <Set name="forwardedHttpsHeader"><Property name="jetty.httpConfig.forwardedHttpsHeader" default="X-Proxied-Https"/></Set>
         <Set name="forwardedSslSessionIdHeader"><Property name="jetty.httpConfig.forwardedSslSessionIdHeader" default="Proxy-ssl-id" /></Set>
         <Set name="forwardedCipherSuiteHeader"><Property name="jetty.httpConfig.forwardedCipherSuiteHeader" default="Proxy-auth-cert"/></Set>

--- a/jetty-server/src/main/config/modules/http-forwarded.mod
+++ b/jetty-server/src/main/config/modules/http-forwarded.mod
@@ -23,6 +23,7 @@ etc/jetty-http-forwarded.xml
 # jetty.httpConfig.forwardedServerHeader=X-Forwarded-Server
 # jetty.httpConfig.forwardedProtoHeader=X-Forwarded-Proto
 # jetty.httpConfig.forwardedForHeader=X-Forwarded-For
+# jetty.httpConfig.forwardedPortHeader=X-Forwarded-Port
 # jetty.httpConfig.forwardedHttpsHeader=X-Proxied-Https
 # jetty.httpConfig.forwardedSslSessionIdHeader=Proxy-ssl-id
 # jetty.httpConfig.forwardedCipherSuiteHeader=Proxy-auth-cert

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -43,7 +43,9 @@ import static java.lang.invoke.MethodType.methodType;
 
 
 /* ------------------------------------------------------------ */
-/** Customize Requests for Proxy Forwarding.
+
+/**
+ * Customize Requests for Proxy Forwarding.
  * <p>
  * This customizer looks at at HTTP request for headers that indicate
  * it has been forwarded by one or more proxies.  Specifically handled are
@@ -59,7 +61,8 @@ import static java.lang.invoke.MethodType.methodType;
  * so that the proxy is not seen as the other end point of the connection on which
  * the request came</p>
  * <p>Headers can also be defined so that forwarded SSL Session IDs and Cipher
- * suites may be customised</p> 
+ * suites may be customised</p>
+ *
  * @see <a href="http://en.wikipedia.org/wiki/X-Forwarded-For">Wikipedia: X-Forwarded-For</a>
  */
 public class ForwardedRequestCustomizer implements Customizer
@@ -76,9 +79,9 @@ public class ForwardedRequestCustomizer implements Customizer
     private String _forwardedHttpsHeader = "X-Proxied-Https";
     private String _forwardedCipherSuiteHeader = "Proxy-auth-cert";
     private String _forwardedSslSessionIdHeader = "Proxy-ssl-id";
-    private boolean _proxyAsAuthority=false;
-    private boolean _sslIsSecure=true;
-    private Trie <MethodHandle> _handles;
+    private boolean _proxyAsAuthority = false;
+    private boolean _sslIsSecure = true;
+    private Trie<MethodHandle> _handles;
 
     public ForwardedRequestCustomizer()
     {
@@ -97,7 +100,7 @@ public class ForwardedRequestCustomizer implements Customizer
 
     /**
      * @param proxyAsAuthority if true, use the proxy address obtained via
-     * {@code X-Forwarded-Server} or RFC7239 "by" as the request authority.
+     *                         {@code X-Forwarded-Server} or RFC7239 "by" as the request authority.
      */
     public void setProxyAsAuthority(boolean proxyAsAuthority)
     {
@@ -114,49 +117,47 @@ public class ForwardedRequestCustomizer implements Customizer
     {
         if (rfc7239only)
         {
-            if (_forwardedHeader==null)
-                _forwardedHeader=HttpHeader.FORWARDED.toString();
-            _forwardedHostHeader=null;
-            _forwardedServerHeader=null;
-            _forwardedForHeader=null;
-            _forwardedPortHeader=null;
-            _forwardedProtoHeader=null;
-            _forwardedHttpsHeader=null;
+            if (_forwardedHeader == null)
+                _forwardedHeader = HttpHeader.FORWARDED.toString();
+            _forwardedHostHeader = null;
+            _forwardedServerHeader = null;
+            _forwardedForHeader = null;
+            _forwardedPortHeader = null;
+            _forwardedProtoHeader = null;
+            _forwardedHttpsHeader = null;
         }
         else
         {
-            if (_forwardedHostHeader==null)
+            if (_forwardedHostHeader == null)
                 _forwardedHostHeader = HttpHeader.X_FORWARDED_HOST.toString();
-            if (_forwardedServerHeader==null)
+            if (_forwardedServerHeader == null)
                 _forwardedServerHeader = HttpHeader.X_FORWARDED_SERVER.toString();
-            if (_forwardedForHeader==null)
+            if (_forwardedForHeader == null)
                 _forwardedForHeader = HttpHeader.X_FORWARDED_FOR.toString();
-            if (_forwardedPortHeader==null)
+            if (_forwardedPortHeader == null)
                 _forwardedPortHeader = HttpHeader.X_FORWARDED_PORT.toString();
-            if (_forwardedProtoHeader==null)
+            if (_forwardedProtoHeader == null)
                 _forwardedProtoHeader = HttpHeader.X_FORWARDED_PROTO.toString();
-            if (_forwardedHttpsHeader==null)
+            if (_forwardedHttpsHeader == null)
                 _forwardedHttpsHeader = "X-Proxied-Https";
         }
 
         updateHandles();
     }
-    
+
     public String getForcedHost()
     {
         return _forcedHost.getValue();
     }
-    
+
     /**
      * Set a forced valued for the host header to control what is returned by {@link ServletRequest#getServerName()} and {@link ServletRequest#getServerPort()}.
      *
-     * @param hostAndPort
-     *            The value of the host header to force.
+     * @param hostAndPort The value of the host header to force.
      */
     public void setForcedHost(String hostAndPort)
     {
         _forcedHost = new HostPortHttpField(hostAndPort);
-        updateHandles();
     }
 
     /**
@@ -168,13 +169,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedHeader 
-     *            The header name for RFC forwarded (default Forwarded)
+     * @param forwardedHeader The header name for RFC forwarded (default Forwarded)
      */
     public void setForwardedHeader(String forwardedHeader)
     {
-        _forwardedHeader = forwardedHeader;
-        updateHandles();
+        if (_forwardedHeader == null || !_forwardedHeader.equals(forwardedHeader))
+        {
+            _forwardedHeader = forwardedHeader;
+            updateHandles();
+        }
     }
 
     public String getForwardedHostHeader()
@@ -183,13 +186,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedHostHeader
-     *            The header name for forwarded hosts (default {@code X-Forwarded-Host})
+     * @param forwardedHostHeader The header name for forwarded hosts (default {@code X-Forwarded-Host})
      */
     public void setForwardedHostHeader(String forwardedHostHeader)
     {
-        _forwardedHostHeader = forwardedHostHeader;
-        updateHandles();
+        if (_forwardedHostHeader == null || !_forwardedHostHeader.equalsIgnoreCase(forwardedHostHeader))
+        {
+            _forwardedHostHeader = forwardedHostHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -201,13 +206,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedServerHeader
-     *            The header name for forwarded server (default {@code X-Forwarded-Server})
+     * @param forwardedServerHeader The header name for forwarded server (default {@code X-Forwarded-Server})
      */
     public void setForwardedServerHeader(String forwardedServerHeader)
     {
-        _forwardedServerHeader = forwardedServerHeader;
-        updateHandles();
+        if (_forwardedServerHeader == null || !_forwardedServerHeader.equalsIgnoreCase(forwardedServerHeader))
+        {
+            _forwardedServerHeader = forwardedServerHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -219,13 +226,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedRemoteAddressHeader
-     *            The header name for forwarded for (default {@code X-Forwarded-For})
+     * @param forwardedRemoteAddressHeader The header name for forwarded for (default {@code X-Forwarded-For})
      */
     public void setForwardedForHeader(String forwardedRemoteAddressHeader)
     {
-        _forwardedForHeader = forwardedRemoteAddressHeader;
-        updateHandles();
+        if (_forwardedForHeader == null || !_forwardedForHeader.equalsIgnoreCase(forwardedRemoteAddressHeader))
+        {
+            _forwardedForHeader = forwardedRemoteAddressHeader;
+            updateHandles();
+        }
     }
 
     public String getForwardedPortHeader()
@@ -234,13 +243,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedPortHeader
-     *            The header name for forwarded hosts (default {@code X-Forwarded-Port})
+     * @param forwardedPortHeader The header name for forwarded hosts (default {@code X-Forwarded-Port})
      */
     public void setForwardedPortHeader(String forwardedPortHeader)
     {
-        _forwardedHostHeader = forwardedPortHeader;
-        updateHandles();
+        if (_forwardedHostHeader == null || !_forwardedHostHeader.equalsIgnoreCase(forwardedPortHeader))
+        {
+            _forwardedHostHeader = forwardedPortHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -256,13 +267,15 @@ public class ForwardedRequestCustomizer implements Customizer
     /**
      * Set the forwardedProtoHeader.
      *
-     * @param forwardedProtoHeader
-     *            the forwardedProtoHeader to set (default {@code X-Forwarded-Proto})
+     * @param forwardedProtoHeader the forwardedProtoHeader to set (default {@code X-Forwarded-Proto})
      */
     public void setForwardedProtoHeader(String forwardedProtoHeader)
     {
-        _forwardedProtoHeader = forwardedProtoHeader;
-        updateHandles();
+        if (_forwardedProtoHeader == null || !_forwardedProtoHeader.equalsIgnoreCase(forwardedProtoHeader))
+        {
+            _forwardedProtoHeader = forwardedProtoHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -274,13 +287,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedCipherSuite
-     *            The header name holding a forwarded cipher suite (default {@code Proxy-auth-cert})
+     * @param forwardedCipherSuiteHeader The header name holding a forwarded cipher suite (default {@code Proxy-auth-cert})
      */
-    public void setForwardedCipherSuiteHeader(String forwardedCipherSuite)
+    public void setForwardedCipherSuiteHeader(String forwardedCipherSuiteHeader)
     {
-        _forwardedCipherSuiteHeader = forwardedCipherSuite;
-        updateHandles();
+        if (_forwardedCipherSuiteHeader == null || !_forwardedCipherSuiteHeader.equalsIgnoreCase(forwardedCipherSuiteHeader))
+        {
+            _forwardedCipherSuiteHeader = forwardedCipherSuiteHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -292,13 +307,15 @@ public class ForwardedRequestCustomizer implements Customizer
     }
 
     /**
-     * @param forwardedSslSessionId
-     *            The header name holding a forwarded SSL Session ID (default {@code Proxy-ssl-id})
+     * @param forwardedSslSessionIdHeader The header name holding a forwarded SSL Session ID (default {@code Proxy-ssl-id})
      */
-    public void setForwardedSslSessionIdHeader(String forwardedSslSessionId)
+    public void setForwardedSslSessionIdHeader(String forwardedSslSessionIdHeader)
     {
-        _forwardedSslSessionIdHeader = forwardedSslSessionId;
-        updateHandles();
+        if (_forwardedSslSessionIdHeader == null || !_forwardedSslSessionIdHeader.equalsIgnoreCase(forwardedSslSessionIdHeader))
+        {
+            _forwardedSslSessionIdHeader = forwardedSslSessionIdHeader;
+            updateHandles();
+        }
     }
 
     /**
@@ -314,10 +331,13 @@ public class ForwardedRequestCustomizer implements Customizer
      */
     public void setForwardedHttpsHeader(String forwardedHttpsHeader)
     {
-        _forwardedHttpsHeader = forwardedHttpsHeader;
-        updateHandles();
+        if (_forwardedHttpsHeader == null || !_forwardedHttpsHeader.equalsIgnoreCase(forwardedHttpsHeader))
+        {
+            _forwardedHttpsHeader = forwardedHttpsHeader;
+            updateHandles();
+        }
     }
-    
+
     /**
      * @return true if the presence of a SSL session or certificate header is sufficient
      * to indicate a secure request (default is true)
@@ -329,7 +349,7 @@ public class ForwardedRequestCustomizer implements Customizer
 
     /**
      * @param sslIsSecure true if the presence of a SSL session or certificate header is sufficient
-     * to indicate a secure request (default is true)
+     *                    to indicate a secure request (default is true)
      */
     public void setSslIsSecure(boolean sslIsSecure)
     {
@@ -362,13 +382,13 @@ public class ForwardedRequestCustomizer implements Customizer
         {
             // Update host header
             httpFields.put(_forcedHost);
-            request.setAuthority(_forcedHost.getHost(),_forcedHost.getPort());
+            request.setAuthority(_forcedHost.getHost(), _forcedHost.getPort());
         }
-        else if (forwarded._rfc7239!=null && forwarded._rfc7239._host!=null)
+        else if (forwarded._rfc7239 != null && forwarded._rfc7239._host != null)
         {
             HostPortHttpField auth = forwarded._rfc7239._host;
             httpFields.put(auth);
-            request.setAuthority(auth.getHost(),auth.getPort());
+            request.setAuthority(auth.getHost(), auth.getPort());
         }
         else if (forwarded._forwardedHost != null)
         {
@@ -378,26 +398,26 @@ public class ForwardedRequestCustomizer implements Customizer
         }
         else if (_proxyAsAuthority)
         {
-            if (forwarded._rfc7239!=null && forwarded._rfc7239._by!=null)
+            if (forwarded._rfc7239 != null && forwarded._rfc7239._by != null)
             {
                 HostPortHttpField auth = forwarded._rfc7239._by;
                 httpFields.put(auth);
-                request.setAuthority(auth.getHost(),auth.getPort());
+                request.setAuthority(auth.getHost(), auth.getPort());
             }
             else if (forwarded._forwardedServer != null)
             {
-                request.setAuthority(forwarded._forwardedServer,request.getServerPort());
+                request.setAuthority(forwarded._forwardedServer, request.getServerPort());
             }
         }
 
         // handle remote end identifier
-        if (forwarded._rfc7239!=null && forwarded._rfc7239._for!=null)
+        if (forwarded._rfc7239 != null && forwarded._rfc7239._for != null)
         {
-            request.setRemoteAddr(InetSocketAddress.createUnresolved(forwarded._rfc7239._for.getHost(),forwarded._rfc7239._for.getPort()));
+            request.setRemoteAddr(InetSocketAddress.createUnresolved(forwarded._rfc7239._for.getHost(), forwarded._rfc7239._for.getPort()));
         }
         else if (forwarded._forwardedFor != null)
         {
-            int port = (forwarded._forwardedPort>0)
+            int port = (forwarded._forwardedPort > 0)
                 ? forwarded._forwardedPort
                 : (forwarded._forwardedFor.getPort() > 0)
                 ? forwarded._forwardedFor.getPort()
@@ -406,7 +426,7 @@ public class ForwardedRequestCustomizer implements Customizer
         }
 
         // handle protocol identifier
-        if (forwarded._rfc7239!=null && forwarded._rfc7239._proto!=null)
+        if (forwarded._rfc7239 != null && forwarded._rfc7239._proto != null)
         {
             request.setScheme(forwarded._rfc7239._proto);
             if (forwarded._rfc7239._proto.equals(config.getSecureScheme()))
@@ -418,7 +438,7 @@ public class ForwardedRequestCustomizer implements Customizer
             if (forwarded._forwardedProto.equals(config.getSecureScheme()))
                 request.setSecure(true);
         }
-        else if (forwarded._forwardedHttps !=null && ("on".equalsIgnoreCase(forwarded._forwardedHttps)||"true".equalsIgnoreCase(forwarded._forwardedHttps)))
+        else if (forwarded._forwardedHttps != null && ("on".equalsIgnoreCase(forwarded._forwardedHttps) || "true".equalsIgnoreCase(forwarded._forwardedHttps)))
         {
             request.setScheme(HttpScheme.HTTPS.asString());
             if (HttpScheme.HTTPS.asString().equals(config.getSecureScheme()))
@@ -441,7 +461,7 @@ public class ForwardedRequestCustomizer implements Customizer
         }
 
         // The left-most value is the farthest downstream client
-        return headerValue.substring(0,commaIndex).trim();
+        return headerValue.substring(0, commaIndex).trim();
     }
 
     protected HostPort getRemoteAddr(String headerValue)
@@ -463,11 +483,11 @@ public class ForwardedRequestCustomizer implements Customizer
             return null;
         }
     }
-    
+
     @Override
     public String toString()
     {
-        return String.format("%s@%x",this.getClass().getSimpleName(),hashCode());
+        return String.format("%s@%x", this.getClass().getSimpleName(), hashCode());
     }
 
     @Deprecated
@@ -475,12 +495,11 @@ public class ForwardedRequestCustomizer implements Customizer
     {
         return _forcedHost.getValue();
     }
-    
+
     /**
      * Set a forced valued for the host header to control what is returned by {@link ServletRequest#getServerName()} and {@link ServletRequest#getServerPort()}.
      *
-     * @param hostHeader
-     *            The value of the host header to force.
+     * @param hostHeader The value of the host header to force.
      */
     @Deprecated
     public void setHostHeader(String hostHeader)
@@ -494,7 +513,7 @@ public class ForwardedRequestCustomizer implements Customizer
         HostPortHttpField _for;
         HostPortHttpField _host;
         String _proto;
-        
+
         private RFC7239()
         {
             super(false);
@@ -503,27 +522,27 @@ public class ForwardedRequestCustomizer implements Customizer
         @Override
         protected void parsedParam(StringBuffer buffer, int valueLength, int paramName, int paramValue)
         {
-            if (valueLength==0 && paramValue>paramName)
+            if (valueLength == 0 && paramValue > paramName)
             {
-                String name=StringUtil.asciiToLowerCase(buffer.substring(paramName,paramValue-1));
-                String value=buffer.substring(paramValue);
-                switch(name)
+                String name = StringUtil.asciiToLowerCase(buffer.substring(paramName, paramValue - 1));
+                String value = buffer.substring(paramValue);
+                switch (name)
                 {
                     case "by":
-                        if (_by==null && !value.startsWith("_") && !"unknown".equals(value))
-                            _by=new HostPortHttpField(value);
+                        if (_by == null && !value.startsWith("_") && !"unknown".equals(value))
+                            _by = new HostPortHttpField(value);
                         break;
                     case "for":
-                        if (_for==null && !value.startsWith("_") && !"unknown".equals(value))
-                            _for=new HostPortHttpField(value);
+                        if (_for == null && !value.startsWith("_") && !"unknown".equals(value))
+                            _for = new HostPortHttpField(value);
                         break;
                     case "host":
-                        if (_host==null)
-                            _host=new HostPortHttpField(value);
+                        if (_host == null)
+                            _host = new HostPortHttpField(value);
                         break;
                     case "proto":
-                        if (_proto==null)
-                            _proto=value;
+                        if (_proto == null)
+                            _proto = value;
                         break;
                 }
             }
@@ -536,7 +555,7 @@ public class ForwardedRequestCustomizer implements Customizer
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         MethodType type = methodType(Void.TYPE, HttpField.class);
 
-        while(true)
+        while (true)
         {
             try
             {
@@ -563,7 +582,7 @@ public class ForwardedRequestCustomizer implements Customizer
                     continue;
                 break;
             }
-            catch (NoSuchMethodException|IllegalAccessException e)
+            catch (NoSuchMethodException | IllegalAccessException e)
             {
                 throw new IllegalStateException(e);
             }
@@ -591,7 +610,7 @@ public class ForwardedRequestCustomizer implements Customizer
 
         public void handleCipherSuite(HttpField field)
         {
-            _request.setAttribute("javax.servlet.request.cipher_suite",field.getValue());
+            _request.setAttribute("javax.servlet.request.cipher_suite", field.getValue());
             if (isSslIsSecure())
             {
                 _request.setSecure(true);
@@ -633,6 +652,7 @@ public class ForwardedRequestCustomizer implements Customizer
         {
             _forwardedPort = field.getIntValue();
         }
+
         public void handleHttps(HttpField field)
         {
             _forwardedHttps = getLeftMost(field.getValue());
@@ -640,11 +660,9 @@ public class ForwardedRequestCustomizer implements Customizer
 
         public void handleRFC7239(HttpField field)
         {
-            if (_rfc7239 ==null)
+            if (_rfc7239 == null)
                 _rfc7239 = new RFC7239();
             _rfc7239.addValue(field.getValue());
         }
-
-
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -18,11 +18,6 @@
 
 package org.eclipse.jetty.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -40,6 +35,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ForwardedRequestCustomizerTest
 {
@@ -247,6 +247,23 @@ public class ForwardedRequestCustomizerTest
         assertEquals("80",_results.poll());
         assertEquals("[2001:db8:cafe::17]",_results.poll());
         assertEquals("1111",_results.poll());
+    }
+
+    @Test
+    public void testForIpv6AndPort() throws Exception
+    {
+        String response=_connector.getResponse(
+                "GET / HTTP/1.1\n"+
+                        "Host: myhost\n"+
+                        "X-Forwarded-For: 1:2:3:4:5:6:7:8\n"+
+                        "X-Forwarded-Port: 2222\n"+
+                        "\n");
+        assertThat(response, Matchers.containsString("200 OK"));
+        assertEquals("http",_results.poll());
+        assertEquals("myhost",_results.poll());
+        assertEquals("80",_results.poll());
+        assertEquals("[1:2:3:4:5:6:7:8]",_results.poll());
+        assertEquals("2222",_results.poll());
     }
 
     @Test

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
@@ -32,6 +32,12 @@ public class HostPort
     private final String _host;
     private final int _port;
 
+    public HostPort(String host, int port) throws IllegalArgumentException
+    {
+        _host = host;
+        _port = port;
+    }
+
     public HostPort(String authority) throws IllegalArgumentException
     {
         if (authority==null)
@@ -66,8 +72,16 @@ public class HostPort
                 int c = authority.lastIndexOf(':');
                 if (c>=0)
                 {
-                    _host=authority.substring(0,c);
-                    _port=StringUtil.toInt(authority,c+1);
+                    if (c!=authority.indexOf(':'))
+                    {
+                        _host="[" + authority + "]";
+                        _port=0;
+                    }
+                    else
+                    {
+                        _host = authority.substring(0, c);
+                        _port = StringUtil.toInt(authority, c + 1);
+                    }
                 }
                 else
                 {
@@ -93,7 +107,6 @@ public class HostPort
             throw new IllegalArgumentException("Bad port");
     }
 
-    /* ------------------------------------------------------------ */
     /** Get the host.
      * @return the host
      */
@@ -102,7 +115,6 @@ public class HostPort
         return _host;
     }
 
-    /* ------------------------------------------------------------ */
     /** Get the port.
      * @return the port
      */
@@ -111,7 +123,6 @@ public class HostPort
         return _port;
     }
     
-    /* ------------------------------------------------------------ */
     /** Get the port.
      * @param defaultPort, the default port to return if a port is not specified
      * @return the port
@@ -121,7 +132,14 @@ public class HostPort
         return _port>0?_port:defaultPort;
     }
 
-    /* ------------------------------------------------------------ */
+    @Override
+    public String toString()
+    {
+        if (_port>0)
+            return normalizeHost(_host) + ":" + _port;
+        return _host;
+    }
+
     /** Normalize IPv6 address as per https://www.ietf.org/rfc/rfc2732.txt
      * @param host A host name
      * @return Host name surrounded by '[' and ']' as needed.

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
@@ -42,7 +42,28 @@ public class HostPortTest
                 Arguments.of("10.10.10.1:80", "10.10.10.1", "80"),
                 Arguments.of("[0::0::0::1]", "[0::0::0::1]", null),
                 Arguments.of("[0::0::0::1]:80", "[0::0::0::1]", "80"),
-                Arguments.of("0:1:2:3:4:5:6","[0:1:2:3:4:5:6]",null)
+                Arguments.of("0:1:2:3:4:5:6","[0:1:2:3:4:5:6]",null),
+                // Localhost tests
+                Arguments.of("localhost:80", "localhost", "80"),
+                Arguments.of("127.0.0.1:80", "127.0.0.1", "80"),
+                Arguments.of("::1","[::1]",null),
+                Arguments.of("[::1]:443","[::1]","443"),
+                // Examples from https://tools.ietf.org/html/rfc2732#section-2
+                Arguments.of("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80", "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", "80"),
+                Arguments.of("[1080:0:0:0:8:800:200C:417A]", "[1080:0:0:0:8:800:200C:417A]", null),
+                Arguments.of("[3ffe:2a00:100:7031::1]", "[3ffe:2a00:100:7031::1]", null),
+                Arguments.of("[1080::8:800:200C:417A]", "[1080::8:800:200C:417A]", null),
+                Arguments.of("[::192.9.5.5]", "[::192.9.5.5]", null),
+                Arguments.of("[::FFFF:129.144.52.38]:80", "[::FFFF:129.144.52.38]", "80"),
+                Arguments.of("[2010:836B:4179::836B:4179]", "[2010:836B:4179::836B:4179]", null),
+                // Modified Examples from above, not using square brackets (valid, but should never have a port)
+                Arguments.of("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210", "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", null),
+                Arguments.of("1080:0:0:0:8:800:200C:417A", "[1080:0:0:0:8:800:200C:417A]", null),
+                Arguments.of("3ffe:2a00:100:7031::1", "[3ffe:2a00:100:7031::1]", null),
+                Arguments.of("1080::8:800:200C:417A", "[1080::8:800:200C:417A]", null),
+                Arguments.of("::192.9.5.5", "[::192.9.5.5]", null),
+                Arguments.of("::FFFF:129.144.52.38", "[::FFFF:129.144.52.38]", null),
+                Arguments.of("2010:836B:4179::836B:4179", "[2010:836B:4179::836B:4179]", null)
         );
     }
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
@@ -18,16 +18,16 @@
 
 package org.eclipse.jetty.util;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HostPortTest
 {
@@ -41,7 +41,8 @@ public class HostPortTest
                 Arguments.of("10.10.10.1", "10.10.10.1", null),
                 Arguments.of("10.10.10.1:80", "10.10.10.1", "80"),
                 Arguments.of("[0::0::0::1]", "[0::0::0::1]", null),
-                Arguments.of("[0::0::0::1]:80", "[0::0::0::1]", "80")
+                Arguments.of("[0::0::0::1]:80", "[0::0::0::1]", "80"),
+                Arguments.of("0:1:2:3:4:5:6","[0:1:2:3:4:5:6]",null)
         );
     }
 


### PR DESCRIPTION
#3630
Added support for the X-Forwarded-Port header.
HostPort now handles the case of a stand alone IPv6 address
Reimplemented header scanning using more efficient Trie and MethodHandles

Signed-off-by: Greg Wilkins <gregw@webtide.com>