### PR TITLE
Issue #4176 setHeader after sendError

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -373,7 +373,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                         if (!_request.hasMetaData())
                             throw new IllegalStateException("state=" + _state);
                         _request.setHandled(false);
-                        _response.getHttpOutput().reopen();
+                        _response.reopen();
 
                         dispatch(DispatcherType.REQUEST, () ->
                         {
@@ -392,7 +392,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                     case ASYNC_DISPATCH:
                     {
                         _request.setHandled(false);
-                        _response.getHttpOutput().reopen();
+                        _response.reopen();
 
                         dispatch(DispatcherType.ASYNC,() -> getServer().handleAsync(this));
                         break;
@@ -409,7 +409,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                             // Get ready to send an error response
                             _request.setHandled(false);
                             _response.resetContent();
-                            _response.getHttpOutput().reopen();
+                            _response.reopen();
 
                             // the following is needed as you cannot trust the response code and reason
                             // as those could have been modified after calling sendError

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
@@ -900,8 +900,8 @@ public class HttpChannelState
             if (_outputState != OutputState.OPEN)
                 throw new IllegalStateException("Response is " + _outputState);
 
-            response.getHttpOutput().closedBySendError();
             response.setStatus(code);
+            response.closedBySendError();
 
             request.setAttribute(ErrorHandler.ERROR_CONTEXT, request.getErrorContext());
             request.setAttribute(ERROR_REQUEST_URI, request.getRequestURI());

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.server;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.channels.IllegalSelectorException;
@@ -28,7 +27,6 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.ServletResponse;
@@ -58,6 +56,7 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.AtomicBiInteger;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
@@ -87,7 +86,7 @@ public class Response implements HttpServletResponse
 
     private final HttpChannel _channel;
     private final HttpFields _fields = new HttpFields();
-    private final AtomicInteger _include = new AtomicInteger();
+    private final AtomicBiInteger _state = new AtomicBiInteger();
     private final HttpOutput _out;
     private int _status = HttpStatus.OK_200;
     private String _reason;
@@ -140,19 +139,46 @@ public class Response implements HttpServletResponse
         return _out;
     }
 
+    public void reopen()
+    {
+        setMutable(true);
+        _out.reopen();
+    }
+
+    public void closedBySendError()
+    {
+        setMutable(false);
+        _out.closedBySendError();
+    }
+
+    private boolean isMutableAndNotIncluded()
+    {
+        return _state.get() == 0;
+    }
+
+    private void setMutable(boolean mutable)
+    {
+        _state.getAndSetHi(mutable ? 0 : 1);
+    }
+
+    private boolean isMutable()
+    {
+        return _state.getHi() == 0;
+    }
+
     public boolean isIncluding()
     {
-        return _include.get() > 0;
+        return _state.getLo() > 0;
     }
 
     public void include()
     {
-        _include.incrementAndGet();
+        _state.add(0,1);
     }
 
     public void included()
     {
-        _include.decrementAndGet();
+        _state.add(0,-1);
         if (_outputType == OutputType.WRITER)
         {
             _writer.reopen();
@@ -438,7 +464,7 @@ public class Response implements HttpServletResponse
         if ((code < HttpServletResponse.SC_MULTIPLE_CHOICES) || (code >= HttpServletResponse.SC_BAD_REQUEST))
             throw new IllegalArgumentException("Not a 3xx redirect code");
 
-        if (isIncluding())
+        if (!isMutableAndNotIncluded())
             return;
 
         if (location == null)
@@ -484,34 +510,34 @@ public class Response implements HttpServletResponse
     @Override
     public void setDateHeader(String name, long date)
     {
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
             _fields.putDateField(name, date);
     }
 
     @Override
     public void addDateHeader(String name, long date)
     {
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
             _fields.addDateField(name, date);
     }
 
     public void setHeader(HttpHeader name, String value)
     {
-        if (HttpHeader.CONTENT_TYPE == name)
-            setContentType(value);
-        else
+        if (isMutableAndNotIncluded())
         {
-            if (isIncluding())
-                return;
-
-            _fields.put(name, value);
-
-            if (HttpHeader.CONTENT_LENGTH == name)
+            if (HttpHeader.CONTENT_TYPE == name)
+                setContentType(value);
+            else
             {
-                if (value == null)
-                    _contentLength = -1L;
-                else
-                    _contentLength = Long.parseLong(value);
+                _fields.put(name, value);
+
+                if (HttpHeader.CONTENT_LENGTH == name)
+                {
+                    if (value == null)
+                        _contentLength = -1L;
+                    else
+                        _contentLength = Long.parseLong(value);
+                }
             }
         }
     }
@@ -519,17 +545,18 @@ public class Response implements HttpServletResponse
     @Override
     public void setHeader(String name, String value)
     {
+        if (!isMutableAndNotIncluded())
+        {
+            if (isMutable() && isIncluding() && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
+                name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
+            else
+                return;
+        }
+
         if (HttpHeader.CONTENT_TYPE.is(name))
             setContentType(value);
         else
         {
-            if (isIncluding())
-            {
-                if (name.startsWith(SET_INCLUDE_HEADER_PREFIX))
-                    name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
-                else
-                    return;
-            }
             _fields.put(name, value);
             if (HttpHeader.CONTENT_LENGTH.is(name))
             {
@@ -565,9 +592,9 @@ public class Response implements HttpServletResponse
     @Override
     public void addHeader(String name, String value)
     {
-        if (isIncluding())
+        if (!isMutableAndNotIncluded())
         {
-            if (name.startsWith(SET_INCLUDE_HEADER_PREFIX))
+            if (isMutable() && isIncluding() && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
                 name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
             else
                 return;
@@ -591,7 +618,7 @@ public class Response implements HttpServletResponse
     @Override
     public void setIntHeader(String name, int value)
     {
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
         {
             _fields.putLongField(name, value);
             if (HttpHeader.CONTENT_LENGTH.is(name))
@@ -602,7 +629,7 @@ public class Response implements HttpServletResponse
     @Override
     public void addIntHeader(String name, int value)
     {
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
         {
             _fields.add(name, Integer.toString(value));
             if (HttpHeader.CONTENT_LENGTH.is(name))
@@ -615,7 +642,7 @@ public class Response implements HttpServletResponse
     {
         if (sc <= 0)
             throw new IllegalArgumentException();
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
         {
             // Null the reason only if the status is different. This allows
             // a specific reason to be sent with setStatusWithReason followed by sendError.
@@ -636,7 +663,7 @@ public class Response implements HttpServletResponse
     {
         if (sc <= 0)
             throw new IllegalArgumentException();
-        if (!isIncluding())
+        if (isMutableAndNotIncluded())
         {
             _status = sc;
             _reason = sm;
@@ -742,7 +769,7 @@ public class Response implements HttpServletResponse
         // Protect from setting after committed as default handling
         // of a servlet HEAD request ALWAYS sets _content length, even
         // if the getHandling committed the response!
-        if (isCommitted() || isIncluding())
+        if (isCommitted() || !isMutableAndNotIncluded())
             return;
 
         if (len > 0)
@@ -818,7 +845,7 @@ public class Response implements HttpServletResponse
         // Protect from setting after committed as default handling
         // of a servlet HEAD request ALWAYS sets _content length, even
         // if the getHandling committed the response!
-        if (isCommitted() || isIncluding())
+        if (isCommitted() || !isMutableAndNotIncluded())
             return;
         _contentLength = len;
         _fields.putLongField(HttpHeader.CONTENT_LENGTH.toString(), len);
@@ -838,7 +865,7 @@ public class Response implements HttpServletResponse
 
     private void setCharacterEncoding(String encoding, EncodingFrom from)
     {
-        if (isIncluding() || isWriting())
+        if (!isMutableAndNotIncluded() || isWriting())
             return;
 
         if (_outputType != OutputType.WRITER && !isCommitted())
@@ -891,7 +918,7 @@ public class Response implements HttpServletResponse
     @Override
     public void setContentType(String contentType)
     {
-        if (isCommitted() || isIncluding())
+        if (isCommitted() || !isMutableAndNotIncluded())
             return;
 
         if (contentType == null)
@@ -1146,7 +1173,7 @@ public class Response implements HttpServletResponse
     @Override
     public void setLocale(Locale locale)
     {
-        if (locale == null || isCommitted() || isIncluding())
+        if (locale == null || isCommitted() || !isMutableAndNotIncluded())
             return;
 
         _locale = locale;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -86,7 +86,7 @@ public class Response implements HttpServletResponse
 
     private final HttpChannel _channel;
     private final HttpFields _fields = new HttpFields();
-    private final AtomicBiInteger _errorSentFlagAndIncludes = new AtomicBiInteger(); // hi is errorSent flag, lo is include count
+    private final AtomicBiInteger _errorSentAndIncludes = new AtomicBiInteger(); // hi is errorSent flag, lo is include count
     private final HttpOutput _out;
     private int _status = HttpStatus.OK_200;
     private String _reason;
@@ -156,27 +156,27 @@ public class Response implements HttpServletResponse
      */
     private boolean isMutable()
     {
-        return _errorSentFlagAndIncludes.get() == 0;
+        return _errorSentAndIncludes.get() == 0;
     }
 
     private void setErrorSent(boolean errorSent)
     {
-        _errorSentFlagAndIncludes.getAndSetHi(errorSent ? 1 : 0);
+        _errorSentAndIncludes.getAndSetHi(errorSent ? 1 : 0);
     }
 
     public boolean isIncluding()
     {
-        return _errorSentFlagAndIncludes.getLo() > 0;
+        return _errorSentAndIncludes.getLo() > 0;
     }
 
     public void include()
     {
-        _errorSentFlagAndIncludes.add(0, 1);
+        _errorSentAndIncludes.add(0, 1);
     }
 
     public void included()
     {
-        _errorSentFlagAndIncludes.add(0, -1);
+        _errorSentAndIncludes.add(0, -1);
         if (_outputType == OutputType.WRITER)
         {
             _writer.reopen();
@@ -543,7 +543,7 @@ public class Response implements HttpServletResponse
     @Override
     public void setHeader(String name, String value)
     {
-        long biInt = _errorSentFlagAndIncludes.get();
+        long biInt = _errorSentAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;
@@ -593,7 +593,7 @@ public class Response implements HttpServletResponse
     @Override
     public void addHeader(String name, String value)
     {
-        long biInt = _errorSentFlagAndIncludes.get();
+        long biInt = _errorSentAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -86,7 +86,7 @@ public class Response implements HttpServletResponse
 
     private final HttpChannel _channel;
     private final HttpFields _fields = new HttpFields();
-    private final AtomicBiInteger _errorSentFlagAndIncludeCount = new AtomicBiInteger(); // hi is errorSent flag, lo is include count
+    private final AtomicBiInteger _errorSentFlagAndIncludes = new AtomicBiInteger(); // hi is errorSent flag, lo is include count
     private final HttpOutput _out;
     private int _status = HttpStatus.OK_200;
     private String _reason;
@@ -156,27 +156,27 @@ public class Response implements HttpServletResponse
      */
     private boolean isMutable()
     {
-        return _errorSentFlagAndIncludeCount.get() == 0;
+        return _errorSentFlagAndIncludes.get() == 0;
     }
 
     private void setErrorSent(boolean errorSent)
     {
-        _errorSentFlagAndIncludeCount.getAndSetHi(errorSent ? 1 : 0);
+        _errorSentFlagAndIncludes.getAndSetHi(errorSent ? 1 : 0);
     }
 
     public boolean isIncluding()
     {
-        return _errorSentFlagAndIncludeCount.getLo() > 0;
+        return _errorSentFlagAndIncludes.getLo() > 0;
     }
 
     public void include()
     {
-        _errorSentFlagAndIncludeCount.add(0, 1);
+        _errorSentFlagAndIncludes.add(0, 1);
     }
 
     public void included()
     {
-        _errorSentFlagAndIncludeCount.add(0, -1);
+        _errorSentFlagAndIncludes.add(0, -1);
         if (_outputType == OutputType.WRITER)
         {
             _writer.reopen();
@@ -543,7 +543,7 @@ public class Response implements HttpServletResponse
     @Override
     public void setHeader(String name, String value)
     {
-        long biInt = _errorSentFlagAndIncludeCount.get();
+        long biInt = _errorSentFlagAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;
@@ -593,7 +593,7 @@ public class Response implements HttpServletResponse
     @Override
     public void addHeader(String name, String value)
     {
-        long biInt = _errorSentFlagAndIncludeCount.get();
+        long biInt = _errorSentFlagAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -58,32 +58,6 @@ public class ErrorHandlerTest
             @Override
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
             {
-                if (baseRequest.getDispatcherType() == DispatcherType.ERROR)
-                {
-                    baseRequest.setHandled(true);
-                    response.sendError(((Integer)request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).intValue());
-                    return;
-                }
-
-                if (target.startsWith("/charencoding/"))
-                {
-                    baseRequest.setHandled(true);
-                    response.setCharacterEncoding("utf-8");
-                    response.sendError(404);
-                    return;
-                }
-
-                if (target.startsWith("/badmessage/"))
-                {
-                    throw new ServletException(new BadMessageException(Integer.valueOf(target.substring(12))));
-                }
-            }
-        });
-        server.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
-            {
 
                 if (baseRequest.getDispatcherType() == DispatcherType.ERROR)
                 {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -689,9 +689,14 @@ public class ResponseTest
         else
             response.sendError(code, message);
 
+
         assertTrue(response.getHttpOutput().isClosed());
         assertEquals(code, response.getStatus());
         assertEquals(null, response.getReason());
+
+        response.setHeader("Should-Be-Ignored","value");
+        assertFalse(response.getHttpFields().containsKey("Should-Be-Ignored"));
+
         assertEquals(expectedMessage, response.getHttpChannel().getRequest().getAttribute(RequestDispatcher.ERROR_MESSAGE));
         assertThat(response.getHttpChannel().getState().unhandle(), is(HttpChannelState.Action.SEND_ERROR));
         assertThat(response.getHttpChannel().getState().unhandle(), is(HttpChannelState.Action.COMPLETE));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -694,7 +694,7 @@ public class ResponseTest
         assertEquals(code, response.getStatus());
         assertEquals(null, response.getReason());
 
-        response.setHeader("Should-Be-Ignored","value");
+        response.setHeader("Should-Be-Ignored", "value");
         assertFalse(response.getHttpFields().containsKey("Should-Be-Ignored"));
 
         assertEquals(expectedMessage, response.getHttpChannel().getRequest().getAttribute(RequestDispatcher.ERROR_MESSAGE));


### PR DESCRIPTION
SendError now makes the response immutable for headers and status. #4176

Signed-off-by: Greg Wilkins <gregw@webtide.com>