### PR TITLE
Fixes #4301 - Demand beforeContent is not forwarded.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -119,7 +119,7 @@ public abstract class HttpReceiver
         }
     }
 
-    private long demand()
+    protected long demand()
     {
         return demand(LongUnaryOperator.identity());
     }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -546,6 +546,12 @@ public class HttpRequest implements Request
         this.responseListeners.add(new Response.DemandedContentListener()
         {
             @Override
+            public void onBeforeContent(Response response, LongConsumer demand)
+            {
+                listener.onBeforeContent(response, demand);
+            }
+
+            @Override
             public void onContent(Response response, LongConsumer demand, ByteBuffer content, Callback callback)
             {
                 listener.onContent(response, demand, content, callback);

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
@@ -420,13 +420,13 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements Connec
         }
 
         @Override
-        public void onHeaders(int request)
+        public boolean onHeaders(int request)
         {
             HttpChannelOverFCGI channel = activeChannels.get(request);
             if (channel != null)
-                channel.responseHeaders();
-            else
-                noChannel(request);
+                return !channel.responseHeaders();
+            noChannel(request);
+            return false;
         }
 
         @Override

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ClientParser.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ClientParser.java
@@ -80,9 +80,9 @@ public class ClientParser extends Parser
         }
 
         @Override
-        public void onHeaders(int request)
+        public boolean onHeaders(int request)
         {
-            listener.onHeaders(request);
+            return listener.onHeaders(request);
         }
 
         @Override

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/Parser.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/Parser.java
@@ -135,7 +135,11 @@ public abstract class Parser
     {
         void onHeader(int request, HttpField field);
 
-        void onHeaders(int request);
+        /**
+         * @param request the request id
+         * @return true to signal to the parser to stop parsing, false to continue parsing
+         */
+        boolean onHeaders(int request);
 
         /**
          * @param request the request id
@@ -158,8 +162,9 @@ public abstract class Parser
             }
 
             @Override
-            public void onHeaders(int request)
+            public boolean onHeaders(int request)
             {
+                return false;
             }
 
             @Override

--- a/jetty-fcgi/fcgi-client/src/test/java/org/eclipse/jetty/fcgi/generator/ClientGeneratorTest.java
+++ b/jetty-fcgi/fcgi-client/src/test/java/org/eclipse/jetty/fcgi/generator/ClientGeneratorTest.java
@@ -109,10 +109,11 @@ public class ClientGeneratorTest
             }
 
             @Override
-            public void onHeaders(int request)
+            public boolean onHeaders(int request)
             {
                 assertEquals(id, request);
                 params.set(params.get() * primes[4]);
+                return false;
             }
         });
 

--- a/jetty-fcgi/fcgi-client/src/test/java/org/eclipse/jetty/fcgi/parser/ClientParserTest.java
+++ b/jetty-fcgi/fcgi-client/src/test/java/org/eclipse/jetty/fcgi/parser/ClientParserTest.java
@@ -90,10 +90,11 @@ public class ClientParserTest
             }
 
             @Override
-            public void onHeaders(int request)
+            public boolean onHeaders(int request)
             {
                 assertEquals(id, request);
                 params.set(params.get() * primes[2]);
+                return false;
             }
         });
 

--- a/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/ServerFCGIConnection.java
+++ b/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/ServerFCGIConnection.java
@@ -144,7 +144,7 @@ public class ServerFCGIConnection extends AbstractConnection
         }
 
         @Override
-        public void onHeaders(int request)
+        public boolean onHeaders(int request)
         {
             HttpChannelOverFCGI channel = channels.get(request);
             if (LOG.isDebugEnabled())
@@ -154,6 +154,7 @@ public class ServerFCGIConnection extends AbstractConnection
                 channel.onRequest();
                 channel.dispatch();
             }
+            return false;
         }
 
         @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
@@ -105,12 +105,24 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
                     if (frame.isEndStream() || informational)
                         responseSuccess(exchange);
                 }
+                else
+                {
+                    if (frame.isEndStream())
+                    {
+                        // There is no demand to trigger response success, so add
+                        // a poison pill to trigger it when there will be demand.
+                        notifyContent(exchange, new DataFrame(stream.getId(), BufferUtil.EMPTY_BUFFER, true), Callback.NOOP);
+                    }
+                }
             }
         }
         else // Response trailers.
         {
             HttpFields trailers = metaData.getFields();
             trailers.forEach(httpResponse::trailer);
+            // Previous DataFrames had endStream=false, so
+            // add a poison pill to trigger response success
+            // after all normal DataFrames have been consumed.
             notifyContent(exchange, new DataFrame(stream.getId(), BufferUtil.EMPTY_BUFFER, true), Callback.NOOP);
         }
     }
@@ -200,7 +212,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
         contentNotifier.offer(exchange, frame, callback);
     }
 
-    private static class ContentNotifier
+    private class ContentNotifier
     {
         private final Queue<DataInfo> queue = new ArrayDeque<>();
         private final HttpReceiverOverHTTP2 receiver;
@@ -234,8 +246,24 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
         private void process(boolean resume)
         {
             // Allow only one thread at a time.
-            if (active(resume))
+            boolean busy = active(resume);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Resuming({}) processing({}) of content", resume, !busy);
+            if (busy)
                 return;
+
+            // Process only if there is demand.
+            synchronized (this)
+            {
+                if (!resume && demand() <= 0)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Stalling processing, content available but no demand");
+                    active = false;
+                    stalled = true;
+                    return;
+                }
+            }
 
             while (true)
             {
@@ -253,7 +281,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
                 {
                     dataInfo = queue.poll();
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Dequeued content {}", dataInfo);
+                        LOG.debug("Processing content {}", dataInfo);
                     if (dataInfo == null)
                     {
                         active = false;
@@ -269,8 +297,12 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
                     boolean proceed = receiver.responseContent(dataInfo.exchange, buffer, Callback.from(callback::succeeded, x -> fail(callback, x)));
                     if (!proceed)
                     {
-                        // Should stall, unless just resumed.
-                        if (stall())
+                        // The call to responseContent() said we should
+                        // stall, but another thread may have just resumed.
+                        boolean stall = stall();
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Stalling({}) processing", stall);
+                        if (stall)
                             return;
                     }
                 }
@@ -287,27 +319,46 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
             {
                 if (active)
                 {
+                    // There is a thread in process(),
+                    // but it may be about to exit, so
+                    // remember "resume" to signal the
+                    // processing thread to continue.
                     if (resume)
                         this.resume = true;
                     return true;
                 }
+
+                // If there is no demand (i.e. stalled
+                // and not resuming) then don't process.
                 if (stalled && !resume)
                     return true;
+
+                // Start processing.
                 active = true;
                 stalled = false;
                 return false;
             }
         }
 
+        /**
+         * Called when there is no demand, this method checks whether
+         * the processing should really stop or it should continue.
+         *
+         * @return true to stop processing, false to continue processing
+         */
         private boolean stall()
         {
             synchronized (this)
             {
                 if (resume)
                 {
+                    // There was no demand, but another thread
+                    // just demanded, continue processing.
                     resume = false;
                     return false;
                 }
+
+                // There is no demand, stop processing.
                 active = false;
                 stalled = true;
                 return true;
@@ -332,7 +383,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements Stream.Listen
             receiver.responseFailure(failure);
         }
 
-        private static class DataInfo
+        private class DataInfo
         {
             private final HttpExchange exchange;
             private final DataFrame frame;


### PR DESCRIPTION
Now correctly handling no demand before the content
in FCGI and HTTP2 transports.

Fixed HttpRequest to correctly forward onBeforeContent()
to wrapped listeners.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>