### PR TITLE
Issue #3734 - throw ISE for WebSocket suspend after close (jetty-9.4)

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SuspendResumeTest
@@ -195,8 +196,7 @@ public class SuspendResumeTest
         assertThat(clientSocket.closeCode, is(StatusCode.NORMAL));
         assertThat(serverSocket.closeCode, is(StatusCode.NORMAL));
 
-        // suspend the client so that no read events occur
-        SuspendToken suspendToken = clientSocket.session.suspend();
-        suspendToken.resume();
+        // suspend after closed throws ISE
+        assertThrows(IllegalStateException.class, () -> clientSocket.session.suspend());
     }
 }

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketSession.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketSession.java
@@ -544,7 +544,7 @@ public class WebSocketSession extends ContainerLifeCycle implements Session, Rem
     @Override
     public SuspendToken suspend()
     {
-        if (!isOpen())
+        if (onCloseCalled.get())
             throw new IllegalStateException("Not open");
 
         return connection.suspend();

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/ReadState.java
@@ -87,10 +87,8 @@ class ReadState
 
     /**
      * Requests that reads from the connection be suspended.
-     *
-     * @return whether the suspending was successful
      */
-    boolean suspending()
+    void suspending()
     {
         synchronized (this)
         {
@@ -101,9 +99,7 @@ class ReadState
             {
                 case READING:
                     state = State.SUSPENDING;
-                    return true;
-                case EOF:
-                    return false;
+                    break;
                 default:
                     throw new IllegalStateException(toString(state));
             }
@@ -131,8 +127,6 @@ class ReadState
                     ByteBuffer bb = buffer;
                     buffer = null;
                     return bb;
-                case EOF:
-                    return null;
                 default:
                     throw new IllegalStateException(toString(state));
             }

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/ReadStateTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/ReadStateTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReadStateTest
 {
@@ -50,7 +49,7 @@ public class ReadStateTest
         ReadState readState = new ReadState();
         assertThat("Initially reading", readState.isReading(), is(true));
 
-        assertTrue(readState.suspending());
+        readState.suspending();
         assertThat("Suspending doesn't take effect immediately", readState.isSuspended(), is(false));
 
         assertNull(readState.resume());
@@ -64,7 +63,7 @@ public class ReadStateTest
         ReadState readState = new ReadState();
         assertThat("Initially reading", readState.isReading(), is(true));
 
-        assertThat(readState.suspending(), is(true));
+        readState.suspending();
         assertThat("Suspending doesn't take effect immediately", readState.isSuspended(), is(false));
 
         ByteBuffer content = BufferUtil.toBuffer("content");
@@ -84,8 +83,8 @@ public class ReadStateTest
 
         assertThat(readState.isReading(), is(false));
         assertThat(readState.isSuspended(), is(true));
-        assertThat(readState.suspending(), is(false));
+        assertThrows(IllegalStateException.class, readState::suspending);
         assertThat(readState.getAction(content), is(ReadState.Action.EOF));
-        assertNull(readState.resume());
+        assertThrows(IllegalStateException.class, readState::resume);
     }
 }


### PR DESCRIPTION
Issue #3734

Changes from #4095 for jetty-9.4.x.
Make suspending or resuming after close result in ISE.

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>