### PR TITLE
Documentation: Added ServicesResourceTransformer to the section on Jetty and Maven

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
@@ -42,3 +42,22 @@ The Jetty HTTP/2 implementation consists of the following sub-projects (each pro
 4.  `http2-client`: Provides the implementation of HTTP/2 client with a low level HTTP/2 API, dealing with HTTP/2 streams, frames, etc.
 5.  `http2-http-client-transport`: Provides the implementation of the HTTP/2 transport for `HttpClient` (see xref:http-client[]).
 Applications can use the higher level API provided by `HttpClient` to send HTTP requests and receive HTTP responses, and the HTTP/2 transport will take care of converting them in HTTP/2 format (see also https://webtide.com/http2-support-for-httpclient/[this blog entry]).
+
+[[http2-merge-config]]
+==== Merging Configuration Files
+If you plan to run your Jetty HTTP/2 application from a jar file, you will need to merge some jetty configuration files when building your jar.
+Both jetty-http and http2-hpack declare the file: `META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder`
+
+The jetty-http version contains the single line:
+```text
+org.eclipse.jetty.http.Http1FieldPreEncoder
+```
+
+The http2-hpack version contains a different line:
+```text
+org.eclipse.jetty.http2.hpack.HpackFieldPreEncoder
+```
+
+Your jar file must include a version of that file containing _both_ lines.
+The easiest way to accomplish this with Maven is to use the shade plugin with the https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer[ServicesResourceTransformer] to do this automatically.
+Other Jetty components may require the ServicesResourceTransformer to work together properly as well.

--- a/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
@@ -43,21 +43,8 @@ The Jetty HTTP/2 implementation consists of the following sub-projects (each pro
 5.  `http2-http-client-transport`: Provides the implementation of the HTTP/2 transport for `HttpClient` (see xref:http-client[]).
 Applications can use the higher level API provided by `HttpClient` to send HTTP requests and receive HTTP responses, and the HTTP/2 transport will take care of converting them in HTTP/2 format (see also https://webtide.com/http2-support-for-httpclient/[this blog entry]).
 
-[[http2-merge-config]]
-==== Merging Configuration Files
-If you plan to run your Jetty HTTP/2 application from a jar file, you will need to merge some jetty configuration files when building your jar.
-Both jetty-http and http2-hpack declare the file: `META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder`
-
-The jetty-http version contains the single line:
-```text
-org.eclipse.jetty.http.Http1FieldPreEncoder
-```
-
-The http2-hpack version contains a different line:
-```text
-org.eclipse.jetty.http2.hpack.HpackFieldPreEncoder
-```
-
-Your jar file must include a version of that file containing _both_ lines.
-The easiest way to accomplish this with Maven is to use the shade plugin with the https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer[ServicesResourceTransformer] to do this automatically.
-Other Jetty components may require the ServicesResourceTransformer to work together properly as well.
+____
+[CAUTION]
+If you plan to run your Jetty HTTP/2 application from a fat (uber) jar file, your build tool will likely need to merge some jetty configuration files.
+Use the ServicesResourceTransformer to do this as described in link:#jetty-maven-helloworld[Using Maven]
+____

--- a/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-helloworld.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/maven/jetty-maven-helloworld.adoc
@@ -32,6 +32,13 @@ Using Maven for Jetty implementations is a popular choice, but users encouraged 
 Other popular tools include Ant and Gradle. 
 ____
 
+____
+[IMPORTANT]
+Various Jetty sub-projects may define configuration files with the same name.
+When two projects declare the same files, these files should be _merged_ rather than overwritten.
+This will happen automatically if you use Maven with the shade plugin and https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer[ServicesResourceTransformer].
+____
+
 First we'll have a look at a very simple HelloWorld java application that embeds Jetty, then a simple webapp which makes use of the link:#jetty-maven-plugin[jetty-maven-plugin] to speed up the development cycle.
 
 [[configuring-embedded-jetty-with-maven]]


### PR DESCRIPTION
Also added a link to that section from the http/2 documentation.  Even if the Maven Shade plugin and Jetty Shadow plugin should have better functionality, I think it's only fair to tell Jetty/Maven users the easy way to avoid some hard-to-diagnose pitfalls.

One thought for the future is that the documentation says that Maven is not required in order to use Jetty.  If Jetty requires merging configuration files from the jars that make it up, then it's probably going to require not just Maven, but the Shade plugin and the ServicesResourceTransformer going forward.  If there's something that works similarly with Gradle, we should mention that too.