### PR TITLE
Fixes #4113 - HttpClient fails with JDK 13 and TLS 1.3.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
@@ -148,17 +148,7 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements Connec
     @Override
     public void onFillable()
     {
-        HttpExchange exchange = channel.getHttpExchange();
-        if (exchange != null)
-        {
-            channel.receive();
-        }
-        else
-        {
-            // If there is no exchange, then could be either a remote close,
-            // or garbage bytes; in both cases we close the connection
-            close();
-        }
+        channel.receive();
     }
 
     @Override

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslClientConnectionFactory.java
@@ -97,7 +97,6 @@ public class SslClientConnectionFactory implements ClientConnectionFactory
         context.put(SSL_ENGINE_CONTEXT_KEY, engine);
 
         SslConnection sslConnection = newSslConnection(byteBufferPool, executor, endPoint, engine);
-        endPoint.setConnection(sslConnection);
 
         EndPoint appEndPoint = sslConnection.getDecryptedEndPoint();
         appEndPoint.setConnection(connectionFactory.newConnection(appEndPoint, context));


### PR DESCRIPTION
1. Now forwarding the fillable event rather than assuming that is due
to garbage bytes or by a server close. This ensures that a HTTP read
consumes the TLS bytes and the `NewSessionTicket` message.
2. Avoid to set the `SslConnection` onto the `EndPoint` in
`SslClientConnectionFactory` - this allows upgrades to work properly,
for example when tunnelling through a secure proxy.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>