### PR TITLE
Updating WebSocket Examples seen in documentation

### DIFF
--- a/jetty-websocket/websocket-client/src/test/java/examples/SimpleEchoSocket.java
+++ b/jetty-websocket/websocket-client/src/test/java/examples/SimpleEchoSocket.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 
@@ -46,13 +47,13 @@ public class SimpleEchoSocket
 
     public boolean awaitClose(int duration, TimeUnit unit) throws InterruptedException
     {
-        return this.closeLatch.await(duration,unit);
+        return this.closeLatch.await(duration, unit);
     }
 
     @OnWebSocketClose
     public void onClose(int statusCode, String reason)
     {
-        System.out.printf("Connection closed: %d - %s%n",statusCode,reason);
+        System.out.printf("Connection closed: %d - %s%n", statusCode, reason);
         this.session = null;
         this.closeLatch.countDown(); // trigger latch
     }
@@ -60,18 +61,16 @@ public class SimpleEchoSocket
     @OnWebSocketConnect
     public void onConnect(Session session)
     {
-        System.out.printf("Got connect: %s%n",session);
+        System.out.printf("Got connect: %s%n", session);
         this.session = session;
         try
         {
             Future<Void> fut;
             fut = session.getRemote().sendStringByFuture("Hello");
-            fut.get(2,TimeUnit.SECONDS); // wait for send to complete.
+            fut.get(2, TimeUnit.SECONDS); // wait for send to complete.
 
             fut = session.getRemote().sendStringByFuture("Thanks for the conversation.");
-            fut.get(2,TimeUnit.SECONDS); // wait for send to complete.
-
-            session.close(StatusCode.NORMAL,"I'm done");
+            fut.get(2, TimeUnit.SECONDS); // wait for send to complete.
         }
         catch (Throwable t)
         {
@@ -82,6 +81,17 @@ public class SimpleEchoSocket
     @OnWebSocketMessage
     public void onMessage(String msg)
     {
-        System.out.printf("Got msg: %s%n",msg);
+        System.out.printf("Got msg: %s%n", msg);
+        if (msg.contains("Thanks"))
+        {
+            session.close(StatusCode.NORMAL, "I'm done");
+        }
+    }
+
+    @OnWebSocketError
+    public void onError(Throwable cause)
+    {
+        System.out.print("WebSocket Error: ");
+        cause.printStackTrace(System.out);
     }
 }

--- a/jetty-websocket/websocket-client/src/test/java/examples/SimpleSecureEchoClient.java
+++ b/jetty-websocket/websocket-client/src/test/java/examples/SimpleSecureEchoClient.java
@@ -1,0 +1,85 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package examples;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
+/**
+ * Example of a simple Echo Client using TLS against a wss:// destination
+ */
+public class SimpleSecureEchoClient
+{
+    public static void main(String[] args)
+    {
+        String destUri = "wss://echo.websocket.org";
+        if (args.length > 0)
+        {
+            destUri = args[0];
+        }
+
+        SslContextFactory ssl = new SslContextFactory.Client();
+        ssl.addExcludeProtocols("tls/1.3");
+        ssl.setExcludeCipherSuites(); // websocket.org only uses WEAK cipher suites
+        HttpClient http = new HttpClient(ssl);
+        WebSocketClient client = new WebSocketClient(http);
+        SimpleEchoSocket socket = new SimpleEchoSocket();
+        try
+        {
+            http.start();
+            client.start();
+
+            URI echoUri = new URI(destUri);
+            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            request.setHeader("Origin", "https://websocket.org/");
+            client.connect(socket, echoUri, request);
+            System.out.printf("Connecting to : %s%n", echoUri);
+
+            // wait for closed socket connection.
+            socket.awaitClose(5, TimeUnit.SECONDS);
+        }
+        catch (Throwable t)
+        {
+            t.printStackTrace();
+        }
+        finally
+        {
+            stop(http);
+            stop(client);
+        }
+    }
+
+    private static void stop(LifeCycle lifeCycle)
+    {
+        try
+        {
+            lifeCycle.stop();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Adding a Secure `wss://` version of the example seen in documentation.
Needed because `wss://echo.websocket.org` has a poor ssllabs score and seems to only use weak cipher suites.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>