### PR TITLE
Issue #4328 - Including jetty-util-9.3.0.RC0 as WEB-INF/lib

### DIFF
--- a/tests/test-distribution/src/main/java/org/eclipse/jetty/tests/distribution/DistributionTester.java
+++ b/tests/test-distribution/src/main/java/org/eclipse/jetty/tests/distribution/DistributionTester.java
@@ -67,6 +67,7 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * <p>Helper class to test the Jetty Distribution</p>.
@@ -111,6 +112,7 @@ public class DistributionTester
     private static final Logger LOGGER = Log.getLogger(DistributionTester.class);
 
     private Config config;
+    public boolean remoteDebug = false;
 
     private DistributionTester(Config config)
     {
@@ -150,6 +152,13 @@ public class DistributionTester
         List<String> commands = new ArrayList<>();
         commands.add(getJavaExecutable());
         commands.add("-Djava.io.tmpdir=" + workDir.toAbsolutePath().toString());
+        if (remoteDebug)
+        {
+            if (JRE.JAVA_8.isCurrentVersion())
+                commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+            else // for Java 9+
+                commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005");
+        }
         commands.add("-jar");
         commands.add(config.jettyHome.toAbsolutePath() + "/start.jar");
         // we get artifacts from local repo first

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -172,9 +173,20 @@ public class DemoBaseTests extends AbstractDistributionTest
             startHttpClient();
             ContentResponse response = client.GET("http://localhost:" + httpPort + "/test-spec/classloader");
             assertEquals(HttpStatus.OK_200, response.getStatus());
-            assertThat(response.getContentAsString(), containsString("<b>Version Result: <span class=\"pass\">PASS</span></b>"));
-            assertThat(response.getContentAsString(), containsString("<b>URI Result: <span class=\"pass\">PASS</span></b>"));
-            assertThat(response.getContentAsString(), not(containsString("<span class=\"fail\">FAIL</span>")));
+
+            String responseContent = response.getContentAsString();
+
+            assertThat(responseContent, allOf(
+                containsString("Webapp loaded <code>org.eclipse.jetty.util.IO</code>(9.3.0.RC0)"),
+                containsString("WEB-INF/lib/jetty-util-9.3.0.RC0.jar"))
+            );
+            assertThat(responseContent, allOf(
+                containsString("Server loaded <code>org.eclipse.jetty.util.IO</code>(" + jettyVersion + ")"),
+                containsString("jetty-distribution-" + jettyVersion + "/lib/jetty-util-" + jettyVersion + ".jar"))
+            );
+            assertThat(responseContent, containsString("<b>Version Result: <span class=\"pass\">PASS</span></b>"));
+            assertThat(responseContent, containsString("<b>URI Result: <span class=\"pass\">PASS</span></b>"));
+            assertThat(responseContent, not(containsString("<span class=\"fail\">FAIL</span>")));
         }
     }
 

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
@@ -177,14 +177,13 @@ public class DemoBaseTests extends AbstractDistributionTest
             String responseContent = response.getContentAsString();
 
             assertThat(responseContent, allOf(
-                containsString("Webapp loaded <code>org.eclipse.jetty.util.IO</code>(9.3.0.RC0)"),
+                containsString("Webapp loaded <code>org.eclipse.jetty.util.IO</code>"),
                 containsString("WEB-INF/lib/jetty-util-9.3.0.RC0.jar"))
             );
             assertThat(responseContent, allOf(
-                containsString("Server loaded <code>org.eclipse.jetty.util.IO</code>(" + jettyVersion + ")"),
+                containsString("Server loaded <code>org.eclipse.jetty.util.IO</code>"),
                 containsString("jetty-distribution-" + jettyVersion + "/lib/jetty-util-" + jettyVersion + ".jar"))
             );
-            assertThat(responseContent, containsString("<b>Version Result: <span class=\"pass\">PASS</span></b>"));
             assertThat(responseContent, containsString("<b>URI Result: <span class=\"pass\">PASS</span></b>"));
             assertThat(responseContent, not(containsString("<span class=\"fail\">FAIL</span>")));
         }

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -43,7 +43,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- also make this webapp an osgi bundle -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
@@ -61,7 +60,7 @@
           </webResources>
         </configuration>
       </plugin>
-
+      <!-- also make this webapp an osgi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -74,7 +73,7 @@
             <Bundle-SymbolicName>org.eclipse.jetty.tests.test-spec-webapp</Bundle-SymbolicName>
             <Bundle-Description>Test Webapp for Servlet 3.1 Features</Bundle-Description>
             <Import-Package>
-              javax.transaction*;version="[1.1,1.3)", com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}", *
+              javax.transaction*;version="[1.1,1.3)", org.eclipse.jetty.util;version="[9.3,10)", com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}", *
             </Import-Package>
             <_nouses />
             <Export-Package>com.acme.test;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";-noimport:=true</Export-Package>
@@ -112,7 +111,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>copy</goal>
             </goals>
@@ -126,6 +125,14 @@
                   <includes>**</includes>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/lib/jndi</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>jetty-util</artifactId>
+                  <version>9.3.0.RC0</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/lib/</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ClassInfo.java
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ClassInfo.java
@@ -1,0 +1,198 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package com.acme.test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.CodeSource;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.invoke.MethodType.methodType;
+
+public class ClassInfo
+{
+    private static final MethodHandle[] LOCATION_METHODS;
+    private static final ModuleLocation MODULE_LOCATION;
+
+    static
+    {
+        List<MethodHandle> locationMethods = new ArrayList<>();
+
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType type = methodType(URI.class, Class.class);
+
+        try
+        {
+            locationMethods.add(lookup.findStatic(ClassInfo.class, "getCodeSourceLocation", type));
+            ModuleLocation moduleLocation = null;
+            try
+            {
+                moduleLocation = new ModuleLocation();
+                locationMethods.add(lookup.findStatic(ClassInfo.class, "getModuleLocation", type));
+            }
+            catch (UnsupportedOperationException e)
+            {
+                System.err.println("JVM Runtime does not support Modules");
+            }
+            MODULE_LOCATION = moduleLocation;
+            locationMethods.add(lookup.findStatic(ClassInfo.class, "getClassLoaderLocation", type));
+            locationMethods.add(lookup.findStatic(ClassInfo.class, "getSystemClassLoaderLocation", type));
+            LOCATION_METHODS = locationMethods.toArray(new MethodHandle[0]);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Unable to establish Location Lookup Handles", e);
+        }
+    }
+
+    /**
+     * Attempt to find the Location of a loaded Class.
+     * <p>
+     * This can be null for primitives, void, and in-memory classes.
+     * </p>
+     *
+     * @param clazz the loaded class to find a location for.
+     * @return the location as a URI (this is a URI pointing to a holder of the class: a directory,
+     * a jar file, a {@code jrt://} resource, etc), or null of no location available.
+     */
+    public static URI getLocationOfClass(Class<?> clazz)
+    {
+        URI location;
+
+        for (MethodHandle locationMethod : LOCATION_METHODS)
+        {
+            try
+            {
+                location = (URI)locationMethod.invoke(clazz);
+                if (location != null)
+                {
+                    return location;
+                }
+            }
+            catch (Throwable cause)
+            {
+                cause.printStackTrace(System.err);
+            }
+        }
+        return null;
+    }
+
+    public static URI getClassLoaderLocation(Class<?> clazz)
+    {
+        return getClassLoaderLocation(clazz, clazz.getClassLoader());
+    }
+
+    public static URI getSystemClassLoaderLocation(Class<?> clazz)
+    {
+        return getClassLoaderLocation(clazz, ClassLoader.getSystemClassLoader());
+    }
+
+    public static URI getClassLoaderLocation(Class<?> clazz, ClassLoader loader)
+    {
+        if (loader == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            String resourceName = clazz.getName().replace('.', '/').concat(".class");
+            if (loader != null)
+            {
+                URL url = loader.getResource(resourceName);
+                if (url != null)
+                {
+                    URI uri = url.toURI();
+                    String uriStr = uri.toASCIIString();
+                    if (uriStr.startsWith("jar:file:"))
+                    {
+                        uriStr = uriStr.substring(4);
+                        int idx = uriStr.indexOf("!/");
+                        if (idx > 0)
+                        {
+                            return URI.create(uriStr.substring(0, idx));
+                        }
+                    }
+                    return uri;
+                }
+            }
+        }
+        catch (URISyntaxException ignored)
+        {
+        }
+        return null;
+    }
+
+    public static URI getCodeSourceLocation(Class<?> clazz)
+    {
+        try
+        {
+            ProtectionDomain domain = AccessController.doPrivileged((PrivilegedAction<ProtectionDomain>)() -> clazz.getProtectionDomain());
+            if (domain != null)
+            {
+                CodeSource source = domain.getCodeSource();
+                if (source != null)
+                {
+                    URL location = source.getLocation();
+
+                    if (location != null)
+                    {
+                        return location.toURI();
+                    }
+                }
+            }
+        }
+        catch (URISyntaxException ignored)
+        {
+        }
+        return null;
+    }
+
+    public static URI getModuleLocation(Class<?> clazz)
+    {
+        // In Jetty 10, this method can be implemented directly, without reflection
+        if (MODULE_LOCATION != null)
+        {
+            return MODULE_LOCATION.getModuleLocation(clazz);
+        }
+        return null;
+    }
+
+    public static List<Method> findMethods(Class<?> clazz, String methodName)
+    {
+        List<Method> methods = new ArrayList<>();
+        for (Method method : clazz.getMethods())
+        {
+            if (method.getName().equalsIgnoreCase(methodName))
+            {
+                methods.add(method);
+            }
+        }
+        return methods;
+    }
+}

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.util.IO;
-
 @WebServlet(urlPatterns = "/classloader")
 public class ClassLoaderServlet extends HttpServlet
 {
@@ -36,26 +34,23 @@ public class ClassLoaderServlet extends HttpServlet
     {
         try
         {
-
             PrintWriter writer = resp.getWriter();
             writer.println("<html>");
             writer.println("<HEAD><link rel=\"stylesheet\" type=\"text/css\"  href=\"stylesheet.css\"/></HEAD>");
             writer.println("<body>");
             writer.println("<h1>ClassLoader Isolation Test</h1>");
 
-            Class<?> webappIO = IO.class;
+            writer.printf("<p>Java version: %s</p>%n", System.getProperty("java.version"));
+
+            Class<?> webappIO = Thread.currentThread().getContextClassLoader().loadClass("org.eclipse.jetty.util.IO");
             URI webappURI = ClassInfo.getLocationOfClass(webappIO);
-            String webappVersion = webappIO.getPackage().getImplementationVersion();
+
             Class<?> serverIO = req.getServletContext().getClass().getClassLoader().loadClass("org.eclipse.jetty.util.IO");
             URI serverURI = ClassInfo.getLocationOfClass(serverIO);
-            String serverVersion = serverIO.getPackage().getImplementationVersion();
 
-            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", webappVersion, webappURI);
-            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", serverVersion, serverURI);
-            if (webappVersion.equals(serverVersion))
-                writer.println("<br/><b>Version Result: <span class=\"fail\">FAIL</span></b>");
-            else
-                writer.println("<br/><b>Version Result: <span class=\"pass\">PASS</span></b>");
+            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.util.IO</code> from %s%n", webappURI);
+            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.util.IO</code> from %s%n", serverURI);
+
             if (webappURI.equals(serverURI))
                 writer.println("<br/><b>URI Result: <span class=\"fail\">FAIL</span></b></p>");
             else

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ModuleLocation.java
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/java/com/acme/test/ModuleLocation.java
@@ -1,0 +1,164 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package com.acme.test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Optional;
+
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+
+import static java.lang.invoke.MethodType.methodType;
+
+/**
+ * Equivalent of ...
+ *
+ * <pre>
+ * Module module = clazz.getModule();
+ * if (module != null)
+ * {
+ *     Configuration configuration = module.getLayer().configuration();
+ *     Optional<ResolvedModule> resolvedModule = configuration.findModule(module.getName());
+ *     if (resolvedModule.isPresent())
+ *     {
+ *         ModuleReference moduleReference = resolvedModule.get().reference();
+ *         Optional<URI> location = moduleReference.location();
+ *         if (location.isPresent())
+ *         {
+ *             return location.get();
+ *         }
+ *     }
+ * }
+ * return null;
+ * </pre>
+ *
+ * In Jetty 10, this entire class can be moved to direct calls to java.lang.Module in TypeUtil.getModuleLocation()
+ */
+class ModuleLocation
+{
+    private static final Logger LOG = Log.getLogger(ModuleLocation.class);
+
+    private final Class<?> classModule;
+    private final MethodHandle handleGetModule;
+    private final MethodHandle handleGetLayer;
+    private final MethodHandle handleConfiguration;
+    private final MethodHandle handleGetName;
+    private final MethodHandle handleOptionalResolvedModule;
+    private final MethodHandle handleReference;
+    private final MethodHandle handleLocation;
+
+    public ModuleLocation()
+    {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        ClassLoader loader = ClassLoader.getSystemClassLoader();
+
+        try
+        {
+            classModule = loader.loadClass("java.lang.Module");
+            handleGetModule = lookup.findVirtual(Class.class, "getModule", methodType(classModule));
+
+            Class<?> classLayer = loader.loadClass("java.lang.ModuleLayer");
+            handleGetLayer = lookup.findVirtual(classModule, "getLayer", methodType(classLayer));
+
+            Class<?> classConfiguration = loader.loadClass("java.lang.module.Configuration");
+            handleConfiguration = lookup.findVirtual(classLayer, "configuration", methodType(classConfiguration));
+
+            handleGetName = lookup.findVirtual(classModule, "getName", methodType(String.class));
+
+            Method findModuleMethod = classConfiguration.getMethod("findModule", String.class);
+            handleOptionalResolvedModule = lookup.findVirtual(classConfiguration, "findModule", methodType(findModuleMethod.getReturnType(), String.class));
+
+            Class<?> classResolvedModule = loader.loadClass("java.lang.module.ResolvedModule");
+            Class<?> classReference = loader.loadClass("java.lang.module.ModuleReference");
+            handleReference = lookup.findVirtual(classResolvedModule, "reference", methodType(classReference));
+
+            Method locationMethod = classReference.getMethod("location");
+            handleLocation = lookup.findVirtual(classReference, "location", methodType(locationMethod.getReturnType()));
+        }
+        catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e)
+        {
+            throw new UnsupportedOperationException("Not supported on this runtime", e);
+        }
+    }
+
+    public URI getModuleLocation(Class<?> clazz)
+    {
+        try
+        {
+            // Module module = clazz.getModule();
+            Object module = handleGetModule.invoke(clazz);
+            if (module == null)
+            {
+                return null;
+            }
+
+            // ModuleLayer layer = module.getLayer();
+            Object layer = handleGetLayer.invoke(module);
+            if (layer == null)
+            {
+                return null;
+            }
+
+            // Configuration configuration = layer.configuration();
+            Object configuration = handleConfiguration.invoke(layer);
+            if (configuration == null)
+            {
+                return null;
+            }
+
+            // String moduleName = module.getName();
+            String moduleName = (String)handleGetName.invoke(module);
+            if (moduleName == null)
+            {
+                return null;
+            }
+
+            // Optional<ResolvedModule> optionalResolvedModule = configuration.findModule(moduleName);
+            Optional<?> optionalResolvedModule = (Optional<?>)handleOptionalResolvedModule.invoke(configuration, moduleName);
+            if (!optionalResolvedModule.isPresent())
+            {
+                return null;
+            }
+
+            // ResolveModule resolved = optionalResolvedModule.get();
+            Object resolved = optionalResolvedModule.get();
+
+            // ModuleReference moduleReference = resolved.reference();
+            Object moduleReference = handleReference.invoke(resolved);
+
+            // Optional<URI> location = moduleReference.location();
+            Optional<URI> location = (Optional<URI>)handleLocation.invoke(moduleReference);
+            if (location != null || location.isPresent())
+            {
+                return location.get();
+            }
+        }
+        catch (Throwable ignored)
+        {
+            if (LOG.isDebugEnabled())
+            {
+                LOG.ignore(ignored);
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
+ not including it as a formal `<dependency>`
+ jetty-util-9.3.0.RC0 is pulled in via plugin dependency
  so that it only lives for the duration of a single plugin
  execution and doesn't contaminate the dependency convergence
  on the rest of the project.
+ verified that META-INF/MANIFEST.MF is consistent to 9.4.22 and 9.4.21
  configuration of OSGI manifest, despite the jetty-util artifact
  not being a formal maven dependency.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>

Closes #4328 