### PR TITLE
configuration for jetty-10 WebSocketClient to be stopped at shutdown

### DIFF
--- a/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/jetty-websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.ShutdownThread;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.WebSocketBehavior;
@@ -65,7 +66,8 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     private final List<WebSocketSessionListener> sessionListeners = new CopyOnWriteArrayList<>();
     private final SessionTracker sessionTracker = new SessionTracker();
     private final FrameHandler.ConfigurationCustomizer configurationCustomizer = new FrameHandler.ConfigurationCustomizer();
-    private WebSocketComponents components = new WebSocketComponents();
+    private final WebSocketComponents components = new WebSocketComponents();
+    private boolean stopAtShutdown = false;
 
     /**
      * Instantiate a WebSocketClient with defaults
@@ -338,6 +340,31 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     public SslContextFactory getSslContextFactory()
     {
         return getHttpClient().getSslContextFactory();
+    }
+
+    /**
+     * Set JVM shutdown behavior.
+     * @param stop If true, this client instance will be explicitly stopped when the
+     * JVM is shutdown. Otherwise the application is responsible for maintaining the WebSocketClient lifecycle.
+     * @see Runtime#addShutdownHook(Thread)
+     * @see ShutdownThread
+     */
+    public synchronized void setStopAtShutdown(boolean stop)
+    {
+        if (stop)
+        {
+            if (!stopAtShutdown && !ShutdownThread.isRegistered(this))
+                ShutdownThread.register(this);
+        }
+        else
+            ShutdownThread.deregister(this);
+
+        stopAtShutdown = stop;
+    }
+
+    public boolean isStopAtShutdown()
+    {
+        return stopAtShutdown;
     }
 
     @Override

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/WebSocketCoreClient.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/client/WebSocketCoreClient.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.util.thread.ShutdownThread;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
@@ -92,18 +91,7 @@ public class WebSocketCoreClient extends ContainerLifeCycle
         if (LOG.isDebugEnabled())
             LOG.debug("connect to websocket {}", request.getURI());
 
-        init();
-
         return request.sendAsync();
-    }
-
-    // TODO: review need for this.
-    private synchronized void init() throws IOException
-    {
-        if (!ShutdownThread.isRegistered(this))
-        {
-            ShutdownThread.register(this);
-        }
     }
 
     public WebSocketExtensionRegistry getExtensionRegistry()


### PR DESCRIPTION
adaptation of changes from PR #1777 for jetty-10

Gives an option for the jetty `WebSocketClient` to be automatically stopped at shutdown.
This PR differs from the changes of #1777 in two ways;  it is disabled by default, and we still register it for shutdown if the client has not been started so this will work:
```java
WebSocketClient client = new WebSocketClient();
client.setStopAtShutdown(true);
client.start();
```