### PR TITLE
Made Utf8Encoders tolerant to incomplete sequences.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -105,7 +105,9 @@ public abstract class Utf8Appendable
             _appendable.append(REPLACEMENT);
             int state = _state;
             _state = UTF8_ACCEPT;
-            throw new NotUtf8Exception("char appended in state " + state);
+            Throwable th = new NotUtf8Exception("char appended in state "+state);
+            LOG.warn(th.toString());
+            LOG.debug(th);
         }
     }
 
@@ -251,7 +253,13 @@ public abstract class Utf8Appendable
                     _codep = 0;
                     _state = UTF8_ACCEPT;
                     _appendable.append(REPLACEMENT);
-                    throw new NotUtf8Exception(reason);
+                    if (b > 0) {
+                        _appendable.append((char)(b & 0xFF));
+                    }
+                    Throwable th= new NotUtf8Exception(reason);
+                    LOG.warn(th.toString());
+                    LOG.debug(th);
+                    break;
 
                 default:
                     _state = next;

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -36,6 +36,29 @@ public class UrlEncodedUtf8Test
     static final Logger LOG = Log.getLogger(UrlEncodedUtf8Test.class);
 
     @Test
+    public void testIncompleteSequestAtTheBeginning() throws Exception
+    {
+        byte[] bytes= { -50, 97, 98, 61, 99 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = ""+Utf8Appendable.REPLACEMENT + "ab";
+        String expected = "c";
+
+        fromString(test,test,name,expected,false);
+        fromInputStream(test,bytes,name,expected,false);
+    }
+
+    @Test
+    public void testIncompleteSequestAtTheMiddle() throws Exception
+    {
+        byte[] bytes= { 97, 98, 61, 99, -50, 97, 98 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String expected = "c"+Utf8Appendable.REPLACEMENT+"ab";
+
+        fromString(test,test,"ab",expected,false);
+        fromInputStream(test,bytes,"ab",expected,false);
+    }
+
+    @Test
     public void testIncompleteSequestAtTheEnd() throws Exception
     {
         byte[] bytes = {97, 98, 61, 99, -50};
@@ -44,6 +67,31 @@ public class UrlEncodedUtf8Test
 
         fromString(test, test, "ab", expected, false);
         fromInputStream(test, bytes, "ab", expected, false);
+    }
+
+    @Test
+    public void testIncompleteSequestAtTheBeginning2() throws Exception
+    {
+        byte[] bytes={ -50, 97, 98, 61 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = ""+Utf8Appendable.REPLACEMENT + "ab";
+        String expected = "";
+
+        fromString(test,test,name,expected,false);
+        fromInputStream(test,bytes,name,expected,false);
+
+    }
+
+    @Test
+    public void testIncompleteSequestAtTheMiddle2() throws Exception
+    {
+        byte[] bytes={ 97, 98, 61, -50, 97, 98 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String expected = ""+Utf8Appendable.REPLACEMENT+"ab";
+
+        fromString(test,test,"ab",expected,false);
+        fromInputStream(test,bytes,"ab",expected,false);
+
     }
 
     @Test
@@ -70,6 +118,30 @@ public class UrlEncodedUtf8Test
     }
 
     @Test
+    public void testIncompleteSequestInMiddleName() throws Exception
+    {
+        byte[] bytes= { 101, -50, 101, 61, 102, 103, 38, 97, 98, 61, 99, 100 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = "e"+Utf8Appendable.REPLACEMENT+"e";
+        String value = "fg";
+
+        fromString(test,test,name,value,false);
+        fromInputStream(test,bytes,name,value,false);
+    }
+
+    @Test
+    public void testIncompleteSequestInBeginningName() throws Exception
+    {
+        byte[] bytes= { -50, 101, 61, 102, 103, 38, 97, 98, 61, 99, 100 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = ""+Utf8Appendable.REPLACEMENT+"e";
+        String value = "fg";
+
+        fromString(test,test,name,value,false);
+        fromInputStream(test,bytes,name,value,false);
+    }
+
+    @Test
     public void testIncompleteSequestInValue() throws Exception
     {
         byte[] bytes = {101, 102, 61, 103, -50, 38, 97, 98, 61, 99, 100};
@@ -79,6 +151,30 @@ public class UrlEncodedUtf8Test
 
         fromString(test, test, name, value, false);
         fromInputStream(test, bytes, name, value, false);
+    }
+
+    @Test
+    public void testIncompleteSequestInBeginningValue() throws Exception
+    {
+        byte[] bytes= { 101, 102, 61, -50, 101, 38, 97, 98, 61, 99, 100 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = "ef";
+        String value = ""+Utf8Appendable.REPLACEMENT+"e";
+
+        fromString(test,test,name,value,false);
+        fromInputStream(test,bytes,name,value,false);
+    }
+
+    @Test
+    public void testIncompleteSequestInMiddleValue() throws Exception
+    {
+        byte[] bytes= { 101, 102, 61, 103, -50, 101, 38, 97, 98, 61, 99, 100 };
+        String test=new String(bytes,StandardCharsets.UTF_8);
+        String name = "ef";
+        String value = "g"+Utf8Appendable.REPLACEMENT+"e";
+
+        fromString(test,test,name,value,false);
+        fromInputStream(test,bytes,name,value,false);
     }
 
     // TODO: Split thrown/not-thrown


### PR DESCRIPTION
The idea of this patch is preventing throw an exception and fail the request if somewhere in beginning or the middle of a form parameter appears an incomplete sequences of UTF-8 chars.

Right now the code tolerance this only at the end, but it is definitely possible to have this at the middle the POST parameter or GET string if a remote side truncate value without knowing about UTF-8 symbols.