### PR TITLE
Issue #4132 - Allow token and authorization endpoints to be configured

### DIFF
--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="OpenIdConfiguration" class="org.eclipse.jetty.security.openid.OpenIdConfiguration">
-    <Arg><Property name="jetty.openid.openIdProvider"/></Arg>
+    <Arg><Property name="jetty.openid.provider" deprecated="jetty.openid.openIdProvider"/></Arg>
+    <Arg><Property name="jetty.openid.provider.authorizationEndpoint"/></Arg>
+    <Arg><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
     <Arg><Property name="jetty.openid.clientId"/></Arg>
     <Arg><Property name="jetty.openid.clientSecret"/></Arg>
     <Call name="addScopes">

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -18,11 +18,17 @@ etc/openid-baseloginservice.xml
 etc/jetty-openid.xml
 
 [ini-template]
-## The OpenID Identity Provider
-# jetty.openid.openIdProvider=https://accounts.google.com/
+## The OpenID Identity Provider's issuer ID (the entire URL *before* ".well-known/openid-configuration")
+# jetty.openid.provider=https://id.example.com/~
+
+## The OpenID Identity Provider's authorization endpoint (optional if the metadata of the OP is accessible)
+# jetty.openid.provider.authorizationEndpoint=https://id.example.com/authorization
+
+## The OpenID Identity Provider's token endpoint (optional if the metadata of the OP is accessible)
+# jetty.openid.provider.tokenEndpoint=https://id.example.com/token
 
 ## The Client Identifier
-# jetty.openid.clientId=test1234.apps.googleusercontent.com
+# jetty.openid.clientId=test1234
 
 ## The Client Secret
 # jetty.openid.clientSecret=XT_Mafv_aUCGheuCaKY8P

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -242,7 +242,7 @@ public class OpenIdCredentials implements Serializable
         {
             connection.setDoOutput(true);
             connection.setRequestMethod("POST");
-            connection.setRequestProperty("Host", configuration.getOpenIdProvider());
+            connection.setRequestProperty("Host", configuration.getIssuer());
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream()))

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
@@ -67,7 +67,7 @@ public class OpenIdLoginService extends ContainerLifeCycle implements LoginServi
     @Override
     public String getName()
     {
-        return _configuration.getOpenIdProvider();
+        return _configuration.getIssuer();
     }
 
     public OpenIdConfiguration getConfiguration()


### PR DESCRIPTION
This PR makes the token and authorization endpoints of the OpenID Connect Provider (OP) configuration, so that metadata doesn't have to be fetched (for whatever reason). See issue #4132 for more details.