### PR TITLE
Issue #3040 - Allow RFC6265 Cookies to include optional SameSite attribute

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -29,6 +29,21 @@ public class HttpCookie
     private static final String __COOKIE_DELIM = "\",;\\ \t";
     private static final String __01Jan1970_COOKIE = DateGenerator.formatCookieDate(0).trim();
 
+    public enum SameSite
+    {
+        EXCLUDED("Excluded"), NONE("None"), STRICT("Strict"), LAX("Lax");
+
+        private String attributeValue;
+        SameSite(String attributeValue) {
+            this.attributeValue = attributeValue;
+        }
+
+        @Override
+        public String toString(){
+            return this.attributeValue;
+        }
+    }
+
     private final String _name;
     private final String _value;
     private final String _comment;
@@ -39,6 +54,7 @@ public class HttpCookie
     private final int _version;
     private final boolean _httpOnly;
     private final long _expiration;
+    private final SameSite _sameSite;
 
     public HttpCookie(String name, String value)
     {
@@ -62,6 +78,11 @@ public class HttpCookie
 
     public HttpCookie(String name, String value, String domain, String path, long maxAge, boolean httpOnly, boolean secure, String comment, int version)
     {
+        this(name, value, domain, path, maxAge, httpOnly, secure, comment, version, SameSite.EXCLUDED);
+    }
+
+    public HttpCookie(String name, String value, String domain, String path, long maxAge, boolean httpOnly, boolean secure, String comment, int version, SameSite sameSite)
+    {
         _name = name;
         _value = value;
         _domain = domain;
@@ -72,6 +93,7 @@ public class HttpCookie
         _comment = comment;
         _version = version;
         _expiration = maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(maxAge);
+        _sameSite = sameSite;
     }
 
     public HttpCookie(String setCookie)
@@ -92,6 +114,8 @@ public class HttpCookie
         _comment = cookie.getComment();
         _version = cookie.getVersion();
         _expiration = _maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(_maxAge);
+        // TODO support for SameSite values has not yet been added to java.net.HttpCookie
+        _sameSite = SameSite.EXCLUDED;
     }
 
     /**
@@ -156,6 +180,14 @@ public class HttpCookie
     public int getVersion()
     {
         return _version;
+    }
+
+    /**
+     * @return the cookie SameSite enum attribute
+     */
+    public SameSite getSameSite()
+    {
+        return _sameSite;
     }
 
     /**
@@ -366,6 +398,12 @@ public class HttpCookie
             buf.append("; Secure");
         if (_httpOnly)
             buf.append("; HttpOnly");
+        if (_sameSite != SameSite.EXCLUDED)
+        {
+            buf.append("; SameSite=");
+            buf.append(_sameSite.toString());
+        }
+
         return buf.toString();
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -47,12 +47,14 @@ public class HttpCookie
         NONE("None"), STRICT("Strict"), LAX("Lax");
 
         private String attributeValue;
-        SameSite(String attributeValue) {
+
+        SameSite(String attributeValue)
+        {
             this.attributeValue = attributeValue;
         }
 
-        @Override
-        public String toString(){
+        public String getAttributeValue()
+        {
             return this.attributeValue;
         }
     }
@@ -127,7 +129,7 @@ public class HttpCookie
         _comment = cookie.getComment();
         _version = cookie.getVersion();
         _expiration = _maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(_maxAge);
-        // TODO support for SameSite values has not yet been added to java.net.HttpCookie
+        // support for SameSite values has not yet been added to java.net.HttpCookie
         _sameSite = getSameSiteFromComment(cookie.getComment());
     }
 
@@ -414,7 +416,7 @@ public class HttpCookie
         if (_sameSite != null)
         {
             buf.append("; SameSite=");
-            buf.append(_sameSite.toString());
+            buf.append(_sameSite.getAttributeValue());
         }
 
         return buf.toString();
@@ -446,7 +448,7 @@ public class HttpCookie
         return null;
     }
 
-    public static String getCommentWithoutFlags(String comment)
+    public static String getCommentWithoutAttributes(String comment)
     {
         if (comment == null)
         {

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -22,12 +22,25 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.util.QuotedStringTokenizer;
+import org.eclipse.jetty.util.StringUtil;
 
 // TODO consider replacing this with java.net.HttpCookie
 public class HttpCookie
 {
     private static final String __COOKIE_DELIM = "\",;\\ \t";
     private static final String __01Jan1970_COOKIE = DateGenerator.formatCookieDate(0).trim();
+
+    /**
+     *If this string is found within the comment parsed with {@link #isHttpOnlyInComment(String)} the check will return true
+     **/
+    private static final String HTTP_ONLY_COMMENT = "__HTTP_ONLY__";
+    /**
+     *These strings are used by {@link #getSameSiteFromComment(String)} to check for a SameSite specifier in the comment
+     **/
+    private static final String SAME_SITE_COMMENT = "__SAME_SITE_";
+    private static final String SAME_SITE_NONE_COMMENT = SAME_SITE_COMMENT + "NONE__";
+    private static final String SAME_SITE_LAX_COMMENT = SAME_SITE_COMMENT + "LAX__";
+    private static final String SAME_SITE_STRICT_COMMENT = SAME_SITE_COMMENT + "STRICT__";
 
     public enum SameSite
     {
@@ -88,12 +101,13 @@ public class HttpCookie
         _domain = domain;
         _path = path;
         _maxAge = maxAge;
-        _httpOnly = httpOnly;
+        // HttpOnly was supported as a comment in cookie flags before the java.net.HttpCookie implementation so need to check that
+        _httpOnly = httpOnly || isHttpOnlyInComment(comment);
         _secure = secure;
-        _comment = comment;
+        _comment = getCommentWithoutFlags(comment);
         _version = version;
         _expiration = maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(maxAge);
-        _sameSite = sameSite;
+        _sameSite = sameSite == null ? getSameSiteFromComment(comment) : sameSite;
     }
 
     public HttpCookie(String setCookie)
@@ -109,13 +123,13 @@ public class HttpCookie
         _domain = cookie.getDomain();
         _path = cookie.getPath();
         _maxAge = cookie.getMaxAge();
-        _httpOnly = cookie.isHttpOnly();
+        _httpOnly = cookie.isHttpOnly() || isHttpOnlyInComment(cookie.getComment());
         _secure = cookie.getSecure();
-        _comment = cookie.getComment();
+        _comment = getCommentWithoutFlags(cookie.getComment());
         _version = cookie.getVersion();
         _expiration = _maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(_maxAge);
-        // TODO support for SameSite values has not yet been added to java.net.HttpCookie
-        _sameSite = null;
+        // TODO support for SameSite values has not yet been added to java.net.HttpCookie so check comment only
+        _sameSite = getSameSiteFromComment(cookie.getComment());
     }
 
     /**
@@ -405,6 +419,68 @@ public class HttpCookie
         }
 
         return buf.toString();
+    }
+
+    private static boolean isHttpOnlyInComment(String comment)
+    {
+        return comment != null && comment.contains(HTTP_ONLY_COMMENT);
+    }
+
+    private static SameSite getSameSiteFromComment(String comment)
+    {
+        if (comment != null)
+        {
+            if (comment.contains(SAME_SITE_NONE_COMMENT))
+            {
+                return SameSite.NONE;
+            }
+            if (comment.contains(SAME_SITE_LAX_COMMENT))
+            {
+                return SameSite.LAX;
+            }
+            if (comment.contains(SAME_SITE_STRICT_COMMENT))
+            {
+                return SameSite.STRICT;
+            }
+        }
+
+        return null;
+    }
+
+    private static String getCommentWithoutFlags(String comment)
+    {
+        if (comment == null)
+        {
+            return null;
+        }
+
+        String strippedComment = comment.trim();
+
+        if (isHttpOnlyInComment(strippedComment))
+        {
+            strippedComment = StringUtil.strip(strippedComment, HTTP_ONLY_COMMENT);
+        }
+
+        SameSite commentSameSite = getSameSiteFromComment(strippedComment);
+        if (commentSameSite != null)
+        {
+            switch (commentSameSite)
+            {
+                case NONE:
+                    strippedComment = StringUtil.strip(strippedComment, SAME_SITE_NONE_COMMENT);
+                    break;
+                case LAX:
+                    strippedComment = StringUtil.strip(strippedComment, SAME_SITE_LAX_COMMENT);
+                    break;
+                case STRICT:
+                    strippedComment = StringUtil.strip(strippedComment, SAME_SITE_STRICT_COMMENT);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return strippedComment.length() == 0 ? null : strippedComment;
     }
 
     public static class SetCookieHttpField extends HttpField

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -31,7 +31,7 @@ public class HttpCookie
 
     public enum SameSite
     {
-        EXCLUDED("Excluded"), NONE("None"), STRICT("Strict"), LAX("Lax");
+        NONE("None"), STRICT("Strict"), LAX("Lax");
 
         private String attributeValue;
         SameSite(String attributeValue) {
@@ -78,7 +78,7 @@ public class HttpCookie
 
     public HttpCookie(String name, String value, String domain, String path, long maxAge, boolean httpOnly, boolean secure, String comment, int version)
     {
-        this(name, value, domain, path, maxAge, httpOnly, secure, comment, version, SameSite.EXCLUDED);
+        this(name, value, domain, path, maxAge, httpOnly, secure, comment, version, null);
     }
 
     public HttpCookie(String name, String value, String domain, String path, long maxAge, boolean httpOnly, boolean secure, String comment, int version, SameSite sameSite)
@@ -115,7 +115,7 @@ public class HttpCookie
         _version = cookie.getVersion();
         _expiration = _maxAge < 0 ? -1 : System.nanoTime() + TimeUnit.SECONDS.toNanos(_maxAge);
         // TODO support for SameSite values has not yet been added to java.net.HttpCookie
-        _sameSite = SameSite.EXCLUDED;
+        _sameSite = null;
     }
 
     /**
@@ -398,7 +398,7 @@ public class HttpCookie
             buf.append("; Secure");
         if (_httpOnly)
             buf.append("; HttpOnly");
-        if (_sameSite != SameSite.EXCLUDED)
+        if (_sameSite != null)
         {
             buf.append("; SameSite=");
             buf.append(_sameSite.toString());

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -25,6 +25,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpCookieTest
@@ -99,22 +102,6 @@ public class HttpCookieTest
 
         httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.STRICT);
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", httpCookie.getRFC6265SetCookie());
-
-        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, false, true, "comment__HTTP_ONLY__", -1, null);
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", httpCookie.getRFC6265SetCookie());
-
-        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_NONE__", -1, null);
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", httpCookie.getRFC6265SetCookie());
-
-        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_LAX__", -1, null);
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", httpCookie.getRFC6265SetCookie());
-
-        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_STRICT__", -1, null);
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", httpCookie.getRFC6265SetCookie());
-
-        // specified SameSite takes precedence over comment value
-        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "comment__SAME_SITE_STRICT__", -1, HttpCookie.SameSite.LAX);
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", httpCookie.getRFC6265SetCookie());
 
         String[] badNameExamples = {
             "\"name\"",
@@ -204,5 +191,31 @@ public class HttpCookieTest
             httpCookie = new HttpCookie("name", goodValueExample, null, "/", 1, true, true, null, -1);
             // should not throw an exception
         }
+    }
+
+    @Test
+    public void testGetHttpOnlyFromComment()
+    {
+        assertTrue(HttpCookie.isHttpOnlyInComment("__HTTP_ONLY__"));
+        assertTrue(HttpCookie.isHttpOnlyInComment("__HTTP_ONLY__comment"));
+        assertFalse(HttpCookie.isHttpOnlyInComment("comment"));
+    }
+
+    @Test
+    public void testGetSameSiteFromComment()
+    {
+        assertEquals(HttpCookie.getSameSiteFromComment("__SAME_SITE_NONE__"), HttpCookie.SameSite.NONE);
+        assertEquals(HttpCookie.getSameSiteFromComment("__SAME_SITE_LAX__"), HttpCookie.SameSite.LAX);
+        assertEquals(HttpCookie.getSameSiteFromComment("__SAME_SITE_STRICT__"), HttpCookie.SameSite.STRICT);
+        assertEquals(HttpCookie.getSameSiteFromComment("__SAME_SITE_NONE____SAME_SITE_STRICT__"), HttpCookie.SameSite.NONE);
+        assertNull(HttpCookie.getSameSiteFromComment("comment"));
+    }
+
+    @Test
+    public void getCommentWithoutFlags()
+    {
+        assertEquals(HttpCookie.getCommentWithoutFlags("comment__SAME_SITE_NONE__"), "comment");
+        assertEquals(HttpCookie.getCommentWithoutFlags("comment__HTTP_ONLY____SAME_SITE_NONE__"), "comment");
+        assertNull(HttpCookie.getCommentWithoutFlags("__SAME_SITE_LAX__"));
     }
 }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -90,6 +90,10 @@ public class HttpCookieTest
         httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1);
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", httpCookie.getRFC6265SetCookie());
 
+
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.NONE);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", httpCookie.getRFC6265SetCookie());
+
         String[] badNameExamples = {
             "\"name\"",
             "name\t",

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -94,6 +94,12 @@ public class HttpCookieTest
         httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.NONE);
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", httpCookie.getRFC6265SetCookie());
 
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.LAX);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", httpCookie.getRFC6265SetCookie());
+
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.STRICT);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", httpCookie.getRFC6265SetCookie());
+
         String[] badNameExamples = {
             "\"name\"",
             "name\t",

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -212,10 +212,10 @@ public class HttpCookieTest
     }
 
     @Test
-    public void getCommentWithoutFlags()
+    public void getCommentWithoutAttributes()
     {
-        assertEquals(HttpCookie.getCommentWithoutFlags("comment__SAME_SITE_NONE__"), "comment");
-        assertEquals(HttpCookie.getCommentWithoutFlags("comment__HTTP_ONLY____SAME_SITE_NONE__"), "comment");
-        assertNull(HttpCookie.getCommentWithoutFlags("__SAME_SITE_LAX__"));
+        assertEquals(HttpCookie.getCommentWithoutAttributes("comment__SAME_SITE_NONE__"), "comment");
+        assertEquals(HttpCookie.getCommentWithoutAttributes("comment__HTTP_ONLY____SAME_SITE_NONE__"), "comment");
+        assertNull(HttpCookie.getCommentWithoutAttributes("__SAME_SITE_LAX__"));
     }
 }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -100,6 +100,22 @@ public class HttpCookieTest
         httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, null, -1, HttpCookie.SameSite.STRICT);
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", httpCookie.getRFC6265SetCookie());
 
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, false, true, "comment__HTTP_ONLY__", -1, null);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", httpCookie.getRFC6265SetCookie());
+
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_NONE__", -1, null);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", httpCookie.getRFC6265SetCookie());
+
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_LAX__", -1, null);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", httpCookie.getRFC6265SetCookie());
+
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "__SAME_SITE_STRICT__", -1, null);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", httpCookie.getRFC6265SetCookie());
+
+        // specified SameSite takes precedence over comment value
+        httpCookie = new HttpCookie("everything", "value", "domain", "path", 0, true, true, "comment__SAME_SITE_STRICT__", -1, HttpCookie.SameSite.LAX);
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", httpCookie.getRFC6265SetCookie());
+
         String[] badNameExamples = {
             "\"name\"",
             "name\t",

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -39,6 +39,7 @@ import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.DateGenerator;
 import org.eclipse.jetty.http.HttpContent;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpCookie.SameSite;
 import org.eclipse.jetty.http.HttpCookie.SetCookieHttpField;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -226,7 +227,10 @@ public class Response implements HttpServletResponse
             throw new IllegalArgumentException("Cookie.name cannot be blank/null");
 
         String comment = cookie.getComment();
-        boolean httpOnly = cookie.isHttpOnly();
+        // HttpOnly was supported as a comment in cookie flags before the java.net.HttpCookie implementation so need to check that
+        boolean httpOnly = cookie.isHttpOnly() || HttpCookie.isHttpOnlyInComment(comment);
+        SameSite sameSite = HttpCookie.getSameSiteFromComment(comment);
+        comment = HttpCookie.getCommentWithoutFlags(comment);
 
         addCookie(new HttpCookie(
             cookie.getName(),
@@ -237,7 +241,8 @@ public class Response implements HttpServletResponse
             httpOnly,
             cookie.getSecure(),
             comment,
-            cookie.getVersion()));
+            cookie.getVersion(),
+            sameSite));
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -82,12 +82,6 @@ public class Response implements HttpServletResponse
      */
     public static final String SET_INCLUDE_HEADER_PREFIX = "org.eclipse.jetty.server.include.";
 
-    /**
-     * If this string is found within the comment of a cookie added with {@link #addCookie(Cookie)}, then the cookie
-     * will be set as HTTP ONLY.
-     */
-    public static final String HTTP_ONLY_COMMENT = "__HTTP_ONLY__";
-
     private final HttpChannel _channel;
     private final HttpFields _fields = new HttpFields();
     private final AtomicInteger _include = new AtomicInteger();
@@ -233,18 +227,6 @@ public class Response implements HttpServletResponse
 
         String comment = cookie.getComment();
         boolean httpOnly = cookie.isHttpOnly();
-
-        if (comment != null)
-        {
-            int i = comment.indexOf(HTTP_ONLY_COMMENT);
-            if (i >= 0)
-            {
-                httpOnly = true;
-                comment = StringUtil.strip(comment.trim(), HTTP_ONLY_COMMENT);
-                if (comment.length() == 0)
-                    comment = null;
-            }
-        }
 
         addCookie(new HttpCookie(
             cookie.getName(),

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -230,7 +230,7 @@ public class Response implements HttpServletResponse
         // HttpOnly was supported as a comment in cookie flags before the java.net.HttpCookie implementation so need to check that
         boolean httpOnly = cookie.isHttpOnly() || HttpCookie.isHttpOnlyInComment(comment);
         SameSite sameSite = HttpCookie.getSameSiteFromComment(comment);
-        comment = HttpCookie.getCommentWithoutFlags(comment);
+        comment = HttpCookie.getCommentWithoutAttributes(comment);
 
         addCookie(new HttpCookie(
             cookie.getName(),


### PR DESCRIPTION
There's a change coming up that changes SameSite behaviors in Chrome so there may be more demand to specify this field.

I matched this change to the suggestion in the ticket on a per-cookie basis. Setting this as a global flag would be another approach but this is less invasive of a change.

The three possible specified values are "None", "Lax", and "Strict". The "Excluded" enum value, in this case, causes the field to not be sent (which matches current behavior).