### PR TITLE
fix Session#finishInvalidate throwsConcurrentModificationException

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.server.session;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1044,7 +1043,7 @@ public class Session implements SessionHandler.SessionIf
                     do
                     {
                         keys = _sessionData.getKeys();
-                        for (String key : new HashSet<>(keys))
+                        for (String key : keys)
                         {
                             Object old = _sessionData.setAttribute(key, null);
                             // if same as remove attribute but attribute was

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.server.session;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1043,7 +1044,7 @@ public class Session implements SessionHandler.SessionIf
                     do
                     {
                         keys = _sessionData.getKeys();
-                        for (String key : keys)
+                        for (String key : new HashSet<>(keys))
                         {
                             Object old = _sessionData.setAttribute(key, null);
                             // if same as remove attribute but attribute was

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.server.session;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -248,7 +249,7 @@ public class SessionData implements Serializable
      */
     public Set<String> getKeys()
     {
-        return _attributes.keySet();
+        return Collections.unmodifiableSet(new HashSet<>(_attributes.keySet()));
     }
 
     public Object setAttribute(String name, Object value)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
@@ -176,7 +176,14 @@ public class SessionData implements Serializable
         _lastAccessed = lastAccessed;
         _maxInactiveMs = maxInactiveMs;
         calcAndSetExpiry();
-        _attributes = attributes;
+        setAttributes(attributes);
+    }
+
+    private void setAttributes(Map<String, Object> attributes) {
+        if(attributes != null) {
+            boolean isConcurrentHashMap = (attributes instanceof ConcurrentHashMap);
+            _attributes = isConcurrentHashMap ? attributes : new ConcurrentHashMap<>(attributes);
+        }
     }
 
     /**
@@ -249,7 +256,7 @@ public class SessionData implements Serializable
      */
     public Set<String> getKeys()
     {
-        return Collections.unmodifiableSet(new HashSet<>(_attributes.keySet()));
+        return _attributes.keySet();
     }
 
     public Object setAttribute(String name, Object value)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
@@ -162,11 +162,6 @@ public class SessionData implements Serializable
 
     public SessionData(String id, String cpath, String vhost, long created, long accessed, long lastAccessed, long maxInactiveMs)
     {
-        this(id, cpath, vhost, created, accessed, lastAccessed, maxInactiveMs, new ConcurrentHashMap<String, Object>());
-    }
-
-    public SessionData(String id, String cpath, String vhost, long created, long accessed, long lastAccessed, long maxInactiveMs, Map<String, Object> attributes)
-    {
         _id = id;
         setContextPath(cpath);
         setVhost(vhost);
@@ -175,14 +170,13 @@ public class SessionData implements Serializable
         _lastAccessed = lastAccessed;
         _maxInactiveMs = maxInactiveMs;
         calcAndSetExpiry();
-        setAttributes(attributes);
+        _attributes = new ConcurrentHashMap<>();
     }
 
-    private void setAttributes(Map<String, Object> attributes) {
-        if(attributes != null) {
-            boolean isConcurrentHashMap = (attributes instanceof ConcurrentHashMap);
-            _attributes = isConcurrentHashMap ? attributes : new ConcurrentHashMap<>(attributes);
-        }
+    public SessionData(String id, String cpath, String vhost, long created, long accessed, long lastAccessed, long maxInactiveMs, Map<String, Object> attributes)
+    {
+        this(id, cpath, vhost, created, accessed, lastAccessed, maxInactiveMs);
+        putAllAttributes(attributes);
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionData.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.server.session;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;


### PR DESCRIPTION
SessionData#setAttribute has a side effect to returned instance of SessionData#getKeys.
Therefore SessionData#setAttribute is called in for ... of loop,
for ... of iteration would throw ConcurrentModificationException.

for fix this problem, It is good to use new HashSet for for ... of loop

Stacktrace:

```
java.util.ConcurrentModificationException: null
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1445)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1469)
	at org.eclipse.jetty.server.session.Session.finishInvalidate(Session.java:1093)
	at org.eclipse.jetty.server.session.Session.invalidate(Session.java:979)
```