### PR TITLE
Use HttpClient instead of HttpURLConnection

### DIFF
--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -58,7 +58,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <New id="HttpClientFactory" class="org.eclipse.jetty.security.openid.OpenIdHttpClientFactory">
+    <Arg type="Boolean"><Property name="jetty.openid.trustAllCertificates" default="false"/></Arg>
+  </New>
   <New id="OpenIdConfiguration" class="org.eclipse.jetty.security.openid.OpenIdConfiguration">
     <Arg><Property name="jetty.openid.provider" deprecated="jetty.openid.openIdProvider"/></Arg>
     <Arg><Property name="jetty.openid.provider.authorizationEndpoint"/></Arg>
     <Arg><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
     <Arg><Property name="jetty.openid.clientId"/></Arg>
     <Arg><Property name="jetty.openid.clientSecret"/></Arg>
+    <Arg><Ref refid="HttpClientFactory"/></Arg>
     <Call name="addScopes">
       <Arg>
         <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
@@ -20,6 +24,7 @@
       <New class="org.eclipse.jetty.security.openid.OpenIdLoginService">
         <Arg><Ref refid="OpenIdConfiguration"/></Arg>
         <Arg><Ref refid="BaseLoginService"/></Arg>
+        <Arg><Ref refid="HttpClientFactory"/></Arg>
         <Call name="setAuthenticateNewUsers">
           <Arg type="boolean">
             <Property name="jetty.openid.authenticateNewUsers" default="false"/>

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -5,6 +5,7 @@ Adds OpenId Connect authentication.
 
 [depend]
 security
+client
 
 [lib]
 lib/jetty-openid-${jetty.version}.jar
@@ -20,6 +21,9 @@ etc/jetty-openid.xml
 [ini-template]
 ## The OpenID Identity Provider's issuer ID (the entire URL *before* ".well-known/openid-configuration")
 # jetty.openid.provider=https://id.example.com/~
+
+## Whether or not all certificates of the OpenID Connect provider's should be trusted. Only set to true during testing.
+# jetty.openid.trustAllCertificates=false
 
 ## The OpenID Identity Provider's authorization endpoint (optional if the metadata of the OP is accessible)
 # jetty.openid.provider.authorizationEndpoint=https://id.example.com/authorization

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdHttpClientFactory.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdHttpClientFactory.java
@@ -1,0 +1,62 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.security.openid;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+public final class OpenIdHttpClientFactory
+{
+    private final boolean trustAll;
+
+    public OpenIdHttpClientFactory()
+    {
+        this(false);
+    }
+
+    public OpenIdHttpClientFactory(boolean trustAll)
+    {
+        this.trustAll = trustAll;
+    }
+
+    public HttpClient createHttpClient()
+    {
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client(trustAll);
+
+        sslContextFactory.setEndpointIdentificationAlgorithm("https");
+
+        HttpClientTransport transport = new HttpClientTransportOverHTTP();
+        HttpClient client = new HttpClient(transport, sslContextFactory);
+
+        client.setFollowRedirects(false);
+
+        try
+        {
+            client.start();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return client;
+    }
+}

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -102,7 +102,7 @@ public class OpenIdAuthenticationTest
         OpenIdConfiguration configuration = new OpenIdConfiguration(openIdProvider.getProvider(), CLIENT_ID, CLIENT_SECRET);
 
         // Configure OpenIdLoginService optionally providing a base LoginService to provide user roles
-        OpenIdLoginService loginService = new OpenIdLoginService(configuration);//, hashLoginService);
+        OpenIdLoginService loginService = new OpenIdLoginService(configuration, new OpenIdHttpClientFactory());
         securityHandler.setLoginService(loginService);
 
         Authenticator authenticator = new OpenIdAuthenticator(configuration, "/error");


### PR DESCRIPTION
This fixes issue #4138 where the HttpClient is used to make connections to the OpenID Connect Provider's token endpoint and metadata endpoint. This allows for accessing those when running with self-signed SSL certs, which is helpful for testing. It also allows for mutual TLS to be done to the token endpoint, client assertion auth, and other more advanced setups.

It doesn't include @gregw 's suggestion to reuse the server threadpool yet. I couldn't figure that out. That needs to be done in `org.eclipse.jetty.security.openid.OpenIdHttpClientFactory#createHttpClient`, I think. Any suggestions on how to handle that?

@lachlan-roberts , I'm low on time this week and next. If @gregw can guide us in how to reuse the threadpool (or if you know), I may need some help making those changes. Will see.