### PR TITLE
Fixes #4258 - RateControl should be per-connection.

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/RateControl.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/RateControl.java
@@ -36,4 +36,18 @@ public interface RateControl
      * @return true IFF the rate is within limits
      */
     public boolean onEvent(Object event);
+
+    /**
+     * Factory to create RateControl instances.
+     */
+    public interface Factory
+    {
+        /**
+         * @return a new RateControl instance.
+         */
+        public default RateControl newRateControl()
+        {
+            return NO_RATE_CONTROL;
+        }
+    }
 }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/RateControl.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/RateControl.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.http2.parser;
 
+import org.eclipse.jetty.io.EndPoint;
+
 /**
  * Controls rate of events via {@link #onEvent(Object)}.
  */
@@ -43,9 +45,10 @@ public interface RateControl
     public interface Factory
     {
         /**
-         * @return a new RateControl instance.
+         * @return a new RateControl instance for the given EndPoint
+         * @param endPoint the EndPoint for which the RateControl is created
          */
-        public default RateControl newRateControl()
+        public default RateControl newRateControl(EndPoint endPoint)
         {
             return NO_RATE_CONTROL;
         }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
@@ -23,6 +23,8 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.jetty.io.EndPoint;
+
 /**
  * <p>An implementation of {@link RateControl} that limits the number of
  * events within a time period.</p>
@@ -78,7 +80,7 @@ public class WindowRateControl implements RateControl
         }
 
         @Override
-        public RateControl newRateControl()
+        public RateControl newRateControl(EndPoint endPoint)
         {
             return WindowRateControl.fromEventsPerSecond(maxEventRate);
         }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
@@ -67,4 +67,20 @@ public class WindowRateControl implements RateControl
         events.add(now + window);
         return size.incrementAndGet() <= maxEvents;
     }
+
+    public static class Factory implements RateControl.Factory
+    {
+        private final int maxEventRate;
+
+        public Factory(int maxEventRate)
+        {
+            this.maxEventRate = maxEventRate;
+        }
+
+        @Override
+        public RateControl newRateControl()
+        {
+            return WindowRateControl.fromEventsPerSecond(maxEventRate);
+        }
+    }
 }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/WindowRateControl.java
@@ -50,6 +50,21 @@ public class WindowRateControl implements RateControl
     {
         this.maxEvents = maxEvents;
         this.window = window.toNanos();
+        if (this.window == 0)
+            throw new IllegalArgumentException("Invalid duration " + window);
+    }
+
+    public int getEventsPerSecond()
+    {
+        try
+        {
+            long rate = maxEvents * 1_000_000_000L / window;
+            return Math.toIntExact(rate);
+        }
+        catch (ArithmeticException x)
+        {
+            return Integer.MAX_VALUE;
+        }
     }
 
     @Override

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
-<!-- ============================================================= --><!-- Configure an HTTP2 on the ssl connector.                       --><!-- ============================================================= -->
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
@@ -10,10 +10,10 @@
         <Set name="initialStreamRecvWindow"><Property name="jetty.http2.initialStreamRecvWindow" default="524288"/></Set>
         <Set name="initialSessionRecvWindow"><Property name="jetty.http2.initialSessionRecvWindow" default="1048576"/></Set>
         <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
-        <Set name="rateControl">
-          <Call class="org.eclipse.jetty.http2.parser.WindowRateControl" name="fromEventsPerSecond">
+        <Set name="rateControlFactory">
+          <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
             <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
-          </Call>
+          </New>
         </Set>
       </New>
     </Arg>

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
-<!-- ============================================================= --><!-- Configure an HTTP2 on the ssl connector.                       --><!-- ============================================================= -->
 <Configure id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
@@ -9,10 +9,10 @@
         <Set name="maxConcurrentStreams"><Property name="jetty.http2c.maxConcurrentStreams" deprecated="http2.maxConcurrentStreams" default="1024"/></Set>
         <Set name="initialStreamRecvWindow"><Property name="jetty.http2c.initialStreamRecvWindow" default="65535"/></Set>
         <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
-        <Set name="rateControl">
-          <Call class="org.eclipse.jetty.http2.parser.WindowRateControl" name="fromEventsPerSecond">
+        <Set name="rateControlFactory">
+          <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
             <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
-          </Call>
+          </New>
         </Set>
       </New>
     </Arg>

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -279,7 +279,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         session.setInitialSessionRecvWindow(getInitialSessionRecvWindow());
         session.setWriteThreshold(getHttpConfiguration().getOutputBufferSize());
 
-        ServerParser parser = newServerParser(connector, session, getRateControlFactory().newRateControl());
+        ServerParser parser = newServerParser(connector, session, getRateControlFactory().newRateControl(endPoint));
         parser.setMaxFrameLength(getMaxFrameLength());
         parser.setMaxSettingsKeys(getMaxSettingsKeys());
 

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -192,14 +192,18 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
     }
 
     /**
-     * @param rateControl ignored
-     * @throws UnsupportedOperationException when invoked
+     * @param rateControl ignored, unless {@code rateControl} it is precisely a WindowRateControl
+     * (not a subclass) object in which case it is used as a prototype in a WindowRateControl.Factory.
+     * @throws UnsupportedOperationException when invoked, unless precisely a WindowRateControl object
      * @deprecated use {@link #setRateControlFactory(RateControl.Factory)} instead
      */
     @Deprecated
     public void setRateControl(RateControl rateControl)
     {
-        throw new UnsupportedOperationException();
+        if (rateControl.getClass() == WindowRateControl.class)
+            setRateControlFactory(new WindowRateControl.Factory(((WindowRateControl)rateControl).getEventsPerSecond()));
+        else
+            throw new UnsupportedOperationException();
     }
 
     /**

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.unixsocket.UnixSocketConnector;
 import org.eclipse.jetty.unixsocket.client.HttpClientTransportOverUnixSockets;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
@@ -156,6 +157,18 @@ public class DistributionTests extends AbstractDistributionTest
     @DisabledOnJre(JRE.JAVA_8)
     public void testSimpleWebAppWithJSPOverH2C() throws Exception
     {
+        testSimpleWebAppWithJSPOverHTTP2(false);
+    }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_8)
+    public void testSimpleWebAppWithJSPOverH2() throws Exception
+    {
+        testSimpleWebAppWithJSPOverHTTP2(true);
+    }
+
+    private void testSimpleWebAppWithJSPOverHTTP2(boolean ssl) throws Exception
+    {
         String jettyVersion = System.getProperty("jettyVersion");
         DistributionTester distribution = DistributionTester.Builder.newInstance()
             .jettyVersion(jettyVersion)
@@ -164,7 +177,7 @@ public class DistributionTests extends AbstractDistributionTest
 
         String[] args1 = {
             "--create-startd",
-            "--add-to-start=http2c,jsp,deploy"
+            "--add-to-start=jsp,deploy," + (ssl ? "http2" : "http2c")
         };
         try (DistributionTester.Run run1 = distribution.start(args1))
         {
@@ -175,13 +188,14 @@ public class DistributionTests extends AbstractDistributionTest
             distribution.installWarFile(war, "test");
 
             int port = distribution.freePort();
-            try (DistributionTester.Run run2 = distribution.start("jetty.http.port=" + port))
+            String portProp = ssl ? "jetty.ssl.port" : "jetty.http.port";
+            try (DistributionTester.Run run2 = distribution.start(portProp + "=" + port))
             {
                 assertTrue(run2.awaitConsoleLogsFor("Started @", 10, TimeUnit.SECONDS));
 
                 HTTP2Client h2Client = new HTTP2Client();
-                startHttpClient(() -> new HttpClient(new HttpClientTransportOverHTTP2(h2Client), null));
-                ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");
+                startHttpClient(() -> new HttpClient(new HttpClientTransportOverHTTP2(h2Client), new SslContextFactory.Client(true)));
+                ContentResponse response = client.GET((ssl ? "https" : "http") + "://localhost:" + port + "/test/index.jsp");
                 assertEquals(HttpStatus.OK_200, response.getStatus());
                 assertThat(response.getContentAsString(), containsString("Hello"));
                 assertThat(response.getContentAsString(), not(containsString("<%")));


### PR DESCRIPTION
Introduced RateControl.Factory to create instances of RateControl
for each connection.
Modified relevant XML files and added distribution test for h2.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>

#4258