### PR TITLE
Don't allow org.eclipse.jetty.server.Response#toString() to throw NPEs.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -1192,7 +1192,8 @@ public class Response implements HttpServletResponse
     @Override
     public String toString()
     {
-        return String.format("%s %d %s%n%s", _channel.getRequest().getHttpVersion(), _status, _reason == null ? "" : _reason, _fields);
+        HttpVersion httpVersion = _channel == null ? null : _channel.getRequest() == null ? null : _channel.getRequest().getHttpVersion();
+        return String.format("%s %d %s%n%s", httpVersion, _status, _reason == null ? "" : _reason, _fields);
     }
 
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -1155,4 +1155,11 @@ public class ResponseTest
             super(handler, new SessionData(id, "", "0.0.0.0", 0, 0, 0, 300));
         }
     }
+
+    @Test
+    public void testToString() {
+        // No NPEs please.
+        new Response(null, null).toString();
+    }
+
 }


### PR DESCRIPTION
Don't allow org.eclipse.jetty.server.Response#toString() to throw NPEs.