### PR TITLE
Fixes #4203 and #4204 - Transfer-Encoding + Content-Length behaviors

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1824,6 +1824,7 @@ public class HttpParser
         _endOfContent = EndOfContent.UNKNOWN_CONTENT;
         _contentLength = -1;
         _hasContentLength = false;
+        _hasTransferEncoding = false;
         _contentPosition = 0;
         _responseStatus = 0;
         _contentChunk = null;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -169,6 +169,7 @@ public class HttpParser
     private Utf8StringBuilder _uri = new Utf8StringBuilder(INITIAL_URI_LENGTH); // Tune?
     private EndOfContent _endOfContent;
     private boolean _hasContentLength;
+    private boolean _hasTransferEncoding;
     private long _contentLength = -1;
     private long _contentPosition;
     private int _chunkLength;
@@ -955,6 +956,9 @@ public class HttpParser
                 switch (_header)
                 {
                     case CONTENT_LENGTH:
+                        if (_hasTransferEncoding && complianceViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH))
+                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Transfer-Encoding and Content-Length");
+
                         if (_hasContentLength)
                         {
                             if (complianceViolation(MULTIPLE_CONTENT_LENGTHS))
@@ -963,9 +967,6 @@ public class HttpParser
                                 throw new BadMessageException(HttpStatus.BAD_REQUEST_400, MULTIPLE_CONTENT_LENGTHS.description);
                         }
                         _hasContentLength = true;
-
-                        if (_endOfContent == EndOfContent.CHUNKED_CONTENT && complianceViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH))
-                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Transfer-Encoding and Content-Length");
 
                         if (_endOfContent != EndOfContent.CHUNKED_CONTENT)
                         {
@@ -978,42 +979,35 @@ public class HttpParser
                         break;
 
                     case TRANSFER_ENCODING:
+                        _hasTransferEncoding = true;
+
                         if (_hasContentLength && complianceViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH))
                             throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Transfer-Encoding and Content-Length");
 
+                        // we encountered another Transfer-Encoding header, but chunked was already set
                         if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
-                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, multiple chunked tokens");
+                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
 
-                        if (HttpHeaderValue.CHUNKED.is(_valueString))
+                        List<String> values = new QuotedCSV(_valueString).getValues();
+                        int chunked = -1;
+                        int len = values.size();
+                        for (int i = 0; i < len; i++)
                         {
-                            _endOfContent = EndOfContent.CHUNKED_CONTENT;
-                            _contentLength = -1;
-                        }
-                        else
-                        {
-                            List<String> values = new QuotedCSV(_valueString).getValues();
-                            int chunked = -1;
-                            int len = values.size();
-                            for (int i = 0; i < len; i++)
+                            if (HttpHeaderValue.CHUNKED.is(values.get(i)))
                             {
-                                if (HttpHeaderValue.CHUNKED.is(values.get(i)))
-                                {
-                                    if (chunked != -1)
-                                        throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, multiple chunked tokens");
-                                    chunked = i;
-                                }
+                                if (chunked != -1)
+                                    throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, multiple chunked tokens");
+                                chunked = i;
+                                // declared chunked
+                                _endOfContent = EndOfContent.CHUNKED_CONTENT;
+                                _contentLength = -1;
                             }
-                            // Was "chunked" token provided? then ensure it was the last token.
-                            if ((chunked >= 0) && (chunked != (len - 1)))
+                            // we have a non-chunked token after a declared chunked token
+                            else if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
                             {
-                                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked token not last");
+                                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
                             }
-                            // if we got here, we've validated the Transfer-Encoding tokens, and are automatically
-                            // in chunked mode per RFC7230 Section-3.3.1
-                            _endOfContent = EndOfContent.CHUNKED_CONTENT;
-                            _contentLength = -1;
                         }
-
                         break;
 
                     case HOST:
@@ -1153,6 +1147,15 @@ public class HttpParser
                             {
                                 setState(State.END);
                                 return _handler.messageComplete();
+                            }
+
+                            // We found Transfer-Encoding headers, but none declared the 'chunked' token
+                            if (_hasTransferEncoding && _endOfContent != EndOfContent.CHUNKED_CONTENT)
+                            {
+                                // Assume Transfer-Encoding chunked per
+                                // https://tools.ietf.org/html/rfc7230#section-3.3.1
+                                _endOfContent = EndOfContent.CHUNKED_CONTENT;
+                                _contentLength = -1;
                             }
 
                             // Was there a required host header?
@@ -1834,6 +1837,7 @@ public class HttpParser
         _endOfContent = EndOfContent.UNKNOWN_CONTENT;
         _contentLength = -1;
         _hasContentLength = false;
+        _hasTransferEncoding = false;
         _contentPosition = 0;
         _responseStatus = 0;
         _contentChunk = null;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -169,6 +169,7 @@ public class HttpParser
     private Utf8StringBuilder _uri = new Utf8StringBuilder(INITIAL_URI_LENGTH); // Tune?
     private EndOfContent _endOfContent;
     private boolean _hasContentLength;
+    private boolean _hasTransferEncoding;
     private long _contentLength = -1;
     private long _contentPosition;
     private int _chunkLength;
@@ -955,6 +956,9 @@ public class HttpParser
                 switch (_header)
                 {
                     case CONTENT_LENGTH:
+                        if (_hasTransferEncoding && complianceViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH))
+                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Transfer-Encoding and Content-Length");
+
                         if (_hasContentLength)
                         {
                             if (complianceViolation(MULTIPLE_CONTENT_LENGTHS))
@@ -978,6 +982,8 @@ public class HttpParser
                         break;
 
                     case TRANSFER_ENCODING:
+                        _hasTransferEncoding = true;
+
                         if (_hasContentLength && complianceViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH))
                             throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Transfer-Encoding and Content-Length");
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -1050,7 +1050,7 @@ public class HttpParserTest
         assertEquals("GET", _methodOrVersion);
         assertEquals("/chunk", _uriOrStatus);
         assertEquals("HTTP/1.0", _versionOrReason);
-        assertThat(_bad, containsString("Bad chunking"));
+        assertThat(_bad, containsString("Bad Transfer-Encoding"));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -343,33 +343,17 @@ public class HttpConnectionTest
     public static Stream<Arguments> http11TransferEncodingChunked()
     {
         return Stream.of(
-            // empty variants
-            // no conflicts on empty tokens, chunked token not specified, will result in chunked
-            Arguments.of(Arrays.asList()), // no entries
-            Arguments.of(Arrays.asList("")), // no entries
-            Arguments.of(Arrays.asList(",")), // no entries
             Arguments.of(Arrays.asList("chunked, ")), // results in 1 entry
-
-            // invalid token values (per https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding)
-            // no conflicts, chunked token not actually specified, will result in chunked
-            Arguments.of(Arrays.asList("bad")),
-            Arguments.of(Arrays.asList("identity")),  // identity was removed in RFC2616 errata and has been dropped in RFC7230
-            Arguments.of(Arrays.asList("'chunked'")), // apostrophe characters
-            Arguments.of(Arrays.asList("`chunked`")), // backtick "quote" characters
-            Arguments.of(Arrays.asList("[chunked]")), // bracketed (seen as mistake in several REST libraries)
-            Arguments.of(Arrays.asList("{chunked}")), // json'd (seen as mistake in several REST libraries)
-            Arguments.of(Arrays.asList("\u201Cchunked\u201D")), // opening and closing (fancy) double quotes characters
+            Arguments.of(Arrays.asList(", chunked")),
 
             // invalid tokens with chunked as last
             // no conflicts, chunked token is specified and is last, will result in chunked
             Arguments.of(Arrays.asList("bogus, chunked")),
             Arguments.of(Arrays.asList("'chunked', chunked")), // apostrophe characters with and without
             Arguments.of(Arrays.asList("identity, chunked")), // identity was removed in RFC2616 errata and has been dropped in RFC7230
-            Arguments.of(Arrays.asList(", chunked")),
 
             // multiple headers
-            Arguments.of(Arrays.asList("", "")), // no entries, 2 separate headers
-            Arguments.of(Arrays.asList("bogus", "identity")), // 2 separate headers
+            Arguments.of(Arrays.asList("identity", "chunked")), // 2 separate headers
             Arguments.of(Arrays.asList("", "chunked")) // 2 separate headers
         );
     }
@@ -402,6 +386,17 @@ public class HttpConnectionTest
     public static Stream<Arguments> http11TransferEncodingInvalidChunked()
     {
         return Stream.of(
+            // == Results in 400 Bad Request
+            Arguments.of(Arrays.asList("bogus", "identity")), // 2 separate headers
+
+            Arguments.of(Arrays.asList("bad")),
+            Arguments.of(Arrays.asList("identity")),  // identity was removed in RFC2616 errata and has been dropped in RFC7230
+            Arguments.of(Arrays.asList("'chunked'")), // apostrophe characters
+            Arguments.of(Arrays.asList("`chunked`")), // backtick "quote" characters
+            Arguments.of(Arrays.asList("[chunked]")), // bracketed (seen as mistake in several REST libraries)
+            Arguments.of(Arrays.asList("{chunked}")), // json'd (seen as mistake in several REST libraries)
+            Arguments.of(Arrays.asList("\u201Cchunked\u201D")), // opening and closing (fancy) double quotes characters
+
             // invalid tokens with chunked not as last
             Arguments.of(Arrays.asList("chunked, bogus")),
             Arguments.of(Arrays.asList("chunked, 'chunked'")),
@@ -410,6 +405,7 @@ public class HttpConnectionTest
             Arguments.of(Arrays.asList("chunked", "identity")), // 2 separate header lines
 
             // multiple chunked tokens present
+            Arguments.of(Arrays.asList("chunked", "identity", "chunked")), // 3 separate header lines
             Arguments.of(Arrays.asList("chunked", "chunked")), // 2 separate header lines
             Arguments.of(Arrays.asList("chunked, chunked")) // on same line
         );

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -369,6 +369,7 @@ public class HttpConnectionTest
 
             // multiple headers
             Arguments.of(Arrays.asList("", "")), // no entries, 2 separate headers
+            Arguments.of(Arrays.asList("bogus", "identity")), // 2 separate headers
             Arguments.of(Arrays.asList("", "chunked")) // 2 separate headers
         );
     }
@@ -405,12 +406,12 @@ public class HttpConnectionTest
             Arguments.of(Arrays.asList("chunked, bogus")),
             Arguments.of(Arrays.asList("chunked, 'chunked'")),
             Arguments.of(Arrays.asList("chunked, identity")),
+            Arguments.of(Arrays.asList("chunked, identity, chunked")), // duplicate chunked
+            Arguments.of(Arrays.asList("chunked", "identity")), // 2 separate header lines
 
             // multiple chunked tokens present
             Arguments.of(Arrays.asList("chunked", "chunked")), // 2 separate header lines
-            Arguments.of(Arrays.asList("chunked, chunked")), // on same line
-            Arguments.of(Arrays.asList("chunked, identity, chunked")),
-            Arguments.of(Arrays.asList("chunked", "identity")) // 2 separate header lines
+            Arguments.of(Arrays.asList("chunked, chunked")) // on same line
         );
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -54,6 +55,9 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -263,43 +267,66 @@ public class HttpConnectionTest
         }
     }
 
+    static final int CHUNKED = -1;
+    static final int DQUOTED_CHUNKED = -2;
+    static final int BAD_CHUNKED = -3;
+
+    public static Stream<Arguments> http11ContentLengthAndChunkedData()
+    {
+        return Stream.of(
+            Arguments.of(new int[]{CHUNKED, 8}),
+            Arguments.of(new int[]{8, CHUNKED}),
+            Arguments.of(new int[]{8, CHUNKED, 8}),
+            Arguments.of(new int[]{DQUOTED_CHUNKED, 8}),
+            Arguments.of(new int[]{8, DQUOTED_CHUNKED}),
+            Arguments.of(new int[]{8, DQUOTED_CHUNKED, 8}),
+            Arguments.of(new int[]{BAD_CHUNKED, 8}),
+            Arguments.of(new int[]{8, BAD_CHUNKED}),
+            Arguments.of(new int[]{8, BAD_CHUNKED, 8})
+        );
+    }
+
     /**
      * More then 1 Content-Length is a bad requests per HTTP rfcs.
      */
-    @Test
-    public void testHttp11ContentLengthAndChunk() throws Exception
+    @ParameterizedTest
+    @MethodSource("http11ContentLengthAndChunkedData")
+    public void testHttp11ContentLengthAndChunk(int[] contentLengths) throws Exception
     {
+
         HttpParser.LOG.info("badMessage: 400 Bad messages EXPECTED...");
-        int[][] contentLengths = {
-            {-1, 8},
-            {8, -1},
-            {8, -1, 8},
-            };
 
-        for (int x = 0; x < contentLengths.length; x++)
+        StringBuilder request = new StringBuilder();
+        request.append("POST / HTTP/1.1\r\n");
+        request.append("Host: local\r\n");
+        for (int n = 0; n < contentLengths.length; n++)
         {
-            StringBuilder request = new StringBuilder();
-            request.append("POST /?id=").append(Integer.toString(x)).append(" HTTP/1.1\r\n");
-            request.append("Host: local\r\n");
-            int[] clen = contentLengths[x];
-            for (int n = 0; n < clen.length; n++)
+            switch (contentLengths[n])
             {
-                if (clen[n] == -1)
+                case CHUNKED:
                     request.append("Transfer-Encoding: chunked\r\n");
-                else
-                    request.append("Content-Length: ").append(Integer.toString(clen[n])).append("\r\n");
+                    break;
+                case DQUOTED_CHUNKED:
+                    request.append("Transfer-Encoding: \"chunked\"\r\n");
+                    break;
+                case BAD_CHUNKED:
+                    request.append("Transfer-Encoding: 'chunked'\r\n");
+                    break;
+                default:
+                    request.append("Content-Length: ").append(contentLengths[n]).append("\r\n");
+                    break;
             }
-            request.append("Content-Type: text/plain\r\n");
-            request.append("Connection: close\r\n");
-            request.append("\r\n");
-            request.append("8;\r\n"); // chunk header
-            request.append("abcdefgh"); // actual content of 8 bytes
-            request.append("\r\n0;\r\n"); // last chunk
-
-            String rawResponse = connector.getResponse(request.toString());
-            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-            assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_BAD_REQUEST));
         }
+        request.append("Content-Type: text/plain\r\n");
+        request.append("Connection: close\r\n");
+        request.append("\r\n");
+        request.append("8;\r\n"); // chunk header
+        request.append("abcdefgh"); // actual content of 8 bytes
+        request.append("\r\n0;\r\n"); // last chunk
+
+        String rawResponse = connector.getResponse(request.toString());
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_BAD_REQUEST));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -270,6 +270,7 @@ public class HttpConnectionTest
     static final int CHUNKED = -1;
     static final int DQUOTED_CHUNKED = -2;
     static final int BAD_CHUNKED = -3;
+    static final int UNKNOWN_TE = -4;
 
     public static Stream<Arguments> http11ContentLengthAndChunkedData()
     {
@@ -282,7 +283,11 @@ public class HttpConnectionTest
             Arguments.of(new int[]{8, DQUOTED_CHUNKED, 8}),
             Arguments.of(new int[]{BAD_CHUNKED, 8}),
             Arguments.of(new int[]{8, BAD_CHUNKED}),
-            Arguments.of(new int[]{8, BAD_CHUNKED, 8})
+            Arguments.of(new int[]{8, BAD_CHUNKED, 8}),
+            Arguments.of(new int[]{UNKNOWN_TE, 8}),
+            Arguments.of(new int[]{8, UNKNOWN_TE}),
+            Arguments.of(new int[]{8, UNKNOWN_TE, 8}),
+            Arguments.of(new int[]{8, UNKNOWN_TE, CHUNKED, DQUOTED_CHUNKED, BAD_CHUNKED, 8})
         );
     }
 
@@ -311,6 +316,9 @@ public class HttpConnectionTest
                     break;
                 case BAD_CHUNKED:
                     request.append("Transfer-Encoding: 'chunked'\r\n");
+                    break;
+                case UNKNOWN_TE:
+                    request.append("Transfer-Encoding: bogus\r\n");
                     break;
                 default:
                     request.append("Content-Length: ").append(contentLengths[n]).append("\r\n");

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -321,12 +322,10 @@ public class PartialRFC2616Test
                 "\n");
         offset = 0;
         response = endp.getResponse();
-        offset = checkContains(response, offset, "HTTP/1.1 200 OK", "2. identity") + 10;
-        offset = checkContains(response, offset, "/R1", "2. identity") + 3;
+        offset = checkContains(response, offset, "HTTP/1.1 400 ", "2. identity") + 10;
         offset = 0;
         response = endp.getResponse();
-        offset = checkContains(response, offset, "HTTP/1.1 200 OK", "2. identity") + 10;
-        offset = checkContains(response, offset, "/R2", "2. identity") + 3;
+        assertThat("There should be no next response as first one closed connection", response, is(nullValue()));
     }
 
     @Test
@@ -358,7 +357,7 @@ public class PartialRFC2616Test
                 "\n" +
                 "abcdef");
         response = endp.getResponse();
-        offset = checkContains(response, offset, "HTTP/1.1 400 Bad", "3. ignore c-l") + 1;
+        offset = checkContains(response, offset, "HTTP/1.1 400 ", "3. ignore c-l") + 1;
         checkNotContained(response, offset, "/R2", "3. _content-length");
     }
 

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/rfcs/RFC2616BaseTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/rfcs/RFC2616BaseTest.java
@@ -360,30 +360,19 @@ public abstract class RFC2616BaseTest
         // request message is terminated with a 'Connection: close'.
 
         StringBuffer req1 = new StringBuffer();
-        req1.append("GET /echo/R1 HTTP/1.1\r\n");
-        req1.append("Host: localhost\r\n");
-        req1.append("Transfer-Encoding: identity\r\n");
-        req1.append("Content-Type: text/plain\r\n");
-        req1.append("\r\n");
-        req1.append("3;\r\n");
-        req1.append("123");
-        req1.append("\r\n");
-        req1.append("0;\r\n\r\n");
-
-        req1.append("GET /echo/R2 HTTP/1.1\r\n");
-        req1.append("Host: localhost\r\n");
-        req1.append("Connection: close\r\n");
-        req1.append("\r\n");
+        req1.append("GET /echo/R1 HTTP/1.1\n");
+        req1.append("Host: localhost\n");
+        req1.append("Transfer-Encoding: identity\n");
+        req1.append("Content-Type: text/plain\n");
+        req1.append("Content-Length: 5\n");
+        req1.append("\n");
+        req1.append("123\r\n");
 
         List<HttpTester.Response> responses = http.requests(req1);
-        assertEquals(2, responses.size(), "Response Count");
+        assertEquals(1, responses.size(), "Response Count");
 
         HttpTester.Response response = responses.get(0);
-        assertThat("4.4.2 Message Length / Response Code", response.getStatus(), is(HttpStatus.OK_200));
-        assertThat("4.4.2 Message Length / Body", response.getContent(), Matchers.containsString("123\n"));
-        response = responses.get(1);
-        assertThat("4.4.2 Message Length / Response Code", response.getStatus(), is(HttpStatus.OK_200));
-        assertEquals("", response.getContent(), "4.4.2 Message Length / No Body");
+        assertThat("4.4.2 Message Length / Response Code", response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
 
         // 4.4.3 -
         // Client - do not send 'Content-Length' if entity-length
@@ -391,25 +380,25 @@ public abstract class RFC2616BaseTest
         // Server - ignore 'Content-Length' if 'Transfer-Encoding' is provided.
 
         StringBuffer req2 = new StringBuffer();
-        req2.append("GET /echo/R1 HTTP/1.1\r\n");
-        req2.append("Host: localhost\r\n");
-        req2.append("Transfer-Encoding: chunked\r\n");
-        req2.append("Content-Type: text/plain\r\n");
-        req2.append("Content-Length: 100\r\n");
-        req2.append("\r\n");
-        req2.append("3;\r\n");
-        req2.append("123");
-        req2.append("3;\r\n");
-        req2.append("456\r\n");
-        req2.append("0\r\n");
-        req2.append("\r\n");
+        req2.append("GET /echo/R1 HTTP/1.1\n");
+        req2.append("Host: localhost\n");
+        req2.append("Transfer-Encoding: chunked\n");
+        req2.append("Content-Type: text/plain\n");
+        req2.append("Content-Length: 100\n");
+        req2.append("\n");
+        req2.append("3;\n");
+        req2.append("123\n");
+        req2.append("3;\n");
+        req2.append("456\n");
+        req2.append("0;\n");
+        req2.append("\n");
 
-        req2.append("GET /echo/R2 HTTP/1.1\r\n");
-        req2.append("Host: localhost\r\n");
-        req2.append("Connection: close\r\n");
-        req2.append("Content-Type: text/plain\r\n");
-        req2.append("Content-Length: 6\r\n");
-        req2.append("\r\n");
+        req2.append("GET /echo/R2 HTTP/1.1\n");
+        req2.append("Host: localhost\n");
+        req2.append("Connection: close\n");
+        req2.append("Content-Type: text/plain\n");
+        req2.append("Content-Length: 6\n");
+        req2.append("\n");
         req2.append("7890AB");
 
         responses = http.requests(req2);

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/rfcs/RFC2616BaseTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/rfcs/RFC2616BaseTest.java
@@ -360,18 +360,20 @@ public abstract class RFC2616BaseTest
         // request message is terminated with a 'Connection: close'.
 
         StringBuffer req1 = new StringBuffer();
-        req1.append("GET /echo/R1 HTTP/1.1\n");
-        req1.append("Host: localhost\n");
-        req1.append("Transfer-Encoding: identity\n");
-        req1.append("Content-Type: text/plain\n");
-        req1.append("Content-Length: 5\n");
-        req1.append("\n");
-        req1.append("123\r\n");
+        req1.append("GET /echo/R1 HTTP/1.1\r\n");
+        req1.append("Host: localhost\r\n");
+        req1.append("Transfer-Encoding: identity\r\n");
+        req1.append("Content-Type: text/plain\r\n");
+        req1.append("\r\n");
+        req1.append("3;\r\n");
+        req1.append("123");
+        req1.append("\r\n");
+        req1.append("0;\r\n\r\n");
 
-        req1.append("GET /echo/R2 HTTP/1.1\n");
-        req1.append("Host: localhost\n");
-        req1.append("Connection: close\n");
-        req1.append("\n");
+        req1.append("GET /echo/R2 HTTP/1.1\r\n");
+        req1.append("Host: localhost\r\n");
+        req1.append("Connection: close\r\n");
+        req1.append("\r\n");
 
         List<HttpTester.Response> responses = http.requests(req1);
         assertEquals(2, responses.size(), "Response Count");
@@ -389,25 +391,25 @@ public abstract class RFC2616BaseTest
         // Server - ignore 'Content-Length' if 'Transfer-Encoding' is provided.
 
         StringBuffer req2 = new StringBuffer();
-        req2.append("GET /echo/R1 HTTP/1.1\n");
-        req2.append("Host: localhost\n");
-        req2.append("Transfer-Encoding: chunked\n");
-        req2.append("Content-Type: text/plain\n");
-        req2.append("Content-Length: 100\n");
-        req2.append("\n");
-        req2.append("3;\n");
-        req2.append("123\n");
-        req2.append("3;\n");
-        req2.append("456\n");
-        req2.append("0;\n");
-        req2.append("\n");
+        req2.append("GET /echo/R1 HTTP/1.1\r\n");
+        req2.append("Host: localhost\r\n");
+        req2.append("Transfer-Encoding: chunked\r\n");
+        req2.append("Content-Type: text/plain\r\n");
+        req2.append("Content-Length: 100\r\n");
+        req2.append("\r\n");
+        req2.append("3;\r\n");
+        req2.append("123");
+        req2.append("3;\r\n");
+        req2.append("456\r\n");
+        req2.append("0\r\n");
+        req2.append("\r\n");
 
-        req2.append("GET /echo/R2 HTTP/1.1\n");
-        req2.append("Host: localhost\n");
-        req2.append("Connection: close\n");
-        req2.append("Content-Type: text/plain\n");
-        req2.append("Content-Length: 6\n");
-        req2.append("\n");
+        req2.append("GET /echo/R2 HTTP/1.1\r\n");
+        req2.append("Host: localhost\r\n");
+        req2.append("Connection: close\r\n");
+        req2.append("Content-Type: text/plain\r\n");
+        req2.append("Content-Length: 6\r\n");
+        req2.append("\r\n");
         req2.append("7890AB");
 
         responses = http.requests(req2);


### PR DESCRIPTION
For:
* Issue #4203 - Some `Transfer-Encoding` and `Content-Length` combinations do not result in expected 400 Bad Request
* Issue #4204 - `Transfer-Encoding` behavior does not follow RFC7230