### PR TITLE
Remove jetty-util transitive OSGi dependency on servlet-api #3726

### DIFF
--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -51,7 +51,6 @@
         <configuration>
           <instructions>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
-            <_nouses>true</_nouses>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -51,6 +51,7 @@
         <configuration>
           <instructions>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
+            <_nouses>true</_nouses>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -50,6 +50,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Export-Package>org.eclipse.jetty.util;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";exclude:="MultiPartInputStreamParser";uses:="org.eclipse.jetty.util.annotation,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.thread";-noimport:=true,*</Export-Package>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
           </instructions>
         </configuration>


### PR DESCRIPTION
#3726 

Make osgi Export-Package explicit for org.eclipse.jetty.util to avoid including the transitive dependency on javax.servlet introduced by MultiPartInputStreamParser, which is a deprecated class and is removed in jetty-10.