### PR TITLE
Issue #3653 Ensure custom SecurityManager.checkPermission is used.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -2612,7 +2612,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                     else
                         callerLoader = callerLoader.getParent();
                 }
-                AccessController.checkPermission(new RuntimePermission("getClassLoader"));
+                System.getSecurityManager().checkPermission(new RuntimePermission("getClassLoader"));
                 return _classLoader;
             }
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -308,6 +308,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     /* ------------------------------------------------------------ */
     public void setUsingSecurityManager(boolean usingSecurityManager)
     {
+        if (usingSecurityManager && System.getSecurityManager() == null)
+            throw new IllegalStateException("No security manager");
         _usingSecurityManager = usingSecurityManager;
     }
 


### PR DESCRIPTION
Issue  #3653.

Change ContextHandler.Context.getClassLoader() method to call SecurityManager.checkPermission(permission) instead of calling the default implementation of AccessController.checkPermission(permission)
