### PR TITLE
Issue #3683 - ensure multipart files are still cleaned up if error occurs

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartParser.java
@@ -131,11 +131,7 @@ public class MultiPartParser
     private HttpTokens.Token next(ByteBuffer buffer)
     {
         byte ch = buffer.get();
-
         HttpTokens.Token t = HttpTokens.TOKENS[0xff & ch];
-        
-        if (DEBUG)
-            LOG.debug("token={}",t);
         
         switch(t.getType())
         {
@@ -271,6 +267,9 @@ public class MultiPartParser
     /* ------------------------------------------------------------------------------- */
     private void parsePreamble(ByteBuffer buffer)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("parsePreamble({})", BufferUtil.toDetailString(buffer));
+
         if (_partialBoundary > 0)
         {
             int partial = _delimiterSearch.startsWith(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining(), _partialBoundary);
@@ -307,6 +306,9 @@ public class MultiPartParser
     /* ------------------------------------------------------------------------------- */
     private void parseDelimiter(ByteBuffer buffer)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("parseDelimiter({})", BufferUtil.toDetailString(buffer));
+
         while (__delimiterStates.contains(_state) && hasNextByte(buffer))
         {
             HttpTokens.Token t = next(buffer);
@@ -354,6 +356,9 @@ public class MultiPartParser
      */
     protected boolean parseMimePartHeaders(ByteBuffer buffer)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("parseMimePartHeaders({})", BufferUtil.toDetailString(buffer));
+
         // Process headers
         while (_state == State.BODY_PART && hasNextByte(buffer))
         {
@@ -575,6 +580,8 @@ public class MultiPartParser
     
     protected boolean parseOctetContent(ByteBuffer buffer)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("parseOctetContent({})", BufferUtil.toDetailString(buffer));
         
         // Starts With
         if (_partialBoundary > 0)

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
@@ -217,6 +217,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testNoBody()
+            throws Exception
     {
         String body = "";
 
@@ -277,6 +278,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testWhitespaceBodyWithCRLF()
+            throws Exception
     {
         String whitespace = "              \n\n\n\r\n\r\n\r\n\r\n";
 
@@ -292,6 +294,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testWhitespaceBody()
+            throws Exception
     {
         String whitespace = " ";
 
@@ -400,6 +403,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testRequestTooBig ()
+            throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 60, 100, 50);
         MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
@@ -415,6 +419,7 @@ public class MultiPartFormInputStreamTest
     
     @Test
     public void testRequestTooBigThrowsErrorOnGetParts ()
+            throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 60, 100, 50);
         MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
@@ -434,6 +439,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testFileTooBig()
+            throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 40, 1024, 30);
         MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
@@ -449,6 +455,7 @@ public class MultiPartFormInputStreamTest
     
     @Test
     public void testFileTooBigThrowsErrorOnGetParts()
+            throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 40, 1024, 30);
         MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
@@ -550,6 +557,7 @@ public class MultiPartFormInputStreamTest
     
     @Test
     public void testCROnlyRequest()
+            throws Exception
     {
         String str = "--AaB03x\r" +
                 "content-disposition: form-data; name=\"field1\"\r" +
@@ -576,6 +584,7 @@ public class MultiPartFormInputStreamTest
 
     @Test
     public void testCRandLFMixRequest()
+            throws Exception
     {
         String str = "--AaB03x\r" +
                 "content-disposition: form-data; name=\"field1\"\r" +

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -487,7 +487,7 @@ public class Request implements HttpServletRequest
                             throw new BadMessageException(HttpStatus.NOT_IMPLEMENTED_501,"Unsupported Content-Encoding");
                         getParts(_contentParameters);
                     }
-                    catch (IOException | ServletException e)
+                    catch (IOException e)
                     {
                         LOG.debug(e);
                         throw new RuntimeIOException(e);
@@ -2320,7 +2320,6 @@ public class Request implements HttpServletRequest
     public Part getPart(String name) throws IOException, ServletException
     {
         getParts();
-
         return _multiParts.getPart(name);
     }
 
@@ -2334,7 +2333,7 @@ public class Request implements HttpServletRequest
         return getParts(null);
     }
 
-    private Collection<Part> getParts(MultiMap<String> params) throws IOException, ServletException
+    private Collection<Part> getParts(MultiMap<String> params) throws IOException
     {        
         if (_multiParts == null)
             _multiParts = (MultiParts)getAttribute(__MULTIPARTS);
@@ -2345,12 +2344,9 @@ public class Request implements HttpServletRequest
             if (config == null)
                 throw new IllegalStateException("No multipart config for servlet");
 
-            _multiParts = newMultiParts(getInputStream(),
-                                       _contentType, config,
-                                       (_context != null?(File)_context.getAttribute("javax.servlet.context.tempdir"):null));
-
+            _multiParts = newMultiParts(config);
             setAttribute(__MULTIPARTS, _multiParts);
-            Collection<Part> parts = _multiParts.getParts(); //causes parsing
+            Collection<Part> parts = _multiParts.getParts();
                        
             String _charset_ = null;
             Part charsetPart = _multiParts.getPart("_charset_");
@@ -2412,7 +2408,7 @@ public class Request implements HttpServletRequest
     }
 
     
-    private MultiParts newMultiParts(ServletInputStream inputStream, String contentType, MultipartConfigElement config, Object object) throws IOException
+    private MultiParts newMultiParts(MultipartConfigElement config) throws IOException
     {
         MultiPartFormDataCompliance compliance = getHttpChannel().getHttpConfiguration().getMultipartFormDataCompliance();
         if(LOG.isDebugEnabled())

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -2417,12 +2417,12 @@ public class Request implements HttpServletRequest
         switch(compliance)
         {
             case RFC7578:
-                return new MultiParts.MultiPartsHttpParser(getInputStream(), contentType, config,
+                return new MultiParts.MultiPartsHttpParser(getInputStream(), getContentType(), config,
                         (_context != null?(File)_context.getAttribute("javax.servlet.context.tempdir"):null), this);
                 
             case LEGACY: 
             default:
-                return new MultiParts.MultiPartsUtilParser(getInputStream(), contentType, config,
+                return new MultiParts.MultiPartsUtilParser(getInputStream(), getContentType(), config,
                     (_context != null?(File)_context.getAttribute("javax.servlet.context.tempdir"):null), this);
                         
         }

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -60,5 +60,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-client</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
@@ -747,11 +747,14 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
         //cleaned up correctly
         if (((Registration)getRegistration()).getMultipartConfig() != null)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("multipart cleanup listener added for {}", this);
+
             //Register a listener to delete tmp files that are created as a result of this
             //servlet calling Request.getPart() or Request.getParts()
-
             ContextHandler ch = ContextHandler.getContextHandler(getServletHandler().getServletContext());
-            ch.addEventListener(MultiPartCleanerListener.INSTANCE);
+            if(!Arrays.asList(ch.getEventListeners()).contains(MultiPartCleanerListener.INSTANCE))
+                ch.addEventListener(MultiPartCleanerListener.INSTANCE);
         }
     }
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/MultiPartServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/MultiPartServletTest.java
@@ -61,7 +61,6 @@ public class MultiPartServletTest
     private Server server;
     private ServerConnector connector;
     private HttpClient client;
-
     private Path tmpDir;
 
     private static final int MAX_FILE_SIZE = 512 * 1024;
@@ -92,7 +91,6 @@ public class MultiPartServletTest
     public void start() throws Exception
     {
         tmpDir = Files.createTempDirectory(MultiPartServletTest.class.getSimpleName());
-        System.err.println(tmpDir);
 
         server = new Server();
         connector = new ServerConnector(server);

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/MultiPartServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/MultiPartServletTest.java
@@ -1,0 +1,157 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.servlet;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.BytesContentProvider;
+import org.eclipse.jetty.client.util.MultiPartContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http.MultiPartFormInputStream;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.MultiPartFormDataCompliance;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.log.StacklessLogging;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MultiPartServletTest
+{
+    private static final Logger LOG = Log.getLogger(MultiPartServletTest.class);
+
+    private Server server;
+    private ServerConnector connector;
+    private HttpClient client;
+
+    private Path tmpDir;
+
+    private static final int MAX_FILE_SIZE = 512 * 1024;
+    private static final int LARGE_MESSAGE_SIZE = 1024 * 1024;
+
+    public static class MultiPartServlet extends HttpServlet
+    {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            if (!req.getContentType().contains(MimeTypes.Type.MULTIPART_FORM_DATA.asString()))
+            {
+                resp.setContentType("text/plain");
+                resp.getWriter().println("not content type " + MimeTypes.Type.MULTIPART_FORM_DATA);
+                resp.getWriter().println("contentType: " + req.getContentType());
+                return;
+            }
+
+            resp.setContentType("text/plain");
+            for (Part part : req.getParts())
+            {
+                resp.getWriter().println("Part: name=" + part.getName() + ", size=" + part.getSize());
+            }
+        }
+    }
+
+    @BeforeEach
+    public void start() throws Exception
+    {
+        tmpDir = Files.createTempDirectory(MultiPartServletTest.class.getSimpleName());
+        System.err.println(tmpDir);
+
+        server = new Server();
+        connector = new ServerConnector(server);
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration()
+                .setMultiPartFormDataCompliance(MultiPartFormDataCompliance.RFC7578);
+        server.addConnector(connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        ServletHolder servletHolder = contextHandler.addServlet(MultiPartServlet.class, "/");
+
+        MultipartConfigElement config = new MultipartConfigElement(tmpDir.toAbsolutePath().toString(),
+                MAX_FILE_SIZE, -1, 1);
+        servletHolder.getRegistration().setMultipartConfig(config);
+
+        server.setHandler(contextHandler);
+
+        server.start();
+
+        client = new HttpClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+
+        IO.delete(tmpDir.toFile());
+    }
+
+    @Test
+    public void testTempFilesDeletedOnError() throws Exception
+    {
+        String partName = "partName";
+
+        byte[] byteArray = new byte[LARGE_MESSAGE_SIZE];
+        for (int i=0; i<byteArray.length; i++)
+            byteArray[i] = 1;
+        BytesContentProvider contentProvider = new BytesContentProvider(byteArray);
+
+        MultiPartContentProvider multiPart = new MultiPartContentProvider();
+        multiPart.addFieldPart(partName, contentProvider, null);
+        multiPart.close();
+
+        try (StacklessLogging stacklessLogging = new StacklessLogging(HttpChannel.class, MultiPartFormInputStream.class))
+        {
+            ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+                    .scheme(HttpScheme.HTTP.asString())
+                    .method(HttpMethod.POST)
+                    .content(multiPart)
+                    .send();
+
+            assertEquals(500, response.getStatus());
+            assertThat(response.getContentAsString(),
+                    containsString("Multipart Mime part partName exceeds max filesize"));
+        }
+
+        assertThat(tmpDir.toFile().list().length, is(0));
+    }
+}


### PR DESCRIPTION
Issue #3683

- separated the parsing from the constructor of `MultiParts` so the `Request.__MULTIPARTS` attribute can be set before a parsing error occurs

- added test to replicate the issue where the files are not deleted when an error occurs

- general cleanups of `MultiParts` and `MultiPartFormInputStream`

