### PR TITLE
Fixes #3747 - Make Jetty Demo work with JPMS.

### DIFF
--- a/jetty-server/src/main/config/modules/jdbc.mod
+++ b/jetty-server/src/main/config/modules/jdbc.mod
@@ -1,0 +1,4 @@
+DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[jpms]
+add-modules: java.sql

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -10,6 +10,7 @@ session
 session-store
 
 [depend]
+jdbc
 sessions
 sessions/jdbc/${db-connection-type}
 
@@ -54,7 +55,3 @@ db-connection-type=datasource
 #jetty.session.jdbc.schema.maxIntervalColumn=maxInterval
 #jetty.session.jdbc.schema.mapColumn=map
 #jetty.session.jdbc.schema.table=JettySessions
-
-
-
-

--- a/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
@@ -3,5 +3,8 @@ DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-m
 [description]
 JDBC Datasource connections for session storage
 
+[depends]
+jdbc
+
 [xml]
 etc/sessions/jdbc/datasource.xml

--- a/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
@@ -3,5 +3,8 @@ DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-m
 [description]
 JDBC Driver connections for session storage
 
+[depend]
+jdbc
+
 [xml]
 etc/sessions/jdbc/driver.xml

--- a/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/start.d/demo.ini
+++ b/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/start.d/demo.ini
@@ -21,3 +21,5 @@ org.eclipse.jetty.websocket.jsr356=false
 etc/test-realm.xml
 jetty.demo.realm=etc/realm.properties
 
+# JDBC needed by test-jndi and test-spec
+--module=jdbc


### PR DESCRIPTION
Introduced module `jdbc` and made other modules that require JDBC depend on it.
Modified demo.ini to enable the `jdbc` module because some webapp descriptor
of the demo requires JDBC classes.

Now the demo can be run fine on the module-path just by adding --jpms.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>