### PR TITLE
Issue #4415 - Addressing Gzip Decoding of large files

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -38,7 +38,7 @@ import org.eclipse.jetty.util.component.Destroyable;
 public class GZIPContentDecoder implements Destroyable
 {
     // Unsigned Integer Max == 2^32
-    private static final long UINT_MAX = 0xffffffffL;
+    private static final long UINT_MAX = 0xFFFFFFFFL;
 
     private final List<ByteBuffer> _inflateds = new ArrayList<>();
     private final Inflater _inflater = new Inflater(true);

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/GZIPContentDecoderTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/GZIPContentDecoderTest.java
@@ -368,7 +368,8 @@ public class GZIPContentDecoderTest
     @ValueSource(longs = {INT_MAX, INT_MAX + 1, UINT_MAX, UINT_MAX + 1})
     public void testLargeGzipStream(long origSize) throws IOException
     {
-        final int BUFSIZE = (1 * 1024 * 1024); // 1MB
+        // Size chosen for trade off between speed of I/O vs speed of Gzip
+        final int BUFSIZE = 1024 * 1024;
 
         // Create a buffer to use over and over again to produce the uncompressed input
         byte[] cbuf = "0123456789ABCDEFGHIJKLMOPQRSTUVWXYZ".getBytes(StandardCharsets.UTF_8);
@@ -380,9 +381,7 @@ public class GZIPContentDecoderTest
             off += len;
         }
 
-        GZIPContentDecoder decoder = new GZIPContentDecoder(BUFSIZE);
-
-        GZIPDecoderOutputStream out = new GZIPDecoderOutputStream(decoder);
+        GZIPDecoderOutputStream out = new GZIPDecoderOutputStream(new GZIPContentDecoder(BUFSIZE));
         GZIPOutputStream outputStream = new GZIPOutputStream(out, BUFSIZE);
 
         for (long bytesLeft = origSize; bytesLeft > 0; )
@@ -432,7 +431,7 @@ public class GZIPContentDecoderTest
         @Override
         public void write(int b) throws IOException
         {
-            write(new byte[]{(byte)(b & 0xFF)}, 0, 1);
+            write(new byte[]{(byte)b}, 0, 1);
         }
     }
 }


### PR DESCRIPTION
+ Now applying proper RFC 1952 ISIZE check.
+ Bit shifting is done with Longs against Long value.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>

Closes #4415 