### PR TITLE
Prevent old jetty-util-9.3.0 from showing up in IDE

### DIFF
--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -114,7 +114,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>copy</goal>
             </goals>
@@ -128,6 +128,15 @@
                   <includes>**</includes>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/lib/jndi</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>jetty-util</artifactId>
+                  <!-- deliberately old version to test classloading -->
+                  <version>9.3.0.RC0</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/lib</outputDirectory>
                 </artifactItem>
               </artifactItems>
           </configuration>
@@ -220,12 +229,6 @@
        <groupId>org.eclipse.jetty.tests</groupId>
        <artifactId>test-container-initializer</artifactId>
        <version>${project.version}</version>
-     </dependency>
-     <dependency>
-       <groupId>org.eclipse.jetty</groupId>
-       <artifactId>jetty-util</artifactId>
-       <!-- deliberately old version to test classloading -->
-       <version>9.3.0.RC0</version>
      </dependency>
   </dependencies>
 </project>

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -76,7 +76,6 @@
             <Import-Package>
               javax.transaction*;version="[1.1,1.3)",
               com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}",
-              org.eclipse.jetty.util;version="[9.3.0,10)",
               *
             </Import-Package>
             <_nouses />

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -76,6 +76,7 @@
             <Import-Package>
               javax.transaction*;version="[1.1,1.3)",
               com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}",
+              org.eclipse.jetty.util;version="[9.3.0,10)",
               *
             </Import-Package>
             <_nouses />


### PR DESCRIPTION
+ Since the `jetty-util-9.3.0.jar` reference is only for testing
  the webapp / war behavior of the WebAppClassloader, having
  that old jar as a `<dependency>` is not necessary.
  Moved it to a `maven-dependency-plugin:copy/artifactItem` instead.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>