### PR TITLE
Issue #3666 - error CloseFrames skip frames in the FrameFlusher queue

### DIFF
--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -175,16 +175,11 @@ public class CloseStatus
     // TODO consider defining a precedence for every CloseStatus, and change SessionState only if higher precedence
     public static boolean isOrdinary(CloseStatus closeStatus)
     {
-        switch (closeStatus.getCode())
-        {
-            case NORMAL:
-            case SHUTDOWN:
-            case NO_CODE:
-                return true;
-
-            default:
-                return false;
-        }
+        int code = closeStatus.getCode();
+        if (code == NORMAL || code == NO_CODE || code >= 3000)
+            return true;
+        else
+            return false;
     }
 
     public int getCode()

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -291,8 +291,8 @@ public class CloseStatus
     public Frame toFrame()
     {
         if (isTransmittableStatusCode(code))
-            return new CloseFrame(this, OpCode.CLOSE, true, asPayloadBuffer(code, reason));
-        return new CloseFrame(this, OpCode.CLOSE);
+            return new CloseFrame(OpCode.CLOSE, true, asPayloadBuffer(code, reason));
+        return new CloseFrame(OpCode.CLOSE);
     }
 
     public static Frame toFrame(int closeStatus)
@@ -356,12 +356,12 @@ public class CloseStatus
 
     class CloseFrame extends Frame implements CloseStatus.Supplier
     {
-        public CloseFrame(CloseStatus closeStatus, byte opcode)
+        public CloseFrame(byte opcode)
         {
             super(opcode);
         }
 
-        public CloseFrame(CloseStatus closeStatus, byte opCode, boolean fin, ByteBuffer payload)
+        public CloseFrame(byte opCode, boolean fin, ByteBuffer payload)
         {
             super(opCode, fin, payload);
         }

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -176,10 +176,7 @@ public class CloseStatus
     public static boolean isOrdinary(CloseStatus closeStatus)
     {
         int code = closeStatus.getCode();
-        if (code == NORMAL || code == NO_CODE || code >= 3000)
-            return true;
-        else
-            return false;
+        return (code == NORMAL || code == NO_CODE || code >= 3000);
     }
 
     public int getCode()


### PR DESCRIPTION
#3666 
if the `FrameFlusher` receives a CloseFrame with an error status it will not queue these frames behind the frames already queued in the `FrameFlusher`, but will fail all frames waiting to be sent and send the error CloseFrame instead