### PR TITLE
Fixes #4195: making test assertion more stable.

### DIFF
--- a/jetty-util/src/test/java/org/eclipse/jetty/util/MultiMapTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/MultiMapTest.java
@@ -471,7 +471,10 @@ public class MultiMapTest
 
         mm.putValues("food", "apple", "cherry", "raspberry");
 
-        assertEquals("{color=red, food=[apple, cherry, raspberry]}", mm.toString());
+        String expected1 = "{color=red, food=[apple, cherry, raspberry]}";
+        String expected2 = "{food=[apple, cherry, raspberry], color=red}";
+        String actual = mm.toString();
+        assertTrue(actual.equals(expected1) || actual.equals(expected2));
     }
 
     /**


### PR DESCRIPTION
In this PR, we propose to fix #4195 by making the test assertions consider both valid cases of `toString` function of the MultiMap.