### PR TITLE
Fixes #3985 - Updates to CookieCutter to reject no-equal cookies

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
@@ -314,11 +314,7 @@ public class CookieCutter
 
                                 if (_compliance == CookieCompliance.RFC6265)
                                 {
-                                    // Rejected cookie-octet characters
-                                    // US-ASCII characters excluding CTLs,
-                                    // whitespace DQUOTE, comma, semicolon,
-                                    // and backslash
-                                    if (Character.isISOControl(c) || Character.isWhitespace(c) || c == '\\')
+                                    if (isRFC6265RejectedCharacter(c))
                                     {
                                         reject = true;
                                     }
@@ -372,12 +368,7 @@ public class CookieCutter
 
                                 if (_compliance == CookieCompliance.RFC6265)
                                 {
-                                    // Rejected cookie-octet characters
-                                    // US-ASCII characters excluding CTLs,
-                                    // whitespace DQUOTE, comma, semicolon,
-                                    // and backslash
-                                    if (Character.isISOControl(c) || Character.isWhitespace(c) ||
-                                        c == ',' || c == '\\')
+                                    if (isRFC6265RejectedCharacter(c))
                                     {
                                         reject = true;
                                     }
@@ -395,5 +386,23 @@ public class CookieCutter
 
         _cookies = cookies.toArray(new Cookie[0]);
         _lastCookies = _cookies;
+    }
+
+    protected boolean isRFC6265RejectedCharacter(char c)
+    {
+        // We only reject if a Control Character is encountered
+        if (Character.isISOControl(c))
+        {
+            return true;
+        }
+
+        /* TODO: Should we also reject for the complete list of invalid characters in RFC6265?
+         *
+         * US-ASCII characters excluding CTLs,
+         * whitespace DQUOTE, comma, semicolon,
+         * and backslash
+         */
+
+        return false;
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCutter.java
@@ -314,7 +314,7 @@ public class CookieCutter
 
                                 if (_compliance == CookieCompliance.RFC6265)
                                 {
-                                    if (isRFC6265RejectedCharacter(c))
+                                    if (isRFC6265RejectedCharacter(inQuoted, c))
                                     {
                                         reject = true;
                                     }
@@ -368,7 +368,7 @@ public class CookieCutter
 
                                 if (_compliance == CookieCompliance.RFC6265)
                                 {
-                                    if (isRFC6265RejectedCharacter(c))
+                                    if (isRFC6265RejectedCharacter(inQuoted, c))
                                     {
                                         reject = true;
                                     }
@@ -388,20 +388,29 @@ public class CookieCutter
         _lastCookies = _cookies;
     }
 
-    protected boolean isRFC6265RejectedCharacter(char c)
+    protected boolean isRFC6265RejectedCharacter(boolean inQuoted, char c)
     {
-        // We only reject if a Control Character is encountered
-        if (Character.isISOControl(c))
+        if (inQuoted)
         {
-            return true;
+            // We only reject if a Control Character is encountered
+            if (Character.isISOControl(c))
+            {
+                return true;
+            }
         }
-
-        /* TODO: Should we also reject for the complete list of invalid characters in RFC6265?
-         *
-         * US-ASCII characters excluding CTLs,
-         * whitespace DQUOTE, comma, semicolon,
-         * and backslash
-         */
+        else
+        {
+            /* From RFC6265 - Section 4.1.1 - Syntax
+             *  cookie-octet  = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+             *                  ; US-ASCII characters excluding CTLs,
+             *                  ; whitespace DQUOTE, comma, semicolon,
+             *                  ; and backslash
+             */
+            return Character.isISOControl(c) || // control characters
+                c > 127 || // 8-bit characters
+                c == ',' || // comma
+                c == ';'; // semicolon
+        }
 
         return false;
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutterTest.java
@@ -245,4 +245,18 @@ public class CookieCutterTest
 
         assertThat("Cookies.length", cookies.length, is(0));
     }
+
+    @Test
+    public void testMultipleCookies()
+    {
+        String rawCookie = "testcookie; server.id=abcd; server.detail=cfg";
+
+        // The first cookie "testcookie" should be ignored, per RFC6265, as it's missing the "=" sign.
+
+        Cookie[] cookies = parseCookieHeaders(CookieCompliance.RFC6265, rawCookie);
+
+        assertThat("Cookies.length", cookies.length, is(2));
+        assertCookie("Cookies[0]", cookies[0], "server.id", "abcd", 0, null);
+        assertCookie("Cookies[1]", cookies[1], "server.detail", "cfg", 0, null);
+    }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
@@ -130,6 +130,7 @@ public class CookieCutter_LenientTest
             Arguments.of("foo=\"bar;baz\"", "foo", "bar;baz"),
             Arguments.of("z=a;b,c:d;e/f[g]", "z", "a"),
             Arguments.of("z=\"a;b,c:d;e/f[g]\"", "z", "a;b,c:d;e/f[g]"),
+            Arguments.of("name=quoted=\"\\\"badly\\\"\"", null, null), // someone attempting to escape a DQUOTE from within a DQUOTED pair)
 
             // Quoted with other Cookie keywords
             Arguments.of("x=\"$Version=0\"", "x", "$Version=0"),

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
@@ -60,12 +60,17 @@ public class CookieCutter_LenientTest
             //   quoted-string  = ( <"> *(qdtext) <"> )
             //   qdtext         = <any TEXT except <">>
 
+            // rejected, as name cannot be DQUOTED
+            Arguments.of("\"a\"=bcd", null, null),
+            Arguments.of("\"a\"=\"b c d\"", null, null),
+
             // lenient with spaces and EOF
             Arguments.of("abc=", "abc", ""),
             Arguments.of("abc = ", "abc", ""),
             Arguments.of("abc = ;", "abc", ""),
             Arguments.of("abc = ; ", "abc", ""),
             Arguments.of("abc = x ", "abc", "x"),
+            Arguments.of("abc = e f g ", "abc", "e f g"),
             Arguments.of("abc=\"\"", "abc", ""),
             Arguments.of("abc= \"\" ", "abc", ""),
             Arguments.of("abc= \"x\" ", "abc", "x"),
@@ -110,17 +115,17 @@ public class CookieCutter_LenientTest
             // Unterminated Quotes with trailing escape
             Arguments.of("x=\"abc\\", "x", "\"abc\\"),
 
-            // UTF-8 values
-            Arguments.of("2sides=\u262F", "2sides", "\u262f"), // 2 byte
-            Arguments.of("currency=\"\u20AC\"", "currency", "\u20AC"), // 3 byte
-            Arguments.of("gothic=\"\uD800\uDF48\"", "gothic", "\uD800\uDF48"), // 4 byte
+            // UTF-8 raw values (not encoded) - VIOLATION of RFC6265
+            Arguments.of("2sides=\u262F", "2sides", "\u262f"), // 2 byte (YIN YANG)
+            Arguments.of("currency=\"\u20AC\"", "currency", "\u20AC"), // 3 byte (EURO SIGN)
+            Arguments.of("gothic=\"\uD800\uDF48\"", "gothic", "\uD800\uDF48"), // 4 byte (GOTHIC LETTER HWAIR)
 
             // Spaces
             Arguments.of("foo=bar baz", "foo", "bar baz"),
             Arguments.of("foo=\"bar baz\"", "foo", "bar baz"),
             Arguments.of("z=a b c d e f g", "z", "a b c d e f g"),
 
-            // Bad tspecials usage
+            // Bad tspecials usage - VIOLATION of RFC6265
             Arguments.of("foo=bar;baz", "foo", "bar"),
             Arguments.of("foo=\"bar;baz\"", "foo", "bar;baz"),
             Arguments.of("z=a;b,c:d;e/f[g]", "z", "a"),
@@ -131,7 +136,7 @@ public class CookieCutter_LenientTest
             Arguments.of("x=\"$Path=/\"", "x", "$Path=/"),
             Arguments.of("x=\"$Path=/ $Domain=.foo.com\"", "x", "$Path=/ $Domain=.foo.com"),
             Arguments.of("x=\" $Path=/ $Domain=.foo.com \"", "x", " $Path=/ $Domain=.foo.com "),
-            Arguments.of("a=\"b; $Path=/a; c=d; $PATH=/c; e=f\"; $Path=/e/", "a", "b; $Path=/a; c=d; $PATH=/c; e=f"),
+            Arguments.of("a=\"b; $Path=/a; c=d; $PATH=/c; e=f\"; $Path=/e/", "a", "b; $Path=/a; c=d; $PATH=/c; e=f"), // VIOLATES RFC6265
 
             // Lots of equals signs
             Arguments.of("query=b=c&d=e", "query", "b=c&d=e"),
@@ -142,7 +147,7 @@ public class CookieCutter_LenientTest
             // Google cookies (seen in wild, has `tspecials` of ':' in value)
             Arguments.of("GAPS=1:A1aaaAaAA1aaAAAaa1a11a:aAaaAa-aaA1-", "GAPS", "1:A1aaaAaAA1aaAAAaa1a11a:aAaaAa-aaA1-"),
 
-            // Strong abuse of cookie spec (lots of tspecials)
+            // Strong abuse of cookie spec (lots of tspecials) - VIOLATION of RFC6265
             Arguments.of("$Version=0; rToken=F_TOKEN''!--\"</a>=&{()}", "rToken", "F_TOKEN''!--\"</a>=&{()}"),
 
             // Commas that were not commas

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
@@ -116,7 +116,7 @@ public class CookieCutter_LenientTest
             Arguments.of("x=\"abc\\", "x", "\"abc\\"),
 
             // UTF-8 raw values (not encoded) - VIOLATION of RFC6265
-            Arguments.of("2sides=\u262F", "2sides", "\u262f"), // 2 byte (YIN YANG)
+            Arguments.of("2sides=\u262F", null, null), // 2 byte (YIN YANG) - rejected due to not being DQUOTED
             Arguments.of("currency=\"\u20AC\"", "currency", "\u20AC"), // 3 byte (EURO SIGN)
             Arguments.of("gothic=\"\uD800\uDF48\"", "gothic", "\uD800\uDF48"), // 4 byte (GOTHIC LETTER HWAIR)
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCutter_LenientTest.java
@@ -130,7 +130,7 @@ public class CookieCutter_LenientTest
             Arguments.of("foo=\"bar;baz\"", "foo", "bar;baz"),
             Arguments.of("z=a;b,c:d;e/f[g]", "z", "a"),
             Arguments.of("z=\"a;b,c:d;e/f[g]\"", "z", "a;b,c:d;e/f[g]"),
-            Arguments.of("name=quoted=\"\\\"badly\\\"\"", null, null), // someone attempting to escape a DQUOTE from within a DQUOTED pair)
+            Arguments.of("name=quoted=\"\\\"badly\\\"\"", "name", "quoted=\"\\\"badly\\\"\""), // someone attempting to escape a DQUOTE from within a DQUOTED pair)
 
             // Quoted with other Cookie keywords
             Arguments.of("x=\"$Version=0\"", "x", "$Version=0"),

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1515,7 +1515,9 @@ public class RequestTest
                 "\n"
         );
         assertTrue(response.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(0, cookies.size()); // this is an invalid cookie
+        assertEquals(1, cookies.size());
+        assertEquals("name", cookies.get(0).getName());
+        assertEquals("quoted=\"\\\"badly\\\"\"", cookies.get(0).getValue());
 
         cookies.clear();
         response = _connector.getResponse(

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1515,9 +1515,7 @@ public class RequestTest
                 "\n"
         );
         assertTrue(response.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(1, cookies.size());
-        assertEquals("name", cookies.get(0).getName());
-        assertEquals("quoted=\"\\\"badly\\\"\"", cookies.get(0).getValue());
+        assertEquals(0, cookies.size()); // this is an invalid cookie
 
         cookies.clear();
         response = _connector.getResponse(


### PR DESCRIPTION
#3985

* If a cookie has no value it is rejected and not stored.
  - `name` is rejected
  - `name=` is accepted, with empty value