### PR TITLE
Issue #4156 - Session Already in Cache during forwarding

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1565,7 +1565,8 @@ public class Request implements HttpServletRequest
             if (sessionHandler == ss.getSessionHandler())
             {
                 session = s;
-                break;
+                if (ss.isValid())
+                    return session;
             }
         }
         return session;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.SessionCookieConfig;
@@ -1523,19 +1522,22 @@ public class SessionHandler extends ScopedHandler
                     oldSessionHandler = baseRequest.getSessionHandler();
                     oldSession = baseRequest.getSession(false);
 
-                    //find any existing session for this request that has already been accessed
-                    existingSession = baseRequest.getSession(this);
-                    if (existingSession == null)
+                    if (oldSessionHandler != this)
                     {
-                        //session for this context has not been visited previously,
-                        //try getting it
-                        baseRequest.setSession(null);
-                        checkRequestedSessionId(baseRequest, request);
-                        existingSession = baseRequest.getSession(false);
-                    }
+                        //find any existing session for this request that has already been accessed
+                        existingSession = baseRequest.getSession(this);
+                        if (existingSession == null)
+                        {
+                            //session for this context has not been visited previously,
+                            //try getting it
+                            baseRequest.setSession(null);
+                            checkRequestedSessionId(baseRequest, request);
+                            existingSession = baseRequest.getSession(false);
+                        }
 
-                    baseRequest.setSession(existingSession);
-                    baseRequest.setSessionHandler(this);
+                        baseRequest.setSession(existingSession);
+                        baseRequest.setSessionHandler(this);
+                    }
                     break;
                 }
                 default:

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/RequestDispatchedSessionTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/RequestDispatchedSessionTest.java
@@ -1,0 +1,146 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.session;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.FormContentProvider;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.Fields;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class RequestDispatchedSessionTest
+{
+    private Server server;
+    private HttpClient client;
+
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        // Default session behavior
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        contextHandler.addServlet(LoginServlet.class, "/login");
+        contextHandler.addServlet(ShowUserServlet.class, "/user");
+        contextHandler.addServlet(DefaultServlet.class, "/");
+
+        HandlerList handlers = new HandlerList();
+        handlers.addHandler(contextHandler);
+        handlers.addHandler(new DefaultHandler());
+
+        server.setHandler(handlers);
+
+        server.start();
+    }
+
+    @AfterEach
+    public void stopServerAndClient()
+    {
+        LifeCycle.stop(server);
+        LifeCycle.stop(client);
+    }
+
+    @BeforeEach
+    public void startClient() throws Exception
+    {
+        client = new HttpClient();
+        client.start();
+    }
+
+    @Test
+    public void testRedirect() throws Exception
+    {
+        Fields postForm = new Fields();
+        postForm.add("username", "whizbat");
+
+        ContentResponse response = client.newRequest(server.getURI().resolve("/login"))
+            .method(HttpMethod.POST)
+            .content(new FormContentProvider(postForm))
+            .send();
+        assertThat("Response status", response.getStatus(), is(HttpStatus.OK_200));
+    }
+
+    public static class LoginServlet extends HttpServlet
+    {
+        public static final String USERNAME = "loggedInUserName";
+
+        protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            if (request.getParameter("username") != null)
+            {
+                if (request.getSession() != null)
+                {
+                    request.getSession().invalidate();
+                }
+                request.getSession(true).setAttribute(USERNAME, request.getParameter("username"));
+                request.getRequestDispatcher("/user").forward(request, response);
+                return;
+            }
+        }
+    }
+
+    public static class ShowUserServlet extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            showUser(req, resp);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            showUser(req, resp);
+        }
+
+        private void showUser(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            resp.setContentType("text/plain");
+            resp.setCharacterEncoding("utf-8");
+            PrintWriter out = resp.getWriter();
+            String userName = (String)req.getSession().getAttribute(LoginServlet.USERNAME);
+            out.printf("UserName is %s%n", userName);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #4156 :
 + check validity of sessions in getSession(SessionHandler)
 + do not replace session in doScope if SessionHandler is the same.
