### PR TITLE
Fixes #3512 - File descriptor is not released after zip file uploaded…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContent.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -218,15 +219,8 @@ public class HttpContent implements Callback, Closeable
     @Override
     public void close()
     {
-        try
-        {
-            if (iterator instanceof Closeable)
-                ((Closeable)iterator).close();
-        }
-        catch (Throwable x)
-        {
-            LOG.ignore(x);
-        }
+        if (iterator instanceof Closeable)
+            IO.close((Closeable)iterator);
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/MultiPartContentProvider.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/MultiPartContentProvider.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -345,10 +346,16 @@ public class MultiPartContentProvider extends AbstractTypedContentProvider imple
                         if (iterator.hasNext())
                             return iterator.next();
                         ++index;
-                        if (index == parts.size())
-                            state = State.LAST_BOUNDARY;
-                        else
+                        if (index < parts.size())
+                        {
                             state = State.MIDDLE_BOUNDARY;
+                            if (iterator instanceof Closeable)
+                                IO.close((Closeable)iterator);
+                        }
+                        else
+                        {
+                            state = State.LAST_BOUNDARY;
+                        }
                         break;
                     }
                     case MIDDLE_BOUNDARY:
@@ -380,14 +387,14 @@ public class MultiPartContentProvider extends AbstractTypedContentProvider imple
         @Override
         public void succeeded()
         {
-            if (iterator instanceof Callback)
+            if (state == State.CONTENT && iterator instanceof Callback)
                 ((Callback)iterator).succeeded();
         }
 
         @Override
         public void failed(Throwable x)
         {
-            if (iterator instanceof Callback)
+            if (state == State.CONTENT && iterator instanceof Callback)
                 ((Callback)iterator).failed(x);
         }
 


### PR DESCRIPTION
… via jetty-client.

#3512.

In case of multiple parts only the last iterator was closed.
Now, every part's iterator is closed.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>