### PR TITLE
Use the X-Forwarded-Proto HTTP header in OIDC authentication if present

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -442,8 +442,17 @@ public class OpenIdAuthenticator extends LoginAuthenticator
     private String getRedirectUri(HttpServletRequest request)
     {
         final StringBuffer redirectUri = new StringBuffer(128);
-        URIUtil.appendSchemeHostPort(redirectUri, request.getScheme(),
-            request.getServerName(), request.getServerPort());
+        String scheme = request.getScheme();
+        int serverPort = request.getServerPort();
+        String forward_proto = request.getHeader("x-forwarded-proto");
+        if (forward_proto != null && !scheme.equals(forward_proto)) {
+            scheme = forward_proto;
+            // Clear the server port so that it does not interfere with the
+            // scheme change. This will use the default value.
+            serverPort = 0;
+        }
+        URIUtil.appendSchemeHostPort(redirectUri, scheme,
+        request.getServerName(), serverPort);
         redirectUri.append(request.getContextPath());
         redirectUri.append(J_SECURITY_CHECK);
         return redirectUri.toString();


### PR DESCRIPTION
Currently this header is ignored, and the scheme from the request is always used. This may cause problems when Jetty is used behind a proxy, as the `redirect_uri` parameter always have to match the outward facing URL.

Signed-off-by: Torkild U. Resheim <torkildr@gmail.com>