### PR TITLE
Fixes #4251 - Http 2.0 clients cannot upgrade protocol in 9.4.22 rele…

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
@@ -84,6 +84,11 @@ public class SettingsBodyParser extends BodyParser
     @Override
     public boolean parse(ByteBuffer buffer)
     {
+        return parse(buffer, getStreamId(), getBodyLength());
+    }
+
+    private boolean parse(ByteBuffer buffer, int streamId, int bodyLength)
+    {
         while (buffer.hasRemaining())
         {
             switch (state)
@@ -91,9 +96,9 @@ public class SettingsBodyParser extends BodyParser
                 case PREPARE:
                 {
                     // SPEC: wrong streamId is treated as connection error.
-                    if (getStreamId() != 0)
+                    if (streamId != 0)
                         return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_settings_frame");
-                    length = getBodyLength();
+                    length = bodyLength;
                     settings = new HashMap<>();
                     state = State.SETTING_ID;
                     break;
@@ -234,7 +239,7 @@ public class SettingsBodyParser extends BodyParser
             }
         });
         if (buffer.hasRemaining())
-            parser.parse(buffer);
+            parser.parse(buffer, 0, buffer.remaining());
         else
             parser.emptyBody(buffer);
         return frameRef.get();

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
@@ -221,6 +221,13 @@ public class SettingsBodyParser extends BodyParser
         return true;
     }
 
+    /**
+     * <p>Parses the given buffer containing the whole body of a {@code SETTINGS} frame
+     * (without header bytes), typically from the {@code HTTP2-Settings} header.</p>
+     *
+     * @param buffer the buffer containing the body of {@code SETTINGS} frame
+     * @return the {@code SETTINGS} frame from the parsed body bytes
+     */
     public static SettingsFrame parseBody(final ByteBuffer buffer)
     {
         AtomicReference<SettingsFrame> frameRef = new AtomicReference<>();

--- a/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2CServerTest.java
+++ b/jetty-http2/http2-server/src/test/java/org/eclipse/jetty/http2/server/HTTP2CServerTest.java
@@ -125,7 +125,7 @@ public class HTTP2CServerTest extends AbstractServerTest
                     "Host: localhost\r\n" +
                     "Connection: something, else, upgrade, HTTP2-Settings\r\n" +
                     "Upgrade: h2c\r\n" +
-                    "HTTP2-Settings: \r\n" +
+                    "HTTP2-Settings: AAEAAEAAAAIAAAABAAMAAABkAAQBAAAAAAUAAEAA\r\n" +
                     "\r\n").getBytes(StandardCharsets.ISO_8859_1));
             output.flush();
 


### PR DESCRIPTION

#4251 
…ase.

Fixed HTTP2-Settings header parsing.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>