### PR TITLE
fixes to websocket idle timeout

### DIFF
--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/FrameHandler.java
@@ -533,25 +533,25 @@ public interface FrameHandler extends IncomingFrames
         @Override
         public Duration getIdleTimeout()
         {
-            return idleTimeout;
+            return idleTimeout==null ? WebSocketConstants.DEFAULT_IDLE_TIMEOUT : idleTimeout;
         }
 
         @Override
         public Duration getWriteTimeout()
         {
-            return writeTimeout;
+            return writeTimeout==null ? WebSocketConstants.DEFAULT_WRITE_TIMEOUT : writeTimeout;
         }
 
         @Override
         public void setIdleTimeout(Duration timeout)
         {
-            this.idleTimeout = timeout==null ? Duration.ZERO : timeout;
+            this.idleTimeout = timeout;
         }
 
         @Override
         public void setWriteTimeout(Duration timeout)
         {
-            this.writeTimeout = timeout==null ? Duration.ZERO : timeout;
+            this.writeTimeout = timeout;
         }
 
         @Override

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
@@ -33,7 +33,7 @@ public final class WebSocketConstants
     public static final int DEFAULT_INPUT_BUFFER_SIZE = 4 * 1024;
     public static final int DEFAULT_OUTPUT_BUFFER_SIZE = 4 * 1024;
     public static final boolean DEFAULT_AUTO_FRAGMENT = true;
-    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ZERO;
+    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(30);
     public static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ZERO;
 
     /**

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConstants.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 public final class WebSocketConstants
 {
@@ -32,6 +33,8 @@ public final class WebSocketConstants
     public static final int DEFAULT_INPUT_BUFFER_SIZE = 4 * 1024;
     public static final int DEFAULT_OUTPUT_BUFFER_SIZE = 4 * 1024;
     public static final boolean DEFAULT_AUTO_FRAGMENT = true;
+    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ZERO;
+    public static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ZERO;
 
     /**
      * Globally Unique Identifier for use in WebSocket handshake within {@code Sec-WebSocket-Accept} and <code>Sec-WebSocket-Key</code> http headers.


### PR DESCRIPTION
revert change causing NPE on `ServerContainer.getDefaultMaxSessionIdleTimeout()`

always set the default websocket idle timeout on the endpoint if no other idle timeout configuration is given