### PR TITLE
# Change isServerClass default value from  true to false

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ClassVisibilityChecker.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ClassVisibilityChecker.java
@@ -41,7 +41,7 @@ public interface ClassVisibilityChecker
     /**
      * Is the class a Server Class.
      * A Server class is a class that is part of the implementation of
-     * the server and is NIT visible to a webapplication. The web
+     * the server and is NOT visible to a web application. The web
      * application may provide it's own implementation of the class,
      * to be loaded from WEB-INF/lib or WEB-INF/classes
      *

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/ClasspathPattern.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/ClasspathPattern.java
@@ -739,8 +739,7 @@ public class ClasspathPattern extends AbstractSet<String>
      * @param name the name to check
      * @param locations configured inclusions and exclusions by location
      * @param location the location of the class (can be null)
-     * @return true if the class is not excluded but is included, or there are
-     * no inclusions. False otherwise.
+     * @return true if the class is not excluded but is included. False otherwise.
      */
     static boolean combine(IncludeExcludeSet<Entry, String> names, String name, IncludeExcludeSet<Entry, URI> locations, Supplier<URI> location)
     {
@@ -763,7 +762,7 @@ public class ClasspathPattern extends AbstractSet<String>
         if (names.hasIncludes() || locations.hasIncludes())
             return byName == Boolean.TRUE || byLocation == Boolean.TRUE;
 
-        // Otherwise there are no includes and it was not excluded, so match
-        return true;
+        // Otherwise there are no includes and it was not excluded, bypass
+        return false;
     }
 }


### PR DESCRIPTION

Since Server Class is defined to be classes that should not be loaded by WebAppClassloader, so, we should reject class loading to have a minimal impact. 

I think it's better to use  `false` as `org.eclipse.jetty.util.ClassVisibilityChecker#isServerClass` default value.

Detail: #4357 