### PR TITLE
Issue #4000 - new SameFileAliasChecker to help with NFC/NFD UTF-8 differences

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
@@ -16,8 +16,9 @@
 //  ========================================================================
 //
 
-package org.eclipse.jetty.server.handler;
+package org.eclipse.jetty.server;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -28,15 +29,25 @@ import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
 
 /**
- * Symbolic Link AliasChecker.
- * <p>An instance of this class can be registered with {@link ContextHandler#addAliasCheck(AliasCheck)}
- * to check resources that are aliased to other locations.   The checker uses the
- * Java {@link Files#readSymbolicLink(Path)} and {@link Path#toRealPath(java.nio.file.LinkOption...)}
- * APIs to check if a file is aliased with symbolic links.</p>
+ * Alias checking for working with FileSystems that normalize access to the
+ * File System.
+ * <p>
+ * The Java {@link Files#isSameFile(Path, Path)} method is used to determine
+ * if the requested file is the same as the alias file.
+ * </p>
+ * <p>
+ * For File Systems that are case insensitive (eg: Microsoft Windows FAT32 and NTFS),
+ * the access to the file can be in any combination or style of upper and lowercase.
+ * </p>
+ * <p>
+ * For File Systems that normalize UTF-8 access (eg: Mac OSX on HFS+ or APFS,
+ * or Linux on XFS) the the actual file could be stored using UTF-16,
+ * but be accessed using NFD UTF-8 or NFC UTF-8 for the same file.
+ * </p>
  */
-public class AllowSymLinkAliasChecker implements AliasCheck
+public class SameFileAliasChecker implements AliasCheck
 {
-    private static final Logger LOG = Log.getLogger(AllowSymLinkAliasChecker.class);
+    private static final Logger LOG = Log.getLogger(SameFileAliasChecker.class);
 
     @Override
     public boolean check(String uri, Resource resource)
@@ -45,50 +56,23 @@ public class AllowSymLinkAliasChecker implements AliasCheck
         if (!(resource instanceof PathResource))
             return false;
 
-        PathResource pathResource = (PathResource)resource;
-
         try
         {
+            PathResource pathResource = (PathResource)resource;
             Path path = pathResource.getPath();
             Path alias = pathResource.getAliasPath();
 
-            if (PathResource.isSame(alias, path))
-                return false; // Unknown why this is an alias
-
-            if (hasSymbolicLink(path) && Files.isSameFile(path, alias))
+            if (Files.isSameFile(path, alias))
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Allow symlink {} --> {}", resource, pathResource.getAliasPath());
+                    LOG.debug("Allow alias to same file {} --> {}", path, alias);
                 return true;
             }
         }
-        catch (Exception e)
+        catch (IOException e)
         {
             LOG.ignore(e);
         }
-
-        return false;
-    }
-
-    private boolean hasSymbolicLink(Path path)
-    {
-        // Is file itself a symlink?
-        if (Files.isSymbolicLink(path))
-        {
-            return true;
-        }
-
-        // Lets try each path segment
-        Path base = path.getRoot();
-        for (Path segment : path)
-        {
-            base = base.resolve(segment);
-            if (Files.isSymbolicLink(base))
-            {
-                return true;
-            }
-        }
-
         return false;
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
@@ -52,7 +52,7 @@ public class AllowSymLinkAliasChecker implements AliasCheck
             Path path = pathResource.getPath();
             Path alias = pathResource.getAliasPath();
 
-            if (PathResource.isSame(alias, path))
+            if (PathResource.isSameName(alias, path))
                 return false; // Unknown why this is an alias
 
             if (hasSymbolicLink(path) && Files.isSameFile(path, alias))

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -80,15 +80,7 @@ public class PathResource extends Resource
         {
             try
             {
-                Path followed = Paths.get(uri).toRealPath(FOLLOW_LINKS);
-                if (!isSame(path, followed))
-                {
-                    return followed;
-                }
-                else
-                {
-                    return null;
-                }
+                return Paths.get(uri).toRealPath(FOLLOW_LINKS);
             }
             catch (IOException ignored)
             {
@@ -112,40 +104,6 @@ public class PathResource extends Resource
             {
                 Path real = abs.toRealPath(FOLLOW_LINKS);
 
-                /*
-                 * If the real path is not the same as the absolute path
-                 * then we know that the real path is the alias for the
-                 * provided path.
-                 *
-                 * For OS's that are case insensitive, this should
-                 * return the real (on-disk / case correct) version
-                 * of the path.
-                 *
-                 * We have to be careful on Windows and OSX.
-                 *
-                 * Assume we have the following scenario
-                 *   Path a = new File("foo").toPath();
-                 *   Files.createFile(a);
-                 *   Path b = new File("FOO").toPath();
-                 *
-                 * There now exists a file called "foo" on disk.
-                 * Using Windows or OSX, with a Path reference of
-                 * "FOO", "Foo", "fOO", etc.. means the following
-                 *
-                 *                        |  OSX    |  Windows   |  Linux
-                 * -----------------------+---------+------------+---------
-                 * Files.exists(a)        |  True   |  True      |  True
-                 * Files.exists(b)        |  True   |  True      |  False
-                 * Files.isSameFile(a,b)  |  True   |  True      |  False
-                 * a.equals(b)            |  False  |  True      |  False
-                 *
-                 * See the javadoc for Path.equals() for details about this FileSystem
-                 * behavior difference
-                 *
-                 * We also cannot rely on a.compareTo(b) as this is roughly equivalent
-                 * in implementation to a.equals(b)
-                 */
-    
                 if (!isSame(abs, real))
                 {
                     return real;
@@ -162,8 +120,62 @@ public class PathResource extends Resource
         }
         return null;
     }
-    
-    private boolean isSame(Path pathA, Path pathB)
+
+    /**
+     * Test if the paths are the same.
+     *
+     * <p>
+     * If the real path is not the same as the absolute path
+     * then we know that the real path is the alias for the
+     * provided path.
+     * </p>
+     *
+     * <p>
+     * For OS's that are case insensitive, this should
+     * return the real (on-disk / case correct) version
+     * of the path.
+     * </p>
+     *
+     * <p>
+     * We have to be careful on Windows and OSX.
+     * </p>
+     *
+     * <p>
+     * Assume we have the following scenario:
+     * </p>
+     *
+     * <pre>
+     *   Path a = new File("foo").toPath();
+     *   Files.createFile(a);
+     *   Path b = new File("FOO").toPath();
+     * </pre>
+     *
+     * <p>
+     * There now exists a file called {@code foo} on disk.
+     * Using Windows or OSX, with a Path reference of
+     * {@code FOO}, {@code Foo}, {@code fOO}, etc.. means the following
+     * </p>
+     *
+     * <pre>
+     *                        |  OSX    |  Windows   |  Linux
+     * -----------------------+---------+------------+---------
+     * Files.exists(a)        |  True   |  True      |  True
+     * Files.exists(b)        |  True   |  True      |  False
+     * Files.isSameFile(a,b)  |  True   |  True      |  False
+     * a.equals(b)            |  False  |  True      |  False
+     * </pre>
+     *
+     * <p>
+     * See the javadoc for Path.equals() for details about this FileSystem
+     * behavior difference
+     * </p>
+     *
+     * <p>
+     * We also cannot rely on a.compareTo(b) as this is roughly equivalent
+     * in implementation to a.equals(b)
+     * </p>
+     */
+    public static boolean isSame(Path pathA, Path pathB)
     {
         int aCount = pathA.getNameCount();
         int bCount = pathB.getNameCount();
@@ -174,7 +186,7 @@ public class PathResource extends Resource
         }
         
         // compare each segment of path, backwards
-        for (int i = bCount - 1; i >= 0; i--)
+        for (int i = bCount; i-- > 0; )
         {
             if (!pathA.getName(i).toString().equals(pathB.getName(i).toString()))
             {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -80,7 +80,15 @@ public class PathResource extends Resource
         {
             try
             {
-                return Paths.get(uri).toRealPath(FOLLOW_LINKS);
+                Path followed = Paths.get(uri).toRealPath(FOLLOW_LINKS);
+                if (!isSame(path, followed))
+                {
+                    return followed;
+                }
+                else
+                {
+                    return null;
+                }
             }
             catch (IOException ignored)
             {
@@ -137,22 +145,10 @@ public class PathResource extends Resource
                  * We also cannot rely on a.compareTo(b) as this is roughly equivalent
                  * in implementation to a.equals(b)
                  */
-
-                int absCount = abs.getNameCount();
-                int realCount = real.getNameCount();
-                if (absCount != realCount)
+    
+                if (!isSame(abs, real))
                 {
-                    // different number of segments
                     return real;
-                }
-
-                // compare each segment of path, backwards
-                for (int i = realCount - 1; i >= 0; i--)
-                {
-                    if (!abs.getName(i).toString().equals(real.getName(i).toString()))
-                    {
-                        return real;
-                    }
                 }
             }
         }
@@ -165,6 +161,28 @@ public class PathResource extends Resource
             LOG.warn("bad alias ({} {}) for {}", e.getClass().getName(), e.getMessage(), path);
         }
         return null;
+    }
+    
+    private boolean isSame(Path pathA, Path pathB)
+    {
+        int aCount = pathA.getNameCount();
+        int bCount = pathB.getNameCount();
+        if (aCount != bCount)
+        {
+            // different number of segments
+            return false;
+        }
+        
+        // compare each segment of path, backwards
+        for (int i = bCount - 1; i >= 0; i--)
+        {
+            if (!pathA.getName(i).toString().equals(pathB.getName(i).toString()))
+            {
+                return false;
+            }
+        }
+        
+        return true;
     }
 
     /**

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -104,7 +104,7 @@ public class PathResource extends Resource
             {
                 Path real = abs.toRealPath(FOLLOW_LINKS);
 
-                if (!isSame(abs, real))
+                if (!isSameName(abs, real))
                 {
                     return real;
                 }
@@ -122,7 +122,7 @@ public class PathResource extends Resource
     }
 
     /**
-     * Test if the paths are the same.
+     * Test if the paths are the same name.
      *
      * <p>
      * If the real path is not the same as the absolute path
@@ -175,7 +175,7 @@ public class PathResource extends Resource
      * in implementation to a.equals(b)
      * </p>
      */
-    public static boolean isSame(Path pathA, Path pathB)
+    public static boolean isSameName(Path pathA, Path pathB)
     {
         int aCount = pathA.getNameCount();
         int bCount = pathB.getNameCount();

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -342,9 +342,13 @@ public class FileSystemResourceTest
             Resource refA2 = base.addPath("swedish-ä.txt");
             Resource refO1 = base.addPath("swedish-ö.txt");
             
-            assertThat("Ref A1", refA1.exists(), is(true));
-            assertThat("Ref A2", refA2.exists(), is(true));
-            assertThat("Ref O1", refO1.exists(), is(true));
+            assertThat("Ref A1 exists", refA1.exists(), is(true));
+            assertThat("Ref A2 exists", refA2.exists(), is(true));
+            assertThat("Ref O1 exists", refO1.exists(), is(true));
+    
+            assertThat("Ref A1 alias", refA1.isAlias(), is(false));
+            assertThat("Ref A2 alias", refA2.isAlias(), is(false));
+            assertThat("Ref O1 alias", refO1.isAlias(), is(false));
             
             assertThat("Ref A1 contents", toString(refA1), is("hi a-with-circle"));
             assertThat("Ref A2 contents", toString(refA2), is("hi a-with-two-dots"));
@@ -1416,11 +1420,19 @@ public class FileSystemResourceTest
 
             Resource r = base.addPath("//foo.txt");
             assertThat("getURI()", r.getURI().toASCIIString(), containsString("//foo.txt"));
-
-            assertThat("isAlias()", r.isAlias(), is(true));
-            assertThat("getAlias()", r.getAlias(), notNullValue());
-            assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("/foo.txt"));
             assertThat("Exists: " + r, r.exists(), is(true));
+            
+            if (PathResource.class.isAssignableFrom(resourceClass))
+            {
+                assertThat("isAlias()", r.isAlias(), is(false));
+                assertThat("getAlias()", r.getAlias(), nullValue());
+            }
+            else
+            {
+                assertThat("isAlias()", r.isAlias(), is(true));
+                assertThat("getAlias()", r.getAlias(), notNullValue());
+                assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("/foo.txt"));
+            }
         }
         catch (InvalidPathException e)
         {
@@ -1449,10 +1461,19 @@ public class FileSystemResourceTest
 
             Resource r = base.addPath("aa//foo.txt");
             assertThat("getURI()", r.getURI().toASCIIString(), containsString("aa//foo.txt"));
-
-            assertThat("isAlias()", r.isAlias(), is(true));
-            assertThat("getAlias()", r.getAlias(), notNullValue());
-            assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("aa/foo.txt"));
+    
+            if (PathResource.class.isAssignableFrom(resourceClass))
+            {
+                assertThat("isAlias()", r.isAlias(), is(false));
+                assertThat("getAlias()", r.getAlias(), nullValue());
+            }
+            else
+            {
+                assertThat("isAlias()", r.isAlias(), is(true));
+                assertThat("getAlias()", r.getAlias(), notNullValue());
+                assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("aa/foo.txt"));
+            }
+            
             assertThat("Exists: " + r, r.exists(), is(true));
         }
         catch (InvalidPathException e)

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -18,20 +18,6 @@
 
 package org.eclipse.jetty.util.resource;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.api.condition.OS.LINUX;
-import static org.junit.jupiter.api.condition.OS.MAC;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
-
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -72,6 +58,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 @ExtendWith(WorkDirExtension.class)
 public class FileSystemResourceTest
@@ -465,7 +465,7 @@ public class FileSystemResourceTest
             assertThat("foo.length", res.length(), is(expected));
         }
     }
-    
+
     @ParameterizedTest
     @MethodSource("fsResourceProvider")
     public void testLength_NotExists(Class resourceClass) throws Exception
@@ -1420,19 +1420,11 @@ public class FileSystemResourceTest
 
             Resource r = base.addPath("//foo.txt");
             assertThat("getURI()", r.getURI().toASCIIString(), containsString("//foo.txt"));
+
+            assertThat("isAlias()", r.isAlias(), is(true));
+            assertThat("getAlias()", r.getAlias(), notNullValue());
+            assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("/foo.txt"));
             assertThat("Exists: " + r, r.exists(), is(true));
-            
-            if (PathResource.class.isAssignableFrom(resourceClass))
-            {
-                assertThat("isAlias()", r.isAlias(), is(false));
-                assertThat("getAlias()", r.getAlias(), nullValue());
-            }
-            else
-            {
-                assertThat("isAlias()", r.isAlias(), is(true));
-                assertThat("getAlias()", r.getAlias(), notNullValue());
-                assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("/foo.txt"));
-            }
         }
         catch (InvalidPathException e)
         {
@@ -1461,19 +1453,10 @@ public class FileSystemResourceTest
 
             Resource r = base.addPath("aa//foo.txt");
             assertThat("getURI()", r.getURI().toASCIIString(), containsString("aa//foo.txt"));
-    
-            if (PathResource.class.isAssignableFrom(resourceClass))
-            {
-                assertThat("isAlias()", r.isAlias(), is(false));
-                assertThat("getAlias()", r.getAlias(), nullValue());
-            }
-            else
-            {
-                assertThat("isAlias()", r.isAlias(), is(true));
-                assertThat("getAlias()", r.getAlias(), notNullValue());
-                assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("aa/foo.txt"));
-            }
-            
+
+            assertThat("isAlias()", r.isAlias(), is(true));
+            assertThat("getAlias()", r.getAlias(), notNullValue());
+            assertThat("getAlias()", r.getAlias().toASCIIString(), containsString("aa/foo.txt"));
             assertThat("Exists: " + r, r.exists(), is(true));
         }
         catch (InvalidPathException e)


### PR DESCRIPTION
#4000 
+ OSX File is `swedish-å.txt`
+ OSX File System stores filename in alt UTF-8 (NFD) form. `swedish-a%CC%8A.txt`
+ HTTP uses normal form UTF-8. `swedish-%C3%A5.txt`
+ A HTTP GET request should work against the resource
  being requested, regardless of UTF-8 style used.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>