### PR TITLE
Issue #3815 Ensure user not in roles for PropertyFileLoginModule

### DIFF
--- a/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModule.java
+++ b/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModule.java
@@ -18,15 +18,16 @@
 
 package org.eclipse.jetty.jaas.spi;
 
-import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 
+import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.PropertyUserStore;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.log.Log;
@@ -116,14 +117,11 @@ public class PropertyFileLoginModule extends AbstractLoginModule
 
         //TODO in future versions change the impl of PropertyUserStore so its not
         //storing Subjects etc, just UserInfo
-        Set<Principal> principals = userIdentity.getSubject().getPrincipals();
+        Set<AbstractLoginService.RolePrincipal> principals = userIdentity.getSubject().getPrincipals(AbstractLoginService.RolePrincipal.class);
 
-        List<String> roles = new ArrayList<String>();
-
-        for (Principal principal : principals)
-        {
-            roles.add(principal.getName());
-        }
+        List<String> roles = principals.stream()
+            .map(AbstractLoginService.RolePrincipal::getName)
+            .collect(Collectors.toList());
 
         Credential credential = (Credential)userIdentity.getSubject().getPrivateCredentials().iterator().next();
         LOG.debug("Found: " + userName + " in PropertyUserStore " + _filename);

--- a/jetty-jaas/src/test/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModuleTest.java
+++ b/jetty-jaas/src/test/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModuleTest.java
@@ -1,0 +1,53 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.jaas.spi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.HashMap;
+
+import javax.security.auth.Subject;
+
+import org.eclipse.jetty.jaas.callback.DefaultCallbackHandler;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.junit.jupiter.api.Test;
+
+public class PropertyFileLoginModuleTest
+{
+    @Test
+    public void testRoles()
+        throws Exception
+    {
+        File file = MavenTestingUtils.getTestResourceFile("login.properties");
+        PropertyFileLoginModule module = new PropertyFileLoginModule();
+        Subject subject = new Subject();
+        HashMap<String, String> options = new HashMap<>();
+        options.put("file", file.getCanonicalPath());
+        module.initialize(subject, new DefaultCallbackHandler(), new HashMap<String, String>(), options);
+        UserInfo fred = module.getUserInfo("fred");
+        assertEquals("fred", fred.getUserName());
+        assertThat(fred.getRoleNames(), containsInAnyOrder("role1", "role2", "role3"));
+        assertThat(fred.getRoleNames(), not(contains("fred")));
+    }
+}

--- a/jetty-jaas/src/test/resources/login.properties
+++ b/jetty-jaas/src/test/resources/login.properties
@@ -1,0 +1,1 @@
+fred=pwd,role1,role2,role3


### PR DESCRIPTION
#3815

The UserPrincipal for the user was being added as a role name. Eg given  a login.properties file containing:

```
fred=pwd,role1,role2
```
Then the roles would list as:  fred,role1,role2.  After the fix, the roles are: role1,role2.