### PR TITLE
Jetty 9.4.x 3729 concurrent naming context

### DIFF
--- a/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/ContextFactory.java
+++ b/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/ContextFactory.java
@@ -18,12 +18,10 @@
 
 package org.eclipse.jetty.jndi;
 
-
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.WeakHashMap;
-
 import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.NameParser;
@@ -77,8 +75,6 @@ public class ContextFactory implements ObjectFactory
      * when finding the comp context.
      */
     private static final ThreadLocal<ClassLoader> __threadClassLoader = new ThreadLocal<ClassLoader>();
-    
-
 
     /**
      * Find or create a context which pertains to a classloader.

--- a/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/ContextFactory.java
+++ b/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/ContextFactory.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.jndi;
 
 import java.io.IOException;
 import java.util.Hashtable;
-import java.util.Map;
 import java.util.WeakHashMap;
 import javax.naming.Context;
 import javax.naming.Name;
@@ -30,6 +29,7 @@ import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.log.Logger;
 
 
@@ -239,17 +239,6 @@ public class ContextFactory implements ObjectFactory
 
     public static void dump(Appendable out, String indent) throws IOException
     {
-        out.append("o.e.j.jndi.ContextFactory@").append(Long.toHexString(__contextMap.hashCode())).append("\n");
-        int size=__contextMap.size();
-        int i=0;
-        for (Map.Entry<ClassLoader,NamingContext> entry : ((Map<ClassLoader,NamingContext>)__contextMap).entrySet())
-        {
-            boolean last=++i==size;
-            ClassLoader loader=entry.getKey();
-            out.append(indent).append(" +- ").append(loader.getClass().getSimpleName()).append("@").append(Long.toHexString(loader.hashCode())).append(": ");
-
-            NamingContext context = entry.getValue();
-            context.dump(out,indent+(last?"    ":" |  "));
-        }
+        Dumpable.dumpObjects(out, indent, String.format("o.e.j.jndi.ContextFactory@",__contextMap.hashCode()), __contextMap);
     }
 }

--- a/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/InitialContextFactory.java
+++ b/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/InitialContextFactory.java
@@ -18,10 +18,8 @@
 
 package org.eclipse.jetty.jndi;
 
-
 import java.util.Hashtable;
 import java.util.Properties;
-
 import javax.naming.CompoundName;
 import javax.naming.Context;
 import javax.naming.Name;

--- a/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/local/localContextRoot.java
+++ b/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/local/localContextRoot.java
@@ -18,11 +18,8 @@
 
 package org.eclipse.jetty.jndi.local;
 
-import java.util.Collections;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Properties;
-
 import javax.naming.Binding;
 import javax.naming.CompoundName;
 import javax.naming.Context;
@@ -40,8 +37,6 @@ import javax.naming.Reference;
 import javax.naming.Referenceable;
 import javax.naming.spi.NamingManager;
 
-import org.eclipse.jetty.jndi.BindingEnumeration;
-import org.eclipse.jetty.jndi.NameEnumeration;
 import org.eclipse.jetty.jndi.NamingContext;
 import org.eclipse.jetty.jndi.NamingUtil;
 import org.eclipse.jetty.util.log.Logger;
@@ -62,7 +57,6 @@ public class localContextRoot implements Context
     protected final static NamingContext __root = new NamingRoot();
     private final Hashtable<String,Object> _env;
 
-
     static class NamingRoot extends NamingContext
     {
         public NamingRoot()
@@ -70,8 +64,6 @@ public class localContextRoot implements Context
             super (null,null,null,new LocalNameParser());
         }
     }
-
-
 
     static class LocalNameParser implements NameParser
     {
@@ -100,10 +92,6 @@ public class localContextRoot implements Context
      */
 
 
-
-
-
-
     public static NamingContext getRoot()
     {
         return __root;
@@ -122,7 +110,6 @@ public class localContextRoot implements Context
     @Override
     public void close() throws NamingException
     {
-
     }
 
     /**
@@ -136,7 +123,6 @@ public class localContextRoot implements Context
         return "";
     }
 
-
     /**
      *
      *
@@ -145,12 +131,8 @@ public class localContextRoot implements Context
     @Override
     public void destroySubcontext(Name name) throws NamingException
     {
-        synchronized (__root)
-        {
-            __root.destroySubcontext(getSuffix(name));
-        }
+        __root.destroySubcontext(getSuffix(name));
     }
-
 
     /**
      *
@@ -160,13 +142,8 @@ public class localContextRoot implements Context
     @Override
     public void destroySubcontext(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-
-           destroySubcontext(__root.getNameParser("").parse(getSuffix(name)));
-        }
+        destroySubcontext(__root.getNameParser("").parse(getSuffix(name)));
     }
-
 
     /**
      *
@@ -179,7 +156,49 @@ public class localContextRoot implements Context
         return _env;
     }
 
+    private Object dereference(Object ctx, String firstComponent) throws NamingException
+    {
+        if (ctx instanceof Reference)
+        {
+            //deference the object
+            try
+            {
+                return NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
+            }
+            catch (NamingException e)
+            {
+                throw e;
+            }
+            catch (Exception e)
+            {
+                __log.warn(e);
+                throw new NamingException (e.getMessage());
+            }
+        }
+        return ctx;
+    }
 
+    private Context getContext(Name cname) throws NamingException
+    {
+        String firstComponent = cname.get(0);
+
+        if (firstComponent.equals(""))
+            return this;
+
+        Binding binding = __root.getBinding (firstComponent);
+        if (binding == null)
+        {
+            NameNotFoundException nnfe = new NameNotFoundException(firstComponent + " is not bound");
+            nnfe.setRemainingName(cname);
+            throw nnfe;
+        }
+        Object ctx = dereference(binding.getObject(), firstComponent);
+
+        if (!(ctx instanceof Context))
+            throw new NotContextException(firstComponent + " not a context in " + this.getNameInNamespace());
+
+        return (Context)ctx;
+    }
 
     /**
      *
@@ -189,79 +208,30 @@ public class localContextRoot implements Context
     @Override
     public void unbind(Name name) throws NamingException
     {
-        synchronized (__root)
+        //__root.unbind(getSuffix(name));
+
+        if (name.size() == 0)
+            return;
+
+        if (__root.isLocked())
+            throw new NamingException ("This context is immutable");
+
+        Name cname = __root.toCanonicalName(name);
+
+        if (cname == null)
+            throw new NamingException ("Name is null");
+
+        if (cname.size() == 0)
+            throw new NamingException ("Name is empty");
+
+        //if no subcontexts, just unbind it
+        if (cname.size() == 1)
         {
-            //__root.unbind(getSuffix(name));
-
-            if (name.size() == 0)
-                return;
-
-
-            if (__root.isLocked())
-                throw new NamingException ("This context is immutable");
-
-            Name cname = __root.toCanonicalName(name);
-
-            if (cname == null)
-                throw new NamingException ("Name is null");
-
-            if (cname.size() == 0)
-                throw new NamingException ("Name is empty");
-
-
-            //if no subcontexts, just unbind it
-            if (cname.size() == 1)
-            {
-                __root.removeBinding (cname);
-            }
-            else
-            {
-                //walk down the subcontext hierarchy
-                if(__log.isDebugEnabled())__log.debug("Checking for existing binding for name="+cname+" for first element of name="+cname.get(0));
-
-                String firstComponent = cname.get(0);
-                Object ctx = null;
-
-
-                if (firstComponent.equals(""))
-                    ctx = this;
-                else
-                {
-                    Binding  binding = __root.getBinding (name.get(0));
-                    if (binding == null)
-                        throw new NameNotFoundException (name.get(0)+ " is not bound");
-
-                    ctx = binding.getObject();
-
-                    if (ctx instanceof Reference)
-                    {
-                        //deference the object
-                        try
-                        {
-                            ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                        }
-                        catch (NamingException e)
-                        {
-                            throw e;
-                        }
-                        catch (Exception e)
-                        {
-                            __log.warn("",e);
-                            throw new NamingException (e.getMessage());
-                        }
-                    }
-                }
-
-                if (ctx instanceof Context)
-                {
-                    ((Context)ctx).unbind (cname.getSuffix(1));
-                }
-                else
-                    throw new NotContextException ("Object bound at "+firstComponent +" is not a Context");
-            }
-
-
-
+            __root.removeBinding (cname);
+        }
+        else
+        {
+            getContext(cname).unbind (cname.getSuffix(1));
         }
     }
 
@@ -276,8 +246,6 @@ public class localContextRoot implements Context
         unbind(__root.getNameParser("").parse(getSuffix(name)));
     }
 
-
-
     /**
      *
      *
@@ -286,10 +254,7 @@ public class localContextRoot implements Context
     @Override
     public Object lookupLink(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-            return lookupLink(__root.getNameParser("").parse(getSuffix(name)));
-        }
+        return lookupLink(__root.getNameParser("").parse(getSuffix(name)));
     }
 
     /**
@@ -300,101 +265,54 @@ public class localContextRoot implements Context
     @Override
     public Object lookupLink(Name name) throws NamingException
     {
-        synchronized (__root)
+        Name cname = __root.toCanonicalName(name);
+
+        if (cname == null || cname.isEmpty())
         {
-            //return __root.lookupLink(getSuffix(name));
+            //If no name create copy of this context with same bindings, but with copy of the environment so it can be modified
+            return __root.shallowCopy();
+        }
 
+        if (cname.size() == 0)
+            throw new NamingException ("Name is empty");
 
-            Name cname = __root.toCanonicalName(name);
+        if (cname.size() == 1)
+        {
+            Binding binding = __root.getBinding (cname);
+            if (binding == null)
+                throw new NameNotFoundException();
 
-            if (cname == null)
+            Object o = binding.getObject();
+
+            //handle links by looking up the link
+            if (o instanceof Reference)
             {
-                //If no name create copy of this context with same bindings, but with copy of the environment so it can be modified
-                NamingContext ctx = new NamingContext (_env, null, null, __root.getNameParser(""));
-                ctx.setBindings(__root.getBindings());
-                return ctx;
-            }
-
-            if (cname.size() == 0)
-                throw new NamingException ("Name is empty");
-
-            if (cname.size() == 1)
-            {
-                Binding binding = __root.getBinding (cname);
-                if (binding == null)
-                    throw new NameNotFoundException();
-
-                Object o = binding.getObject();
-
-                //handle links by looking up the link
-                if (o instanceof Reference)
+                //deference the object
+                try
                 {
-                    //deference the object
-                    try
-                    {
-                        return NamingManager.getObjectInstance(o, cname.getPrefix(1), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
+                    return NamingManager.getObjectInstance(o, cname.getPrefix(1), __root, _env);
                 }
-                else
+                catch (NamingException e)
                 {
-                    //object is either a LinkRef which we don't dereference
-                    //or a plain object in which case spec says we return it
-                    return o;
+                    throw e;
+                }
+                catch (Exception e)
+                {
+                    __log.warn("",e);
+                    throw new NamingException (e.getMessage());
                 }
             }
-
-
-            //it is a multipart name, recurse to the first subcontext
-            String firstComponent = cname.get(0);
-            Object ctx = null;
-
-            if (firstComponent.equals(""))
-                ctx = this;
             else
             {
-                Binding binding = __root.getBinding (firstComponent);
-                if (binding == null)
-                    throw new NameNotFoundException ();
-
-                ctx = binding.getObject();
-
-                if (ctx instanceof Reference)
-                {
-                    //deference the object
-                    try
-                    {
-                        ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
-                }
+                //object is either a LinkRef which we don't dereference
+                //or a plain object in which case spec says we return it
+                return o;
             }
-
-            if (!(ctx instanceof Context))
-                throw new NotContextException();
-
-            return ((Context)ctx).lookup (cname.getSuffix(1));
-
-
         }
-    }
 
+        //it is a multipart name, recurse to the first subcontext
+        return getContext(cname).lookup (cname.getSuffix(1));
+    }
 
     /**
      *
@@ -407,7 +325,6 @@ public class localContextRoot implements Context
         return _env.remove(propName);
     }
 
-
     /**
      *
      *
@@ -416,122 +333,65 @@ public class localContextRoot implements Context
     @Override
     public Object lookup(Name name) throws NamingException
     {
-        synchronized (__root)
+        if(__log.isDebugEnabled())__log.debug("Looking up name=\""+name+"\"");
+        Name cname = __root.toCanonicalName(name);
+
+        if ((cname == null) || cname.isEmpty())
         {
-            //return __root.lookup(getSuffix(name));
-
-            if(__log.isDebugEnabled())__log.debug("Looking up name=\""+name+"\"");
-            Name cname = __root.toCanonicalName(name);
-
-            if ((cname == null) || (cname.size() == 0))
-            {
-                __log.debug("Null or empty name, returning copy of this context");
-                NamingContext ctx = new NamingContext (_env, null, null, __root.getNameParser(""));
-                ctx.setBindings(__root.getBindings());
-                return ctx;
-            }
-
-
-
-            if (cname.size() == 1)
-            {
-                Binding binding = __root.getBinding (cname);
-                if (binding == null)
-                {
-                    NameNotFoundException nnfe = new NameNotFoundException();
-                    nnfe.setRemainingName(cname);
-                    throw nnfe;
-                }
-
-
-                Object o = binding.getObject();
-
-                //handle links by looking up the link
-                if (o instanceof LinkRef)
-                {
-                    //if link name starts with ./ it is relative to current context
-                    String linkName = ((LinkRef)o).getLinkName();
-                    if (linkName.startsWith("./"))
-                        return lookup (linkName.substring(2));
-                    else
-                    {
-                        //link name is absolute
-                        InitialContext ictx = new InitialContext();
-                        return ictx.lookup (linkName);
-                    }
-                }
-                else if (o instanceof Reference)
-                {
-                    //deference the object
-                    try
-                    {
-                        return NamingManager.getObjectInstance(o, cname, __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (final Exception e)
-                    {
-                        throw new NamingException (e.getMessage())
-                        {
-                            { initCause(e);}
-                        };
-                    }
-                }
-                else
-                    return o;
-            }
-
-            //it is a multipart name, get the first subcontext
-
-            String firstComponent = cname.get(0);
-            Object ctx = null;
-
-            if (firstComponent.equals(""))
-                ctx = this;
-            else
-            {
-
-                Binding binding = __root.getBinding (firstComponent);
-                if (binding == null)
-                {
-                    NameNotFoundException nnfe = new NameNotFoundException();
-                    nnfe.setRemainingName(cname);
-                    throw nnfe;
-                }
-
-                //as we have bound a reference to an object factory
-                //for the component specific contexts
-                //at "comp" we need to resolve the reference
-                ctx = binding.getObject();
-
-                if (ctx instanceof Reference)
-                {
-                    //deference the object
-                    try
-                    {
-                        ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
-                }
-            }
-            if (!(ctx instanceof Context))
-                throw new NotContextException();
-
-            return ((Context)ctx).lookup (cname.getSuffix(1));
-
+            return __root.shallowCopy();
         }
-    }
 
+        if (cname.size() == 1)
+        {
+            Binding binding = __root.getBinding (cname);
+            if (binding == null)
+            {
+                NameNotFoundException nnfe = new NameNotFoundException();
+                nnfe.setRemainingName(cname);
+                throw nnfe;
+            }
+
+            Object o = binding.getObject();
+
+            //handle links by looking up the link
+            if (o instanceof LinkRef)
+            {
+                //if link name starts with ./ it is relative to current context
+                String linkName = ((LinkRef)o).getLinkName();
+                if (linkName.startsWith("./"))
+                    return lookup (linkName.substring(2));
+                else
+                {
+                    //link name is absolute
+                    InitialContext ictx = new InitialContext();
+                    return ictx.lookup (linkName);
+                }
+            }
+            else if (o instanceof Reference)
+            {
+                // TODO use deference
+                try
+                {
+                    return NamingManager.getObjectInstance(o, cname, __root, _env);
+                }
+                catch (NamingException e)
+                {
+                    throw e;
+                }
+                catch (final Exception e)
+                {
+                    throw new NamingException (e.getMessage())
+                    {
+                        { initCause(e);}
+                    };
+                }
+            }
+            else
+                return o;
+        }
+
+        return getContext(cname).lookup(cname.getSuffix(1));
+    }
 
     /**
      *
@@ -541,12 +401,8 @@ public class localContextRoot implements Context
     @Override
     public Object lookup(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-            return lookup(__root.getNameParser("").parse(getSuffix(name)));
-        }
+        return lookup(__root.getNameParser("").parse(getSuffix(name)));
     }
-
 
     /**
      *
@@ -556,13 +412,8 @@ public class localContextRoot implements Context
     @Override
     public void bind(String name, Object obj) throws NamingException
     {
-        synchronized (__root)
-        {
-           bind(__root.getNameParser("").parse(getSuffix(name)), obj);
-
-        }
+        bind(__root.getNameParser("").parse(getSuffix(name)), obj);
     }
-
 
     /**
      *
@@ -572,85 +423,37 @@ public class localContextRoot implements Context
     @Override
     public void bind(Name name, Object obj) throws NamingException
     {
-        synchronized (__root)
+        if (__root.isLocked())
+            throw new NamingException ("This context is immutable");
+
+        Name cname = __root.toCanonicalName(name);
+
+        if (cname == null)
+            throw new NamingException ("Name is null");
+
+        if (cname.size() == 0)
+            throw new NamingException ("Name is empty");
+
+        //if no subcontexts, just bind it
+        if (cname.size() == 1)
         {
-           // __root.bind(getSuffix(name), obj);
-
-
-            if (__root.isLocked())
-                throw new NamingException ("This context is immutable");
-
-            Name cname = __root.toCanonicalName(name);
-
-            if (cname == null)
-                throw new NamingException ("Name is null");
-
-            if (cname.size() == 0)
-                throw new NamingException ("Name is empty");
-
-
-            //if no subcontexts, just bind it
-            if (cname.size() == 1)
+            //get the object to be bound
+            Object objToBind = NamingManager.getStateToBind(obj, name,this, _env);
+            // Check for Referenceable
+            if (objToBind instanceof Referenceable)
             {
-                //get the object to be bound
-                Object objToBind = NamingManager.getStateToBind(obj, name,this, _env);
-                // Check for Referenceable
-                if (objToBind instanceof Referenceable)
-                {
-                    objToBind = ((Referenceable)objToBind).getReference();
-                }
-
-                //anything else we should be able to bind directly
-                __root.addBinding (cname, objToBind);
+                objToBind = ((Referenceable)objToBind).getReference();
             }
-            else
-            {
-                if(__log.isDebugEnabled())__log.debug("Checking for existing binding for name="+cname+" for first element of name="+cname.get(0));
 
-                //walk down the subcontext hierarchy
-                //need to ignore trailing empty "" name components
+            //anything else we should be able to bind directly
+            __root.addBinding (cname, objToBind);
+        }
+        else
+        {
+            if(__log.isDebugEnabled())
+                __log.debug("Checking for existing binding for name="+cname+" for first element of name="+cname.get(0));
 
-                String firstComponent = cname.get(0);
-                Object ctx = null;
-
-                if (firstComponent.equals(""))
-                    ctx = this;
-                else
-                {
-
-                    Binding  binding = __root.getBinding (firstComponent);
-                    if (binding == null)
-                        throw new NameNotFoundException (firstComponent+ " is not bound");
-
-                    ctx = binding.getObject();
-
-                    if (ctx instanceof Reference)
-                    {
-                        //deference the object
-                        try
-                        {
-                            ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), this, _env);
-                        }
-                        catch (NamingException e)
-                        {
-                            throw e;
-                        }
-                        catch (Exception e)
-                        {
-                            __log.warn("",e);
-                            throw new NamingException (e.getMessage());
-                        }
-                    }
-                }
-
-
-                if (ctx instanceof Context)
-                {
-                    ((Context)ctx).bind (cname.getSuffix(1), obj);
-                }
-                else
-                    throw new NotContextException ("Object bound at "+firstComponent +" is not a Context");
-            }
+            getContext(cname).bind (cname.getSuffix(1), obj);
         }
     }
 
@@ -662,82 +465,37 @@ public class localContextRoot implements Context
     @Override
     public void rebind(Name name, Object obj) throws NamingException
     {
-        synchronized (__root)
+        if (__root.isLocked())
+            throw new NamingException ("This context is immutable");
+
+        Name cname = __root.toCanonicalName(name);
+
+        if (cname == null)
+            throw new NamingException ("Name is null");
+
+        if (cname.size() == 0)
+            throw new NamingException ("Name is empty");
+
+        //if no subcontexts, just bind it
+        if (cname.size() == 1)
         {
-            //__root.rebind(getSuffix(name), obj);
+            //check if it is a Referenceable
+            Object objToBind = NamingManager.getStateToBind(obj, name, __root, _env);
 
-
-            if (__root.isLocked())
-                throw new NamingException ("This context is immutable");
-
-            Name cname = __root.toCanonicalName(name);
-
-            if (cname == null)
-                throw new NamingException ("Name is null");
-
-            if (cname.size() == 0)
-                throw new NamingException ("Name is empty");
-
-
-            //if no subcontexts, just bind it
-            if (cname.size() == 1)
+            if (objToBind instanceof Referenceable)
             {
-                //check if it is a Referenceable
-                Object objToBind = NamingManager.getStateToBind(obj, name, __root, _env);
-
-                if (objToBind instanceof Referenceable)
-                {
-                    objToBind = ((Referenceable)objToBind).getReference();
-                }
-                __root.removeBinding(cname);
-                __root.addBinding (cname, objToBind);
+                objToBind = ((Referenceable)objToBind).getReference();
             }
-            else
-            {
-                //walk down the subcontext hierarchy
-                if(__log.isDebugEnabled())__log.debug("Checking for existing binding for name="+cname+" for first element of name="+cname.get(0));
+            __root.removeBinding(cname);
+            __root.addBinding (cname, objToBind);
+        }
+        else
+        {
+            //walk down the subcontext hierarchy
+            if(__log.isDebugEnabled())
+                __log.debug("Checking for existing binding for name="+cname+" for first element of name="+cname.get(0));
 
-                String firstComponent = cname.get(0);
-                Object ctx = null;
-
-
-                if (firstComponent.equals(""))
-                    ctx = this;
-                else
-                {
-                    Binding  binding = __root.getBinding (name.get(0));
-                    if (binding == null)
-                        throw new NameNotFoundException (name.get(0)+ " is not bound");
-
-                    ctx = binding.getObject();
-
-
-                    if (ctx instanceof Reference)
-                    {
-                        //deference the object
-                        try
-                        {
-                            ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                        }
-                        catch (NamingException e)
-                        {
-                            throw e;
-                        }
-                        catch (Exception e)
-                        {
-                            __log.warn("",e);
-                            throw new NamingException (e.getMessage());
-                        }
-                    }
-                }
-
-                if (ctx instanceof Context)
-                {
-                    ((Context)ctx).rebind (cname.getSuffix(1), obj);
-                }
-                else
-                    throw new NotContextException ("Object bound at "+firstComponent +" is not a Context");
-            }
+            getContext(cname).rebind (cname.getSuffix(1), obj);
         }
     }
 
@@ -749,11 +507,9 @@ public class localContextRoot implements Context
     @Override
     public void rebind(String name, Object obj) throws NamingException
     {
-        synchronized (__root)
-        {
-            rebind(__root.getNameParser("").parse(getSuffix(name)), obj);
-        }
+        rebind(__root.getNameParser("").parse(getSuffix(name)), obj);
     }
+
     /**
      *
      *
@@ -762,10 +518,7 @@ public class localContextRoot implements Context
     @Override
     public void rename(Name oldName, Name newName) throws NamingException
     {
-        synchronized (__root)
-        {
-            throw new OperationNotSupportedException();
-        }
+        throw new OperationNotSupportedException();
     }
 
     /**
@@ -776,10 +529,7 @@ public class localContextRoot implements Context
     @Override
     public void rename(String oldName, String newName) throws NamingException
     {
-        synchronized (__root)
-        {
-           throw new OperationNotSupportedException();
-        }
+        throw new OperationNotSupportedException();
     }
 
     /**
@@ -790,18 +540,15 @@ public class localContextRoot implements Context
     @Override
     public Context createSubcontext(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-            //if the subcontext comes directly off the root, use the env of the InitialContext
-            //as the root itself has no environment. Otherwise, it inherits the env of the parent
-            //Context further down the tree.
-            //NamingContext ctx = (NamingContext)__root.createSubcontext(name);
-            //if (ctx.getParent() == __root)
-            //    ctx.setEnv(_env);
-            //return ctx;
+        //if the subcontext comes directly off the root, use the env of the InitialContext
+        //as the root itself has no environment. Otherwise, it inherits the env of the parent
+        //Context further down the tree.
+        //NamingContext ctx = (NamingContext)__root.createSubcontext(name);
+        //if (ctx.getParent() == __root)
+        //    ctx.setEnv(_env);
+        //return ctx;
 
-            return createSubcontext(__root.getNameParser("").parse(name));
-        }
+        return createSubcontext(__root.getNameParser("").parse(name));
     }
 
     /**
@@ -812,92 +559,45 @@ public class localContextRoot implements Context
     @Override
     public Context createSubcontext(Name name) throws NamingException
     {
-        synchronized (__root)
+        //if the subcontext comes directly off the root, use the env of the InitialContext
+        //as the root itself has no environment. Otherwise, it inherits the env of the parent
+        //Context further down the tree.
+        //NamingContext ctx = (NamingContext)__root.createSubcontext(getSuffix(name));
+        //if (ctx.getParent() == __root)
+        //    ctx.setEnv(_env);
+        //return ctx;
+
+        if (__root.isLocked())
         {
-            //if the subcontext comes directly off the root, use the env of the InitialContext
-            //as the root itself has no environment. Otherwise, it inherits the env of the parent
-            //Context further down the tree.
-            //NamingContext ctx = (NamingContext)__root.createSubcontext(getSuffix(name));
-            //if (ctx.getParent() == __root)
-            //    ctx.setEnv(_env);
-            //return ctx;
-
-
-
-
-            if (__root.isLocked())
-            {
-                NamingException ne = new NamingException ("This context is immutable");
-                ne.setRemainingName(name);
-                throw ne;
-            }
-
-            Name cname = __root.toCanonicalName (name);
-
-            if (cname == null)
-                throw new NamingException ("Name is null");
-            if (cname.size() == 0)
-                throw new NamingException ("Name is empty");
-
-            if (cname.size() == 1)
-            {
-                //not permitted to bind if something already bound at that name
-                Binding binding = __root.getBinding (cname);
-                if (binding != null)
-                    throw new NameAlreadyBoundException (cname.toString());
-
-                //make a new naming context with the root as the parent
-                Context ctx = new NamingContext ((Hashtable)_env.clone(), cname.get(0), __root,  __root.getNameParser(""));
-                __root.addBinding (cname, ctx);
-                return ctx;
-            }
-
-
-            //If the name has multiple subcontexts, walk the hierarchy by
-            //fetching the first one. All intermediate subcontexts in the
-            //name must already exist.
-            String firstComponent = cname.get(0);
-            Object ctx = null;
-
-            if (firstComponent.equals(""))
-                ctx = this;
-            else
-            {
-                Binding binding = __root.getBinding (firstComponent);
-                if (binding == null)
-                    throw new NameNotFoundException (firstComponent + " is not bound");
-
-                ctx = binding.getObject();
-
-                if (ctx instanceof Reference)
-                {
-                    //deference the object
-                    if(__log.isDebugEnabled())__log.debug("Object bound at "+firstComponent +" is a Reference");
-                    try
-                    {
-                        ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
-                }
-            }
-
-            if (ctx instanceof Context)
-            {
-                return ((Context)ctx).createSubcontext (cname.getSuffix(1));
-            }
-            else
-                throw new NotContextException (firstComponent +" is not a Context");
+            NamingException ne = new NamingException ("This context is immutable");
+            ne.setRemainingName(name);
+            throw ne;
         }
-    }
 
+        Name cname = __root.toCanonicalName (name);
+
+        if (cname == null)
+            throw new NamingException ("Name is null");
+        if (cname.size() == 0)
+            throw new NamingException ("Name is empty");
+
+        if (cname.size() == 1)
+        {
+            //not permitted to bind if something already bound at that name
+            Binding binding = __root.getBinding (cname);
+            if (binding != null)
+                throw new NameAlreadyBoundException (cname.toString());
+
+            //make a new naming context with the root as the parent
+            Context ctx = new NamingContext (_env, cname.get(0), __root,  __root.getNameParser(""));
+            __root.addBinding (cname, ctx);
+            return ctx;
+        }
+
+        //If the name has multiple subcontexts,
+        return getContext(cname).createSubcontext(cname.getSuffix(1));
+
+    }
 
     /**
      *
@@ -929,12 +629,8 @@ public class localContextRoot implements Context
     @Override
     public NamingEnumeration list(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-            return list(__root.getNameParser("").parse(getSuffix(name)));
-        }
+        return __root.list(name);
     }
-
 
     /**
      *
@@ -944,67 +640,7 @@ public class localContextRoot implements Context
     @Override
     public NamingEnumeration list(Name name) throws NamingException
     {
-        synchronized (__root)
-        {
-            //return __root.list(getSuffix(name));
-
-
-            Name cname = __root.toCanonicalName(name);
-
-            if (cname == null)
-            {
-                List<Binding> empty = Collections.emptyList();
-                return new NameEnumeration(empty.iterator());
-            }
-
-
-            if (cname.size() == 0)
-            {
-               return new NameEnumeration (__root.getBindings().values().iterator());
-            }
-
-
-
-            //multipart name
-            String firstComponent = cname.get(0);
-            Object ctx = null;
-
-            if (firstComponent.equals(""))
-                ctx = this;
-            else
-            {
-                Binding binding = __root.getBinding (firstComponent);
-                if (binding == null)
-                    throw new NameNotFoundException ();
-
-                ctx = binding.getObject();
-
-                if (ctx instanceof Reference)
-                {
-                    //deference the object
-                    if(__log.isDebugEnabled())__log.debug("Dereferencing Reference for "+name.get(0));
-                    try
-                    {
-                        ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
-                }
-            }
-
-            if (!(ctx instanceof Context))
-                throw new NotContextException();
-
-            return ((Context)ctx).list (cname.getSuffix(1));
-
-        }
+        return __root.list(name);
     }
 
     /**
@@ -1015,69 +651,8 @@ public class localContextRoot implements Context
     @Override
     public NamingEnumeration listBindings(Name name) throws NamingException
     {
-        synchronized (__root)
-        {
-            //return __root.listBindings(getSuffix(name));
-
-            Name cname = __root.toCanonicalName (name);
-
-            if (cname == null)
-            {
-                List<Binding> empty = Collections.emptyList();
-                return new BindingEnumeration(empty.iterator());
-            }
-
-            if (cname.size() == 0)
-            {
-               return new BindingEnumeration (__root.getBindings().values().iterator());
-            }
-
-
-
-            //multipart name
-            String firstComponent = cname.get(0);
-            Object ctx = null;
-
-            //if a name has a leading "/" it is parsed as "" so ignore it by staying
-            //at this level in the tree
-            if (firstComponent.equals(""))
-                ctx = this;
-            else
-            {
-                //it is a non-empty name component
-                Binding binding = __root.getBinding (firstComponent);
-                if (binding == null)
-                    throw new NameNotFoundException ();
-
-                ctx = binding.getObject();
-
-                if (ctx instanceof Reference)
-                {
-                    //deference the object
-                    try
-                    {
-                        ctx = NamingManager.getObjectInstance(ctx, getNameParser("").parse(firstComponent), __root, _env);
-                    }
-                    catch (NamingException e)
-                    {
-                        throw e;
-                    }
-                    catch (Exception e)
-                    {
-                        __log.warn("",e);
-                        throw new NamingException (e.getMessage());
-                    }
-                }
-            }
-
-            if (!(ctx instanceof Context))
-                throw new NotContextException();
-
-            return ((Context)ctx).listBindings (cname.getSuffix(1));
-
-        }
+        return __root.listBindings(name);
     }
-
 
     /**
      *
@@ -1087,12 +662,8 @@ public class localContextRoot implements Context
     @Override
     public NamingEnumeration listBindings(String name) throws NamingException
     {
-        synchronized (__root)
-        {
-            return listBindings(__root.getNameParser("").parse(getSuffix(name)));
-        }
+        return __root.listBindings(name);
     }
-
 
     /**
      *

--- a/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
+++ b/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
@@ -18,7 +18,9 @@
 
 package org.eclipse.jetty.jndi.java;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -49,6 +51,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 /**
  *
@@ -288,7 +291,7 @@ public class TestJNDI
         ClassLoader currentLoader = currentThread.getContextClassLoader();
         ClassLoader childLoader1 = new URLClassLoader(new URL[0], currentLoader);
         ClassLoader childLoader2 = new URLClassLoader(new URL[0], currentLoader);
-        
+        InitialContext initCtx = null;
         try
         {
 
@@ -325,7 +328,7 @@ public class TestJNDI
             
             //Set up the tccl before doing any jndi operations
             currentThread.setContextClassLoader(childLoader1);
-            InitialContext initCtx = new InitialContext();
+            initCtx = new InitialContext();
             
             //Test we can lookup the root java: naming tree
             Context sub0 = (Context)initCtx.lookup("java:");
@@ -439,30 +442,66 @@ public class TestJNDI
 
             //check locking the context
             Context ectx = (Context)initCtx.lookup("java:comp");
+            //make a deep structure lie ttt/ttt2 for later use
+            Context ttt = ectx.createSubcontext("ttt");
+            ttt.createSubcontext("ttt2");
+            //bind a value
             ectx.bind("crud", "xxx");
-            ectx.addToEnvironment("org.eclipse.jndi.immutable", "TRUE");
+            //lock
+            ectx.addToEnvironment("org.eclipse.jetty.jndi.lock", "TRUE");
+            //check we can't get the lock
+            assertFalse(ectx.getEnvironment().containsKey("org.eclipse.jetty.jndi.lock"));
+            //check once locked we can still do lookups
             assertEquals ("xxx", initCtx.lookup("java:comp/crud"));
+            assertNotNull(initCtx.lookup("java:comp/ttt/ttt2"));
+            
+            //test trying to bind into java:comp after lock
+            InitialContext zzz = null;
             try
             {
-                ectx.bind("crud2", "xxx2");
+                zzz = new InitialContext();
+
+                ((Context)zzz.lookup("java:comp")).bind("crud2", "xxx2");
+                fail("Should not be able to write to locked context");
+
             }
             catch (NamingException ne)
             {
-                //expected failure to modify immutable context
+                assertThat(ne.getMessage(), Matchers.containsString("immutable"));
             }
-            
+            finally
+            {
+                zzz.close();
+            }
 
-            initCtx.close();
+            //test trying to bind into a deep structure inside java:comp after lock
+            try
+            {
+                zzz = new InitialContext();
+
+                ((Context)zzz.lookup("java:comp/ttt/ttt2")).bind("zzz2", "zzz2");
+                fail("Should not be able to write to locked context");
+            }
+            catch (NamingException ne)
+            {
+                assertThat(ne.getMessage(), Matchers.containsString("immutable"));
+            }
+            finally
+            {
+                zzz.close();
+            }
         }
         finally
         {
             //make some effort to clean up
+            initCtx.close();
             InitialContext ic = new InitialContext();
             Context java = (Context)ic.lookup("java:");
             java.destroySubcontext("zero");
             java.destroySubcontext("fee");
             currentThread.setContextClassLoader(childLoader1);
             Context comp = (Context)ic.lookup("java:comp");
+            comp.addToEnvironment("org.eclipse.jetty.jndi.unlock", "TRUE");
             comp.destroySubcontext("env");
             comp.unbind("crud");
             comp.unbind("crud2");

--- a/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/PlusConfiguration.java
+++ b/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/PlusConfiguration.java
@@ -19,11 +19,11 @@
 package org.eclipse.jetty.plus.webapp;
 
 import java.util.Random;
-
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 
+import org.eclipse.jetty.jndi.NamingContext;
 import org.eclipse.jetty.plus.annotation.InjectionCollection;
 import org.eclipse.jetty.plus.annotation.LifeCycleCallbackCollection;
 import org.eclipse.jetty.plus.jndi.Transaction;
@@ -106,10 +106,10 @@ public class PlusConfiguration extends AbstractConfiguration
         try
         {
             Random random = new Random ();
-            _key = new Integer(random.nextInt());
+            _key = random.nextInt();
             Context context = new InitialContext();
             Context compCtx = (Context)context.lookup("java:comp");
-            compCtx.addToEnvironment("org.eclipse.jetty.jndi.lock", _key);
+            compCtx.addToEnvironment(NamingContext.LOCK_PROPERTY, _key);
         }
         finally
         {


### PR DESCRIPTION
#3729 

The creation of the java:comp/env namespace is not threadsafe. According to the jndi spec, access to naming Contexts is not threadsafe, and callers must do any synchronization themselves. So we should ensure that we create the java:comp/env namespace in a threadsafe manner. Also:

-  went above-and-beyond and ensured thread safety for adding/removing bindings and subcontexts to Contexts
- ensured that the java:comp context is made readonly all the way down the subcontext tree once the webapp starts
- some tweaks to the Context locking mechanism (which is the implementation of read-only) 
-  did a general code-cleanup of cruft