### PR TITLE
Issue #4237 - allow openid module to be configured without context xml

### DIFF
--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -34,10 +34,8 @@
             </goals>
             <configuration>
               <instructions>
-                <Bundle-Description>Jetty Jaspi</Bundle-Description>
-                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
-                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -34,7 +34,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -23,6 +23,26 @@
           <onlyAnalyze>org.eclipse.jetty.jaspi.*</onlyAnalyze>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Bundle-Description>Jetty Jaspi</Bundle-Description>
+                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/jetty-jaspi/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
+++ b/jetty-jaspi/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
@@ -1,0 +1,1 @@
+org.eclipse.jetty.security.jaspi.JaspiAuthenticatorFactory

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -35,10 +35,8 @@
             </goals>
             <configuration>
               <instructions>
-                <Bundle-Description>Jetty OpenId</Bundle-Description>
-                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
-                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -24,6 +24,26 @@
           <onlyAnalyze>org.eclipse.jetty.security.openid.*</onlyAnalyze>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Bundle-Description>Jetty OpenId</Bundle-Description>
+                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -35,7 +35,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
                 <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticatorFactory.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticatorFactory.java
@@ -21,13 +21,12 @@ package org.eclipse.jetty.security.openid;
 import javax.servlet.ServletContext;
 
 import org.eclipse.jetty.security.Authenticator;
-import org.eclipse.jetty.security.DefaultAuthenticatorFactory;
 import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.security.Constraint;
 
-public class OpenIdAuthenticatorFactory extends DefaultAuthenticatorFactory
+public class OpenIdAuthenticatorFactory implements Authenticator.Factory
 {
     @Override
     public Authenticator getAuthenticator(Server server, ServletContext context, Authenticator.AuthConfiguration configuration, IdentityService identityService, LoginService loginService)
@@ -35,6 +34,6 @@ public class OpenIdAuthenticatorFactory extends DefaultAuthenticatorFactory
         String auth = configuration.getAuthMethod();
         if (Constraint.__OPENID_AUTH.equalsIgnoreCase(auth))
             return new OpenIdAuthenticator();
-        return super.getAuthenticator(server, context, configuration, identityService, loginService);
+        return null;
     }
 }

--- a/jetty-openid/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
+++ b/jetty-openid/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
@@ -1,0 +1,1 @@
+org.eclipse.jetty.security.openid.OpenIdAuthenticatorFactory

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,10 +32,8 @@
             </goals>
             <configuration>
               <instructions>
-                <Bundle-Description>Jetty Security</Bundle-Description>
-                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
-                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
-                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,7 +32,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor);resolution:=optional", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar);resolution:=optional"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,7 +32,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,8 +32,7 @@
             </goals>
             <configuration>
               <instructions>
-                   <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
-            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor);resolution:=optional", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar);resolution:=optional"</Require-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -21,6 +21,26 @@
           <onlyAnalyze>org.eclipse.jetty.security.*</onlyAnalyze>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Bundle-Description>Jetty Security</Bundle-Description>
+                <Export-Package>org.eclipse.jetty.security.*;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}"</Export-Package>
+                <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+                <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.security.Authenticator.Factory</Provide-Capability>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,7 +32,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)"</Require-Capability>
+                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -32,8 +32,8 @@
             </goals>
             <configuration>
               <instructions>
-                <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
-                <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
+                   <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.security.Authenticator$Factory</Provide-Capability>
               </instructions>
             </configuration>
           </execution>

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -367,6 +367,9 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
                 Authenticator authenticator = _authenticatorFactory.getAuthenticator(getServer(), ContextHandler.getCurrentContext(),
                     this, _identityService, _loginService);
 
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Created authenticator {} with {}", authenticator, _authenticatorFactory);
+
                 if (authenticator != null)
                     setAuthenticator(authenticator);
             }
@@ -379,6 +382,9 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
 
                     if (authenticator != null)
                     {
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Created authenticator {} with {}", authenticator, factory);
+
                         setAuthenticator(authenticator);
                         break;
                     }

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -367,11 +367,13 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
                 Authenticator authenticator = _authenticatorFactory.getAuthenticator(getServer(), ContextHandler.getCurrentContext(),
                     this, _identityService, _loginService);
 
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Created authenticator {} with {}", authenticator, _authenticatorFactory);
-
                 if (authenticator != null)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Created authenticator {} with {}", authenticator, _authenticatorFactory);
+
                     setAuthenticator(authenticator);
+                }
             }
             else
             {

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -79,6 +79,8 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
             addBean(factory);
             _authenticatorFactories.add(factory);
         }
+
+        _authenticatorFactories.add(new DefaultAuthenticatorFactory());
     }
 
     /**

--- a/jetty-security/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
+++ b/jetty-security/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
@@ -1,0 +1,1 @@
+org.eclipse.jetty.security.DefaultAuthenticatorFactory

--- a/jetty-security/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
+++ b/jetty-security/src/main/resources/META-INF/services/org.eclipse.jetty.security.Authenticator$Factory
@@ -1,1 +1,0 @@
-org.eclipse.jetty.security.DefaultAuthenticatorFactory


### PR DESCRIPTION
Issue #4237

Remove the need to use a context xml file to configure the `OpenIdAuthenticatorFactory` and set init param on security handler.

`Authenticator.Factory` is now discovered by the `ServiceLoader`, a list of them is kept in `SecurityHandler` and they are tried one at a time until one creates an `Authenticator`. So it is no longer necessary to set any configuration for the `OpenIdAuthenticatorFactory`.

The init param to configure the openid error page is now to be set in web.xml:
```xml
<context-param>
  <param-name>org.eclipse.jetty.security.openid.error_page</param-name>
  <param-value>/error</param-value>
</context-param>
```
