### PR TITLE
Update Tycho and Eclipse CBI plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <asm.version>7.1</asm.version>
     <jmh.version>1.21</jmh.version>
     <jmhjar.name>benchmarks</jmhjar.name>
-    <tycho-version>1.2.0</tycho-version>
-    <cbi-plugins.version>1.1.5</cbi-plugins.version>
+    <tycho-version>1.4.0</tycho-version>
+    <cbi-plugins.version>1.1.7</cbi-plugins.version>
     <junit.version>5.5.1</junit.version>
     <maven.version>3.6.0</maven.version>
     <maven.resolver.version>1.3.1</maven.resolver.version>


### PR DESCRIPTION
* Tycho to 1.4.0
* CBI to 1.1.7

These updates are important for both speed and m2e compatibility so
warnings are not shown in the eclipse ide.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>