### PR TITLE
Issue #3680 Remove config-only infinispan artifacts from bom.

### DIFF
--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -211,17 +211,12 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>infinispan-remote</artifactId>
+        <artifactId>infinispan-common</artifactId>
         <version>9.4.19-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-remote-query</artifactId>
-        <version>9.4.19-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>infinispan-embedded</artifactId>
         <version>9.4.19-SNAPSHOT</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
#3680 

Removed infinispan-remote and infinispan-embedded artifacts from the bom as they are config only. Also added infinispan-common, which was not included transitively before.