### PR TITLE
Jetty-util should not OSGi export usage of servlet-api 

### DIFF
--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -51,6 +51,7 @@
         <configuration>
           <instructions>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
+            <_nouses>true</_nouses>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
#3726
jetty-util should not export the that it may internally use the servlet-api

Signed-off-by: Greg Wilkins <gregw@webtide.com>