### PR TITLE
Issue #4130 - Don't add scopes if none are provided

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -131,7 +131,8 @@ public class OpenIdConfiguration implements Serializable
 
     public void addScopes(String... scopes)
     {
-        Collections.addAll(this.scopes, scopes);
+        if (scopes != null)
+            Collections.addAll(this.scopes, scopes);
     }
 
     public List<String> getScopes()


### PR DESCRIPTION
This fixes an NPE reported in issue #4130 . It can be triggered by adding the OpenID module and changing the `openid.ini` module created by that to not have any scopes, like this:

```
## Additional Scopes to Request
#jetty.openid.scopes=
```

This PR fixes the NPE.