### PR TITLE
Fix #3985 by ignore invalid cookie format without value

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
@@ -18,14 +18,14 @@
 
 package org.eclipse.jetty.server;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import javax.servlet.http.Cookie;
-
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+
+import javax.servlet.http.Cookie;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Cookie parser
@@ -321,6 +321,10 @@ public class CookieCutter
                         {
                             case ' ':
                             case '\t':
+                                continue;
+                            case ';':
+                                // in name part but we got a ; not a valid cookie
+                                tokenstart = -1;
                                 continue;
 
                             case '=':

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
@@ -18,10 +18,10 @@
 
 package org.eclipse.jetty.server;
 
-import javax.servlet.http.Cookie;
-
 import org.eclipse.jetty.http.CookieCompliance;
 import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.Cookie;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -244,5 +244,20 @@ public class CookieCutterTest
         Cookie[] cookies = parseCookieHeaders(CookieCompliance.RFC6265, rawCookie);
 
         assertThat("Cookies.length", cookies.length, is(0));
+    }
+
+
+    @Test
+    public void testMultipleCookies()
+    {
+        String rawCookie = "testcookie; server.id=abcd; server.detail=cfg";
+
+        // The first cookie "testcookie" should be ignored, per RFC6265, as it's missing the "=" sign.
+
+        Cookie[] cookies = parseCookieHeaders(CookieCompliance.RFC6265, rawCookie);
+
+        assertThat("Cookies.length", cookies.length, is(2));
+        assertCookie("Cookies[0]", cookies[0], "server.id", "abcd", 0, null);
+        assertCookie("Cookies[1]", cookies[1], "server.detail", "cfg", 0, null);
     }
 }


### PR DESCRIPTION
Problem:
#3985  when it has a invalid cookie pattern like `testcookie; a=c; c=d`, the correct cookie `a=c` is missing.

Solution:
in the name parsing part, if we encounter a `;`, we ignore it.  but I'm not sure whether the name part can contains quote.
I test with firefox:
```
JSESSIONID=E1E43B0237253CBB9F589E470625BB4D; "asasx="=as; comm100_guid2=qqq
```
it shows below which I think it's not a valid case:
![image](https://user-images.githubusercontent.com/3148215/63139980-dc54cc80-c012-11e9-9cbf-d728fc6427e4.png)
