### PR TITLE
Issue #3782 - X-Forwarded-Port refers to node listening port

### DIFF
--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -33,6 +33,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- avoid depending on a range dependency from a transitive dependency -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.0.1</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>

--- a/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
+++ b/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
@@ -12,6 +12,7 @@
         <Set name="forwardedProtoHeader"><Property name="jetty.httpConfig.forwardedProtoHeader" default="X-Forwarded-Proto"/></Set>
         <Set name="forwardedForHeader"><Property name="jetty.httpConfig.forwardedForHeader" default="X-Forwarded-For"/></Set>
         <Set name="forwardedPortHeader"><Property name="jetty.httpConfig.forwardedPortHeader" default="X-Forwarded-Port"/></Set>
+        <Set name="forwardedPortHeaderRemote"><Property name="jetty.httpConfig.forwardedPortHeaderRemote" default="false"/></Set>
         <Set name="forwardedHttpsHeader"><Property name="jetty.httpConfig.forwardedHttpsHeader" default="X-Proxied-Https"/></Set>
         <Set name="forwardedSslSessionIdHeader"><Property name="jetty.httpConfig.forwardedSslSessionIdHeader" default="Proxy-ssl-id" /></Set>
         <Set name="forwardedCipherSuiteHeader"><Property name="jetty.httpConfig.forwardedCipherSuiteHeader" default="Proxy-auth-cert"/></Set>

--- a/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
+++ b/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
@@ -6,13 +6,13 @@
       <New class="org.eclipse.jetty.server.ForwardedRequestCustomizer">
         <Set name="forwardedOnly"><Property name="jetty.httpConfig.forwardedOnly" default="false"/></Set>
         <Set name="proxyAsAuthority"><Property name="jetty.httpConfig.forwardedProxyAsAuthority" default="false"/></Set>
+        <Set name="forwardedPortAsAuthority"><Property name="jetty.httpConfig.forwardedPortAsAuthority" default="true"/></Set>
         <Set name="forwardedHeader"><Property name="jetty.httpConfig.forwardedHeader" default="Forwarded"/></Set>
         <Set name="forwardedHostHeader"><Property name="jetty.httpConfig.forwardedHostHeader" default="X-Forwarded-Host"/></Set>
         <Set name="forwardedServerHeader"><Property name="jetty.httpConfig.forwardedServerHeader" default="X-Forwarded-Server"/></Set>
         <Set name="forwardedProtoHeader"><Property name="jetty.httpConfig.forwardedProtoHeader" default="X-Forwarded-Proto"/></Set>
         <Set name="forwardedForHeader"><Property name="jetty.httpConfig.forwardedForHeader" default="X-Forwarded-For"/></Set>
         <Set name="forwardedPortHeader"><Property name="jetty.httpConfig.forwardedPortHeader" default="X-Forwarded-Port"/></Set>
-        <Set name="forwardedPortHeaderRemote"><Property name="jetty.httpConfig.forwardedPortHeaderRemote" default="false"/></Set>
         <Set name="forwardedHttpsHeader"><Property name="jetty.httpConfig.forwardedHttpsHeader" default="X-Proxied-Https"/></Set>
         <Set name="forwardedSslSessionIdHeader"><Property name="jetty.httpConfig.forwardedSslSessionIdHeader" default="Proxy-ssl-id" /></Set>
         <Set name="forwardedCipherSuiteHeader"><Property name="jetty.httpConfig.forwardedCipherSuiteHeader" default="Proxy-auth-cert"/></Set>

--- a/jetty-server/src/main/config/modules/http-forwarded.mod
+++ b/jetty-server/src/main/config/modules/http-forwarded.mod
@@ -16,15 +16,21 @@ etc/jetty-http-forwarded.xml
 [ini-template]
 ### ForwardedRequestCustomizer Configuration
 
+## If true, only the RFC7239 Forwarded header is accepted
 # jetty.httpConfig.forwardedOnly=false
+
+## if true, the proxy address obtained from X-Forwarded-Server or RFC7239 is used as the request authority.
 # jetty.httpConfig.forwardedProxyAsAuthority=false
+
+## if true, the X-Forwarded-Port header applies to the authority, else it applies to the remote client address
+# jetty.httpConfig.forwardedPortAsAuthority=true
+
 # jetty.httpConfig.forwardedHeader=Forwarded
 # jetty.httpConfig.forwardedHostHeader=X-Forwarded-Host
 # jetty.httpConfig.forwardedServerHeader=X-Forwarded-Server
 # jetty.httpConfig.forwardedProtoHeader=X-Forwarded-Proto
 # jetty.httpConfig.forwardedForHeader=X-Forwarded-For
 # jetty.httpConfig.forwardedPortHeader=X-Forwarded-Port
-# jetty.httpConfig.forwardedPortHeaderRemote=false
 # jetty.httpConfig.forwardedHttpsHeader=X-Proxied-Https
 # jetty.httpConfig.forwardedSslSessionIdHeader=Proxy-ssl-id
 # jetty.httpConfig.forwardedCipherSuiteHeader=Proxy-auth-cert

--- a/jetty-server/src/main/config/modules/http-forwarded.mod
+++ b/jetty-server/src/main/config/modules/http-forwarded.mod
@@ -24,6 +24,7 @@ etc/jetty-http-forwarded.xml
 # jetty.httpConfig.forwardedProtoHeader=X-Forwarded-Proto
 # jetty.httpConfig.forwardedForHeader=X-Forwarded-For
 # jetty.httpConfig.forwardedPortHeader=X-Forwarded-Port
+# jetty.httpConfig.forwardedPortHeaderRemote=false
 # jetty.httpConfig.forwardedHttpsHeader=X-Proxied-Https
 # jetty.httpConfig.forwardedSslSessionIdHeader=Proxy-ssl-id
 # jetty.httpConfig.forwardedCipherSuiteHeader=Proxy-auth-cert

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -49,6 +49,7 @@ public class ForwardedRequestCustomizerTest
     final AtomicReference<Integer> _serverPort = new AtomicReference<>();
     final AtomicReference<String> _remoteAddr = new AtomicReference<>();
     final AtomicReference<Integer> _remotePort = new AtomicReference<>();
+    final AtomicReference<String> _requestURL = new AtomicReference<>();
 
     ForwardedRequestCustomizer _customizer;
 
@@ -77,6 +78,7 @@ public class ForwardedRequestCustomizerTest
             _serverPort.set(request.getServerPort());
             _remoteAddr.set(request.getRemoteAddr());
             _remotePort.set(request.getRemotePort());
+            _requestURL.set(request.getRequestURL().toString());
             return true;
         };
 
@@ -101,6 +103,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("1.2.3.4"));
         assertThat("serverPort", _serverPort.get(), is(2222));
+        assertThat("requestURL", _requestURL.get(), is("http://1.2.3.4:2222/"));
     }
 
     @Test
@@ -115,6 +118,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("[::1]"));
         assertThat("serverPort", _serverPort.get(), is(2222));
+        assertThat("requestURL", _requestURL.get(), is("http://[::1]:2222/"));
     }
 
     @Test
@@ -129,6 +133,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("1.2.3.4"));
         assertThat("serverPort", _serverPort.get(), is(2222));
+        assertThat("requestURL", _requestURL.get(), is("http://1.2.3.4:2222/"));
     }
 
     @Test
@@ -143,6 +148,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("[::1]"));
         assertThat("serverPort", _serverPort.get(), is(2222));
+        assertThat("requestURL", _requestURL.get(), is("http://[::1]:2222/"));
     }
 
     /**
@@ -168,6 +174,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("[2001:db8:cafe::17]"));
         assertThat("remotePort", _remotePort.get(), is(4711));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     /**
@@ -192,6 +199,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
 
         // With spaces
         HttpTester.Response response2 = HttpTester.parseResponse(
@@ -206,6 +214,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
 
         // As multiple headers
         HttpTester.Response response3 = HttpTester.parseResponse(
@@ -222,6 +231,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     /**
@@ -246,6 +256,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
 
         // New syntax
         HttpTester.Response response2 = HttpTester.parseResponse(
@@ -261,6 +272,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     /**
@@ -284,6 +296,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://example.com/"));
     }
 
     @Test
@@ -303,6 +316,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(443));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("https://myhost/"));
     }
 
     @Test
@@ -322,6 +336,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(443));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("https://myhost/"));
     }
 
     @Test
@@ -341,6 +356,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("10.9.8.7"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     @Test
@@ -359,6 +375,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("10.9.8.7"));
         assertThat("remotePort", _remotePort.get(), is(1111));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     @Test
@@ -377,6 +394,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("[2001:db8:cafe::17]"));
         assertThat("remotePort", _remotePort.get(), is(1111));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
     }
 
     @Test
@@ -393,9 +411,10 @@ public class ForwardedRequestCustomizerTest
         assertThat("status", response.getStatus(), is(200));
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("myhost"));
-        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("serverPort", _serverPort.get(), is(2222));
         assertThat("remoteAddr", _remoteAddr.get(), is("[1:2:3:4:5:6:7:8]"));
-        assertThat("remotePort", _remotePort.get(), is(2222));
+        assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost:2222/"));
     }
 
     @Test
@@ -414,9 +433,10 @@ public class ForwardedRequestCustomizerTest
         assertThat("status", response.getStatus(), is(200));
         assertThat("scheme", _scheme.get(), is("http"));
         assertThat("serverName", _serverName.get(), is("myhost"));
-        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("serverPort", _serverPort.get(), is(2222));
         assertThat("remoteAddr", _remoteAddr.get(), is("[1:2:3:4:5:6:7:8]"));
-        assertThat("remotePort", _remotePort.get(), is(2222));
+        assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost:2222/"));
     }
 
     @Test
@@ -435,6 +455,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(443));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("https://myhost/"));
     }
 
     @Test
@@ -456,6 +477,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
 
         _customizer.setSslIsSecure(true);
         response = HttpTester.parseResponse(
@@ -473,6 +495,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(443));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("https://myhost/"));
     }
 
     @Test
@@ -494,6 +517,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
 
         _customizer.setSslIsSecure(true);
         response = HttpTester.parseResponse(
@@ -511,6 +535,51 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(443));
         assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("https://myhost/"));
+    }
+
+    /**
+     * Resetting the server port via a forwarding header
+     */
+    @Test
+    public void testPort_For() throws Exception
+    {
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-Port: 4444\n" +
+                    "X-Forwarded-For: 192.168.1.200\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(4444));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.168.1.200"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost:4444/"));
+    }
+
+    /**
+     * Test setting the server Port before the "Host" header has been seen.
+     */
+    @Test
+    public void testPort_For_LateHost() throws Exception
+    {
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "X-Forwarded-Port: 4444\n" + // this order is intentional
+                    "X-Forwarded-For: 192.168.1.200\n" +
+                    "Host: myhost\n" + // leave this as the last header
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(4444));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.168.1.200"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost:4444/"));
     }
 
     @Test
@@ -532,6 +601,7 @@ public class ForwardedRequestCustomizerTest
         assertThat("serverPort", _serverPort.get(), is(80));
         assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
         assertThat("remotePort", _remotePort.get(), is(0));
+        assertThat("requestURL", _requestURL.get(), is("http://example.com/"));
     }
 
     interface RequestTester

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -19,25 +19,20 @@
 package org.eclipse.jetty.server;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.eclipse.jetty.util.IO;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,11 +41,15 @@ public class ForwardedRequestCustomizerTest
     private Server _server;
     private LocalConnector _connector;
     private RequestHandler _handler;
-    final Deque<String> _results = new ArrayDeque<>();
     final AtomicBoolean _wasSecure = new AtomicBoolean(false);
     final AtomicReference<String> _sslSession = new AtomicReference<>();
     final AtomicReference<String> _sslCertificate = new AtomicReference<>();
-    
+    final AtomicReference<String> _scheme = new AtomicReference<>();
+    final AtomicReference<String> _serverName = new AtomicReference<>();
+    final AtomicReference<Integer> _serverPort = new AtomicReference<>();
+    final AtomicReference<String> _remoteAddr = new AtomicReference<>();
+    final AtomicReference<Integer> _remotePort = new AtomicReference<>();
+
     ForwardedRequestCustomizer _customizer;
 
     @BeforeEach
@@ -62,29 +61,25 @@ public class ForwardedRequestCustomizerTest
         http.getHttpConfiguration().setRequestHeaderSize(512);
         http.getHttpConfiguration().setResponseHeaderSize(512);
         http.getHttpConfiguration().setOutputBufferSize(2048);
-        http.getHttpConfiguration().addCustomizer(_customizer=new ForwardedRequestCustomizer());
-        _connector = new LocalConnector(_server,http);
+        http.getHttpConfiguration().addCustomizer(_customizer = new ForwardedRequestCustomizer());
+        _connector = new LocalConnector(_server, http);
         _server.addConnector(_connector);
         _handler = new RequestHandler();
         _server.setHandler(_handler);
 
-        _handler._checker = new RequestTester()
+        _handler._checker = (request, response) ->
         {
-            @Override
-            public boolean check(HttpServletRequest request,HttpServletResponse response)
-            {
-                _wasSecure.set(request.isSecure());
-                _sslSession.set(String.valueOf(request.getAttribute("javax.servlet.request.ssl_session_id")));
-                _sslCertificate.set(String.valueOf(request.getAttribute("javax.servlet.request.cipher_suite")));
-                _results.add(request.getScheme());
-                _results.add(request.getServerName());
-                _results.add(Integer.toString(request.getServerPort()));
-                _results.add(request.getRemoteAddr());
-                _results.add(Integer.toString(request.getRemotePort()));
-                return true;
-            }
+            _wasSecure.set(request.isSecure());
+            _sslSession.set(String.valueOf(request.getAttribute("javax.servlet.request.ssl_session_id")));
+            _sslCertificate.set(String.valueOf(request.getAttribute("javax.servlet.request.cipher_suite")));
+            _scheme.set(request.getScheme());
+            _serverName.set(request.getServerName());
+            _serverPort.set(request.getServerPort());
+            _remoteAddr.set(request.getRemoteAddr());
+            _remotePort.set(request.getRemotePort());
+            return true;
         };
-        
+
         _server.start();
     }
 
@@ -92,391 +87,468 @@ public class ForwardedRequestCustomizerTest
     public void destroy() throws Exception
     {
         _server.stop();
-        _server.join();
     }
 
     @Test
     public void testHostIpv4() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-                "Host: 1.2.3.4:2222\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("1.2.3.4",_results.poll());
-        assertEquals("2222",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: 1.2.3.4:2222\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("1.2.3.4"));
+        assertThat("serverPort", _serverPort.get(), is(2222));
     }
 
     @Test
     public void testHostIpv6() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-                "Host: [::1]:2222\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("[::1]",_results.poll());
-        assertEquals("2222",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: [::1]:2222\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("[::1]"));
+        assertThat("serverPort", _serverPort.get(), is(2222));
     }
-
-
 
     @Test
     public void testURIIpv4() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET http://1.2.3.4:2222/ HTTP/1.1\n"+
-                "Host: wrong\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("1.2.3.4",_results.poll());
-        assertEquals("2222",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET http://1.2.3.4:2222/ HTTP/1.1\n" +
+                    "Host: wrong\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("1.2.3.4"));
+        assertThat("serverPort", _serverPort.get(), is(2222));
     }
 
     @Test
     public void testURIIpv6() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET http://[::1]:2222/ HTTP/1.1\n"+
-                "Host: wrong\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("[::1]",_results.poll());
-        assertEquals("2222",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET http://[::1]:2222/ HTTP/1.1\n" +
+                    "Host: wrong\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("[::1]"));
+        assertThat("serverPort", _serverPort.get(), is(2222));
     }
 
-
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7239#section-4">RFC 7239: Section 4</a>
+     *
+     * Examples of syntax.
+     */
     @Test
     public void testRFC7239_Examples_4() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=\"_gazonk\"\n"+
-             "Forwarded: For=\"[2001:db8:cafe::17]:4711\"\n"+
-             "Forwarded: for=192.0.2.60;proto=http;by=203.0.113.43\n"+
-             "Forwarded: for=192.0.2.43, for=198.51.100.17\n"+
-            "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("[2001:db8:cafe::17]",_results.poll());
-        assertEquals("4711",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=\"_gazonk\"\n" +
+                    "Forwarded: For=\"[2001:db8:cafe::17]:4711\"\n" +
+                    "Forwarded: for=192.0.2.60;proto=http;by=203.0.113.43\n" +
+                    "Forwarded: for=192.0.2.43, for=198.51.100.17\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("[2001:db8:cafe::17]"));
+        assertThat("remotePort", _remotePort.get(), is(4711));
     }
-    
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7239#section-7.1">RFC 7239: Section 7.1</a>
+     *
+     * Examples of syntax with regards to HTTP header fields
+     */
     @Test
     public void testRFC7239_Examples_7_1() throws Exception
     {
-        _connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=192.0.2.43,for=\"[2001:db8:cafe::17]\",for=unknown\n"+
-            "\n");
-        _connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown\n"+
-            "\n");
-        _connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=192.0.2.43\n"+
-             "Forwarded: for=\"[2001:db8:cafe::17]\", for=unknown\n"+
-            "\n");
+        // Without spaces
+        HttpTester.Response response1 = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=192.0.2.43,for=\"[2001:db8:cafe::17]\",for=unknown\n" +
+                    "\n"));
 
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
+        assertThat("status", response1.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+
+        // With spaces
+        HttpTester.Response response2 = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown\n" +
+                    "\n"));
+        assertThat("status", response2.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+
+        // As multiple headers
+        HttpTester.Response response3 = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=192.0.2.43\n" +
+                    "Forwarded: for=\"[2001:db8:cafe::17]\", for=unknown\n" +
+                    "\n"));
+
+        assertThat("status", response3.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7239#section-7.4">RFC 7239: Section 7.4</a>
+     *
+     * Transition
+     */
     @Test
     public void testRFC7239_Examples_7_4() throws Exception
     {
-        _connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=192.0.2.43, for=\"[2001:db8:cafe::17]\"\n"+
-            "\n");
+        // Old syntax
+        HttpTester.Response response1 = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-For: 192.0.2.43, 2001:db8:cafe::17\n" +
+                    "\n"));
 
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
+        assertThat("status", response1.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+
+        // New syntax
+        HttpTester.Response response2 = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=192.0.2.43, for=\"[2001:db8:cafe::17]\"\n" +
+                    "\n"));
+
+        assertThat("status", response2.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
+    /**
+     * <a href="https://tools.ietf.org/html/rfc7239#section-7.5">RFC 7239: Section 7.5</a>
+     *
+     * Example Usage
+     */
     @Test
     public void testRFC7239_Examples_7_5() throws Exception
     {
-        _connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Forwarded: for=192.0.2.43,for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com\n"+
-            "\n");
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: for=192.0.2.43,for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com\n" +
+                    "\n"));
 
-        assertEquals("http",_results.poll());
-        assertEquals("example.com",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("example.com"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
     @Test
-    public void testProto() throws Exception
+    public void testProto_OldSyntax() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "X-Forwarded-Proto: foobar\n"+
-             "Forwarded: proto=https\n"+
-            "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("https",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("443",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-Proto: https\n" +
+                    "\n"));
+
+        assertTrue(_wasSecure.get(), "wasSecure");
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("https"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(443));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+    }
+
+    @Test
+    public void testRFC7239_Proto() throws Exception
+    {
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Forwarded: proto=https\n" +
+                    "\n"));
+
+        assertTrue(_wasSecure.get(), "wasSecure");
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("https"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(443));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
     @Test
     public void testFor() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "X-Forwarded-For: 10.9.8.7,6.5.4.3\n"+
-             "X-Forwarded-For: 8.9.8.7,7.5.4.3\n"+
-            "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("10.9.8.7",_results.poll());
-        assertEquals("0",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-For: 10.9.8.7,6.5.4.3\n" +
+                    "X-Forwarded-For: 8.9.8.7,7.5.4.3\n" +
+                    "\n"));
+
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("10.9.8.7"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
     @Test
     public void testForIpv4WithPort() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-                "Host: myhost\n"+
-                "X-Forwarded-For: 10.9.8.7:1111,6.5.4.3:2222\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("10.9.8.7",_results.poll());
-        assertEquals("1111",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-For: 10.9.8.7:1111,6.5.4.3:2222\n" +
+                    "\n"));
+
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("10.9.8.7"));
+        assertThat("remotePort", _remotePort.get(), is(1111));
     }
 
     @Test
     public void testForIpv6WithPort() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-                "Host: myhost\n"+
-                "X-Forwarded-For: [2001:db8:cafe::17]:1111,6.5.4.3:2222\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("[2001:db8:cafe::17]",_results.poll());
-        assertEquals("1111",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-For: [2001:db8:cafe::17]:1111,6.5.4.3:2222\n" +
+                    "\n"));
+
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("[2001:db8:cafe::17]"));
+        assertThat("remotePort", _remotePort.get(), is(1111));
     }
 
     @Test
     public void testForIpv6AndPort() throws Exception
     {
-        String response=_connector.getResponse(
-                "GET / HTTP/1.1\n"+
-                        "Host: myhost\n"+
-                        "X-Forwarded-For: 1:2:3:4:5:6:7:8\n"+
-                        "X-Forwarded-Port: 2222\n"+
-                        "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("[1:2:3:4:5:6:7:8]",_results.poll());
-        assertEquals("2222",_results.poll());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-For: 1:2:3:4:5:6:7:8\n" +
+                    "X-Forwarded-Port: 2222\n" +
+                    "\n"));
 
-        response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-                "Host: myhost\n"+
-                "X-Forwarded-Port: 2222\n"+
-                "X-Forwarded-For: 1:2:3:4:5:6:7:8\n"+
-                "X-Forwarded-For: 7:7:7:7:7:7:7:7\n"+
-                "X-Forwarded-Port: 3333\n"+
-                "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("[1:2:3:4:5:6:7:8]",_results.poll());
-        assertEquals("2222",_results.poll());
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("[1:2:3:4:5:6:7:8]"));
+        assertThat("remotePort", _remotePort.get(), is(2222));
+    }
+
+    @Test
+    public void testForIpv6AndPort_MultiField() throws Exception
+    {
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-Port: 2222\n" +
+                    "X-Forwarded-For: 1:2:3:4:5:6:7:8\n" +
+                    "X-Forwarded-For: 7:7:7:7:7:7:7:7\n" +
+                    "X-Forwarded-Port: 3333\n" +
+                    "\n"));
+
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("[1:2:3:4:5:6:7:8]"));
+        assertThat("remotePort", _remotePort.get(), is(2222));
     }
 
     @Test
     public void testLegacyProto() throws Exception
     {
-        String response=_connector.getResponse(
-            "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "X-Proxied-Https: on\n"+
-            "\n");
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("https",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("443",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
-        assertTrue(_wasSecure.get());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Proxied-Https: on\n" +
+                    "\n"));
+        assertTrue(_wasSecure.get(), "wasSecure");
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("https"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(443));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
     @Test
     public void testSslSession() throws Exception
     {
         _customizer.setSslIsSecure(false);
-        String response=_connector.getResponse(
-             "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Proxy-Ssl-Id: Wibble\n"+
-             "\n");
-        
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
-        assertFalse(_wasSecure.get());
-        assertEquals("Wibble",_sslSession.get());
-      
-        _customizer.setSslIsSecure(true);  
-        response=_connector.getResponse(
-             "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Proxy-Ssl-Id: 0123456789abcdef\n"+
-             "\n");
-        
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("https",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("443",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
-        assertTrue(_wasSecure.get());
-        assertEquals("0123456789abcdef",_sslSession.get());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Proxy-Ssl-Id: Wibble\n" +
+                    "\n"));
+
+        assertFalse(_wasSecure.get(), "wasSecure");
+        assertThat("sslSession", _sslSession.get(), is("Wibble"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+
+        _customizer.setSslIsSecure(true);
+        response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Proxy-Ssl-Id: 0123456789abcdef\n" +
+                    "\n"));
+
+        assertTrue(_wasSecure.get(), "wasSecure");
+        assertThat("sslSession", _sslSession.get(), is("0123456789abcdef"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("https"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(443));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
-    
+
     @Test
     public void testSslCertificate() throws Exception
     {
         _customizer.setSslIsSecure(false);
-        String response=_connector.getResponse(
-             "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Proxy-auth-cert: Wibble\n"+
-             "\n");
-        
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("http",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
-        assertFalse(_wasSecure.get());
-        assertEquals("Wibble",_sslCertificate.get());
-        
-      
-        _customizer.setSslIsSecure(true);  
-        response=_connector.getResponse(
-             "GET / HTTP/1.1\n"+
-             "Host: myhost\n"+
-             "Proxy-auth-cert: 0123456789abcdef\n"+
-             "\n");
-        
-        assertThat(response, Matchers.containsString("200 OK"));
-        assertEquals("https",_results.poll());
-        assertEquals("myhost",_results.poll());
-        assertEquals("443",_results.poll());
-        assertEquals("0.0.0.0",_results.poll());
-        assertEquals("0",_results.poll());
-        assertTrue(_wasSecure.get());
-        assertEquals("0123456789abcdef",_sslCertificate.get());
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Proxy-auth-cert: Wibble\n" +
+                    "\n"));
+
+        assertFalse(_wasSecure.get(), "wasSecure");
+        assertThat("sslCertificate", _sslCertificate.get(), is("Wibble"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
+
+        _customizer.setSslIsSecure(true);
+        response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "Proxy-auth-cert: 0123456789abcdef\n" +
+                    "\n"));
+
+        assertTrue(_wasSecure.get(), "wasSecure");
+        assertThat("sslCertificate", _sslCertificate.get(), is("0123456789abcdef"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("https"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(443));
+        assertThat("remoteAddr", _remoteAddr.get(), is("0.0.0.0"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
 
-
     @Test
-    public void testMixed() throws Exception
+    public void testMixed_For_Port_RFC_For() throws Exception
     {
-        String response = _connector.getResponse(
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
             "GET / HTTP/1.1\n" +
                 "Host: myhost\n" +
                 "X-Forwarded-For: 11.9.8.7:1111,8.5.4.3:2222\n" +
                 "X-Forwarded-Port: 3333\n" +
-                "Forwarded: for=192.0.2.43,for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com\n"+
+                "Forwarded: for=192.0.2.43,for=198.51.100.17;by=203.0.113.60;proto=http;host=example.com\n" +
                 "X-Forwarded-For: 11.9.8.7:1111,8.5.4.3:2222\n" +
-                "\n");
+                "\n"));
 
-        assertEquals("http",_results.poll());
-        assertEquals("example.com",_results.poll());
-        assertEquals("80",_results.poll());
-        assertEquals("192.0.2.43",_results.poll());
-        assertEquals("0",_results.poll());
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("example.com"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.0.2.43"));
+        assertThat("remotePort", _remotePort.get(), is(0));
     }
-    
-    
+
     interface RequestTester
     {
-        boolean check(HttpServletRequest request,HttpServletResponse response) throws IOException;
+        boolean check(HttpServletRequest request, HttpServletResponse response) throws IOException;
     }
 
     private class RequestHandler extends AbstractHandler
     {
         private RequestTester _checker;
-        @SuppressWarnings("unused")
-        private String _content;
 
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
         {
-            ((Request)request).setHandled(true);
+            baseRequest.setHandled(true);
 
-            if (request.getContentLength()>0
-                    && !MimeTypes.Type.FORM_ENCODED.asString().equals(request.getContentType())
-                    && !request.getContentType().startsWith("multipart/form-data"))
-                _content=IO.toString(request.getInputStream());
-
-            if (_checker!=null && _checker.check(request,response))
+            if (_checker != null && _checker.check(request, response))
                 response.setStatus(200);
             else
                 response.sendError(500);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -560,6 +560,31 @@ public class ForwardedRequestCustomizerTest
         assertThat("requestURL", _requestURL.get(), is("http://myhost:4444/"));
     }
 
+
+
+    /**
+     * Resetting the server port via a forwarding header
+     */
+    @Test
+    public void testRemote_Port_For() throws Exception
+    {
+        _customizer.setForwardedPortHeaderRemote(true);
+        HttpTester.Response response = HttpTester.parseResponse(
+            _connector.getResponse(
+                "GET / HTTP/1.1\n" +
+                    "Host: myhost\n" +
+                    "X-Forwarded-Port: 4444\n" +
+                    "X-Forwarded-For: 192.168.1.200\n" +
+                    "\n"));
+        assertThat("status", response.getStatus(), is(200));
+        assertThat("scheme", _scheme.get(), is("http"));
+        assertThat("serverName", _serverName.get(), is("myhost"));
+        assertThat("serverPort", _serverPort.get(), is(80));
+        assertThat("remoteAddr", _remoteAddr.get(), is("192.168.1.200"));
+        assertThat("remotePort", _remotePort.get(), is(4444));
+        assertThat("requestURL", _requestURL.get(), is("http://myhost/"));
+    }
+
     /**
      * Test setting the server Port before the "Host" header has been seen.
      */

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -568,7 +568,7 @@ public class ForwardedRequestCustomizerTest
     @Test
     public void testRemote_Port_For() throws Exception
     {
-        _customizer.setForwardedPortHeaderRemote(true);
+        _customizer.setForwardedPortAsAuthority(false);
         HttpTester.Response response = HttpTester.parseResponse(
             _connector.getResponse(
                 "GET / HTTP/1.1\n" +

--- a/jetty-server/src/test/resources/jetty-logging.properties
+++ b/jetty-server/src/test/resources/jetty-logging.properties
@@ -1,4 +1,5 @@
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.LEVEL=WARN
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.server.ConnectionLimit.LEVEL=DEBUG


### PR DESCRIPTION
+ Making existing testcases more reliable and easier to maintain.
+ Updating testcases to test requestURL as well.
+ Adding new testcases for `X-Forwarded-Port` where they only modify the port of an existing `Host:` header.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>
