### PR TITLE
Jetty could not running on MacOS Catalina(10.15)

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
@@ -61,6 +61,13 @@ public class AllowSymLinkAliasChecker implements AliasCheck
                     LOG.debug("Allow symlink {} --> {}", resource, pathResource.getAliasPath());
                 return true;
             }
+
+            if (containsReservedPathByMacOS(alias) && Files.isSameFile(path, alias))
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
+                return true;
+            }
         }
         catch (Exception e)
         {
@@ -68,6 +75,10 @@ public class AllowSymLinkAliasChecker implements AliasCheck
         }
 
         return false;
+    }
+
+    private boolean containsReservedPathByMacOS(Path path) {
+        return path.startsWith("/System/Volumes/Data");
     }
 
     private boolean hasSymbolicLink(Path path)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
@@ -61,13 +61,6 @@ public class AllowSymLinkAliasChecker implements AliasCheck
                     LOG.debug("Allow symlink {} --> {}", resource, pathResource.getAliasPath());
                 return true;
             }
-
-            if (containsReservedPathByMacOS(alias) && Files.isSameFile(path, alias))
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
-                return true;
-            }
         }
         catch (Exception e)
         {
@@ -75,10 +68,6 @@ public class AllowSymLinkAliasChecker implements AliasCheck
         }
 
         return false;
-    }
-
-    private boolean containsReservedPathByMacOS(Path path) {
-        return path.startsWith("/System/Volumes/Data");
     }
 
     private boolean hasSymbolicLink(Path path)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -238,6 +238,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         addAliasCheck(new ApproveNonExistentDirectoryAliases());
         if (File.separatorChar == '/')
             addAliasCheck(new AllowSymLinkAliasChecker());
+        if (MacOSMountPathChecker.RUNNING_ON_MAC_OS)
+            addAliasCheck(new MacOSMountPathChecker());
 
         if (contextPath != null)
             setContextPath(contextPath);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -40,17 +40,21 @@ import java.nio.file.Path;
  * /dev/disk1s1   489620264 230478144 255695688    48% 1975282 9223372036852800525    0%   /System/Volumes/Data
  */
 
-public class MacOSMountPathChecker implements AliasCheck {
+public class MacOSMountPathChecker implements AliasCheck
+{
     private static final Logger LOG = Log.getLogger(MacOSMountPathChecker.class);
     private static final boolean RUNNING_ON_MAC_OS = System.getProperty("os.name").startsWith("Mac OS X");
 
     @Override
-    public boolean check(String uri, Resource resource) {
-        if (!RUNNING_ON_MAC_OS) {
+    public boolean check(String uri, Resource resource)
+    {
+        if (!RUNNING_ON_MAC_OS)
+        {
             return false;
         }
 
-        if (!(resource instanceof PathResource)) {
+        if (!(resource instanceof PathResource))
+        {
             return false;
         }
 
@@ -58,23 +62,29 @@ public class MacOSMountPathChecker implements AliasCheck {
         Path path = pathResource.getPath();
         Path alias = pathResource.getAliasPath();
 
-        try {
+        try
+        {
             boolean allowed = isAllowed(alias, Files.isSameFile(path, alias));
-            if (LOG.isDebugEnabled()) {
+            if (LOG.isDebugEnabled())
+            {
                 LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
             }
             return allowed;
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             LOG.ignore(e);
             return false;
         }
     }
 
-    boolean isAllowed(Path alias, boolean isSamePathAndAlias) {
+    boolean isAllowed(Path alias, boolean isSamePathAndAlias)
+    {
         return containsMacOSMountPath(alias) && isSamePathAndAlias;
     }
 
-    private boolean containsMacOSMountPath(Path alias) {
+    private boolean containsMacOSMountPath(Path alias)
+    {
         return alias.startsWith("/System/Volumes/Data");
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -34,10 +34,12 @@ import java.nio.file.Path;
  *
  * Under 10.15
  * ---
- * /dev/disk1s1   489620264 230478144 255695688    48% 1975282 9223372036852800525    0%   /
+ * Filesystem      Mounted On
+ * /dev/disk1s1    /
  *
  * From 10.15
- * /dev/disk1s1   489620264 230478144 255695688    48% 1975282 9223372036852800525    0%   /System/Volumes/Data
+ * Filesystem      Mounted On
+ * /dev/disk1s1   /System/Volumes/Data
  */
 
 public class MacOSMountPathChecker implements AliasCheck

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -1,0 +1,75 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import org.eclipse.jetty.server.handler.ContextHandler.AliasCheck;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.util.resource.Resource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * MacOS 10.15 have different real path with before version.
+ * So content initializing failed due to the failed loading the resources has valid alias.
+ *
+ * Under 10.15
+ * ---
+ * /dev/disk1s1   489620264 230478144 255695688    48% 1975282 9223372036852800525    0%   /
+ *
+ * From 10.15
+ * /dev/disk1s1   489620264 230478144 255695688    48% 1975282 9223372036852800525    0%   /System/Volumes/Data
+ */
+
+public class MacOSMountPathChecker implements AliasCheck {
+    private static final Logger LOG = Log.getLogger(MacOSMountPathChecker.class);
+
+    @Override
+    public boolean check(String uri, Resource resource) {
+        if (!(resource instanceof PathResource)) {
+            return false;
+        }
+
+        PathResource pathResource = (PathResource) resource;
+        Path path = pathResource.getPath();
+        Path alias = pathResource.getAliasPath();
+
+        try {
+            boolean allowed = isAllowed(alias, Files.isSameFile(path, alias));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
+            }
+            return allowed;
+        } catch (IOException e) {
+            LOG.ignore(e);
+            return false;
+        }
+    }
+
+    boolean isAllowed(Path alias, boolean isSamePathAndAlias) {
+        return containsMacOSMountPath(alias) && isSamePathAndAlias;
+    }
+
+    private boolean containsMacOSMountPath(Path alias) {
+        return alias.startsWith("/System/Volumes/Data");
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -64,12 +64,12 @@ public class MacOSMountPathChecker implements AliasCheck
 
         try
         {
-            boolean allowed = isAllowed(alias, Files.isSameFile(path, alias));
+            boolean valid = isValidAlias(alias, Files.isSameFile(path, alias));
             if (LOG.isDebugEnabled())
             {
                 LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
             }
-            return allowed;
+            return valid;
         }
         catch (IOException e)
         {
@@ -78,7 +78,7 @@ public class MacOSMountPathChecker implements AliasCheck
         }
     }
 
-    boolean isAllowed(Path alias, boolean isSamePathAndAlias)
+    boolean isValidAlias(Path alias, boolean isSamePathAndAlias)
     {
         return containsMacOSMountPath(alias) && isSamePathAndAlias;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -72,6 +72,7 @@ public class MacOSMountPathChecker implements AliasCheck
             {
                 LOG.debug("Allow path by MacOS mount location {} --> {}", resource, pathResource.getAliasPath());
             }
+
             return valid;
         }
         catch (IOException e)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -42,9 +42,14 @@ import java.nio.file.Path;
 
 public class MacOSMountPathChecker implements AliasCheck {
     private static final Logger LOG = Log.getLogger(MacOSMountPathChecker.class);
+    private static final boolean RUNNING_ON_MAC_OS = System.getProperty("os.name").startsWith("Mac OS X");
 
     @Override
     public boolean check(String uri, Resource resource) {
+        if (!RUNNING_ON_MAC_OS) {
+            return false;
+        }
+
         if (!(resource instanceof PathResource)) {
             return false;
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -43,7 +43,7 @@ import java.nio.file.Path;
 public class MacOSMountPathChecker implements AliasCheck
 {
     private static final Logger LOG = Log.getLogger(MacOSMountPathChecker.class);
-    private static final boolean RUNNING_ON_MAC_OS = System.getProperty("os.name").startsWith("Mac OS X");
+    static final boolean RUNNING_ON_MAC_OS = System.getProperty("os.name").startsWith("Mac OS X");
 
     @Override
     public boolean check(String uri, Resource resource)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MacOSMountPathChecker.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 public class MacOSMountPathChecker implements AliasCheck
 {
     private static final Logger LOG = Log.getLogger(MacOSMountPathChecker.class);
+
     static final boolean RUNNING_ON_MAC_OS = System.getProperty("os.name").startsWith("Mac OS X");
 
     @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
@@ -1,0 +1,38 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author sam
+ */
+class MacOSMountPathCheckerTest {
+    @Test
+    void pathContainingMacOSMountPathShouldBeTreatedAsAlias() {
+        Path alias = Paths.get("/System/Volumes/Data/Users/jetty/test.xml");
+        assertThat(new MacOSMountPathChecker().isAllowed(alias, true), is(true));
+    }
+}

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
@@ -26,9 +26,6 @@ import java.nio.file.Paths;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * @author sam
- */
 class MacOSMountPathCheckerTest
 {
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
@@ -29,10 +29,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author sam
  */
-class MacOSMountPathCheckerTest {
+class MacOSMountPathCheckerTest
+{
     @Test
-    void pathContainingMacOSMountPathShouldBeTreatedAsAlias() {
-        Path alias = Paths.get("/System/Volumes/Data/Users/jetty/test.xml");
+    void pathContainingMacOSMountPathShouldBeTreatedAsAlias()
+    {
+        Path alias = Paths.get("/System/Volumes/Data/Users/jetty/app-config.xml");
         assertThat(new MacOSMountPathChecker().isAllowed(alias, true), is(true));
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MacOSMountPathCheckerTest.java
@@ -35,6 +35,6 @@ class MacOSMountPathCheckerTest
     void pathContainingMacOSMountPathShouldBeTreatedAsAlias()
     {
         Path alias = Paths.get("/System/Volumes/Data/Users/jetty/app-config.xml");
-        assertThat(new MacOSMountPathChecker().isAllowed(alias, true), is(true));
+        assertThat(new MacOSMountPathChecker().isValidAlias(alias, true), is(true));
     }
 }


### PR DESCRIPTION
MacOS 10.15 has different mount path with previous version. 
So AllowAliasCheck module deny all kind of resources has alias.