### PR TITLE
Fixes #4150 - Module org.eclipse.jetty.alpn.client not found, require…

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -111,7 +111,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-client</artifactId>
       <version>${project.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-client/src/main/config/modules/client.mod
+++ b/jetty-client/src/main/config/modules/client.mod
@@ -5,3 +5,4 @@ Adds the Jetty HTTP client to the server classpath.
 
 [lib]
 lib/jetty-client-${jetty.version}.jar
+lib/jetty-alpn-client-${jetty.version}.jar

--- a/jetty-client/src/main/java/module-info.java
+++ b/jetty-client/src/main/java/module-info.java
@@ -26,14 +26,13 @@ module org.eclipse.jetty.client
     exports org.eclipse.jetty.client.proxy;
     exports org.eclipse.jetty.client.util;
 
+    requires org.eclipse.jetty.alpn.client;
     requires org.eclipse.jetty.http;
     requires org.eclipse.jetty.io;
     requires org.eclipse.jetty.util;
 
     // Only required if using SPNEGO.
     requires static java.security.jgss;
-    // Only required if using the dynamic transport.
-    requires static org.eclipse.jetty.alpn.client;
     // Only required if using JMX.
     requires static org.eclipse.jetty.jmx;
 }

--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -121,7 +121,7 @@
                   <destFileName>test-spec.war</destFileName>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.eclipse.jetty</groupId>
+                  <groupId>org.eclipse.jetty.tests</groupId>
                   <artifactId>test-proxy-webapp</artifactId>
                   <version>${project.version}</version>
                   <type>war</type>
@@ -416,7 +416,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
+      <groupId>org.eclipse.jetty.tests</groupId>
       <artifactId>test-proxy-webapp</artifactId>
       <type>war</type>
       <version>${project.version}</version>

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -18,14 +18,18 @@
 
 package org.eclipse.jetty.tests.distribution;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
@@ -337,6 +341,47 @@ public class DistributionTests extends AbstractDistributionTest
         finally
         {
             IO.delete(jettyBase.toFile());
+        }
+    }
+
+    @Test
+    public void testWebAppWithProxyAndJPMS() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        DistributionTester distribution = DistributionTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        String[] args1 = {
+            "--create-startd",
+            "--add-to-start=http,webapp,deploy,resources"
+        };
+        try (DistributionTester.Run run1 = distribution.start(args1))
+        {
+            assertTrue(run1.awaitFor(5, TimeUnit.SECONDS));
+            assertEquals(0, run1.getExitValue());
+
+            Path logFile = distribution.getJettyBase().resolve("resources").resolve("jetty-logging.properties");
+            try (BufferedWriter writer = Files.newBufferedWriter(logFile, StandardCharsets.UTF_8, StandardOpenOption.CREATE))
+            {
+                writer.write("org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog");
+                writer.newLine();
+                writer.write("org.eclipse.jetty.LEVEL=INFO");
+            }
+
+            File war = distribution.resolveArtifact("org.eclipse.jetty.tests:test-proxy-webapp:war:" + jettyVersion);
+            distribution.installWarFile(war, "proxy");
+
+            int port = distribution.freePort();
+            try (DistributionTester.Run run2 = distribution.start("--jpms", "jetty.http.port=" + port, "jetty.server.dumpAfterStart=true"))
+            {
+                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+
+                startHttpClient(() -> new HttpClient(new HttpClientTransportOverHTTP(1)));
+                ContentResponse response = client.GET("http://localhost:" + port + "/proxy/current/");
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+            }
         }
     }
 }

--- a/tests/test-webapps/test-proxy-webapp/pom.xml
+++ b/tests/test-webapps/test-proxy-webapp/pom.xml
@@ -7,7 +7,6 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.jetty</groupId>
   <artifactId>test-proxy-webapp</artifactId>
   <name>Test :: Jetty Proxy Webapp</name>
   <packaging>war</packaging>


### PR DESCRIPTION
…d by org.eclipse.jetty.proxy

Made jetty-alpn-client required by jetty-client.
Fixed groupId for test-proxy-webapp.
Added test case for the failing configuration.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>