### PR TITLE
Issue #4076 Fix restart of quickstarted webapp

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
@@ -191,6 +191,18 @@ public class QuickStartConfiguration extends AbstractConfiguration
         }
     }
 
+    @Override
+    public void postConfigure(WebAppContext context) throws Exception
+    {
+        super.postConfigure(context);
+        ServletContainerInitializersStarter starter = (ServletContainerInitializersStarter)context.getAttribute(AnnotationConfiguration.CONTAINER_INITIALIZER_STARTER);
+        if (starter != null)
+        {
+            context.removeBean(starter);
+            context.removeAttribute(AnnotationConfiguration.CONTAINER_INITIALIZER_STARTER);
+        }
+    }
+
     protected void quickStart(WebAppContext context)
         throws Exception
     {


### PR DESCRIPTION
#4076 

Ensure ServletContainerInitializerStarter added by QuickStartConfigurion.configure() method is removed in QuickStartConfiguration.postConfigure() method.