### PR TITLE
Issue #4240 - use default charset utf-8 for cgi request form encoding

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CGI.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CGI.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
@@ -251,7 +252,11 @@ public class CGI extends HttpServlet
                 String parameterName = names.nextElement();
                 parameterMap.addValues(parameterName, req.getParameterValues(parameterName));
             }
-            bodyFormEncoded = UrlEncoded.encode(parameterMap, Charset.forName(req.getCharacterEncoding()), true);
+
+            String characterEncoding = req.getCharacterEncoding();
+            Charset charset = characterEncoding != null
+                ? Charset.forName(characterEncoding) : StandardCharsets.UTF_8;
+            bodyFormEncoded = UrlEncoded.encode(parameterMap, charset, true);
         }
 
         EnvList env = new EnvList(_env);

--- a/tests/test-webapps/test-jetty-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/webapp/WEB-INF/web.xml
@@ -125,6 +125,7 @@
     <servlet-name>CGI</servlet-name>
     <servlet-class>org.eclipse.jetty.servlets.CGI</servlet-class>
     <load-on-startup>1</load-on-startup>
+    <async-supported>true</async-supported>
   </servlet>
   
   <servlet-mapping>


### PR DESCRIPTION
Signed-off-by: Lachlan Roberts <lachlan@webtide.com>

Issue #4240