### PR TITLE
Issue #4096 - allow thread to exit ReservedThreadExecutor on stop

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -163,6 +163,9 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
     {
         if (_lease != null)
             _lease.close();
+
+        super.doStop();
+
         while (true)
         {
             ReservedThread thread = _stack.pollFirst();
@@ -171,7 +174,6 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
             _size.decrementAndGet();
             thread.stop();
         }
-        super.doStop();
     }
 
     @Override
@@ -277,7 +279,7 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
                 LOG.debug("{} waiting", this);
 
             Runnable task = null;
-            while (task == null)
+            while (isRunning() && task == null)
             {
                 boolean idle = false;
 


### PR DESCRIPTION
In issue #4096 a thread was getting stuck in the `ReservedThreadExecutor.ReservedThread.reservedWait()` when stopping the thread pool.

This change allows the thread to exit the loop if the `ReservedThreadExecutor` is no longer running.

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>