### PR TITLE
Fixes #2195 - Jetty start.jar can expand properties in JVM Args now

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -705,7 +705,7 @@ public class StartArgs
                 }
                 else
                 {
-                    cmd.addRawArg(x);
+                    cmd.addRawArg(getProperties().expand(x));
                 }
             }
 


### PR DESCRIPTION
Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>