### PR TITLE
Issue #4104 - WebSocketSession will reject outgoing frames if closed

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/EventSocket.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/EventSocket.java
@@ -37,7 +37,7 @@ public class EventSocket
 {
     private static Logger LOG = Log.getLogger(EventSocket.class);
 
-    protected Session session;
+    public Session session;
     private String behavior;
     public volatile Throwable failure = null;
     public volatile int closeCode = -1;

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketUpgradeRequest.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketUpgradeRequest.java
@@ -601,7 +601,6 @@ public class WebSocketUpgradeRequest extends HttpRequest implements CompleteList
         session.setUpgradeResponse(new ClientUpgradeResponse(response));
         connection.addListener(session);
 
-        ExtensionStack extensionStack = new ExtensionStack(getExtensionFactory());
         List<ExtensionConfig> extensions = new ArrayList<>();
         HttpField extField = response.getHeaders().getField(HttpHeader.SEC_WEBSOCKET_EXTENSIONS);
         if (extField != null)
@@ -619,8 +618,9 @@ public class WebSocketUpgradeRequest extends HttpRequest implements CompleteList
                 }
             }
         }
-        extensionStack.negotiate(extensions);
 
+        ExtensionStack extensionStack = new ExtensionStack(getExtensionFactory());
+        extensionStack.negotiate(extensions);
         extensionStack.configure(connection.getParser());
         extensionStack.configure(connection.getGenerator());
 

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/io/WebSocketClientConnection.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/io/WebSocketClientConnection.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.websocket.client.io;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
 
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -28,7 +27,6 @@ import org.eclipse.jetty.websocket.api.BatchMode;
 import org.eclipse.jetty.websocket.api.WebSocketPolicy;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.eclipse.jetty.websocket.api.extensions.Frame;
-import org.eclipse.jetty.websocket.api.extensions.IncomingFrames;
 import org.eclipse.jetty.websocket.client.masks.Masker;
 import org.eclipse.jetty.websocket.client.masks.RandomMasker;
 import org.eclipse.jetty.websocket.common.WebSocketFrame;
@@ -47,18 +45,6 @@ public class WebSocketClientConnection extends AbstractWebSocketConnection
         this.masker = new RandomMasker();
     }
 
-    @Override
-    public InetSocketAddress getLocalAddress()
-    {
-        return getEndPoint().getLocalAddress();
-    }
-
-    @Override
-    public InetSocketAddress getRemoteAddress()
-    {
-        return getEndPoint().getRemoteAddress();
-    }
-
     /**
      * Override to set the masker.
      */
@@ -70,11 +56,5 @@ public class WebSocketClientConnection extends AbstractWebSocketConnection
             masker.setMask((WebSocketFrame)frame);
         }
         super.outgoingFrame(frame, callback, batchMode);
-    }
-
-    @Override
-    public void setNextIncomingFrames(IncomingFrames incoming)
-    {
-        getParser().setIncomingFramesHandler(incoming);
     }
 }

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.websocket.api.WebSocketPolicy;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.extensions.Frame;
+import org.eclipse.jetty.websocket.api.extensions.IncomingFrames;
 import org.eclipse.jetty.websocket.common.CloseInfo;
 import org.eclipse.jetty.websocket.common.Generator;
 import org.eclipse.jetty.websocket.common.LogicalConnection;
@@ -393,6 +394,12 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
     }
 
     @Override
+    public InetSocketAddress getLocalAddress()
+    {
+        return getEndPoint().getLocalAddress();
+    }
+
+    @Override
     public InetSocketAddress getRemoteAddress()
     {
         return getEndPoint().getRemoteAddress();
@@ -647,6 +654,12 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
         }
 
         setInitialBuffer(prefilled);
+    }
+
+    @Override
+    public void setNextIncomingFrames(IncomingFrames incoming)
+    {
+        getParser().setIncomingFramesHandler(incoming);
     }
 
     /**

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketServerConnection.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketServerConnection.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.websocket.server;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
 
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -26,7 +25,6 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.websocket.api.WebSocketPolicy;
-import org.eclipse.jetty.websocket.api.extensions.IncomingFrames;
 import org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection;
 
 public class WebSocketServerConnection extends AbstractWebSocketConnection implements Connection.UpgradeTo
@@ -34,27 +32,8 @@ public class WebSocketServerConnection extends AbstractWebSocketConnection imple
     public WebSocketServerConnection(EndPoint endp, Executor executor, Scheduler scheduler, WebSocketPolicy policy, ByteBufferPool bufferPool)
     {
         super(endp, executor, scheduler, policy, bufferPool);
+
         if (policy.getIdleTimeout() > 0)
-        {
             endp.setIdleTimeout(policy.getIdleTimeout());
-        }
-    }
-
-    @Override
-    public InetSocketAddress getLocalAddress()
-    {
-        return getEndPoint().getLocalAddress();
-    }
-
-    @Override
-    public InetSocketAddress getRemoteAddress()
-    {
-        return getEndPoint().getRemoteAddress();
-    }
-
-    @Override
-    public void setNextIncomingFrames(IncomingFrames incoming)
-    {
-        getParser().setIncomingFramesHandler(incoming);
     }
 }


### PR DESCRIPTION
Issue #4104

Outgoing frames will now go `RemoteEndpoint->Session->ExtensionStack`
instead of just `RemoteEndpoint->ExtensionStack.`

This will allow the Session to check whether it has been closed before
allowing the frame through the ExtensionStack.

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>