### PR TITLE
Issue #995 - UrlEncoded.encodeString should not encode unreserved characters

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -945,7 +945,8 @@ public class UrlEncoded extends MultiMap<String> implements Cloneable
             }
             else if (b >= 'a' && b <= 'z' ||
                 b >= 'A' && b <= 'Z' ||
-                b >= '0' && b <= '9')
+                b >= '0' && b <= '9' ||
+                b == '-' || b == '.' || b == '_' || b == '~')
             {
                 encoded[n++] = b;
             }


### PR DESCRIPTION
**Issue #995**

The characters `-._~` are all unreserved characters and should not be encoded.
See https://tools.ietf.org/html/rfc3986#section-2.3 