### PR TITLE
Issue #2788 -  Graceful close of HTTP/2 Connection.

### DIFF
--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/HTTP2Test.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/HTTP2Test.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -38,12 +39,14 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.DataFrame;
 import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.parser.RateControl;
 import org.eclipse.jetty.http2.parser.ServerParser;
@@ -790,6 +793,129 @@ public class HTTP2Test extends AbstractTest
         assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
         assertTrue(closeLatch.await(5, TimeUnit.SECONDS));
         assertTrue(goAwayLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testGracefulServerGoAway() throws Exception
+    {
+        AtomicReference<Session> serverSessionRef = new AtomicReference<>();
+        CountDownLatch serverSessionLatch = new CountDownLatch(1);
+        CountDownLatch dataLatch = new CountDownLatch(2);
+        start(new ServerSessionListener.Adapter()
+        {
+            @Override
+            public void onAccept(Session session)
+            {
+                serverSessionRef.set(session);
+                serverSessionLatch.countDown();
+            }
+
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                return new Stream.Listener.Adapter()
+                {
+                    @Override
+                    public void onData(Stream stream, DataFrame frame, Callback callback)
+                    {
+                        callback.succeeded();
+                        dataLatch.countDown();
+                        if (frame.isEndStream())
+                        {
+                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, new HttpFields());
+                            stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
+                        }
+                    }
+                };
+            }
+        });
+
+        CountDownLatch clientCloseLatch = new CountDownLatch(1);
+        Session clientSession = newClient(new Session.Listener.Adapter()
+        {
+            @Override
+            public void onClose(Session session, GoAwayFrame frame)
+            {
+                clientCloseLatch.countDown();
+            }
+        });
+        assertTrue(serverSessionLatch.await(5, TimeUnit.SECONDS));
+        Session serverSession = serverSessionRef.get();
+
+        CountDownLatch responseLatch = new CountDownLatch(2);
+        MetaData.Request metaData1 = newRequest("GET", new HttpFields());
+        HeadersFrame request1 = new HeadersFrame(metaData1, null, false);
+        FuturePromise<Stream> promise1 = new FuturePromise<>();
+        Stream.Listener.Adapter listener = new Stream.Listener.Adapter()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                if (frame.isEndStream())
+                {
+                    MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                    assertEquals(HttpStatus.OK_200, response.getStatus());
+                    responseLatch.countDown();
+                }
+            }
+        };
+        clientSession.newStream(request1, promise1, listener);
+        Stream stream1 = promise1.get(5, TimeUnit.SECONDS);
+        stream1.data(new DataFrame(stream1.getId(), ByteBuffer.allocate(1), false), Callback.NOOP);
+
+        MetaData.Request metaData2 = newRequest("GET", new HttpFields());
+        HeadersFrame request2 = new HeadersFrame(metaData2, null, false);
+        FuturePromise<Stream> promise2 = new FuturePromise<>();
+        clientSession.newStream(request2, promise2, listener);
+        Stream stream2 = promise2.get(5, TimeUnit.SECONDS);
+        stream2.data(new DataFrame(stream2.getId(), ByteBuffer.allocate(1), false), Callback.NOOP);
+
+        assertTrue(dataLatch.await(5, TimeUnit.SECONDS));
+
+        // Both requests are now on the server, shutdown gracefully the server session.
+        long timeout = 2000;
+        ((HTTP2Session)serverSession).shutdown(ErrorCode.NO_ERROR.code, "graceful", Callback.NOOP, timeout);
+        // TODO: there is no API to shutdown gracefully the server.
+        //  Server does not implement Graceful.
+        //  Connector implements Graceful, but the only thing it does is to close the acceptor.
+        //  There is no component that forwards the graceful shutdown, so it cannot arrive at the HTTP/2 session.
+        //  Furthermore, the semantic of stop() is blocking, so we cannot return from it because then
+        //  other components such as the SelectorManager will be stopped and the graceful HTTP2Session
+        //  close cannot be completed.
+        //  There is also an ordering issue for Connector components where the SelectorManager is stopped
+        //  _before_ the HTTP/2 ConnectionFactory, but that may be changed easily.
+
+        // GOAWAY should not arrive to the client yet.
+        assertFalse(clientCloseLatch.await(timeout / 2, TimeUnit.MILLISECONDS));
+
+        // New requests should be immediately rejected.
+        MetaData.Request metaData3 = newRequest("GET", new HttpFields());
+        HeadersFrame request3 = new HeadersFrame(metaData3, null, false);
+        FuturePromise<Stream> promise3 = new FuturePromise<>();
+        CountDownLatch resetLatch = new CountDownLatch(1);
+        clientSession.newStream(request3, promise3, new Stream.Listener.Adapter()
+        {
+            @Override
+            public void onReset(Stream stream, ResetFrame frame)
+            {
+                resetLatch.countDown();
+            }
+        });
+        Stream stream3 = promise3.get(5, TimeUnit.SECONDS);
+        stream3.data(new DataFrame(stream3.getId(), ByteBuffer.allocate(1), true), Callback.NOOP);
+        assertTrue(resetLatch.await(5, TimeUnit.SECONDS));
+
+        // Finish the previous requests and expect the responses.
+        stream1.data(new DataFrame(stream1.getId(), ByteBuffer.allocate(1), true), Callback.NOOP);
+        stream2.data(new DataFrame(stream2.getId(), ByteBuffer.allocate(1), true), Callback.NOOP);
+        assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
+
+        // Now GOAWAY should arrive to the client.
+        assertTrue(clientCloseLatch.await(5, TimeUnit.SECONDS));
+        // Wait to process the GOAWAY frames and close the EndPoints.
+        Thread.sleep(1000);
+        assertFalse(((HTTP2Session)clientSession).getEndPoint().isOpen());
+        assertFalse(((HTTP2Session)serverSession).getEndPoint().isOpen());
     }
 
     private static void sleep(long time)

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -298,7 +298,8 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
         {
             // It's a bad client, it does not deserve to be
             // treated gently by just resetting the stream.
-            session.close(ErrorCode.FLOW_CONTROL_ERROR.code, "stream_window_exceeded", Callback.NOOP);
+            // TODO: no cast
+            ((HTTP2Session)session).onConnectionFailure(ErrorCode.FLOW_CONTROL_ERROR.code, "stream_window_exceeded");
             callback.failed(new IOException("stream_window_exceeded"));
             return;
         }
@@ -519,6 +520,7 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
 
     private void updateStreamCount(int deltaStream, int deltaClosing)
     {
+        // TODO: no cast
         ((HTTP2Session)session).updateStreamCount(isLocal(), deltaStream, deltaClosing);
     }
 

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerSession.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerSession.java
@@ -104,13 +104,20 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
                 }
                 else
                 {
-                    stream = createRemoteStream(streamId);
-                    if (stream != null)
+                    if (isClosed())
                     {
-                        onStreamOpened(stream);
-                        stream.process(frame, Callback.NOOP);
-                        Stream.Listener listener = notifyNewStream(stream, frame);
-                        stream.setListener(listener);
+                        reset(new ResetFrame(streamId, ErrorCode.REFUSED_STREAM_ERROR.code), Callback.NOOP);
+                    }
+                    else
+                    {
+                        stream = createRemoteStream(streamId);
+                        if (stream != null)
+                        {
+                            onStreamOpened(stream);
+                            stream.process(frame, Callback.NOOP);
+                            Stream.Listener listener = notifyNewStream(stream, frame);
+                            stream.setListener(listener);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Implemented HTTP2Session.shutdown() to shutdown the session
gracefully with a timeout.
It's a draft because there are a number of issues to be resolved.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>