### PR TITLE
Issue #4363 Restore contextXml config for jetty maven plugin

### DIFF
--- a/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/pom.xml
@@ -88,6 +88,7 @@
         <configuration>
           <systemPropertyVariables>
             <jetty.port.file>${jetty.port.file}</jetty.port.file>
+            <context.path>/setbycontextxml</context.path>
             <pingServlet>true</pingServlet>
             <helloServlet>true</helloServlet>
             <helloTestServlet>true</helloTestServlet>
@@ -117,6 +118,7 @@
               </systemProperties>
               <nonBlocking>true</nonBlocking>
               <jettyXml>${basedir}/src/config/jetty.xml</jettyXml>
+              <contextXml>${basedir}/src/config/context.xml</contextXml>
               <useTestScope>true</useTestScope>
             </configuration>
           </execution>

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/context.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+
+  <Set name="contextPath">/setbycontextxml</Set>
+
+</Configure>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
@@ -539,9 +539,10 @@ public abstract class AbstractJettyMojo extends AbstractMojo
                 path = workDir.resolve(path);
                 contextXml = path.toFile().getAbsolutePath();
             }
-
-            XmlConfiguration xmlConfiguration = new XmlConfiguration(Resource.toURL(path.toFile()));
+            
             getLog().info("Applying context xml file " + contextXml);
+            XmlConfiguration xmlConfiguration = new XmlConfiguration(Resource.toURL(path.toFile()));
+            xmlConfiguration.configure(webApp);
         }
 
         //If no contextPath was specified, go with default of project artifactid

--- a/jetty-maven-plugin/src/test/java/org/eclipse/jetty/maven/plugin/it/TestGetContent.java
+++ b/jetty-maven-plugin/src/test/java/org/eclipse/jetty/maven/plugin/it/TestGetContent.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- *
+ * 
  */
 public class TestGetContent
 {
@@ -42,6 +42,9 @@ public class TestGetContent
         throws Exception
     {
         int port = getPort();
+        String contextPath = getContextPath();
+        if (contextPath.endsWith("/"))
+            contextPath = contextPath.substring(0, contextPath.lastIndexOf('/'));
         assertTrue(port > 0);
         HttpClient httpClient = new HttpClient();
         try
@@ -50,16 +53,16 @@ public class TestGetContent
 
             if (Boolean.getBoolean("helloServlet"))
             {
-                String response = httpClient.GET("http://localhost:" + port + "/hello?name=beer").getContentAsString();
+                String response = httpClient.GET("http://localhost:" + port + contextPath + "/hello?name=beer").getContentAsString();
                 assertEquals("Hello beer", response.trim(), "it test " + System.getProperty("maven.it.name"));
-                response = httpClient.GET("http://localhost:" + port + "/hello?name=foo").getContentAsString();
+                response = httpClient.GET("http://localhost:" + port + contextPath + "/hello?name=foo").getContentAsString();
                 assertEquals("Hello foo", response.trim(), "it test " + System.getProperty("maven.it.name"));
                 System.out.println("helloServlet");
             }
             if (Boolean.getBoolean("pingServlet"))
             {
                 System.out.println("pingServlet");
-                String response = httpClient.GET("http://localhost:" + port + "/ping?name=beer").getContentAsString();
+                String response = httpClient.GET("http://localhost:" + port + contextPath + "/ping?name=beer").getContentAsString();
                 assertEquals("pong beer", response.trim(), "it test " + System.getProperty("maven.it.name"));
                 System.out.println("pingServlet ok");
             }
@@ -67,7 +70,7 @@ public class TestGetContent
             String pathToCheck = System.getProperty("pathToCheck");
             if (StringUtils.isNotBlank(contentCheck))
             {
-                String url = "http://localhost:" + port;
+                String url = "http://localhost:" + port + contextPath;
                 if (pathToCheck != null)
                 {
                     url += pathToCheck;
@@ -79,9 +82,9 @@ public class TestGetContent
             }
             if (Boolean.getBoolean("helloTestServlet"))
             {
-                String response = httpClient.GET("http://localhost:" + port + "/testhello?name=beer").getContentAsString();
+                String response = httpClient.GET("http://localhost:" + port + contextPath + "/testhello?name=beer").getContentAsString();
                 assertEquals("Hello from test beer", response.trim(), "it test " + System.getProperty("maven.it.name"));
-                response = httpClient.GET("http://localhost:" + port + "/testhello?name=foo").getContentAsString();
+                response = httpClient.GET("http://localhost:" + port + contextPath + "/testhello?name=foo").getContentAsString();
                 assertEquals("Hello from test foo", response.trim(), "it test " + System.getProperty("maven.it.name"));
                 System.out.println("helloServlet");
             }
@@ -90,6 +93,11 @@ public class TestGetContent
         {
             httpClient.stop();
         }
+    }
+
+    public static String getContextPath()
+    {
+        return System.getProperty("context.path", "/");
     }
 
     public static int getPort()


### PR DESCRIPTION
#4363 
Application of configured <contextXml> file to the webapp deployed by the mvn jetty:run goal was accidentally deleted. This PR restores the line and adds an explicit test for it.