### PR TITLE
#3713 - Emit warning when invoking deprecated method in Jetty XML.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -18,13 +18,10 @@
 
 package org.eclipse.jetty.util;
 
-import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -35,9 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -501,175 +496,22 @@ public class TypeUtil
         }
     }
 
-
-    public static Object call(Class<?> oClass, String methodName, Object obj, Object[] arg)
-       throws InvocationTargetException, NoSuchMethodException
+    @Deprecated
+    public static Object call(Class<?> oClass, String methodName, Object obj, Object[] arg) throws InvocationTargetException, NoSuchMethodException
     {
-        Objects.requireNonNull(oClass,"Class cannot be null");
-        Objects.requireNonNull(methodName,"Method name cannot be null");
-        if (StringUtil.isBlank(methodName))
-        {
-            throw new IllegalArgumentException("Method name cannot be blank");
-        }
-        
-        // Lets just try all methods for now
-        for (Method method : oClass.getMethods())
-        {
-            if (!method.getName().equals(methodName))
-                continue;            
-            if (method.getParameterCount() != arg.length)
-                continue;
-            if (Modifier.isStatic(method.getModifiers()) != (obj == null))
-                continue;
-            if ((obj == null) && method.getDeclaringClass() != oClass)
-                continue;
-
-            try
-            {
-                return method.invoke(obj, arg);
-            }
-            catch (IllegalAccessException | IllegalArgumentException e)
-            {
-                LOG.ignore(e);
-            }
-        }
-        
-        // Lets look for a method with optional arguments
-        Object[] args_with_opts=null;
-        
-        for (Method method : oClass.getMethods())
-        {
-            if (!method.getName().equals(methodName))
-                continue;            
-            if (method.getParameterCount() != arg.length+1)
-                continue;
-            if (!method.getParameterTypes()[arg.length].isArray())
-                continue;
-            if (Modifier.isStatic(method.getModifiers()) != (obj == null))
-                continue;
-            if ((obj == null) && method.getDeclaringClass() != oClass)
-                continue;
-
-            if (args_with_opts==null)
-                args_with_opts=ArrayUtil.addToArray(arg,new Object[]{},Object.class);
-            try
-            {
-                return method.invoke(obj, args_with_opts);
-            }
-            catch (IllegalAccessException | IllegalArgumentException e)
-            {
-                LOG.ignore(e);
-            }
-        }
-        
-        
-        throw new NoSuchMethodException(methodName);
+        throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public static Object construct(Class<?> klass, Object[] arguments) throws InvocationTargetException, NoSuchMethodException
     {
-        Objects.requireNonNull(klass,"Class cannot be null");
-        
-        for (Constructor<?> constructor : klass.getConstructors())
-        {
-            if (arguments == null)
-            {
-                // null arguments in .newInstance() is allowed
-                if (constructor.getParameterCount() != 0)
-                    continue;
-            }
-            else if (constructor.getParameterCount() != arguments.length)
-                continue;
-
-            try
-            {
-                return constructor.newInstance(arguments);
-            }
-            catch (InstantiationException | IllegalAccessException | IllegalArgumentException e)
-            {
-                LOG.ignore(e);
-            }
-        }
-        throw new NoSuchMethodException("<init>");
+        throw new UnsupportedOperationException();
     }
-    
+
+    @Deprecated
     public static Object construct(Class<?> klass, Object[] arguments, Map<String, Object> namedArgMap) throws InvocationTargetException, NoSuchMethodException
     {
-        Objects.requireNonNull(klass,"Class cannot be null");
-        Objects.requireNonNull(namedArgMap,"Named Argument Map cannot be null");
-        
-        for (Constructor<?> constructor : klass.getConstructors())
-        {
-            if (arguments == null)
-            {
-                // null arguments in .newInstance() is allowed
-                if (constructor.getParameterCount() != 0)
-                    continue;
-            }
-            else if (constructor.getParameterCount() != arguments.length)
-                continue;
-
-            try
-            {
-                Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
-                
-                if (arguments == null || arguments.length == 0)
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Constructor has no arguments");
-                    return constructor.newInstance(arguments);
-                }
-                else if (parameterAnnotations == null || parameterAnnotations.length == 0)
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Constructor has no parameter annotations");
-                    return constructor.newInstance(arguments);
-                }
-                else
-                {
-                   Object[] swizzled = new Object[arguments.length];
-                   
-                   int count = 0;
-                   for ( Annotation[] annotations : parameterAnnotations )
-                   {
-                       for ( Annotation annotation : annotations)
-                       {
-                           if ( annotation instanceof Name )
-                           {
-                               Name param = (Name)annotation;
-                               
-                               if (namedArgMap.containsKey(param.value()))
-                               {
-                                   if (LOG.isDebugEnabled())
-                                       LOG.debug("placing named {} in position {}", param.value(), count);
-                                   swizzled[count] = namedArgMap.get(param.value());
-                               }
-                               else
-                               {
-                                   if (LOG.isDebugEnabled())
-                                       LOG.debug("placing {} in position {}", arguments[count], count);
-                                   swizzled[count] = arguments[count];
-                               }
-                               ++count;
-                           }
-                           else
-                           {
-                               if (LOG.isDebugEnabled())
-                                   LOG.debug("passing on annotation {}", annotation);
-                           }
-                       }
-                   }
-                   
-                   return constructor.newInstance(swizzled);
-                }
-                
-            }
-            catch (InstantiationException | IllegalAccessException | IllegalArgumentException e)
-            {
-                LOG.ignore(e);
-            }
-        }
-        throw new NoSuchMethodException("<init>");
+        throw new UnsupportedOperationException();
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -896,7 +896,7 @@ public class XmlConfiguration
                     argsWithVarargs = ArrayUtil.addToArray(arg, new Object[0], Object.class);
                 try
                 {
-                    invokeMethod(method, obj, argsWithVarargs);
+                    return invokeMethod(method, obj, argsWithVarargs);
                 }
                 catch (IllegalAccessException | IllegalArgumentException e)
                 {
@@ -974,7 +974,9 @@ public class XmlConfiguration
                         continue;
                 }
                 else if (constructor.getParameterCount() != arguments.length)
+                {
                     continue;
+                }
 
                 try
                 {

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -577,7 +577,7 @@ public class XmlConfiguration
                 Field field = oClass.getField(attr);
                 if (Modifier.isPublic(field.getModifiers()))
                 {
-                    field.set(obj, value);
+                    setField(field, obj, value);
                     return;
                 }
             }
@@ -677,7 +677,7 @@ public class XmlConfiguration
         {
             Object result = constructor.newInstance(args);
             if (constructor.getAnnotation(Deprecated.class) != null)
-                LOG.warn("Deprecated {} in {}", constructor, _url);
+                LOG.warn("Deprecated constructor {} in {}", constructor, _url);
             return result;
         }
 
@@ -685,8 +685,23 @@ public class XmlConfiguration
         {
             Object result = method.invoke(obj, args);
             if (method.getAnnotation(Deprecated.class) != null)
-                LOG.warn("Deprecated {} in {}", method, _url);
+                LOG.warn("Deprecated method {} in {}", method, _url);
             return result;
+        }
+
+        private Object getField(Field field, Object object) throws IllegalAccessException
+        {
+            Object result = field.get(object);
+            if (field.getAnnotation(Deprecated.class) != null)
+                LOG.warn("Deprecated field {} in {}", field, _url);
+            return result;
+        }
+
+        private void setField(Field field, Object obj, Object arg) throws IllegalAccessException
+        {
+            field.set(obj, arg);
+            if (field.getAnnotation(Deprecated.class) != null)
+                LOG.warn("Deprecated field {} in {}", field, _url);
         }
 
         /**
@@ -787,7 +802,7 @@ public class XmlConfiguration
                 {
                     // Try the field.
                     Field field = oClass.getField(name);
-                    obj = field.get(obj);
+                    obj = getField(field, obj);
                     configure(obj, node, 0);
                 }
                 catch (NoSuchFieldException nsfe)

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
@@ -27,6 +27,9 @@ public class AnnotatedTestConfiguration
     private String third;
     private String deprecated;
     private AnnotatedTestConfiguration nested;
+    // Do not remove deprecation, used in tests.
+    @Deprecated
+    public String obsolete;
 
     // Do not remove deprecation, used in tests.
     @Deprecated

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
@@ -25,9 +25,15 @@ public class AnnotatedTestConfiguration
     private String first;
     private String second;
     private String third;
-    
-    AnnotatedTestConfiguration nested;
-    
+    private String deprecated;
+    private AnnotatedTestConfiguration nested;
+
+    // Do not remove deprecation, used in tests.
+    @Deprecated
+    public AnnotatedTestConfiguration()
+    {
+    }
+
     public AnnotatedTestConfiguration(@Name("first") String first, @Name("second") String second, @Name("third") String third)
     {
         this.first = first;
@@ -74,5 +80,18 @@ public class AnnotatedTestConfiguration
     {
         this.nested = nested;
     }
-    
+
+    // Do not remove deprecation, used in tests.
+    @Deprecated
+    public void setDeprecated(String value)
+    {
+        this.deprecated = value;
+    }
+
+    // Do not remove deprecation, used in tests.
+    @Deprecated
+    public String getDeprecated()
+    {
+        return deprecated;
+    }
 }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -993,10 +993,14 @@ public class XmlConfigurationTest
     @Test
     public void testDeprecated() throws Exception
     {
+        Class<?> testClass = AnnotatedTestConfiguration.class;
         XmlConfiguration xmlConfiguration = new XmlConfiguration("" +
-            "<Configure class=\"org.eclipse.jetty.xml.AnnotatedTestConfiguration\">" +
+            "<Configure class=\"" + testClass.getName() + "\">" +
             "  <Set name=\"deprecated\">foo</Set>" +
-            "  <Call name=\"setDeprecated\"><Arg><Get name=\"deprecated\" /></Arg></Call>" +
+            "  <Set name=\"obsolete\">" +
+            "    <Call name=\"setDeprecated\"><Arg><Get name=\"deprecated\" /></Arg></Call>" +
+            "  </Set>" +
+            "  <Get name=\"obsolete\" />" +
             "</Configure>");
 
         ByteArrayOutputStream logBytes = null;
@@ -1012,14 +1016,18 @@ public class XmlConfigurationTest
 
         if (logBytes != null)
         {
-            List<String> warnings = Arrays.stream(logBytes.toString("UTF-8").split(System.lineSeparator()))
-                .filter(line -> line.contains(":WARN:") && line.contains("AnnotatedTestConfiguration"))
+            String[] lines = logBytes.toString("UTF-8").split(System.lineSeparator());
+            List<String> warnings = Arrays.stream(lines)
+                .filter(line -> line.contains(":WARN:"))
+                .filter(line -> line.contains(testClass.getSimpleName()))
                 .collect(Collectors.toList());
             // 1. Deprecated constructor
-            // 2. Deprecated <Set>
-            // 3. Deprecated <Get>
-            // 4. Deprecated <Call>
-            assertEquals(4, warnings.size());
+            // 2. Deprecated <Set> method
+            // 3. Deprecated <Get> method
+            // 4. Deprecated <Call> method
+            // 5. Deprecated <Set> field
+            // 6. Deprecated <Get> field
+            assertEquals(6, warnings.size());
         }
     }
 }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -981,4 +981,17 @@ public class XmlConfigurationTest
             assertThat(propName, tc.getTestString(), startsWith("file:"));
         }
     }
+
+    @Test
+    public void testDeprecated() throws Exception
+    {
+        XmlConfiguration xmlConfiguration = new XmlConfiguration("" +
+            "<Configure class=\"org.eclipse.jetty.xml.AnnotatedTestConfiguration\">" +
+            "  <Set name=\"deprecated\">foo</Set>" +
+            "  <Call name=\"setDeprecated\"><Arg><Get name=\"deprecated\" /></Arg></Call>" +
+            "</Configure>");
+
+        xmlConfiguration.configure();
+        // Cannot test that the warnings are logged.
+    }
 }


### PR DESCRIPTION
#3713.

Added warnings for invocation of deprecated constructors and methods.
Moved methods exclusively used by XmlConfiguration from TypeUtil.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>