### PR TITLE
Issue #3968 - prevent ReadPending and ISE from AbstractWebSocketConnection

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
@@ -21,9 +21,13 @@ package org.eclipse.jetty.websocket.common.io;
 import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 
 class ReadState
 {
+    private static final Logger LOG = Log.getLogger(ReadState.class);
+
     public static final ByteBuffer NO_ACTION = BufferUtil.EMPTY_BUFFER;
 
     private State state = State.READING;
@@ -54,6 +58,9 @@ class ReadState
     {
         synchronized (this)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("suspending {}", state);
+
             switch (state)
             {
                 case READING:
@@ -71,6 +78,9 @@ class ReadState
     {
         synchronized (this)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("suspend parse {} {}", state, BufferUtil.toDetailString(buffer));
+
             switch (state)
             {
                 case READING:
@@ -94,6 +104,9 @@ class ReadState
     {
         synchronized (this)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("suspend {}", state);
+
             switch (state)
             {
                 case READING:
@@ -121,6 +134,9 @@ class ReadState
     {
         synchronized (this)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("resuming {}", state);
+
             switch (state)
             {
                 case SUSPENDING:
@@ -143,6 +159,9 @@ class ReadState
     {
         synchronized (this)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("eof {}", state);
+
             state = State.EOF;
         }
     }

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
@@ -33,6 +33,14 @@ class ReadState
     private State state = State.READING;
     private ByteBuffer buffer;
 
+    public ByteBuffer getBuffer()
+    {
+        synchronized (this)
+        {
+            return buffer;
+        }
+    }
+
     boolean isReading()
     {
         synchronized (this)
@@ -49,8 +57,38 @@ class ReadState
         }
     }
 
+    public Action getAction(ByteBuffer buffer)
+    {
+        synchronized (this)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} getAction({})", this, BufferUtil.toDetailString(buffer));
+
+            switch (state)
+            {
+                case READING:
+                    return buffer.hasRemaining() ? Action.PARSE : Action.FILL;
+
+                case SUSPENDING:
+                    this.buffer = buffer;
+                    this.state = State.SUSPENDED;
+                    return Action.SUSPEND;
+
+                case EOF:
+                    return Action.EOF;
+
+                case DISCARDING:
+                    return buffer.hasRemaining() ? Action.DISCARD : Action.FILL;
+
+                case SUSPENDED:
+                default:
+                    throw new IllegalStateException(toString(state));
+            }
+        }
+    }
+
     /**
-     * Requests that reads from the connection be suspended when {@link #suspend()} is called.
+     * Requests that reads from the connection be suspended.
      *
      * @return whether the suspending was successful
      */
@@ -74,58 +112,6 @@ class ReadState
         }
     }
 
-    public boolean suspendParse(ByteBuffer buffer)
-    {
-        synchronized (this)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("suspend parse {} {}", state, BufferUtil.toDetailString(buffer));
-
-            switch (state)
-            {
-                case READING:
-                    return false;
-                case SUSPENDING:
-                    this.buffer = buffer;
-                    this.state = State.SUSPENDED;
-                    return true;
-                default:
-                    throw new IllegalStateException(toString(state));
-            }
-        }
-    }
-
-    /**
-     * Suspends reads from the connection if {@link #suspending()} was called.
-     *
-     * @return whether reads from the connection should be suspended
-     */
-    boolean suspend()
-    {
-        synchronized (this)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("suspend {}", state);
-
-            switch (state)
-            {
-                case READING:
-                    return false;
-                case SUSPENDING:
-                    state = State.SUSPENDED;
-                    return true;
-                case SUSPENDED:
-                    if (buffer == null)
-                        throw new IllegalStateException();
-                    return true;
-                case EOF:
-                    return true;
-                default:
-                    throw new IllegalStateException(toString(state));
-            }
-        }
-    }
-
     /**
      * @return a ByteBuffer to finish processing, or null if we should register fillInterested
      * If return value is {@link BufferUtil#EMPTY_BUFFER} no action should be taken.
@@ -141,14 +127,14 @@ class ReadState
             {
                 case SUSPENDING:
                     state = State.READING;
-                    return NO_ACTION;
+                    return null;
                 case SUSPENDED:
                     state = State.READING;
                     ByteBuffer bb = buffer;
                     buffer = null;
                     return bb;
                 case EOF:
-                    return NO_ACTION;
+                    return null;
                 default:
                     throw new IllegalStateException(toString(state));
             }
@@ -166,6 +152,29 @@ class ReadState
         }
     }
 
+    public void discard()
+    {
+        synchronized (this)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("discard {}", state);
+
+            switch (state)
+            {
+                case READING:
+                case SUSPENDED:
+                case SUSPENDING:
+                    state = State.DISCARDING;
+                    break;
+
+                case DISCARDING:
+                case EOF:
+                default:
+                    throw new IllegalStateException(toString(state));
+            }
+        }
+    }
+
     private String toString(State state)
     {
         return String.format("%s@%x[%s]", getClass().getSimpleName(), hashCode(), state);
@@ -178,6 +187,15 @@ class ReadState
         {
             return toString(state);
         }
+    }
+
+    public enum Action
+    {
+        FILL,
+        PARSE,
+        DISCARD,
+        SUSPEND,
+        EOF
     }
 
     private enum State
@@ -196,6 +214,11 @@ class ReadState
          * Suspended, won't read from the connection until resumed.
          */
         SUSPENDED,
+
+        /**
+         * Reading from connection and discarding bytes until EOF.
+         */
+        DISCARDING,
 
         /**
          * Won't read from the connection (terminal state).


### PR DESCRIPTION
Issue #3968

If someone called `AbstractWebSocketConnection.resume()` in between the calls `readState.suspendParse(buffer)` and `readState.suspend()` it could result in `fillInterested()` being called twice.

These changes combine `ReadMode` and `ReadState` so decisions can be made atomically.