### PR TITLE
Issue #3558 - only notify WS onError if onClose has not been called

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/ConcurrentConnectTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/ConcurrentConnectTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConcurrentConnectTest
@@ -130,7 +131,7 @@ public class ConcurrentConnectTest
             assertTrue(l.closed.await(5, TimeUnit.SECONDS));
             assertThat(l.closeCode, is(StatusCode.NORMAL));
             assertThat(l.closeReason, is("close from client"));
-            //assertNull(l.failure); //TODO: we can get failures after close??
+            assertNull(l.failure);
         }
 
         closeListener.closeLatch.await(5, TimeUnit.SECONDS);

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketSession.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketSession.java
@@ -397,7 +397,10 @@ public class WebSocketSession extends ContainerLifeCycle implements Session, Rem
         }
         if (openFuture != null && !openFuture.isDone())
             openFuture.completeExceptionally(cause);
-        websocket.onError(cause);
+
+        // Only notify onError if onClose has not been called.
+        if (!onCloseCalled.get())
+            websocket.onError(cause);
     }
 
     /**


### PR DESCRIPTION
Issue #3558
Signed-off-by: Lachlan Roberts <lachlan@webtide.com>