### PR TITLE
Issue #3748 Fix regression for injecting Resource on AsyncListeners

### DIFF
--- a/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/NamingContext.java
+++ b/jetty-jndi/src/main/java/org/eclipse/jetty/jndi/NamingContext.java
@@ -1103,7 +1103,8 @@ public class NamingContext implements Context, Dumpable
     /* ------------------------------------------------------------ */
     public boolean isLocked()
     {
-        return _lock != null || (_parent!=null && _parent.isLocked());
+        //TODO lock whole hierarchy?
+        return _lock != null;
     }
 
     /* ------------------------------------------------------------ */

--- a/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
+++ b/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
@@ -479,7 +479,10 @@ public class TestJNDI
             {
                 zzz = new InitialContext();
 
-                ((Context)zzz.lookup("java:comp/ttt/ttt2")).bind("zzz2", "zzz2");
+                //TODO test deep locking
+                //  ((Context)zzz.lookup("java:comp/ttt/ttt2")).bind("zzz2", "zzz2");
+                // fail("Should not be able to write to locked context");
+                ((Context)zzz.lookup("java:comp")).bind("foo", "bar");
                 fail("Should not be able to write to locked context");
             }
             catch (NamingException ne)

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
@@ -1,0 +1,145 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.tests.distribution;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DemoBaseTests extends AbstractDistributionTest
+{
+    @Test
+    public void testJspDump() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        DistributionTester distribution = DistributionTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(Paths.get("demo-base"))
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        int httpPort = distribution.freePort();
+        int httpsPort = distribution.freePort();
+        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
+
+        String[] args = {
+            "jetty.http.port=" + httpPort,
+            "jetty.httpConfig.port=" + httpsPort,
+            "jetty.ssl.port=" + httpsPort
+        };
+
+        try (DistributionTester.Run run1 = distribution.start(args))
+        {
+            assertTrue(run1.awaitConsoleLogsFor("Started @", 20, TimeUnit.SECONDS));
+
+            startHttpClient();
+            ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/jsp/dump.jsp");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("PathInfo"));
+            assertThat(response.getContentAsString(), not(containsString("<%")));
+        }
+    }
+
+    @Test
+    public void testAsyncRest() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        DistributionTester distribution = DistributionTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(Paths.get("demo-base"))
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        int httpPort = distribution.freePort();
+        int httpsPort = distribution.freePort();
+        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
+
+        String[] args = {
+            "jetty.http.port=" + httpPort,
+            "jetty.httpConfig.port=" + httpsPort,
+            "jetty.ssl.port=" + httpsPort
+        };
+
+        try (DistributionTester.Run run1 = distribution.start(args))
+        {
+            assertTrue(run1.awaitConsoleLogsFor("Started @", 20, TimeUnit.SECONDS));
+
+            startHttpClient();
+            ContentResponse response;
+
+            response = client.GET("http://localhost:" + httpPort + "/async-rest/testSerial?items=kayak");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("Blocking: kayak"));
+
+            response = client.GET("http://localhost:" + httpPort + "/async-rest/testSerial?items=mouse,beer,gnome");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("Blocking: mouse,beer,gnome"));
+
+            response = client.GET("http://localhost:" + httpPort + "/async-rest/testAsync?items=kayak");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("Asynchronous: kayak"));
+
+            response = client.GET("http://localhost:" + httpPort + "/async-rest/testAsync?items=mouse,beer,gnome");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("Asynchronous: mouse,beer,gnome"));
+        }
+    }
+
+    @Test
+    public void testSpec() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        DistributionTester distribution = DistributionTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(Paths.get("demo-base"))
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        int httpPort = distribution.freePort();
+        int httpsPort = distribution.freePort();
+        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
+
+        String[] args = {
+            "jetty.http.port=" + httpPort,
+            "jetty.httpConfig.port=" + httpsPort,
+            "jetty.ssl.port=" + httpsPort
+        };
+
+        try (DistributionTester.Run run1 = distribution.start(args))
+        {
+            assertTrue(run1.awaitConsoleLogsFor("Started @", 20, TimeUnit.SECONDS));
+
+            startHttpClient();
+            ContentResponse response = client.POST("http://localhost:" + httpPort + "/test-spec/asy/xx").send();
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContentAsString(), containsString("<span class=\"pass\">PASS</span>"));
+            assertThat(response.getContentAsString(), not(containsString("<span class=\"fail\">FAIL</span>")));
+        }
+    }
+}

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -190,29 +190,6 @@ public class DistributionTests extends AbstractDistributionTest
     }
 
     @Test
-    public void testDemoBase() throws Exception
-    {
-        String jettyVersion = System.getProperty("jettyVersion");
-        DistributionTester distribution = DistributionTester.Builder.newInstance()
-                .jettyVersion(jettyVersion)
-                .jettyBase(Paths.get("demo-base"))
-                .mavenLocalRepository(System.getProperty("mavenRepoPath"))
-                .build();
-
-        int port = distribution.freePort();
-        try (DistributionTester.Run run1 = distribution.start("jetty.http.port=" + port))
-        {
-            assertTrue(run1.awaitConsoleLogsFor("Started @", 20, TimeUnit.SECONDS));
-
-            startHttpClient();
-            ContentResponse response = client.GET("http://localhost:" + port + "/test/jsp/dump.jsp");
-            assertEquals(HttpStatus.OK_200, response.getStatus());
-            assertThat(response.getContentAsString(), containsString("PathInfo"));
-            assertThat(response.getContentAsString(), not(containsString("<%")));
-        }
-    }
-
-    @Test
     public void testUnixSocket() throws Exception
     {
         Path tmpSockFile;

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AnnotatedAsyncListenerTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AnnotatedAsyncListenerTest.java
@@ -1,0 +1,159 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import javax.annotation.Resource;
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.annotations.AnnotationConfiguration;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.plus.jndi.EnvEntry;
+import org.eclipse.jetty.plus.webapp.EnvConfiguration;
+import org.eclipse.jetty.plus.webapp.PlusConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.webapp.Configuration;
+import org.eclipse.jetty.webapp.FragmentConfiguration;
+import org.eclipse.jetty.webapp.MetaInfConfiguration;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebInfConfiguration;
+import org.eclipse.jetty.webapp.WebXmlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AnnotatedAsyncListenerTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private HttpClient client;
+
+    private void start(HttpServlet servlet) throws Exception
+    {
+        QueuedThreadPool serverExecutor = new QueuedThreadPool();
+        serverExecutor.setName("server");
+        server = new Server(serverExecutor);
+        connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+
+        Path webAppDir = MavenTestingUtils.getTargetTestingPath(AnnotatedAsyncListenerTest.class.getName() + "@" + servlet.hashCode());
+        Path webInf = webAppDir.resolve("WEB-INF");
+        Files.createDirectories(webInf);
+
+        try (BufferedWriter writer = Files.newBufferedWriter(webInf.resolve("web.xml"), StandardCharsets.UTF_8, StandardOpenOption.CREATE))
+        {
+            writer.write("<web-app xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\" " +
+                "version=\"3.1\">" +
+                "</web-app>");
+        }
+
+        WebAppContext context = new WebAppContext(webAppDir.toString(), "/");
+        context.setConfigurations(new Configuration[]
+            {
+                new AnnotationConfiguration(),
+                new WebXmlConfiguration(),
+                new WebInfConfiguration(),
+                new MetaInfConfiguration(),
+                new FragmentConfiguration(),
+                new EnvConfiguration(),
+                new PlusConfiguration()
+            });
+        context.addServlet(new ServletHolder(servlet), "/*");
+        new EnvEntry(context, "value", 1307D, false);
+        server.setHandler(context);
+
+        QueuedThreadPool clientExecutor = new QueuedThreadPool();
+        clientExecutor.setName("client");
+        client = new HttpClient();
+        client.setExecutor(clientExecutor);
+        server.addBean(client);
+
+        server.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void testAnnotatedAsyncListener() throws Exception
+    {
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException
+            {
+                AsyncContext asyncContext = request.startAsync();
+                AnnotatedAsyncListener listener = asyncContext.createListener(AnnotatedAsyncListener.class);
+                assertEquals(listener.value, 1307D);
+                asyncContext.complete();
+            }
+        });
+
+        ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/test");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    public static class AnnotatedAsyncListener implements AsyncListener
+    {
+        @Resource(mappedName = "value")
+        private Double value;
+
+        @Override
+        public void onComplete(AsyncEvent event)
+        {
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event)
+        {
+        }
+
+        @Override
+        public void onError(AsyncEvent event)
+        {
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event)
+        {
+        }
+    }
+}


### PR DESCRIPTION
#3748 

Remove deep locking of java:comp/env that was added by #3729. This prevents the @Resource injection of AsyncListeners, possibly other servlet artifacts that are lazily created.

Deep locking needs to be re-evaluated.