### PR TITLE
Correct the working directory for CGI scripts

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CGI.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CGI.java
@@ -353,7 +353,7 @@ public class CGI extends HttpServlet
         LOG.debug("Environment: " + env.getExportString());
         LOG.debug("Command: " + execCmd);
 
-        final Process p = Runtime.getRuntime().exec(execCmd, env.getEnvArray(), _docRoot);
+        final Process p = Runtime.getRuntime().exec(execCmd, env.getEnvArray(), command.getAbsoluteFile().getParentFile());
 
         // hook processes input to browser's output (async)
         if (bodyFormEncoded != null)


### PR DESCRIPTION
According to http://www.ietf.org/rfc/rfc3875 the working directory for a CGI script invocation "SHOULD be set to the directory containing the script". Previously Jetty's CGI servlet instead used the CGI servlet's resourceBase, which does not account for the possibility of scripts existing in sub-directories of the resourceBase.

Fixes: #326