### PR TITLE
source:jar javadoc:jar are already triggered by eclipse-release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1283,9 +1283,8 @@
             <artifactId>maven-source-plugin</artifactId>
             <executions>
               <execution>
-                <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>
@@ -1295,7 +1294,6 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
               <execution>
-                <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
                 </goals>

--- a/scripts/release-jetty.sh
+++ b/scripts/release-jetty.sh
@@ -167,7 +167,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
     # This is equivalent to 'mvn release:perform'
     if proceedyn "Build/Deploy from tag $TAG_NAME? (Y/n)" y; then
         git checkout $TAG_NAME
-        mvn clean package source:jar javadoc:jar gpg:sign javadoc:aggregate-jar deploy \
+        mvn clean package gpg:sign javadoc:aggregate-jar deploy \
             -Peclipse-release $DEPLOY_OPTS
         reportMavenTestFailures
         git checkout $GIT_BRANCH_ID


### PR DESCRIPTION
so no need to call directly as it add more jars to deploy :)

Signed-off-by: olivier lamy <oliver.lamy@gmail.com>