### PR TITLE
Issue #3712 - rename maxIdleTime usage to idleTimeout for WebSockets

### DIFF
--- a/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/WebSocket.java
+++ b/jetty-websocket/jetty-websocket-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/WebSocket.java
@@ -18,14 +18,14 @@
 
 package org.eclipse.jetty.websocket.api.annotations;
 
-import org.eclipse.jetty.websocket.api.BatchMode;
-import org.eclipse.jetty.websocket.api.StatusCode;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.eclipse.jetty.websocket.api.BatchMode;
+import org.eclipse.jetty.websocket.api.StatusCode;
 
 /**
  * Tags a POJO as being a WebSocket class.
@@ -39,26 +39,33 @@ public @interface WebSocket
     /**
      * The size of the buffer (in bytes) used to read from the network layer.
      */
-    int inputBufferSize() default -2;
+    int inputBufferSize() default -1;
 
     /**
      * The maximum size of a binary message (in bytes) during parsing/generating.
      * <p>
      * Binary messages over this maximum will result in a close code 1009 {@link StatusCode#MESSAGE_TOO_LARGE}
      */
-    int maxBinaryMessageSize() default -2;
+    int maxBinaryMessageSize() default -1;
+
+    /**
+     * The time in ms (milliseconds) that a websocket may be idle before closing.
+     * @deprecated use {@link #idleTimeout()} instead
+     */
+    @Deprecated
+    int maxIdleTime() default -1;
 
     /**
      * The time in ms (milliseconds) that a websocket may be idle before closing.
      */
-    int maxIdleTime() default -2;
+    int idleTimeout() default -1;
 
     /**
      * The maximum size of a text message during parsing/generating.
      * <p>
      * Text messages over this maximum will result in a close code 1009 {@link StatusCode#MESSAGE_TOO_LARGE}
      */
-    int maxTextMessageSize() default -2;
+    int maxTextMessageSize() default -1;
 
     /**
      * The output frame buffering mode.

--- a/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-websocket/jetty-websocket-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -296,14 +296,20 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
     {
         JettyWebSocketFrameHandlerMetadata metadata = new JettyWebSocketFrameHandlerMetadata();
 
-        if (anno.inputBufferSize()>=0)
-            metadata.setInputBufferSize(anno.inputBufferSize());
-        if (anno.maxBinaryMessageSize()>=0)
-           metadata.setMaxBinaryMessageSize(anno.maxBinaryMessageSize());
-        if (anno.maxTextMessageSize()>=0)
-        metadata.setMaxTextMessageSize(anno.maxTextMessageSize());
-        if (anno.maxIdleTime()>=0)
-            metadata.setIdleTimeout(Duration.ofMillis(anno.maxIdleTime()));
+        int max = anno.inputBufferSize();
+        if (max>=0)
+            metadata.setInputBufferSize(max);
+        max = anno.maxBinaryMessageSize();
+        if (max>=0)
+           metadata.setMaxBinaryMessageSize(max);
+        max = anno.maxTextMessageSize();
+        if (max>=0)
+            metadata.setMaxTextMessageSize(max);
+        max = anno.idleTimeout();
+        if (max<0)
+            max = anno.maxIdleTime();
+        if (max>=0)
+            metadata.setIdleTimeout(Duration.ofMillis(max));
         metadata.setBatchMode(anno.batchMode());
 
         Method onmethod;

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientConfigTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientConfigTest.java
@@ -36,8 +36,8 @@ import org.eclipse.jetty.websocket.api.WebSocketTimeoutException;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.common.WebSocketSession;
-import org.eclipse.jetty.websocket.core.internal.WebSocketCoreSession;
 import org.eclipse.jetty.websocket.core.internal.WebSocketConnection;
+import org.eclipse.jetty.websocket.core.internal.WebSocketCoreSession;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.websocket.tests.EchoSocket;
@@ -98,7 +98,7 @@ public class ClientConfigTest
         server.stop();
     }
 
-    @WebSocket(maxIdleTime=idleTimeout, maxTextMessageSize=maxMessageSize, maxBinaryMessageSize=maxMessageSize, inputBufferSize=inputBufferSize, batchMode=BatchMode.ON)
+    @WebSocket(idleTimeout=idleTimeout, maxTextMessageSize=maxMessageSize, maxBinaryMessageSize=maxMessageSize, inputBufferSize=inputBufferSize, batchMode=BatchMode.ON)
     public class AnnotatedConfigEndpoint extends EventSocket
     {
     }
@@ -182,7 +182,7 @@ public class ClientConfigTest
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMaxIdleTime(String param) throws Exception
+    public void testIdleTimeout(String param) throws Exception
     {
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/");
         EventSocket clientEndpoint = getClientSocket(param);

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerConfigTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerConfigTest.java
@@ -40,8 +40,8 @@ import org.eclipse.jetty.websocket.api.WebSocketTimeoutException;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.common.WebSocketSession;
-import org.eclipse.jetty.websocket.core.internal.WebSocketCoreSession;
 import org.eclipse.jetty.websocket.core.internal.WebSocketConnection;
+import org.eclipse.jetty.websocket.core.internal.WebSocketCoreSession;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletContainerInitializer;
@@ -96,7 +96,7 @@ public class ServerConfigTest
         return Stream.of("servletConfig", "annotatedConfig", "containerConfig", "sessionConfig").map(Arguments::of);
     }
 
-    @WebSocket(maxIdleTime=idleTimeout, maxTextMessageSize=maxMessageSize, maxBinaryMessageSize=maxMessageSize, inputBufferSize=inputBufferSize, batchMode=BatchMode.ON)
+    @WebSocket(idleTimeout=idleTimeout, maxTextMessageSize=maxMessageSize, maxBinaryMessageSize=maxMessageSize, inputBufferSize=inputBufferSize, batchMode=BatchMode.ON)
     public static class AnnotatedConfigEndpoint extends EventSocket
     {
     }
@@ -257,7 +257,7 @@ public class ServerConfigTest
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMaxIdleTime(String path) throws Exception
+    public void testIdleTimeout(String path) throws Exception
     {
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/" + path);
         EventSocket clientEndpoint = new EventSocket();

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServlet.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketServlet.java
@@ -71,7 +71,7 @@ import org.eclipse.jetty.websocket.core.WebSocketExtensionRegistry;
  * <b>Configuration / Init-Parameters:</b>
  * </p>
  * <dl>
- * <dt>maxIdleTime</dt>
+ * <dt>idleTimeout</dt>
  * <dd>set the time in ms that a websocket may be idle before closing<br>
  * <dt>maxTextMessageSize</dt>
  * <dd>set the size in UTF-8 bytes that a websocket may be accept as a Text Message before closing<br>
@@ -119,7 +119,13 @@ public abstract class WebSocketServlet extends HttpServlet
             components = WebSocketComponents.ensureWebSocketComponents(servletContext);
             mapping = new WebSocketMapping(components);
 
-            String max = getInitParameter("maxIdleTime");
+            String max = getInitParameter("idleTimeout");
+            if (max == null)
+            {
+                max = getInitParameter("maxIdleTime");
+                if (max != null)
+                    LOG.warn("'maxIdleTime' init param is deprecated, use 'idleTimeout' instead");
+            }
             if (max != null)
                 customizer.setIdleTimeout(Duration.ofMillis(Long.parseLong(max)));
 

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
@@ -55,7 +55,7 @@ import org.eclipse.jetty.websocket.core.WebSocketComponents;
  * <b>Configuration / Init-Parameters:</b>
  * </p>
  * <dl>
- * <dt>maxIdleTime</dt>
+ * <dt>idleTimeout</dt>
  * <dd>set the time in ms that a websocket may be idle before closing<br>
  * <dt>maxTextMessageSize</dt>
  * <dd>set the size in UTF-8 bytes that a websocket may be accept as a Text Message before closing<br>
@@ -164,7 +164,13 @@ public class WebSocketUpgradeFilter implements Filter, Dumpable
         else
             mapping = new WebSocketMapping(WebSocketComponents.ensureWebSocketComponents(context));
 
-        String max = config.getInitParameter("maxIdleTime");
+        String max = config.getInitParameter("idleTimeout");
+        if (max == null)
+        {
+            max = config.getInitParameter("maxIdleTime");
+            if (max != null)
+                LOG.warn("'maxIdleTime' init param is deprecated, use 'idleTimeout' instead");
+        }
         if (max != null)
             defaultCustomizer.setIdleTimeout(Duration.ofMillis(Long.parseLong(max)));
 


### PR DESCRIPTION
Issue #3712 

- renamed maxIdleTime usage to idleTimeout, `Session.setMaxIdleTimeout` remains but this is part of the javax api

- also changed default values of the `@WebSocket` annotation to -1 from -2, this should not change any behavior 