### PR TITLE
NPE possible when setContentType is called before setMimeTypes

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/gzip/CompressedResponseWrapper.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/gzip/CompressedResponseWrapper.java
@@ -136,7 +136,7 @@ public abstract class CompressedResponseWrapper extends HttpServletResponseWrapp
                 if (colon>0)
                     ct=ct.substring(0,colon);
 
-                if (!_mimeTypes.matches(StringUtil.asciiToLowerCase(ct)))
+                if (_mimeTypes!=null && !_mimeTypes.matches(StringUtil.asciiToLowerCase(ct)))
                     noCompression();
             }
         }


### PR DESCRIPTION
When setContentType is invoked before setMimeTypes, a NPE is possible because of a missing `null` check.

```java
    @Override
    public void setContentType(String ct)
    {
        super.setContentType(ct);

        if (!_noCompression && (_compressedStream==null || _compressedStream.getOutputStream()==null))
        {
            if (ct!=null)
            {
                int colon=ct.indexOf(";");
                if (colon>0)
                    ct=ct.substring(0,colon);
                
                // it could be that _mimeTypes is null.
                if (!_mimeTypes.matches(StringUtil.asciiToLowerCase(ct)))
                    noCompression();
            }
        }
    }
```

The PR has an additional check on the nullability of the field.