### PR TITLE
Issue #4383 - avoid NPE from MultiPart Cleanup

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -497,7 +497,6 @@ public class MultiPartFormInputStream
         _parsed = true;
 
         MultiPartParser parser = null;
-        Handler handler = new Handler();
         try
         {
             // if its not a multipart request, don't parse it
@@ -530,7 +529,7 @@ public class MultiPartFormInputStream
                 contentTypeBoundary = QuotedStringTokenizer.unquote(value(_contentType.substring(bstart, bend)).trim());
             }
 
-            parser = new MultiPartParser(handler, contentTypeBoundary);
+            parser = new MultiPartParser(new Handler(), contentTypeBoundary);
             byte[] data = new byte[_bufferSize];
             int len;
             long total = 0;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -382,17 +382,20 @@ public class MultiPartFormInputStream
     @Deprecated
     public Collection<Part> getParsedParts()
     {
-        if (_parts.isEmpty())
-            return Collections.emptyList();
-
-        Collection<List<Part>> values = _parts.values();
-        List<Part> parts = new ArrayList<>();
-        for (List<Part> o : values)
+        synchronized (this)
         {
-            List<Part> asList = LazyList.getList(o, false);
-            parts.addAll(asList);
+            if (_parts.isEmpty())
+                return Collections.emptyList();
+
+            Collection<List<Part>> values = _parts.values();
+            List<Part> parts = new ArrayList<>();
+            for (List<Part> o : values)
+            {
+                List<Part> asList = LazyList.getList(o, false);
+                parts.addAll(asList);
+            }
+            return parts;
         }
-        return parts;
     }
 
     /**

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -59,13 +59,13 @@ import org.eclipse.jetty.util.log.Logger;
 public class MultiPartFormInputStream
 {
     private static final Logger LOG = Log.getLogger(MultiPartFormInputStream.class);
-    private InputStream _in;
-    private MultipartConfigElement _config;
-    private String _contentType;
-    private MultiMap<Part> _parts = new MultiMap<>();
+    private final MultiMap<Part> _parts = new MultiMap<>();
+    private final InputStream _in;
+    private final MultipartConfigElement _config;
+    private final File _contextTmpDir;
+    private final String _contentType;
     private Throwable _err;
     private File _tmpDir;
-    private File _contextTmpDir;
     private boolean _deleteOnExit;
     private boolean _writeFilesWithFilenames;
     private boolean _parsed;
@@ -332,14 +332,10 @@ public class MultiPartFormInputStream
     public MultiPartFormInputStream(InputStream in, String contentType, MultipartConfigElement config, File contextTmpDir)
     {
         _contentType = contentType;
-        _config = config;
-        _contextTmpDir = contextTmpDir;
-        if (_contextTmpDir == null)
-            _contextTmpDir = new File(System.getProperty("java.io.tmpdir"));
+        _contextTmpDir =  (contextTmpDir != null) ? contextTmpDir : new File(System.getProperty("java.io.tmpdir"));
+        _config = (config != null) ? config : new MultipartConfigElement(_contextTmpDir.getAbsolutePath());
 
-        if (_config == null)
-            _config = new MultipartConfigElement(_contextTmpDir.getAbsolutePath());
-
+        _in = new BufferedInputStream(in);
         if (in instanceof ServletInputStream)
         {
             if (((ServletInputStream)in).isFinished())
@@ -348,7 +344,6 @@ public class MultiPartFormInputStream
                 return;
             }
         }
-        _in = new BufferedInputStream(in);
     }
 
     /**

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -64,12 +64,12 @@ public class MultiPartFormInputStream
     private final MultipartConfigElement _config;
     private final File _contextTmpDir;
     private final String _contentType;
-    private Throwable _err;
-    private File _tmpDir;
-    private boolean _deleteOnExit;
-    private boolean _writeFilesWithFilenames;
-    private boolean _parsed;
-    private int _bufferSize = 16 * 1024;
+    private volatile Throwable _err;
+    private volatile File _tmpDir;
+    private volatile boolean _deleteOnExit;
+    private volatile boolean _writeFilesWithFilenames;
+    private volatile boolean _parsed;
+    private volatile int _bufferSize = 16 * 1024;
 
     public class MultiPart implements Part
     {

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -336,12 +336,17 @@ public class MultiPartFormInputStream
         _contextTmpDir =  (contextTmpDir != null) ? contextTmpDir : new File(System.getProperty("java.io.tmpdir"));
         _config = (config != null) ? config : new MultipartConfigElement(_contextTmpDir.getAbsolutePath());
 
-        _in = new BufferedInputStream(in);
         if (in instanceof ServletInputStream)
         {
             if (((ServletInputStream)in).isFinished())
+            {
+                _in = null;
                 _parsed = true;
+                return;
+            }
         }
+        
+        _in = new BufferedInputStream(in);
     }
 
     /**

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -59,11 +59,10 @@ import org.eclipse.jetty.util.log.Logger;
 public class MultiPartFormInputStream
 {
     private static final Logger LOG = Log.getLogger(MultiPartFormInputStream.class);
-    private static final MultiMap<Part> EMPTY_MAP = new MultiMap<>(Collections.emptyMap());
     private InputStream _in;
     private MultipartConfigElement _config;
     private String _contentType;
-    private MultiMap<Part> _parts;
+    private MultiMap<Part> _parts = new MultiMap<>();
     private Throwable _err;
     private File _tmpDir;
     private File _contextTmpDir;
@@ -345,7 +344,6 @@ public class MultiPartFormInputStream
         {
             if (((ServletInputStream)in).isFinished())
             {
-                _parts = EMPTY_MAP;
                 _parsed = true;
                 return;
             }
@@ -358,7 +356,7 @@ public class MultiPartFormInputStream
      */
     public boolean isEmpty()
     {
-        if (_parts == null)
+        if (_parts.isEmpty())
             return true;
 
         Collection<List<Part>> values = _parts.values();
@@ -379,7 +377,7 @@ public class MultiPartFormInputStream
     @Deprecated
     public Collection<Part> getParsedParts()
     {
-        if (_parts == null)
+        if (_parts.isEmpty())
             return Collections.emptyList();
 
         Collection<List<Part>> values = _parts.values();
@@ -492,9 +490,6 @@ public class MultiPartFormInputStream
         Handler handler = new Handler();
         try
         {
-            // initialize
-            _parts = new MultiMap<>();
-
             // if its not a multipart request, don't parse it
             if (_contentType == null || !_contentType.startsWith("multipart/form-data"))
                 return;

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
@@ -554,7 +554,7 @@ public class MultiPartFormInputStreamTest
 
         // The call to getParts should throw an error.
         Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
-        assertThat(error.getMessage(), is("Unexpected state ERROR"));
+        assertThat(error.getMessage(), is("CLOSING"));
 
         // There was no error with the cleanup.
         assertNull(cleanupError.get());
@@ -576,12 +576,10 @@ public class MultiPartFormInputStreamTest
 
         // The call to getParts should throw because we have already cleaned up the parts.
         Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
-        assertThat(error.getMessage(), is("Could not start parsing COMPLETED"));
+        assertThat(error.getMessage(), is("CLOSED"));
 
-        // No tmp files are remaining.
-        String[] fileList = _tmpDir.list();
-        assertNotNull(fileList);
-        assertThat(fileList.length, is(0));
+        // Even though we called getParts() we never even created the tmp directory as we had already called deleteParts().
+        assertFalse(_tmpDir.exists());
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormInputStreamTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ReadListener;
@@ -507,6 +509,79 @@ public class MultiPartFormInputStreamTest
         assertThat(stuff.exists(), is(true));
         part.cleanUp();
         assertThat(stuff.exists(), is(false));  //tmp file was removed after cleanup
+    }
+
+    @Test
+    public void testAsyncCleanUp() throws Exception
+    {
+        final CountDownLatch reading = new CountDownLatch(1);
+        final InputStream wrappedStream = new ByteArrayInputStream(createMultipartRequestString("myFile").getBytes());
+
+        // This stream won't allow the parser to exit because it will never return anything less than 0.
+        InputStream slowStream = new InputStream() {
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException
+            {
+                return Math.max(0, super.read(b, off, len));
+            }
+
+            @Override
+            public int read() throws IOException
+            {
+                reading.countDown();
+                return wrappedStream.read();
+            }
+        };
+
+        MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 1024, 50);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(slowStream, _contentType, config, _tmpDir);
+
+        // In another thread delete the parts when we detect that we have started parsing.
+        CompletableFuture<Throwable> cleanupError = new CompletableFuture<>();
+        new Thread(() ->
+        {
+            try
+            {
+                assertTrue(reading.await(5, TimeUnit.SECONDS));
+                mpis.deleteParts();
+                cleanupError.complete(null);
+            }
+            catch (Throwable t)
+            {
+                cleanupError.complete(t);
+            }
+        }).start();
+
+        // The call to getParts should throw an error.
+        Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
+        assertThat(error.getMessage(), is("Unexpected state ERROR"));
+
+        // There was no error with the cleanup.
+        assertNull(cleanupError.get());
+
+        // No tmp files are remaining.
+        String[] fileList = _tmpDir.list();
+        assertNotNull(fileList);
+        assertThat(fileList.length, is(0));
+    }
+
+    @Test
+    public void testParseAfterCleanUp() throws Exception
+    {
+        final InputStream input = new ByteArrayInputStream(createMultipartRequestString("myFile").getBytes());
+        MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 1024, 50);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(input, _contentType, config, _tmpDir);
+
+        mpis.deleteParts();
+
+        // The call to getParts should throw because we have already cleaned up the parts.
+        Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
+        assertThat(error.getMessage(), is("Could not start parsing COMPLETED"));
+
+        // No tmp files are remaining.
+        String[] fileList = _tmpDir.list();
+        assertNotNull(fileList);
+        assertThat(fileList.length, is(0));
     }
 
     @Test

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiParts.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiParts.java
@@ -46,6 +46,7 @@ public interface MultiParts extends Closeable
 
     Part getPart(String name) throws IOException;
 
+    @Deprecated
     boolean isEmpty();
 
     ContextHandler.Context getContext();

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -2310,7 +2310,7 @@ public class Request implements HttpServletRequest
         return getParts(null);
     }
 
-    private synchronized Collection<Part> getParts(MultiMap<String> params) throws IOException
+    private Collection<Part> getParts(MultiMap<String> params) throws IOException
     {
         if (_multiParts == null)
             _multiParts = (MultiParts)getAttribute(MULTIPARTS);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -2310,7 +2310,7 @@ public class Request implements HttpServletRequest
         return getParts(null);
     }
 
-    private Collection<Part> getParts(MultiMap<String> params) throws IOException
+    private synchronized Collection<Part> getParts(MultiMap<String> params) throws IOException
     {
         if (_multiParts == null)
             _multiParts = (MultiParts)getAttribute(MULTIPARTS);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -351,16 +351,23 @@ public class RequestTest
             @Override
             public void requestDestroyed(ServletRequestEvent sre)
             {
-                MultiParts m = (MultiParts)sre.getServletRequest().getAttribute(Request.MULTIPARTS);
-                assertNotNull(m);
-                ContextHandler.Context c = m.getContext();
-                assertNotNull(c);
-                assertTrue(c == sre.getServletContext());
-                assertTrue(!m.isEmpty());
-                assertTrue(testTmpDir.list().length == 2);
-                super.requestDestroyed(sre);
-                String[] files = testTmpDir.list();
-                assertTrue(files.length == 0);
+                try
+                {
+                    MultiParts m = (MultiParts)sre.getServletRequest().getAttribute(Request.MULTIPARTS);
+                    assertNotNull(m);
+                    ContextHandler.Context c = m.getContext();
+                    assertNotNull(c);
+                    assertTrue(c == sre.getServletContext());
+                    assertTrue(!m.getParts().isEmpty());
+                    assertTrue(testTmpDir.list().length == 2);
+                    super.requestDestroyed(sre);
+                    String[] files = testTmpDir.list();
+                    assertTrue(files.length == 0);
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
             }
         });
         _server.stop();
@@ -411,16 +418,23 @@ public class RequestTest
             @Override
             public void requestDestroyed(ServletRequestEvent sre)
             {
-                MultiParts m = (MultiParts)sre.getServletRequest().getAttribute(Request.MULTIPARTS);
-                assertNotNull(m);
-                ContextHandler.Context c = m.getContext();
-                assertNotNull(c);
-                assertTrue(c == sre.getServletContext());
-                assertTrue(!m.isEmpty());
-                assertTrue(testTmpDir.list().length == 2);
-                super.requestDestroyed(sre);
-                String[] files = testTmpDir.list();
-                assertTrue(files.length == 0);
+                try
+                {
+                    MultiParts m = (MultiParts)sre.getServletRequest().getAttribute(Request.MULTIPARTS);
+                    assertNotNull(m);
+                    ContextHandler.Context c = m.getContext();
+                    assertNotNull(c);
+                    assertTrue(c == sre.getServletContext());
+                    assertTrue(!m.getParts().isEmpty());
+                    assertTrue(testTmpDir.list().length == 2);
+                    super.requestDestroyed(sre);
+                    String[] files = testTmpDir.list();
+                    assertTrue(files.length == 0);
+                }
+                catch (IOException t)
+                {
+                    throw new RuntimeException(t);
+                }
             }
         });
         _server.stop();


### PR DESCRIPTION
Always assign _parts when constructed so it is never null.

Signed-off-by: Lachlan Roberts <lachlan@webtide.com>

Closes #4383 