### PR TITLE
Issue #3787 - Jetty client throws EOFException instead of SSLHandshakeException on certificate errors

### DIFF
--- a/examples/embedded/src/test/java/org/eclipse/jetty/embedded/ProxyServerTest.java
+++ b/examples/embedded/src/test/java/org/eclipse/jetty/embedded/ProxyServerTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +54,7 @@ public class ProxyServerTest extends AbstractEmbeddedTest
         server.stop();
     }
 
+    @Tag("external")
     @Test
     public void testGetProxiedRFC() throws Exception
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -410,6 +410,9 @@ public abstract class HttpReceiver
         if (exchange == null)
             return false;
 
+        if (LOG.isDebugEnabled())
+            LOG.debug("Response failure " + exchange.getResponse(), failure);
+
         // Mark atomically the response as completed, with respect
         // to concurrency between response success and response failure.
         if (exchange.responseComplete(failure))
@@ -514,7 +517,7 @@ public abstract class HttpReceiver
 
         HttpResponse response = exchange.getResponse();
         if (LOG.isDebugEnabled())
-            LOG.debug("Response failure {} {} on {}: {}", response, exchange, getHttpChannel(), failure);
+            LOG.debug("Response abort {} {} on {}: {}", response, exchange, getHttpChannel(), failure);
         List<Response.ResponseListener> listeners = exchange.getConversation().getResponseListeners();
         ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
         notifier.notifyFailure(listeners, response, failure);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpSender.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpSender.java
@@ -344,6 +344,9 @@ public abstract class HttpSender implements AsyncContentProvider.Listener
         if (exchange == null)
             return;
 
+        if (LOG.isDebugEnabled())
+            LOG.debug("Request failure " + exchange.getRequest(), failure);
+
         // Mark atomically the request as completed, with respect
         // to concurrency between request success and request failure.
         if (exchange.requestComplete(failure))
@@ -559,7 +562,7 @@ public abstract class HttpSender implements AsyncContentProvider.Listener
 
         Request request = exchange.getRequest();
         if (LOG.isDebugEnabled())
-            LOG.debug("Request failure {} {} on {}: {}", request, exchange, getHttpChannel(), failure);
+            LOG.debug("Request abort {} {} on {}: {}", request, exchange, getHttpChannel(), failure);
         HttpDestination destination = getHttpChannel().getHttpDestination();
         destination.getRequestNotifier().notifyFailure(request, failure);
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
@@ -288,7 +288,6 @@ public class HttpSenderOverHTTP extends HttpSender
         public void failed(Throwable x)
         {
             release();
-            callback.failed(x);
             super.failed(x);
         }
 
@@ -297,6 +296,13 @@ public class HttpSenderOverHTTP extends HttpSender
         {
             super.onCompleteSuccess();
             callback.succeeded();
+        }
+
+        @Override
+        protected void onCompleteFailure(Throwable cause)
+        {
+            super.onCompleteFailure(cause);
+            callback.failed(cause);
         }
 
         private void release()

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -533,7 +533,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                             return filled = -1;
                                         continue;
                                     }
-                                     // Handle in needsFillInterest().
+                                    // Handle in needsFillInterest().
                                     return filled = 0;
 
                                 default:

--- a/jetty-io/src/test/resources/jetty-logging.properties
+++ b/jetty-io/src/test/resources/jetty-logging.properties
@@ -1,5 +1,5 @@
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
-org.eclipse.jetty.LEVEL=INFO
+#org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.io.AbstractConnection.LEVEL=DEBUG
 #org.eclipse.jetty.io.ManagedSelector.LEVEL=DEBUG
 #org.eclipse.jetty.io.ssl.SslConnection.LEVEL=DEBUG


### PR DESCRIPTION
@gregw the real fix is in commit 2c75e87.

I gave up trying to solve the "race" because calling `completeWrite()` directly may succeed the callback that calls application (or test) code that may block (especially in the client).

We have tests that do that: block the write side until the read side completes. If we don't dispatch `completeWrite()` we don't execute the next line of code that would wake up the read side, so we deadlock.

Instead, exceptions happening in `fill()` or `flush()` are now remembered in a field, and rethrown if further `fill()` operations are triggered.
If a second exception is thrown, the first one is rethrown, with the second as suppressed.

This ensures that the original exception is always reported, no matter if it was generated on the write side but we are now on the read side.