### PR TITLE
Fixes #4374 - Jetty client: Response.AsyncContentListener.onContent i…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -502,21 +502,12 @@ public class HttpRequest implements Request
     @Override
     public Request onResponseContent(final Response.ContentListener listener)
     {
-        this.responseListeners.add(new Response.DemandedContentListener()
+        this.responseListeners.add(new Response.ContentListener()
         {
             @Override
-            public void onContent(Response response, LongConsumer demand, ByteBuffer content, Callback callback)
+            public void onContent(Response response, ByteBuffer content)
             {
-                try
-                {
-                    listener.onContent(response, content);
-                    callback.succeeded();
-                    demand.accept(1);
-                }
-                catch (Throwable x)
-                {
-                    callback.failed(x);
-                }
+                listener.onContent(response, content);
             }
         });
         return this;
@@ -525,16 +516,12 @@ public class HttpRequest implements Request
     @Override
     public Request onResponseContentAsync(final Response.AsyncContentListener listener)
     {
-        this.responseListeners.add(new Response.DemandedContentListener()
+        this.responseListeners.add(new Response.AsyncContentListener()
         {
             @Override
-            public void onContent(Response response, LongConsumer demand, ByteBuffer content, Callback callback)
+            public void onContent(Response response, ByteBuffer content, Callback callback)
             {
-                listener.onContent(response, content, Callback.from(() ->
-                {
-                    callback.succeeded();
-                    demand.accept(1);
-                }, callback::failed));
+                listener.onContent(response, content, callback);
             }
         });
         return this;

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.client;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -84,6 +85,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.IO;
@@ -1786,6 +1788,57 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 assertEquals(200, response.getStatus());
             }
         }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testContentListenerAsCompleteListener(Scenario scenario) throws Exception
+    {
+        byte[] bytes = new byte[1024];
+        new Random().nextBytes(bytes);
+        start(scenario, new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, org.eclipse.jetty.server.Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                ServletOutputStream output = response.getOutputStream();
+                output.write(bytes);
+            }
+        });
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CountDownLatch latch = new CountDownLatch(1);
+        class L implements Response.ContentListener, Response.CompleteListener
+        {
+            @Override
+            public void onContent(Response response, ByteBuffer content)
+            {
+                try
+                {
+                    BufferUtil.writeTo(content, baos);
+                }
+                catch (IOException x)
+                {
+                    baos.reset();
+                    x.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onComplete(Result result)
+            {
+                if (result.isSucceeded())
+                    latch.countDown();
+            }
+        }
+
+        client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .send(new L());
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertArrayEquals(bytes, baos.toByteArray());
     }
 
     private void assertCopyRequest(Request original)


### PR DESCRIPTION
…s not called.

#4374.

Now the various content listeners inherit from each other, like
it should have been from the beginning.
This also allowed to remove code duplication due to the default
implementation of the methods in various places.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>