### PR TITLE
Issue #3913 Fix races in session request reference counting

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -1046,6 +1046,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
 
     private void notifyComplete(Request request)
     {
+        request.onCompleted();
         notifyEvent1(listener -> listener::onComplete, request);
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -759,8 +759,8 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (idleTO >= 0 && getIdleTimeout() != _oldIdleTimeout)
             setIdleTimeout(_oldIdleTimeout);
 
+        _request.onCompleted();
         notifyComplete(_request);
-
         _transport.onCompleted();
     }
 
@@ -1046,7 +1046,6 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
 
     private void notifyComplete(Request request)
     {
-        request.onCompleted();
         notifyEvent1(listener -> listener::onComplete, request);
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -221,6 +221,7 @@ public class Request implements HttpServletRequest
     private long _timeStamp;
     private MultiParts _multiParts; //if the request is a multi-part mime
     private AsyncContextState _async;
+    private List<HttpSession> _sessions; //list of sessions used during lifetime of request
 
     public Request(HttpChannel channel, HttpInput input)
     {
@@ -366,6 +367,39 @@ public class Request implements HttpServletRequest
             _requestAttributeListeners.add((ServletRequestAttributeListener)listener);
         if (listener instanceof AsyncListener)
             throw new IllegalArgumentException(listener.getClass().toString());
+    }
+    
+    /**
+     * Remember a session that this request has just entered.
+     * 
+     * @param s the session
+     */
+    public void enterSession(final HttpSession s)
+    {
+        if (s == null)
+            return;
+
+        if (_sessions == null)
+            _sessions = new ArrayList<>();
+        if (LOG.isDebugEnabled())
+            LOG.debug("Request {} entering session={}", this, s);
+        _sessions.add(s);
+    }
+
+    /**
+     * Complete this request's access to a session.
+     *
+     * @param s the session
+     */
+    private void leaveSession(final HttpSession s)
+    {
+        if (s == null)
+            return;
+        
+        Session session = Session.class.cast(s);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Request {} leaving session {}", this, session);
+        session.getSessionHandler().complete(session);
     }
 
     private MultiMap<String> getParameters()
@@ -1466,6 +1500,46 @@ public class Request implements HttpServletRequest
         return session.getId();
     }
 
+    /**
+     * Called when the request is fully finished being handled.
+     * For every session in any context that the session has
+     * accessed, ensure that the session is completed.
+     */
+    public void onCompleted()
+    {
+        if (_sessions != null && _sessions.size() > 0)
+        {
+            for (HttpSession s:_sessions)
+                leaveSession(s);
+        }
+    }
+    
+    /**
+     * Find a session that this request has already entered for the
+     * given SessionHandler 
+     *
+     * @param sessionHandler the SessionHandler (ie context) to check
+     * @return
+     */
+    public HttpSession getSession(SessionHandler sessionHandler)
+    {
+        if (_sessions == null || _sessions.size() == 0 || sessionHandler == null)
+            return null;
+        
+        HttpSession session = null;
+        
+        for (HttpSession s:_sessions)
+        {
+            Session ss =  Session.class.cast(s);
+            if (sessionHandler == ss.getSessionHandler())
+            {
+                session = s;
+                break;
+            }
+        }
+        return session;
+    }
+    
     /*
      * @see javax.servlet.http.HttpServletRequest#getSession()
      */
@@ -1788,6 +1862,7 @@ public class Request implements HttpServletRequest
         _inputState = INPUT_NONE;
         _multiParts = null;
         _remote = null;
+        _sessions = null;
         _input.recycle();
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -374,7 +374,7 @@ public class Request implements HttpServletRequest
      * 
      * @param s the session
      */
-    public void enterSession(final HttpSession s)
+    public void enterSession(HttpSession s)
     {
         if (s == null)
             return;
@@ -391,12 +391,12 @@ public class Request implements HttpServletRequest
      *
      * @param s the session
      */
-    private void leaveSession(final HttpSession s)
+    private void leaveSession(HttpSession s)
     {
         if (s == null)
             return;
         
-        Session session = Session.class.cast(s);
+        Session session = (Session)s;
         if (LOG.isDebugEnabled())
             LOG.debug("Request {} leaving session {}", this, session);
         session.getSessionHandler().complete(session);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -296,7 +296,6 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         _removeUnloadableSessions = removeUnloadableSessions;
     }
 
-    
     /**
      * Get a session object.
      *
@@ -311,8 +310,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     {
         return getAndEnter(id, true);
     }
-    
-    
+
     /** Get a session object.
      *
      * If the session object is not in this session store, try getting
@@ -434,7 +432,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
 
         if (ex != null)
             throw ex;
-        return session;        
+        return session;
     }
 
     /**
@@ -503,17 +501,14 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         }
     }
 
-
-
     /**
      * @deprecated
      */
     @Override
     public void put(String id, Session session) throws Exception
     {
-        release(id,session);
+        release(id, session);
     }
-
 
     /**
      * Finish using the Session object.
@@ -545,7 +540,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                 return;
 
             session.complete();
-            
+
             //don't do anything with the session until the last request for it has finished
             if ((session.getRequests() <= 0))
             {
@@ -728,7 +723,8 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             LOG.debug("Checking for idle {}", session.getId());
         try (Lock s = session.lock())
         {
-            if (getEvictionPolicy() > 0 && session.isIdleLongerThan(getEvictionPolicy()) && session.isValid() && session.isResident() && session.getRequests() <= 0)
+            if (getEvictionPolicy() > 0 && session.isIdleLongerThan(getEvictionPolicy())
+                && session.isValid() && session.isResident() && session.getRequests() <= 0)
             {
                 //Be careful with saveOnInactiveEviction - you may be able to re-animate a session that was
                 //being managed on another node and has expired.
@@ -858,6 +854,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     public String toString()
     {
         return String.format("%s@%x[evict=%d,removeUnloadable=%b,saveOnCreate=%b,saveOnInactiveEvict=%b]",
-            this.getClass().getName(), this.hashCode(), _evictionPolicy, _removeUnloadableSessions, _saveOnCreate, _saveOnInactiveEviction);
+            this.getClass().getName(), this.hashCode(), _evictionPolicy,
+            _removeUnloadableSessions, _saveOnCreate, _saveOnInactiveEviction);
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -111,12 +111,13 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     public abstract Session newSession(HttpServletRequest request, SessionData data);
 
     /**
-     * Get the session matching the key
+     * Get the session matching the key from the cache. Does not load
+     * the session.
      *
      * @param id session id
      * @return the Session object matching the id
      */
-    public abstract Session doGet(String id);
+    protected abstract Session doGet(String id);
 
     /**
      * Put the session into the map if it wasn't already there
@@ -125,7 +126,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
      * @param session the session object
      * @return null if the session wasn't already in the map, or the existing entry otherwise
      */
-    public abstract Session doPutIfAbsent(String id, Session session);
+    protected abstract Session doPutIfAbsent(String id, Session session);
 
     /**
      * Replace the mapping from id to oldValue with newValue
@@ -135,7 +136,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
      * @param newValue the new value
      * @return true if replacement was done
      */
-    public abstract boolean doReplace(String id, Session oldValue, Session newValue);
+    protected abstract boolean doReplace(String id, Session oldValue, Session newValue);
 
     /**
      * Remove the session with this identity from the store
@@ -295,17 +296,35 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         _removeUnloadableSessions = removeUnloadableSessions;
     }
 
+    
     /**
      * Get a session object.
      *
      * If the session object is not in this session store, try getting
      * the data for it from a SessionDataStore associated with the
-     * session manager.
+     * session manager. The usage count of the session is incremented.
      *
      * @see org.eclipse.jetty.server.session.SessionCache#get(java.lang.String)
      */
     @Override
     public Session get(String id) throws Exception
+    {
+        return getAndEnter(id, true);
+    }
+    
+    
+    /** Get a session object.
+     *
+     * If the session object is not in this session store, try getting
+     * the data for it from a SessionDataStore associated with the
+     * session manager.
+     * 
+     * @param id The session to retrieve
+     * @param enter if true, the usage count of the session will be incremented
+     * @return
+     * @throws Exception
+     */
+    protected Session getAndEnter(String id, boolean enter) throws Exception
     {
         Session session = null;
         Exception ex = null;
@@ -320,7 +339,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             if (session == null)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Session {} not found locally, attempting to load", id);
+                    LOG.debug("Session {} not found locally in {}, attempting to load", id, this);
 
                 //didn't get a session, try and create one and put in a placeholder for it
                 PlaceHolderSession phs = new PlaceHolderSession(_handler, new SessionData(id, null, null, 0, 0, 0, 0));
@@ -357,6 +376,8 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                             {
                                 //successfully swapped in the session
                                 session.setResident(true);
+                                if (enter)
+                                    session.use();
                                 phsLock.close();
                                 break;
                             }
@@ -383,7 +404,10 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                             session = null;
                             continue;
                         }
+                        //I will use this session too
                         session = s;
+                        if (enter)
+                            session.use();
                         break;
                     }
                 }
@@ -401,6 +425,8 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                     }
 
                     //got the session
+                    if (enter)
+                        session.use();
                     break;
                 }
             }
@@ -408,7 +434,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
 
         if (ex != null)
             throw ex;
-        return session;
+        return session;        
     }
 
     /**
@@ -447,7 +473,50 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     }
 
     /**
-     * Put the Session object back into the session store.
+     * Add an entirely new session (created by the application calling Request.getSession(true))
+     * to the cache. The usage count of the fresh session is incremented.
+     * 
+     * @param id the id
+     * @param session
+     */
+    @Override
+    public void add(String id, Session session) throws Exception
+    {
+        if (id == null || session == null)
+            throw new IllegalArgumentException("Add key=" + id + " session=" + (session == null ? "null" : session.getId()));
+
+        try (Lock lock = session.lock())
+        {
+            if (session.getSessionHandler() == null)
+                throw new IllegalStateException("Session " + id + " is not managed");
+
+            if (!session.isValid())
+                throw new IllegalStateException("Session " + id + " is not valid");
+
+            if (doPutIfAbsent(id, session) == null)
+            {
+                session.setResident(true); //its in the cache
+                session.use(); //the request is using it
+            }
+            else
+                throw new IllegalStateException("Session " + id + " already in cache");
+        }
+    }
+
+
+
+    /**
+     * @deprecated
+     */
+    @Override
+    public void put(String id, Session session) throws Exception
+    {
+        release(id,session);
+    }
+
+
+    /**
+     * Finish using the Session object.
      *
      * This should be called when a request exists the session. Only when the last
      * simultaneous request exists the session will any action be taken.
@@ -459,10 +528,10 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
      * If the evictionPolicy == SessionCache.EVICT_ON_SESSION_EXIT then after we have saved
      * the session, we evict it from the cache.
      *
-     * @see org.eclipse.jetty.server.session.SessionCache#put(java.lang.String, org.eclipse.jetty.server.session.Session)
+     * @see org.eclipse.jetty.server.session.SessionCache#release(java.lang.String, org.eclipse.jetty.server.session.Session)
      */
     @Override
-    public void put(String id, Session session) throws Exception
+    public void release(String id, Session session) throws Exception
     {
         if (id == null || session == null)
             throw new IllegalArgumentException("Put key=" + id + " session=" + (session == null ? "null" : session.getId()));
@@ -472,9 +541,11 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             if (session.getSessionHandler() == null)
                 throw new IllegalStateException("Session " + id + " is not managed");
 
-            if (!session.isValid())
+            if (session.isInvalid())
                 return;
 
+            session.complete();
+            
             //don't do anything with the session until the last request for it has finished
             if ((session.getRequests() <= 0))
             {
@@ -586,7 +657,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     public Session delete(String id) throws Exception
     {
         //get the session, if its not in memory, this will load it
-        Session session = get(id);
+        Session session = getAndEnter(id, false);
 
         //Always delete it from the backing data store
         if (_sessionDataStore != null)
@@ -696,7 +767,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         if (StringUtil.isBlank(newId))
             throw new IllegalArgumentException("New session id is null");
 
-        Session session = get(oldId);
+        Session session = getAndEnter(oldId, true);
         renewSessionId(session, newId, newExtendedId);
 
         return session;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
@@ -84,7 +84,7 @@ public class Session implements SessionHandler.SessionIf
     protected final SessionHandler _handler; // the manager of the session
 
     protected String _extendedId; // the _id plus the worker name
-    
+
     protected long _requests;
 
     protected boolean _idChanged;
@@ -128,7 +128,8 @@ public class Session implements SessionHandler.SessionIf
                     {
                         //grab the lock and check what happened to the session: if it didn't get evicted and
                         //it hasn't expired, we need to reset the timer
-                        if (Session.this.isResident() && Session.this.getRequests() <= 0 && Session.this.isValid() && !Session.this.isExpiredAt(now))
+                        if (Session.this.isResident() && Session.this.getRequests() <= 0 && Session.this.isValid() &&
+                            !Session.this.isExpiredAt(now))
                         {
                             //session wasn't expired or evicted, we need to reset the timer
                             SessionInactivityTimer.this.schedule(Session.this.calculateInactivityTimeout(now));
@@ -211,8 +212,6 @@ public class Session implements SessionHandler.SessionIf
         _sessionData = data;
         _sessionInactivityTimer = new SessionInactivityTimer();
     }
-    
-    
 
     /**
      * Returns the current number of requests that are active in the Session.
@@ -221,12 +220,10 @@ public class Session implements SessionHandler.SessionIf
      */
     public long getRequests()
     {
-        long r;
         try (Lock lock = _lock.lock())
         {
-            r = _requests;
+            return _requests;
         }
-        return r;
     }
 
     public void setExtendedId(String extendedId)
@@ -242,7 +239,7 @@ public class Session implements SessionHandler.SessionIf
         }
     }
 
-    protected void use ()
+    protected void use()
     {
         try (Lock lock = _lock.lock())
         {
@@ -254,7 +251,7 @@ public class Session implements SessionHandler.SessionIf
             _sessionInactivityTimer.cancel();
         }
     }
-    
+
     protected boolean access(long time)
     {
         try (Lock lock = _lock.lock())
@@ -383,7 +380,7 @@ public class Session implements SessionHandler.SessionIf
     public void didActivate()
     {
         HttpSessionEvent event = new HttpSessionEvent(this);
-        for (Iterator<String> iter = _sessionData.getKeys().iterator(); iter.hasNext(); )
+        for (Iterator<String> iter = _sessionData.getKeys().iterator(); iter.hasNext();)
         {
             Object value = _sessionData.getAttribute(iter.next());
             if (value instanceof HttpSessionActivationListener)
@@ -400,7 +397,7 @@ public class Session implements SessionHandler.SessionIf
     public void willPassivate()
     {
         HttpSessionEvent event = new HttpSessionEvent(this);
-        for (Iterator<String> iter = _sessionData.getKeys().iterator(); iter.hasNext(); )
+        for (Iterator<String> iter = _sessionData.getKeys().iterator(); iter.hasNext();)
         {
             Object value = _sessionData.getAttribute(iter.next());
             if (value instanceof HttpSessionActivationListener)
@@ -418,7 +415,7 @@ public class Session implements SessionHandler.SessionIf
             return _state == State.VALID;
         }
     }
-    
+
     public boolean isInvalid()
     {
         try (Lock lock = _lock.lock())
@@ -591,7 +588,8 @@ public class Session implements SessionHandler.SessionIf
                     time = (remaining > 0 ? (Math.min(maxInactive, TimeUnit.SECONDS.toMillis(evictionPolicy))) : 0);
 
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Session {} timer set to lesser of maxInactive={} and inactivityEvict={}", getId(), maxInactive, evictionPolicy);
+                        LOG.debug("Session {} timer set to lesser of maxInactive={} and inactivityEvict={}", getId(),
+                            maxInactive, evictionPolicy);
                 }
             }
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
@@ -118,6 +118,16 @@ public interface SessionCache extends LifeCycle
     {
         return renewSessionId(oldId, newId);
     }
+    
+    /**
+     * Adds a new Session, with a never-before-used id,
+     *  to the cache.
+     * 
+     * @param id
+     * @param session
+     * @throws Exception
+     */
+    void add(String id, Session session) throws Exception;
 
     /**
      * Get an existing Session. If necessary, the cache will load the data for
@@ -138,9 +148,24 @@ public interface SessionCache extends LifeCycle
      * @param id the session id
      * @param session the current session object
      * @throws Exception if any error occurred
+     * @deprecated @see release
      */
     void put(String id, Session session) throws Exception;
-
+    
+    
+    /**
+     * Finish using a Session. This is called by the SessionHandler
+     * once a request is finished with a Session. SessionCache
+     * implementations may want to delay writing out Session contents
+     * until the last request exits a Session.
+     *
+     * @param id the session id
+     * @param session the current session object
+     * @throws Exception if any error occurred
+     */
+    void release(String id, Session session) throws Exception;
+    
+    
     /**
      * Check to see if a Session is in the cache. Does NOT consult
      * the SessionDataStore.

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -73,7 +73,8 @@ public class SessionHandler extends ScopedHandler
 {
     static final Logger LOG = Log.getLogger("org.eclipse.jetty.server.session");
 
-    public static final EnumSet<SessionTrackingMode> DEFAULT_TRACKING = EnumSet.of(SessionTrackingMode.COOKIE, SessionTrackingMode.URL);
+    public static final EnumSet<SessionTrackingMode> DEFAULT_TRACKING = EnumSet.of(SessionTrackingMode.COOKIE,
+        SessionTrackingMode.URL);
 
     /**
      * Session cookie name.
@@ -126,7 +127,8 @@ public class SessionHandler extends ScopedHandler
 
     @SuppressWarnings("unchecked")
     public static final Class<? extends EventListener>[] SESSION_LISTENER_TYPES =
-        new Class[]{
+        new Class[]
+        {
             HttpSessionAttributeListener.class,
             HttpSessionIdListener.class,
             HttpSessionListener.class
@@ -138,7 +140,6 @@ public class SessionHandler extends ScopedHandler
      * max number of minutes that you can set.
      */
     public static final java.math.BigDecimal MAX_INACTIVE_MINUTES = new java.math.BigDecimal(Integer.MAX_VALUE / 60);
-
 
     static final HttpSessionContext __nullSessionContext = new HttpSessionContext()
     {
@@ -196,7 +197,6 @@ public class SessionHandler extends ScopedHandler
     protected Scheduler _scheduler;
     protected boolean _ownScheduler = false;
 
-
     /**
      * Constructor.
      */
@@ -237,9 +237,8 @@ public class SessionHandler extends ScopedHandler
             // Do we need to refresh the cookie?
             if (isUsingCookies() &&
                 (s.isIdChanged() ||
-                    (getSessionCookieConfig().getMaxAge() > 0 && getRefreshCookieAge() > 0 && ((now - s.getCookieSetTime()) / 1000 > getRefreshCookieAge()))
-                )
-            )
+                    (getSessionCookieConfig().getMaxAge() > 0 && getRefreshCookieAge() > 0 
+                        && ((now - s.getCookieSetTime())/1000 > getRefreshCookieAge()))))
             {
                 HttpCookie cookie = getSessionCookie(session, _context == null ? "/" : (_context.getContextPath()), secure);
                 s.cookieSet();
@@ -381,7 +380,6 @@ public class SessionHandler extends ScopedHandler
         //not used
     }
 
-   
     /*
      * @see org.eclipse.thread.AbstractLifeCycle#doStart()
      */
@@ -521,7 +519,7 @@ public class SessionHandler extends ScopedHandler
     {
         String id = getSessionIdManager().getId(extendedId);
         Session session = getSession(id);
-        
+
         if (session != null && !session.getExtendedId().equals(extendedId))
             session.setIdChanged(true);
         return session;
@@ -849,7 +847,8 @@ public class SessionHandler extends ScopedHandler
     public void setSessionIdPathParameterName(String param)
     {
         _sessionIdPathParameterName = (param == null || "none".equals(param)) ? null : param;
-        _sessionIdPathParameterNamePrefix = (param == null || "none".equals(param)) ? null : (";" + _sessionIdPathParameterName + "=");
+        _sessionIdPathParameterNamePrefix = (param == null || "none".equals(param)) ? 
+                                            null : (";" + _sessionIdPathParameterName + "=");
     }
 
     /**
@@ -890,7 +889,6 @@ public class SessionHandler extends ScopedHandler
                 }
 
                 session.setExtendedId(_sessionIdManager.getExtendedId(id, null));
-                //session.getSessionData().setLastNode(_sessionIdManager.getWorkerName());  //TODO write through the change of node?
             }
             return session;
         }
@@ -1290,7 +1288,8 @@ public class SessionHandler extends ScopedHandler
                 //most efficient if it can be done as a bulk operation to eg reduce
                 //roundtrips to the persistent store. Only do this if the HouseKeeper that
                 //does the scavenging is configured to actually scavenge
-                if (_sessionIdManager.getSessionHouseKeeper() != null && _sessionIdManager.getSessionHouseKeeper().getIntervalSec() > 0)
+                if (_sessionIdManager.getSessionHouseKeeper() != null
+                    && _sessionIdManager.getSessionHouseKeeper().getIntervalSec() > 0)
                 {
                     _candidateSessionIdsForExpiry.add(session.getId());
                     if (LOG.isDebugEnabled())
@@ -1462,7 +1461,8 @@ public class SessionHandler extends ScopedHandler
      * @see org.eclipse.jetty.server.Handler#handle(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, int)
      */
     @Override
-    public void doScope(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    public void doScope(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException
     {
         SessionHandler oldSessionHandler = null;
         HttpSession oldSession = null;
@@ -1471,7 +1471,8 @@ public class SessionHandler extends ScopedHandler
         try
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Entering scope {}, dispatch={} asyncstarted={}", this, baseRequest.getDispatcherType(), baseRequest.isAsyncStarted());
+                LOG.debug("Entering scope {}, dispatch={} asyncstarted={}", this, baseRequest.getDispatcherType(), baseRequest
+                    .isAsyncStarted());
 
             switch (baseRequest.getDispatcherType())
             {
@@ -1494,7 +1495,7 @@ public class SessionHandler extends ScopedHandler
                     //remember previous sessionhandler and session
                     oldSessionHandler = baseRequest.getSessionHandler();
                     oldSession = baseRequest.getSession(false);
-                    
+
                     //find any existing session for this request that has already been accessed
                     existingSession = baseRequest.getSession(this);
                     if (existingSession == null)
@@ -1518,7 +1519,9 @@ public class SessionHandler extends ScopedHandler
             {
                 HttpCookie cookie = access(existingSession, request.isSecure());
                 // Handle changed ID or max-age refresh, but only if this is not a redispatched request
-                if ((cookie != null) && (request.getDispatcherType() == DispatcherType.ASYNC || request.getDispatcherType() == DispatcherType.REQUEST))
+                if ((cookie != null) 
+                    && (request.getDispatcherType() == DispatcherType.ASYNC
+                        || request.getDispatcherType() == DispatcherType.REQUEST))
                     baseRequest.getResponse().replaceCookie(cookie);
             }
 
@@ -1535,8 +1538,9 @@ public class SessionHandler extends ScopedHandler
         finally
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Leaving scope {} dispatch={}, async={}, session={}, oldsession={}, oldsessionhandler={}", 
-                    this, baseRequest.getDispatcherType(), baseRequest.isAsyncStarted(), baseRequest.getSession(false), oldSession, oldSessionHandler);
+                LOG.debug("Leaving scope {} dispatch={}, async={}, session={}, oldsession={}, oldsessionhandler={}",
+                    this, baseRequest.getDispatcherType(), baseRequest.isAsyncStarted(), baseRequest.getSession(false),
+                    oldSession, oldSessionHandler);
 
             // revert the session handler to the previous, unless it was null, in which case remember it as
             // the first session handler encountered.
@@ -1552,7 +1556,8 @@ public class SessionHandler extends ScopedHandler
      * @see org.eclipse.jetty.server.Handler#handle(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, int)
      */
     @Override
-    public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException
     {
         nextHandle(target, baseRequest, request, response);
     }
@@ -1583,7 +1588,7 @@ public class SessionHandler extends ScopedHandler
 
         boolean requestedSessionIdFromCookie = false;
         HttpSession session = null;
-        
+
         //first try getting id from a cookie
         if (isUsingCookies())
         {
@@ -1605,9 +1610,9 @@ public class SessionHandler extends ScopedHandler
                         }
                     }
                 }
-            }  
+            }
         }
-        
+
         //try getting id from a url
         if (isUsingURLs() && (requestedSessionId == null))
         {

--- a/tests/test-sessions/test-jdbc-sessions/src/test/java/org/eclipse/jetty/server/session/ClusteredSessionMigrationTest.java
+++ b/tests/test-sessions/test-jdbc-sessions/src/test/java/org/eclipse/jetty/server/session/ClusteredSessionMigrationTest.java
@@ -68,6 +68,7 @@ public class ClusteredSessionMigrationTest extends AbstractTestBase
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT);
+        cacheFactory.setSaveOnCreate(true); //immediately save the session when it is created so node2 can see it
         SessionDataStoreFactory storeFactory = createSessionDataStoreFactory();
         ((AbstractSessionDataStoreFactory)storeFactory).setGracePeriodSec(TestServer.DEFAULT_SCAVENGE_SEC);
 

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
@@ -225,7 +225,7 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
             if ("init".equals(action))
             {
                 HttpSession session = request.getSession(true);
-                session.setAttribute("init", "init");
+                session.setAttribute("test", "init");
                 sendResult(session, httpServletResponse.getWriter());
             }
             else

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
                     scopeListener.setExitSynchronizer(synchronizer);
                     ContentResponse response1 = client.GET("http://localhost:" + port1 + contextPath + servletMapping.substring(1) + "?action=init");
                     assertEquals(HttpServletResponse.SC_OK, response1.getStatus());
-                    assertEquals("init", response1.getContentAsString());
+                    assertTrue(response1.getContentAsString().startsWith("init"));
                     String sessionCookie = response1.getHeaders().get("Set-Cookie");
                     assertTrue(sessionCookie != null);
 
@@ -147,7 +147,7 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
                         request.header("Cookie", sessionCookie); //use existing session
                         ContentResponse response2 = request.send();
                         assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
-                        assertEquals("test", response2.getContentAsString());
+                        assertTrue(response2.getContentAsString().startsWith("test"));
                         //ensure request has finished being handled
                         synchronizer.await(5, TimeUnit.SECONDS);
                         Thread.sleep(requestInterval);
@@ -248,11 +248,11 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
         {
             if (session != null)
             {
-                writer.print(session.getAttribute("test"));
+                writer.println(session.getAttribute("test"));
             }
             else
             {
-                writer.print("null");
+                writer.println("null");
             }
         }
     }

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
@@ -232,13 +232,15 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
             {
                 HttpSession session = request.getSession(false);
 
-                // if we node hopped we should get the session and test should already be present
-                sendResult(session, httpServletResponse.getWriter());
 
                 if (session != null)
                 {
                     session.setAttribute("test", "test");
                 }
+                
+                // if we node hopped we should get the session and test should already be present
+                sendResult(session, httpServletResponse.getWriter());
+
             }
         }
 

--- a/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-sessions-common/src/main/java/org/eclipse/jetty/server/session/AbstractClusteredSessionScavengingTest.java
@@ -116,7 +116,9 @@ public abstract class AbstractClusteredSessionScavengingTest extends AbstractTes
                     // Mangle the cookie, replacing Path with $Path, etc.
                     sessionCookie = sessionCookie.replaceFirst("(\\W)(P|p)ath=", "$1\\$Path=");
                     String id = TestServer.extractSessionId(sessionCookie);
-                    Session s1 = m1.getSessionCache().get(id);
+                    
+                    //Peek at the contents of the cache without doing all the reference counting etc
+                    Session s1 = ((AbstractSessionCache)m1.getSessionCache()).doGet(id);
                     assertNotNull(s1);
                     long expiry = s1.getSessionData().getExpiry();
 

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/AsyncTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/AsyncTest.java
@@ -292,10 +292,11 @@ public class AsyncTest
 
         server.start();
         int port = server.getPort();
-
+        HttpClient client = new HttpClient();
+        
         try (StacklessLogging stackless = new StacklessLogging(Log.getLogger("org.eclipse.jetty.server.session")))
         {
-            HttpClient client = new HttpClient();
+            
             client.start();
             String url = "http://localhost:" + port + "/ctxA/test?action=asyncComplete";
 
@@ -318,6 +319,7 @@ public class AsyncTest
         }
         finally
         {
+            client.stop();
             server.stop();
         }
     }

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/CreationTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/CreationTest.java
@@ -113,10 +113,10 @@ public class CreationTest
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=test");
             response = request.send();
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
-
+   
             //ensure request has finished being handled
             synchronizer.await(5, TimeUnit.SECONDS);
-
+            
             //session should now be evicted from the cache again
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(TestServer.extractSessionId(sessionCookie)));
         }
@@ -406,6 +406,7 @@ public class CreationTest
             if (action != null && action.startsWith("forward"))
             {
                 HttpSession session = request.getSession(true);
+                
                 _id = session.getId();
                 session.setAttribute("value", new Integer(1));
 
@@ -414,7 +415,9 @@ public class CreationTest
                 dispatcherB.forward(request, httpServletResponse);
 
                 if (action.endsWith("inv"))
+                {
                     session.invalidate();
+                }
                 else
                 {
                     session = request.getSession(false);

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/IdleSessionTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/IdleSessionTest.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.server.session;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -75,6 +76,8 @@ public class IdleSessionTest
         _server1 = new TestServer(0, inactivePeriod, scavengePeriod, cacheFactory, storeFactory);
         ServletHolder holder = new ServletHolder(_servlet);
         ServletContextHandler contextHandler = _server1.addContext(contextPath);
+        TestContextScopeListener scopeListener = new TestContextScopeListener();
+        contextHandler.addEventListener(scopeListener);
         contextHandler.addServlet(holder, servletMapping);
         _server1.start();
         int port1 = _server1.getPort();
@@ -86,24 +89,34 @@ public class IdleSessionTest
             String url = "http://localhost:" + port1 + contextPath + servletMapping;
 
             //make a request to set up a session on the server
+            CountDownLatch synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             ContentResponse response = client.GET(url + "?action=init");
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             String sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
 
             //and wait until the session should be passivated out
             pause(evictionSec * 2);
-
+            
             //check that the session has been idled
             String id = TestServer.extractSessionId(sessionCookie);
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertTrue(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
 
             //make another request to reactivate the session
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             Request request = client.newRequest(url + "?action=test");
             ContentResponse response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
-
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             //check session reactivated
             assertTrue(contextHandler.getSessionHandler().getSessionCache().contains(id));
 
@@ -119,17 +132,27 @@ public class IdleSessionTest
             ((TestSessionDataStore)contextHandler.getSessionHandler().getSessionCache().getSessionDataStore())._map.clear();
 
             //make a request
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             request = client.newRequest(url + "?action=testfail");
             response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
 
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             //Test trying to reactivate an expired session (ie before the scavenger can get to it)
             //make a request to set up a session on the server
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             response = client.GET(url + "?action=init");
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
             id = TestServer.extractSessionId(sessionCookie);
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
 
             //and wait until the session should be idled out
             pause(evictionSec * 2);
@@ -146,9 +169,14 @@ public class IdleSessionTest
             pause(inactivePeriod + (3 * scavengePeriod));
 
             //make another request to reactivate the session
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             request = client.newRequest(url + "?action=testfail");
             response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
 
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertFalse(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
@@ -174,6 +202,8 @@ public class IdleSessionTest
         _server1 = new TestServer(0, inactivePeriod, scavengePeriod, cacheFactory, storeFactory);
         ServletHolder holder = new ServletHolder(_servlet);
         ServletContextHandler contextHandler = _server1.addContext(contextPath);
+        TestContextScopeListener scopeListener = new TestContextScopeListener();
+        contextHandler.addEventListener(scopeListener);
         contextHandler.addServlet(holder, servletMapping);
         _server1.start();
         int port1 = _server1.getPort();
@@ -185,10 +215,15 @@ public class IdleSessionTest
             String url = "http://localhost:" + port1 + contextPath + servletMapping;
 
             //make a request to set up a session on the server
+            CountDownLatch synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             ContentResponse response = client.GET(url + "?action=init");
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             String sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
 
             //the session should never be cached
             String id = TestServer.extractSessionId(sessionCookie);
@@ -196,10 +231,15 @@ public class IdleSessionTest
             assertTrue(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
 
             //make another request to reactivate the session
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             Request request = client.newRequest(url + "?action=test");
             ContentResponse response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
-
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             //check session still not in the cache
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertTrue(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
@@ -209,17 +249,28 @@ public class IdleSessionTest
             ((TestSessionDataStore)contextHandler.getSessionHandler().getSessionCache().getSessionDataStore())._map.clear();
 
             //make a request
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             request = client.newRequest(url + "?action=testfail");
             response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
 
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             //Test trying to reactivate an expired session (ie before the scavenger can get to it)
             //make a request to set up a session on the server
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             response = client.GET(url + "?action=init");
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
             id = TestServer.extractSessionId(sessionCookie);
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
 
             //stop the scavenger
             if (_server1.getHouseKeeper() != null)
@@ -233,10 +284,15 @@ public class IdleSessionTest
             pause(inactivePeriod + (3 * scavengePeriod));
 
             //make another request to reactivate the session
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             request = client.newRequest(url + "?action=testfail");
             response2 = request.send();
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
-
+            
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertFalse(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
         }

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/NullSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/NullSessionCacheTest.java
@@ -55,15 +55,18 @@ public class NullSessionCacheTest
         SessionData data = store.newSessionData("1234", now - 20, now - 10, now - 20, TimeUnit.MINUTES.toMillis(10));
         data.setExpiry(now + TimeUnit.DAYS.toMillis(1));
         Session session = cache.newSession(null, data); //mimic a request making a session
-        session.complete(); //mimic request leaving session
-        cache.put("1234", session); //null cache doesn't store the session
-        assertFalse(cache.contains("1234"));
+        cache.add("1234", session); 
+        assertFalse(cache.contains("1234"));//null cache doesn't actually store the session
+        
+        //mimic releasing the session after the request is finished
+        cache.release("1234", session);
         assertTrue(store.exists("1234"));
+        assertFalse(cache.contains("1234"));
 
+        //simulate a new request using the previously created session
         session = cache.get("1234"); //get the session again
         session.access(now); //simulate a request
-        session.complete(); //simulate a request leaving
-        cache.put("1234", session); //finish with the session
+        cache.release("1234", session); //finish with the session
 
         assertFalse(session.isResident());
     }

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SessionRenewTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SessionRenewTest.java
@@ -19,6 +19,10 @@
 package org.eclipse.jetty.server.session;
 
 import java.io.IOException;
+import java.net.HttpCookie;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -60,7 +64,19 @@ public class SessionRenewTest
 
         //make the server with a NullSessionCache
         _server = new TestServer(0, -1, -1, cacheFactory, storeFactory);
-        doTest(new RenewalVerifier());
+        doTest(new RenewalVerifier()
+            {
+
+                @Override
+                public void verify(WebAppContext context, String oldSessionId, String newSessionId) throws Exception
+                {
+                    //null cache means it should contain neither session
+                    assertFalse(context.getSessionHandler().getSessionCache().contains(newSessionId));
+                    assertFalse(context.getSessionHandler().getSessionCache().contains(oldSessionId));
+                    super.verify(context, oldSessionId, newSessionId);
+                }
+            
+            });
     }
 
     /**
@@ -90,6 +106,73 @@ public class SessionRenewTest
         });
     }
 
+    @Test
+    public void testSessionRenewalMultiContext() throws Exception
+    {
+        DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
+        cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT);
+        SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
+
+        _server = new TestServer(0, -1, -1, cacheFactory, storeFactory);
+        
+        String contextPathA = "";
+        String servletMapping = "/server";
+        WebAppContext contextA = _server.addWebAppContext(".", contextPathA);
+        TestContextScopeListener scopeListener = new TestContextScopeListener();
+        contextA.addEventListener(scopeListener);
+        contextA.setParentLoaderPriority(true);
+        contextA.addServlet(TestServlet.class, servletMapping);
+        
+        WebAppContext contextB = _server.addWebAppContext(".", "/B");
+        contextB.setParentLoaderPriority(true);
+
+        HttpClient client = new HttpClient();
+        try
+        {
+            _server.start();
+            int port = _server.getPort();
+
+            client.start();
+
+            //pre-create session data for both contextA and contextB
+            long now = System.currentTimeMillis();
+            SessionData dataA = contextA.getSessionHandler().getSessionCache().getSessionDataStore().newSessionData("1234", now - 20, now - 10, now - 20, TimeUnit.MINUTES.toMillis(10));
+            contextA.getSessionHandler().getSessionCache().getSessionDataStore().store("1234", dataA);
+            SessionData dataB = contextB.getSessionHandler().getSessionCache().getSessionDataStore().newSessionData("1234", now - 20, now - 10, now - 20, TimeUnit.MINUTES.toMillis(10));
+            contextB.getSessionHandler().getSessionCache().getSessionDataStore().store("1234", dataB);
+
+            //make a request to change the sessionid
+            CountDownLatch synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
+            Request request = client.newRequest("http://localhost:" + port + contextPathA + servletMapping + "?action=renew");
+            request.cookie(new HttpCookie(SessionHandler.__DefaultSessionCookie, "1234"));
+            ContentResponse renewResponse = request.send();
+            assertEquals(HttpServletResponse.SC_OK, renewResponse.getStatus());
+            String newSessionCookie = renewResponse.getHeaders().get("Set-Cookie");
+            assertTrue(newSessionCookie != null);
+            String updatedId = TestServer.extractSessionId(newSessionCookie);
+
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
+            //session ids should be updated on all contexts
+            contextA.getSessionHandler().getSessionCache().contains(updatedId);
+            contextB.getSessionHandler().getSessionCache().contains(updatedId);
+
+            Session sessiona = ((AbstractSessionCache)contextA.getSessionHandler().getSessionCache()).getAndEnter(updatedId, false);
+            Session sessionb = ((AbstractSessionCache)contextB.getSessionHandler().getSessionCache()).getAndEnter(updatedId, false);
+
+            //sessions should nor have any usecounts
+            assertEquals(0, sessiona.getRequests());
+            assertEquals(0, sessionb.getRequests());
+
+        }
+        finally
+        {
+            client.stop();
+            _server.stop();
+        }
+    }
     /**
      * Perform the test by making a request to create a session
      * then another request that will renew the session id.
@@ -101,6 +184,8 @@ public class SessionRenewTest
         String contextPath = "";
         String servletMapping = "/server";
         WebAppContext context = _server.addWebAppContext(".", contextPath);
+        TestContextScopeListener scopeListener = new TestContextScopeListener();
+        context.addEventListener(scopeListener);
         context.setParentLoaderPriority(true);
         context.addServlet(TestServlet.class, servletMapping);
         TestHttpSessionIdListener testListener = new TestHttpSessionIdListener();
@@ -115,18 +200,28 @@ public class SessionRenewTest
             client.start();
 
             //make a request to create a session
+            CountDownLatch synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             ContentResponse response = client.GET("http://localhost:" + port + contextPath + servletMapping + "?action=create");
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
 
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             String sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
             assertFalse(testListener.isCalled());
 
             //make a request to change the sessionid
+            synchronizer = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(synchronizer);
             Request request = client.newRequest("http://localhost:" + port + contextPath + servletMapping + "?action=renew");
             ContentResponse renewResponse = request.send();
-
             assertEquals(HttpServletResponse.SC_OK, renewResponse.getStatus());
+           
+            //ensure request has finished being handled
+            synchronizer.await(5, TimeUnit.SECONDS);
+            
             String renewSessionCookie = renewResponse.getHeaders().get("Set-Cookie");
             assertNotNull(renewSessionCookie);
             assertNotSame(sessionCookie, renewSessionCookie);
@@ -175,6 +270,16 @@ public class SessionRenewTest
         }
     }
 
+    public static class TestServletB extends HttpServlet
+    {
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+           //Ensure a session exists
+        }
+        
+    }
     public static class TestServlet extends HttpServlet
     {
         private static final long serialVersionUID = 1L;
@@ -194,7 +299,8 @@ public class SessionRenewTest
                 assertTrue(beforeSession != null);
                 String beforeSessionId = beforeSession.getId();
 
-                ((Session)beforeSession).renewId(request);
+                //((Session)beforeSession).renewId(request);
+                request.changeSessionId();
 
                 HttpSession afterSession = request.getSession(false);
 
@@ -210,10 +316,6 @@ public class SessionRenewTest
                 assertTrue(sessionIdManager.isIdInUse(afterSessionId)); //new session id should be in use
                 assertFalse(sessionIdManager.isIdInUse(beforeSessionId));
 
-                HttpSession session = sessionManager.getSession(afterSessionId);
-                assertNotNull(session);
-                session = sessionManager.getSession(beforeSessionId);
-                assertNull(session);
 
                 if (((Session)afterSession).isIdChanged())
                     ((org.eclipse.jetty.server.Response)response).replaceCookie(sessionManager.getSessionCookie(afterSession, request.getContextPath(), request.isSecure()));


### PR DESCRIPTION
#3913
Fixed races in the reference counting used by sessioncache to work out when it can evict a session. As part of fixing races, also discovered a couple of other problem cases to do with complex server-side forwarding chains to other contexts, and also problems with cleaning up sessions on async dispatches. The code is now a lot simpler and clearer in the lifecycle and reference counts for sessions.