### PR TITLE
Issue #4350 Remove exclude of MultiPartInputStreamParser from jetty-util osgi

### DIFF
--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithAnnotations.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithAnnotations.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.osgi.test;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -25,6 +26,8 @@ import javax.inject.Inject;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.MultiPartContentProvider;
+import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -126,6 +129,11 @@ public class TestJettyOSGiBootWithAnnotations
             response = client.GET("http://127.0.0.1:" + port + "/frag.html");
             content = response.getContentAsString();
             assertTrue(content.contains("<h1>FRAGMENT</h1>"));
+            MultiPartContentProvider multiPart = new MultiPartContentProvider();
+            multiPart.addFieldPart("field", new StringContentProvider("foo"), null);
+            response = client.newRequest("http://127.0.0.1:" + port + "/multi").method("POST")
+                .content(multiPart).send();
+            assertEquals(HttpStatus.OK_200, response.getStatus());
         }
         finally
         {

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -50,7 +50,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>org.eclipse.jetty.util;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";exclude:="MultiPartInputStreamParser";uses:="org.eclipse.jetty.util.annotation,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.thread";-noimport:=true,*</Export-Package>
+            <Export-Package>org.eclipse.jetty.util;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";uses:="org.eclipse.jetty.util.annotation,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.thread";-noimport:=true,*</Export-Package>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.util.security.CredentialProvider)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
           </instructions>
         </configuration>


### PR DESCRIPTION
Issue #4350 

I think we can remove the exclusion of MultiPartInputStreamParser from the Export-Package of jetty-util, but still ensure that javax.servlet isn't in the uses clause, which addressed #3871 
Added a test for the osgi environment do to a multipart-upload that can be modified to use LEGACY rather than RFC7578.