### PR TITLE
Tolerate multiple Accept-Encoding headers in GzipHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.CompressedContentFormat;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
@@ -442,7 +443,8 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     @Override
     public Deflater getDeflater(Request request, long contentLength)
     {
-        String ua = request.getHttpFields().get(HttpHeader.USER_AGENT);
+        HttpFields httpFields = request.getHttpFields();
+        String ua = httpFields.get(HttpHeader.USER_AGENT);
         if (ua != null && !isAgentGzipable(ua))
         {
             LOG.debug("{} excluded user agent {}", this, request);
@@ -456,16 +458,13 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
         }
 
         // check the accept encoding header
-        HttpField accept = request.getHttpFields().getField(HttpHeader.ACCEPT_ENCODING);
-
-        if (accept == null)
+        if (!httpFields.contains(HttpHeader.ACCEPT_ENCODING))
         {
             LOG.debug("{} excluded !accept {}", this, request);
             return null;
         }
-        boolean gzip = accept.contains("gzip");
 
-        if (!gzip)
+        if (!httpFields.contains(HttpHeader.ACCEPT_ENCODING, "gzip"))
         {
             LOG.debug("{} excluded not gzip accept {}", this, request);
             return null;

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
@@ -286,6 +286,34 @@ public class GzipHandlerTest
     }
 
     @Test
+    public void testGzipHandlerWithMultipleAcceptEncodingHeaders() throws Exception
+    {
+        // generated and parsed test
+        HttpTester.Request request = HttpTester.newRequest();
+        HttpTester.Response response;
+
+        request.setMethod("GET");
+        request.setURI("/ctx/content?vary=Accept-Encoding,Other");
+        request.setVersion("HTTP/1.0");
+        request.setHeader("Host", "tester");
+        request.setHeader("accept-encoding", "deflate");
+        request.setHeader("accept-encoding", "gzip");
+
+        response = HttpTester.parseResponse(_connector.getResponse(request.generate()));
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get("Content-Encoding"), Matchers.equalToIgnoringCase("gzip"));
+        assertThat(response.get("ETag"), is(__contentETagGzip));
+        assertThat(response.getCSV("Vary", false), Matchers.contains("Accept-Encoding", "Other"));
+
+        InputStream testIn = new GZIPInputStream(new ByteArrayInputStream(response.getContentBytes()));
+        ByteArrayOutputStream testOut = new ByteArrayOutputStream();
+        IO.copy(testIn, testOut);
+
+        assertEquals(__content, testOut.toString("UTF8"));
+    }
+
+    @Test
     public void testGzipNotMicro() throws Exception
     {
         // generated and parsed test


### PR DESCRIPTION
Hi,

`Accept-Encoding` seems to be one of those headers that can occur multiple times in a request. GzipHandler doesn't tolerate this at the moment and causes issues like https://github.com/spring-projects/spring-boot/issues/18176.

This PR is an attempt to fix this.

Cheers,
Christoph