### PR TITLE
support meaningful JMX ObjectNames for HttpDestinations by avoiding race condition at creation

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -540,24 +540,14 @@ public class HttpClient extends ContainerLifeCycle
         port = normalizePort(scheme, port);
 
         Origin origin = new Origin(scheme, host, port);
-        HttpDestination destination = destinations.get(origin);
-        if (destination == null)
-        {
-            destination = transport.newHttpDestination(origin);
-            addManaged(destination);
-            HttpDestination existing = destinations.putIfAbsent(origin, destination);
-            if (existing != null)
-            {
-                removeBean(destination);
-                destination = existing;
+        return destinations.computeIfAbsent(origin, o -> {
+            HttpDestination newDestination = getTransport().newHttpDestination(o);
+            addManaged(newDestination);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Created {}", newDestination);
             }
-            else
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Created {}", destination);
-            }
-        }
-        return destination;
+            return newDestination;
+        });
     }
 
     protected boolean removeDestination(HttpDestination destination)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -540,12 +540,12 @@ public class HttpClient extends ContainerLifeCycle
         port = normalizePort(scheme, port);
 
         Origin origin = new Origin(scheme, host, port);
-        return destinations.computeIfAbsent(origin, o -> {
+        return destinations.computeIfAbsent(origin, o ->
+        {
             HttpDestination newDestination = getTransport().newHttpDestination(o);
             addManaged(newDestination);
-            if (LOG.isDebugEnabled()) {
+            if (LOG.isDebugEnabled())
                 LOG.debug("Created {}", newDestination);
-            }
             return newDestination;
         });
     }


### PR DESCRIPTION
This pull request fixes an issue that causes JMX ObjectNames for Destinations to be non-determistic.

This is due to a race condition in the original code of HttpClient : since computeIfAbsent was not used, the usual pattern (create - putIfAbsent - keep the version that is really in the map) is used.

The issue is that registering the JMX Bean is done at creation time, and not at the end of the process, which makes it possible to register a bean for the same destination more than once, making it impossible to have a deterministic name for the JMX probe. (It also forces to unregister a destination if it needs to be discarded)

Side note : this issue was revealed when trying to use a naming strategy for destinations that allows a consistent collection of metrics (clientName_scheme_host_port). It would be nice to add this to the standard codebase as well : 

```
package org.eclipse.jetty.client.http.jmx;

import javax.management.ObjectName;

import org.eclipse.jetty.JMXUtils;
import org.eclipse.jetty.client.http.HttpDestinationOverHTTP;
import org.eclipse.jetty.jmx.ObjectMBean;

/**
 * The package and class names are critical for this class to be discovered by
 * org.eclipse.jetty.jmx.MBeanContainer#findConstructor(java.lang.Class)
 */
public class HttpDestinationOverHTTPMBean extends ObjectMBean {

	/**
	 * Creates a new ObjectMBean wrapping the given {@code managedObject}.
	 *
	 * @param managedObject the object to manage
	 */
	public HttpDestinationOverHTTPMBean(Object managedObject) {
		super(managedObject);
	}

	@Override
	public ObjectName getObjectName() {
		HttpDestinationOverHTTP destination = (HttpDestinationOverHTTP) _managed;

		String formattedDestination = destination.getHttpClient().getName()
                                + "_" + destination.getScheme()
				+ "_" + destination.getHost()
				+ "_" + destination.getPort();

		return JMXUtils.buildObjectName(HttpDestinationOverHTTP.class, formattedDestination);
	}

	private ObjectName buildObjectName(Class<?> clazz, String context) {
		Package pkg = clazz.getPackage();
		String domain = pkg == null ? "" : pkg.getName();

		String type = clazz.getName().toLowerCase(Locale.ENGLISH);
		int dot = type.lastIndexOf('.');
		if (dot >= 0) {
			type = type.substring(dot + 1);
		}

		StringBuilder buf = new StringBuilder();
		buf.append("type=").append(type);
		if (context != null) {
			buf.append(",context=").append(context);
		}

		String basis = buf.toString();
		try {
			return ObjectName.getInstance(domain + ":" + basis);
		}
		catch (MalformedObjectNameException e) {
			throw new IllegalStateException("Invalid name [" + basis + "]", e);
		}
	}
}
```

This is my first pull request (ever), let me know if you need something more in order to merge it, thank you!