### PR TITLE
Jetty 9.4.x 3722 session destroy listeners

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -370,11 +370,22 @@ public class SessionHandler extends ScopedHandler
         
         if (_sessionListeners!=null)
         {
-            HttpSessionEvent event=new HttpSessionEvent(session);      
-            for (int i = _sessionListeners.size()-1; i>=0; i--)
+            //We annoint the calling thread with
+            //the webapp's classloader because the calling thread may
+            //come from the scavenger, rather than a request thread
+            Runnable r = new Runnable()
             {
-                _sessionListeners.get(i).sessionDestroyed(event);
-            }
+                @Override
+                public void run ()
+                {
+                    HttpSessionEvent event=new HttpSessionEvent(session);
+                    for (int i = _sessionListeners.size()-1; i>=0; i--)
+                    {
+                        _sessionListeners.get(i).sessionDestroyed(event);
+                    }
+                }
+            };
+            _sessionContext.run(r);
         }
     }
     

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestHttpSessionListenerWithWebappClasses.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestHttpSessionListenerWithWebappClasses.java
@@ -1,3 +1,21 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
 package org.eclipse.jetty.server.session;
 
 import javax.servlet.http.HttpSessionEvent;

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestHttpSessionListenerWithWebappClasses.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/TestHttpSessionListenerWithWebappClasses.java
@@ -1,0 +1,43 @@
+package org.eclipse.jetty.server.session;
+
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * TestHttpSessionListenerWithWebappClasses
+ * 
+ * A session listener class that checks that sessionDestroyed
+ * events can reference classes known only to the webapp, ie
+ * that the calling thread has been correctly annointed with 
+ * the webapp loader.
+ *
+ */
+public class TestHttpSessionListenerWithWebappClasses extends TestHttpSessionListener
+{
+    public TestHttpSessionListenerWithWebappClasses()
+    {
+        super();
+    }
+
+    public TestHttpSessionListenerWithWebappClasses(boolean access)
+    {
+        super(access);
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se)
+    {
+        //try loading a class that is known only to the webapp
+        //to test that the calling thread has been properly
+        //annointed with the webapp's classloader
+        try
+        {
+            Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass("Foo");
+        }
+        catch (Exception cnfe)
+        {
+            ex=cnfe;
+        }
+        super.sessionDestroyed(se);
+    }
+
+}


### PR DESCRIPTION
#3722 

Ensure HttpSessionListener.sessionDestroyed thread caller annointed with webapp classloader. Note that the sessionCreated method never needs the same treatment as it is always called from a request thread.