### PR TITLE
Better advice for skipping tests in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The first build may take a longer than expected as Maven downloads all the depen
 
 The build tests do a lot of stress testing, and on some machines it is necessary to set the file descriptor limit to greater than 2048 for the tests to all pass successfully.
 
-It is possible to bypass tests by building with `mvn -Dmaven.test.skip=true install` but note that this will not produce some of the test jars that are leveraged in other places in the build.
+It is possible to bypass tests by building with `mvn clean install -DskipTests`.
 
 Professional Services
 ---------------------


### PR DESCRIPTION
This causes test artifacts to be built even though tests are not run.