### PR TITLE
Fixes #3197 - Use jetty specific websocket API jar.

### DIFF
--- a/aggregates/jetty-all/pom.xml
+++ b/aggregates/jetty-all/pom.xml
@@ -209,8 +209,8 @@
     </dependency>
     <!-- dependencies that jetty-all needs (some optional) -->
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/aggregates/jetty-websocket-all/pom.xml
+++ b/aggregates/jetty-websocket-all/pom.xml
@@ -144,8 +144,8 @@
     </dependency>
     <!-- dependencies that jetty-all needs (some optional) -->
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -315,8 +315,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
@@ -146,7 +146,7 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("org.eclipse.jetty.websocket").artifactId("javax-websocket-common").versionAsInProject().noStart());
         res.add(mavenBundle().groupId("org.eclipse.jetty.websocket").artifactId("javax-websocket-client").versionAsInProject().noStart());
         res.add(mavenBundle().groupId("org.eclipse.jetty.websocket").artifactId("javax-websocket-server").versionAsInProject().noStart());
-        res.add(mavenBundle().groupId("javax.websocket").artifactId("javax.websocket-api").versionAsInProject().noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty.toolchain").artifactId("jetty-javax-websocket-api").versionAsInProject().noStart());
         res.add(mavenBundle().groupId( "org.eclipse.jetty.osgi" ).artifactId( "jetty-osgi-boot" ).versionAsInProject().start());
         return res;
     }
@@ -158,9 +158,9 @@ public class TestOSGiUtil
         res.add(systemProperty("osgi.console.enable.builtin").value("true")); 
         return res;
     }
-    
-    
-    
+
+
+
     public static List<Option> jspDependencies()
     {
         List<Option> res = new ArrayList<>();

--- a/jetty-websocket/javax-websocket-client/pom.xml
+++ b/jetty-websocket/javax-websocket-client/pom.xml
@@ -28,8 +28,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-websocket/javax-websocket-client/src/main/java/module-info.java
+++ b/jetty-websocket/javax-websocket-client/src/main/java/module-info.java
@@ -24,7 +24,7 @@ module org.eclipse.jetty.websocket.javax.client
 {
     exports org.eclipse.jetty.websocket.javax.client;
 
-    requires javax.websocket.api;
+    requires jetty.websocket.api;
     requires org.eclipse.jetty.client;
     requires org.eclipse.jetty.http;
     requires org.eclipse.jetty.io;

--- a/jetty-websocket/javax-websocket-common/pom.xml
+++ b/jetty-websocket/javax-websocket-common/pom.xml
@@ -74,8 +74,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
     </dependency>
 
     <dependency>

--- a/jetty-websocket/javax-websocket-common/src/main/java/module-info.java
+++ b/jetty-websocket/javax-websocket-common/src/main/java/module-info.java
@@ -24,7 +24,7 @@ module org.eclipse.jetty.websocket.javax.common
     exports org.eclipse.jetty.websocket.javax.common.messages;
     exports org.eclipse.jetty.websocket.javax.common.util;
 
-    requires javax.websocket.api;
+    requires jetty.websocket.api;
     requires org.eclipse.jetty.http;
     requires org.eclipse.jetty.io;
     requires org.eclipse.jetty.util;

--- a/jetty-websocket/javax-websocket-server/pom.xml
+++ b/jetty-websocket/javax-websocket-server/pom.xml
@@ -33,8 +33,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-websocket/javax-websocket-server/src/main/java/module-info.java
+++ b/jetty-websocket/javax-websocket-server/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module org.eclipse.jetty.websocket.javax.server
     exports org.eclipse.jetty.websocket.javax.server;
 
     requires jetty.servlet.api;
-    requires javax.websocket.api;
+    requires jetty.websocket.api;
     requires org.eclipse.jetty.client;
     requires org.eclipse.jetty.http;
     requires org.eclipse.jetty.io;

--- a/jetty-websocket/javax-websocket-tests/pom.xml
+++ b/jetty-websocket/javax-websocket-tests/pom.xml
@@ -33,8 +33,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -908,9 +908,9 @@
          <version>${servlet.api.version}</version>
       </dependency>
       <dependency>
-         <groupId>javax.websocket</groupId>
-         <artifactId>javax.websocket-api</artifactId>
-         <version>1.1</version>
+         <groupId>org.eclipse.jetty.toolchain</groupId>
+         <artifactId>jetty-javax-websocket-api</artifactId>
+         <version>1.1.1</version>
       </dependency>
       <dependency>
         <groupId>jakarta.annotation</groupId>

--- a/tests/test-webapps/test-jetty-webapp/pom.xml
+++ b/tests/test-webapps/test-jetty-webapp/pom.xml
@@ -195,8 +195,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
#3197.

Introduced jetty-javax-websocket-api artifact with proper
OSGi manifest entries and JPMS Automatic-Module-Name.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>