### PR TITLE
Fixes #3929 - Deadlock between new HTTP2Connection() and Server.stop().

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -106,17 +106,19 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
                     switch (b._managed)
                     {
                         case MANAGED:
-                            if (!l.isRunning())
+                            if (l.isStopped())
                                 start(l);
                             break;
 
                         case AUTO:
-                            if (l.isRunning())
-                                unmanage(b);
-                            else
+                            if (l.isStopped())
                             {
                                 manage(b);
                                 start(l);
+                            }
+                            else
+                            {
+                                unmanage(b);
                             }
                             break;
 
@@ -142,7 +144,7 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
                     {
                         try
                         {
-                            l.stop();
+                            stop(l);
                         }
                         catch (Throwable cause2)
                         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -106,7 +106,7 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
                     switch (b._managed)
                     {
                         case MANAGED:
-                            if (l.isStopped())
+                            if (l.isStopped() || l.isFailed())
                                 start(l);
                             break;
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
@@ -652,4 +652,27 @@ public class ContainerLifeCycleTest
         assertThat(root.getContainedBeans(Integer.class), containsInAnyOrder(Integer.valueOf(0), Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)));
         assertThat(root.getContainedBeans(String.class), containsInAnyOrder("leaf"));
     }
+
+    @Test
+    public void testBeanStoppingAddedToStartingBean() throws Exception
+    {
+        ContainerLifeCycle longLived = new ContainerLifeCycle()
+        {
+            @Override
+            protected void doStop() throws Exception
+            {
+                super.doStop();
+
+                ContainerLifeCycle shortLived = new ContainerLifeCycle();
+                shortLived.addBean(this);
+                shortLived.start();
+
+                assertTrue(shortLived.isStarted());
+                assertTrue(isStopping());
+                assertFalse(shortLived.isManaged(this));
+            }
+        };
+        longLived.start();
+        longLived.stop();
+    }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
@@ -130,10 +130,7 @@ public class ContainerLifeCycleTest
         container.stop();
         container.destroy();
 
-        assertThrows(IllegalStateException.class, () ->
-        {
-            container.start();
-        });
+        assertThrows(IllegalStateException.class, container::start);
     }
 
     @Test
@@ -211,13 +208,13 @@ public class ContainerLifeCycleTest
     {
         ContainerLifeCycle a0 = new ContainerLifeCycle();
         String dump = trim(a0.dump());
-        dump = check(dump, "ContainerLifeCycl");
+        check(dump, "ContainerLifeCycl");
 
         ContainerLifeCycle aa0 = new ContainerLifeCycle();
         a0.addBean(aa0);
         dump = trim(a0.dump());
         dump = check(dump, "ContainerLifeCycl");
-        dump = check(dump, "+? ContainerLife");
+        check(dump, "+? ContainerLife");
 
         ContainerLifeCycle aa1 = new ContainerLifeCycle();
         a0.addBean(aa1);
@@ -225,7 +222,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "ContainerLifeCycl");
         dump = check(dump, "+? ContainerLife");
         dump = check(dump, "+? ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
 
         ContainerLifeCycle aa2 = new ContainerLifeCycle();
         a0.addBean(aa2, false);
@@ -234,7 +231,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "+? ContainerLife");
         dump = check(dump, "+? ContainerLife");
         dump = check(dump, "+~ ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
 
         aa1.start();
         a0.start();
@@ -243,7 +240,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "+= ContainerLife");
         dump = check(dump, "+~ ContainerLife");
         dump = check(dump, "+~ ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
 
         a0.manage(aa1);
         a0.removeBean(aa2);
@@ -251,7 +248,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "ContainerLifeCycl");
         dump = check(dump, "+= ContainerLife");
         dump = check(dump, "+= ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
 
         ContainerLifeCycle aaa0 = new ContainerLifeCycle();
         aa0.addBean(aaa0);
@@ -260,7 +257,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "+= ContainerLife");
         dump = check(dump, "|  +~ Container");
         dump = check(dump, "+= ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
 
         ContainerLifeCycle aa10 = new ContainerLifeCycle();
         aa1.addBean(aa10, true);
@@ -270,7 +267,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "|  +~ Container");
         dump = check(dump, "+= ContainerLife");
         dump = check(dump, "   += Container");
-        dump = check(dump, "");
+        check(dump, "");
 
         final ContainerLifeCycle a1 = new ContainerLifeCycle();
         final ContainerLifeCycle a2 = new ContainerLifeCycle();
@@ -302,7 +299,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "   +> java.util.Arrays$ArrayList");
         dump = check(dump, "      +: ContainerLifeCycle");
         dump = check(dump, "      +: ContainerLifeCycle");
-        dump = check(dump, "");
+        check(dump, "");
 
         a2.addBean(aa0, true);
         dump = trim(a0.dump());
@@ -320,7 +317,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "   +> java.util.Arrays$ArrayList");
         dump = check(dump, "      +: ContainerLifeCycle");
         dump = check(dump, "      +: ContainerLifeCycle");
-        dump = check(dump, "");
+        check(dump, "");
 
         a2.unmanage(aa0);
         dump = trim(a0.dump());
@@ -337,7 +334,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "   +> java.util.Arrays$ArrayList");
         dump = check(dump, "      +: ContainerLifeCycle");
         dump = check(dump, "      +: ContainerLifeCycle");
-        dump = check(dump, "");
+        check(dump, "");
 
         a0.unmanage(aa);
         dump = trim(a0.dump());
@@ -347,7 +344,7 @@ public class ContainerLifeCycleTest
         dump = check(dump, "+= ContainerLife");
         dump = check(dump, "|  += Container");
         dump = check(dump, "+~ ContainerLife");
-        dump = check(dump, "");
+        check(dump, "");
     }
 
     @Test
@@ -505,7 +502,7 @@ public class ContainerLifeCycleTest
         assertEquals(c00, child.poll());
     }
 
-    private final class InheritedListenerLifeCycle extends AbstractLifeCycle implements Container.InheritedListener
+    private static final class InheritedListenerLifeCycle extends AbstractLifeCycle implements Container.InheritedListener
     {
         @Override
         public void beanRemoved(Container p, Object c)
@@ -628,7 +625,7 @@ public class ContainerLifeCycleTest
     }
 
     @Test
-    public void testGetBeans() throws Exception
+    public void testGetBeans()
     {
         TestContainerLifeCycle root = new TestContainerLifeCycle();
         TestContainerLifeCycle left = new TestContainerLifeCycle();
@@ -638,19 +635,24 @@ public class ContainerLifeCycleTest
         TestContainerLifeCycle leaf = new TestContainerLifeCycle();
         right.addBean(leaf);
 
-        root.addBean(Integer.valueOf(0));
-        root.addBean(Integer.valueOf(1));
-        left.addBean(Integer.valueOf(2));
-        right.addBean(Integer.valueOf(3));
-        leaf.addBean(Integer.valueOf(4));
+        Integer zero = 0;
+        Integer one = 1;
+        Integer two = 2;
+        Integer three = 3;
+        Integer four = 4;
+        root.addBean(zero);
+        root.addBean(one);
+        left.addBean(two);
+        right.addBean(three);
+        leaf.addBean(four);
         leaf.addBean("leaf");
 
         assertThat(root.getBeans(Container.class), containsInAnyOrder(left, right));
-        assertThat(root.getBeans(Integer.class), containsInAnyOrder(Integer.valueOf(0), Integer.valueOf(1)));
+        assertThat(root.getBeans(Integer.class), containsInAnyOrder(zero, one));
         assertThat(root.getBeans(String.class), containsInAnyOrder());
 
         assertThat(root.getContainedBeans(Container.class), containsInAnyOrder(left, right, leaf));
-        assertThat(root.getContainedBeans(Integer.class), containsInAnyOrder(Integer.valueOf(0), Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)));
+        assertThat(root.getContainedBeans(Integer.class), containsInAnyOrder(zero, one, two, three, four));
         assertThat(root.getContainedBeans(String.class), containsInAnyOrder("leaf"));
     }
 


### PR DESCRIPTION
#3929.

Previously beans were started if they were not running, which
included them being in a STOPPING state.
Now beans are only started if they are in STOPPED state.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>