### PR TITLE
ServletContext#setSessionTrackingModes throw IAE if SSL and another mode

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -1084,6 +1084,18 @@ public class SessionHandler extends ScopedHandler
 
     public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes)
     {
+        if (sessionTrackingModes != null &&
+            sessionTrackingModes.size() > 1 &&
+            sessionTrackingModes.contains(SessionTrackingMode.SSL))
+        {
+            for (SessionTrackingMode sessionTrackingMode:sessionTrackingModes)
+            {
+                if (sessionTrackingMode != SessionTrackingMode.SSL)
+                {
+                    throw new IllegalArgumentException("sessionTrackingModes specifies a combination of SessionTrackingMode.SSL with a session tracking mode other than SessionTrackingMode.SSL");
+                }
+            }
+        }
         _sessionTrackingModes = new HashSet<>(sessionTrackingModes);
         _usingCookies = _sessionTrackingModes.contains(SessionTrackingMode.COOKIE);
         _usingURLs = _sessionTrackingModes.contains(SessionTrackingMode.URL);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -1088,13 +1088,7 @@ public class SessionHandler extends ScopedHandler
             sessionTrackingModes.size() > 1 &&
             sessionTrackingModes.contains(SessionTrackingMode.SSL))
         {
-            for (SessionTrackingMode sessionTrackingMode:sessionTrackingModes)
-            {
-                if (sessionTrackingMode != SessionTrackingMode.SSL)
-                {
-                    throw new IllegalArgumentException("sessionTrackingModes specifies a combination of SessionTrackingMode.SSL with a session tracking mode other than SessionTrackingMode.SSL");
-                }
-            }
+            throw new IllegalArgumentException ("sessionTrackingModes specifies a combination of SessionTrackingMode.SSL with a session tracking mode other than SessionTrackingMode.SSL");
         }
         _sessionTrackingModes = new HashSet<>(sessionTrackingModes);
         _usingCookies = _sessionTrackingModes.contains(SessionTrackingMode.COOKIE);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
@@ -18,13 +18,14 @@
 
 package org.eclipse.jetty.server.session;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import javax.servlet.SessionTrackingMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import javax.servlet.SessionTrackingMode;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 
 public class SessionHandlerTest
 {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
@@ -1,0 +1,39 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.session;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.SessionTrackingMode;
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class SessionHandlerTest
+{
+    @Test
+    public void testSessionTrackingMode()
+    {
+        SessionHandler sessionHandler = new SessionHandler();
+        sessionHandler.setSessionTrackingModes(new HashSet<>(
+            Arrays.asList(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)));
+        Assertions.assertThrows(IllegalArgumentException.class,() ->
+            sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.SSL, SessionTrackingMode.URL))));
+    }
+}

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
@@ -32,8 +32,7 @@ public class SessionHandlerTest
     public void testSessionTrackingMode()
     {
         SessionHandler sessionHandler = new SessionHandler();
-        sessionHandler.setSessionTrackingModes(new HashSet<>(
-            Arrays.asList(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)));
+        sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)));
         sessionHandler.setSessionTrackingModes(Collections.singleton(SessionTrackingMode.SSL));
         Assertions.assertThrows(IllegalArgumentException.class,() ->
             sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.SSL, SessionTrackingMode.URL))));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.servlet.SessionTrackingMode;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 public class SessionHandlerTest
@@ -33,6 +34,7 @@ public class SessionHandlerTest
         SessionHandler sessionHandler = new SessionHandler();
         sessionHandler.setSessionTrackingModes(new HashSet<>(
             Arrays.asList(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)));
+        sessionHandler.setSessionTrackingModes(Collections.singleton(SessionTrackingMode.SSL));
         Assertions.assertThrows(IllegalArgumentException.class,() ->
             sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.SSL, SessionTrackingMode.URL))));
     }


### PR DESCRIPTION
according to Javadoc and failing tck tests
ServletContext#setSessionTrackingModes
IllegalArgumentException - if sessionTrackingModes specifies a combination of SessionTrackingMode.SSL with a session tracking mode other than SessionTrackingMode.SSL

https://javaee.github.io/javaee-spec/javadocs/javax/servlet/ServletContext.html#setSessionTrackingModes-java.util.Set-

Signed-off-by: olivier lamy <oliver.lamy@gmail.com>