### PR TITLE
Fixes #3822 - trustAll will not work on some servers.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
@@ -74,6 +75,7 @@ import javax.net.ssl.StandardConstants;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import org.eclipse.jetty.util.StringUtil;
@@ -98,21 +100,41 @@ import org.eclipse.jetty.util.security.Password;
 public class SslContextFactory extends AbstractLifeCycle implements Dumpable
 {
     public static final TrustManager[] TRUST_ALL_CERTS = new X509TrustManager[]{
-        new X509TrustManager()
+        new X509ExtendedTrustManager()
         {
             @Override
-            public java.security.cert.X509Certificate[] getAcceptedIssuers()
+            public X509Certificate[] getAcceptedIssuers()
             {
-                return new java.security.cert.X509Certificate[]{};
+                return new X509Certificate[0];
             }
 
             @Override
-            public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType)
+            public void checkClientTrusted(X509Certificate[] certs, String authType)
             {
             }
 
             @Override
-            public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType)
+            public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+            {
+            }
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+            {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] certs, String authType)
+            {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+            {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
             {
             }
         }


### PR DESCRIPTION
#3822.

Made TRUST_ALL_CERTS implement X509ExtendedTrustManager,
so that it does not get wrapped in sun.security.ssl.AbstractTrustManagerWrapper,
which performs additional trust checks.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>