### PR TITLE
Issue #4401 - Fix WebSocket ClassLoader issues.

### DIFF
--- a/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketSession.java
+++ b/jetty-websocket/javax-websocket-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketSession.java
@@ -292,6 +292,11 @@ public class JavaxWebSocketSession implements javax.websocket.Session
         return frameHandler;
     }
 
+    public void abort()
+    {
+        coreSession.abort();
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/ContainerDefaultConfigurator.java
+++ b/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/ContainerDefaultConfigurator.java
@@ -29,7 +29,6 @@ import javax.websocket.server.ServerEndpointConfig.Configurator;
 
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.websocket.core.ExtensionConfig;
 
 /**
  * The "Container Default Configurator" per the JSR-356 spec.
@@ -73,7 +72,9 @@ public final class ContainerDefaultConfigurator extends Configurator
         }
         catch (Exception e)
         {
-            throw new InstantiationException(String.format("%s: %s", e.getClass().getName(), e.getMessage()));
+            InstantiationException instantiationException = new InstantiationException(String.format("%s: %s", e.getClass().getName(), e.getMessage()));
+            instantiationException.initCause(e);
+            throw instantiationException;
         }
     }
 

--- a/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/ContainerDefaultConfigurator.java
+++ b/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/ContainerDefaultConfigurator.java
@@ -72,7 +72,7 @@ public final class ContainerDefaultConfigurator extends Configurator
         }
         catch (Exception e)
         {
-            InstantiationException instantiationException = new InstantiationException(String.format("%s: %s", e.getClass().getName(), e.getMessage()));
+            InstantiationException instantiationException = new InstantiationException();
             instantiationException.initCause(e);
             throw instantiationException;
         }

--- a/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketConfiguration.java
+++ b/jetty-websocket/javax-websocket-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketConfiguration.java
@@ -39,6 +39,7 @@ public class JavaxWebSocketConfiguration extends AbstractConfiguration
         addDependents("org.eclipse.jetty.annotations.AnnotationConfiguration", WebAppConfiguration.class.getName());
         protectAndExpose("org.eclipse.jetty.websocket.servlet."); // For WebSocketUpgradeFilter
         protectAndExpose("org.eclipse.jetty.websocket.javax.server.config.");
+        protectAndExpose("org.eclipse.jetty.websocket.javax.client.JavaxWebSocketClientContainerProvider");
         hide("org.eclipse.jetty.websocket.javax.server.internal");
     }
 }

--- a/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/LocalServer.java
+++ b/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/LocalServer.java
@@ -82,6 +82,15 @@ public class LocalServer extends ContainerLifeCycle implements LocalFuzzer.Provi
     private boolean ssl = false;
     private SslContextFactory.Server sslContextFactory;
 
+    public LocalServer()
+    {
+        QueuedThreadPool threadPool = new QueuedThreadPool();
+        threadPool.setName("qtp-LocalServer");
+
+        // Configure Server
+        server = new Server(threadPool);
+    }
+
     public void enableSsl(boolean ssl)
     {
         this.ssl = ssl;
@@ -179,11 +188,6 @@ public class LocalServer extends ContainerLifeCycle implements LocalFuzzer.Provi
     @Override
     protected void doStart() throws Exception
     {
-        QueuedThreadPool threadPool = new QueuedThreadPool();
-        threadPool.setName("qtp-LocalServer");
-
-        // Configure Server
-        server = new Server(threadPool);
         if (ssl)
         {
             // HTTP Configuration

--- a/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/WSServer.java
+++ b/jetty-websocket/javax-websocket-tests/src/main/java/org/eclipse/jetty/websocket/javax/tests/WSServer.java
@@ -24,12 +24,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 
-import org.eclipse.jetty.annotations.AnnotationConfiguration;
-import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.JAR;
@@ -129,11 +126,7 @@ public class WSServer extends LocalServer implements LocalFuzzer.Provider
         context.setContextPath(this.contextPath);
         context.setBaseResource(new PathResource(this.contextDir));
         context.setAttribute("org.eclipse.jetty.websocket.javax", Boolean.TRUE);
-
-        context.addConfiguration(new AnnotationConfiguration());
-        context.addConfiguration(new PlusConfiguration());
         context.addConfiguration(new JavaxWebSocketConfiguration());
-
         return context;
     }
 
@@ -162,7 +155,6 @@ public class WSServer extends LocalServer implements LocalFuzzer.Provider
     @Override
     protected Handler createRootHandler(Server server) throws Exception
     {
-        HandlerCollection handlers = new HandlerCollection();
         contexts = new ContextHandlerCollection();
         return contexts;
     }

--- a/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/ContainerProviderServerTest.java
+++ b/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/ContainerProviderServerTest.java
@@ -31,8 +31,8 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.websocket.javax.tests.EventSocket;
 import org.eclipse.jetty.websocket.javax.tests.WSServer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static javax.websocket.CloseReason.CloseCodes.NORMAL_CLOSURE;
@@ -55,10 +55,10 @@ public class ContainerProviderServerTest
         }
     }
 
-    private static WSServer server;
+    private WSServer server;
 
-    @BeforeAll
-    public static void startServer() throws Exception
+    @BeforeEach
+    public void startServer() throws Exception
     {
         Path testdir = MavenTestingUtils.getTargetTestingPath(ContainerProviderServerTest.class.getName());
         server = new WSServer(testdir, "app");
@@ -69,14 +69,14 @@ public class ContainerProviderServerTest
         server.deployWebapp(webapp);
     }
 
-    @AfterAll
-    public static void stopServer() throws Exception
+    @AfterEach
+    public void stopServer() throws Exception
     {
         server.stop();
     }
 
     @Test
-    public void test() throws Exception
+    public void testJavaxWsContainerInServer() throws Exception
     {
         WebSocketContainer client = ContainerProvider.getWebSocketContainer();
         EventSocket clientSocket = new EventSocket();

--- a/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/ContainerProviderServerTest.java
+++ b/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/ContainerProviderServerTest.java
@@ -1,0 +1,89 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.tests.server;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import javax.websocket.server.ServerEndpoint;
+
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.websocket.javax.tests.EventSocket;
+import org.eclipse.jetty.websocket.javax.tests.WSServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static javax.websocket.CloseReason.CloseCodes.NORMAL_CLOSURE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContainerProviderServerTest
+{
+    @ServerEndpoint("/echo")
+    public static class MySocket
+    {
+        @OnOpen
+        public void onOpen()
+        {
+            WebSocketContainer client = ContainerProvider.getWebSocketContainer();
+            assertNotNull(client);
+        }
+    }
+
+    private static WSServer server;
+
+    @BeforeAll
+    public static void startServer() throws Exception
+    {
+        Path testdir = MavenTestingUtils.getTargetTestingPath(ContainerProviderServerTest.class.getName());
+        server = new WSServer(testdir, "app");
+        server.createWebInf();
+        server.copyEndpoint(MySocket.class);
+        server.start();
+        WebAppContext webapp = server.createWebAppContext();
+        server.deployWebapp(webapp);
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        WebSocketContainer client = ContainerProvider.getWebSocketContainer();
+        EventSocket clientSocket = new EventSocket();
+        Session session = client.connectToServer(clientSocket, server.getWsUri().resolve("/app/echo"));
+        session.close(new CloseReason(NORMAL_CLOSURE, null));
+        assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientSocket.closeReason.getCloseCode(), is(NORMAL_CLOSURE));
+        assertNull(clientSocket.error);
+    }
+}

--- a/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/WebAppClassLoaderTest.java
+++ b/jetty-websocket/javax-websocket-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/WebAppClassLoaderTest.java
@@ -1,0 +1,133 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2019 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.tests.server;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import javax.websocket.server.ServerEndpoint;
+
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.websocket.javax.tests.EventSocket;
+import org.eclipse.jetty.websocket.javax.tests.WSServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WebAppClassLoaderTest
+{
+    @ServerEndpoint("/echo")
+    public static class MySocket
+    {
+        private final static CompletableFuture<ClassLoader> constructorClassLoader = new CompletableFuture<>();
+        private final static CompletableFuture<ClassLoader> onOpenClassLoader = new CompletableFuture<>();
+        private final static CompletableFuture<ClassLoader> onMessageClassLoader = new CompletableFuture<>();
+        private final static CompletableFuture<ClassLoader> onErrorClassLoader = new CompletableFuture<>();
+        private final static CompletableFuture<ClassLoader> onCloseClassLoader = new CompletableFuture<>();
+
+        public MySocket()
+        {
+            constructorClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+
+        @OnOpen
+        public void onOpen(Session session)
+        {
+            onOpenClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+
+        @OnMessage
+        public void onMessage(Session session, String msg)
+        {
+            onMessageClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+
+        @OnError
+        public void onError(Throwable error)
+        {
+            onErrorClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+
+        @OnClose
+        public void onClose(CloseReason closeReason)
+        {
+            onCloseClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+    }
+
+    private static WSServer server;
+    private static WebAppContext webapp;
+
+    @BeforeAll
+    public static void startServer() throws Exception
+    {
+        Path testdir = MavenTestingUtils.getTargetTestingPath(WebAppClassLoaderTest.class.getName());
+        server = new WSServer(testdir, "app");
+        server.createWebInf();
+        server.copyEndpoint(MySocket.class);
+        server.start();
+        webapp = server.createWebAppContext();
+        server.deployWebapp(webapp);
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception
+    {
+        server.stop();
+    }
+
+    private ClassLoader getClassLoader(String event) throws Exception
+    {
+        ClassLoader webAppClassLoader = webapp.getClassLoader();
+        Class<?> aClass = webAppClassLoader.loadClass(MySocket.class.getName());
+        Field field = aClass.getDeclaredField(event + "ClassLoader");
+        field.setAccessible(true);
+        return ((CompletableFuture<ClassLoader>)field.get(null)).get(5, TimeUnit.SECONDS);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"constructor", "onOpen", "onMessage", "onError", "onClose"})
+    public void test(String event) throws Exception
+    {
+        WebSocketContainer client = ContainerProvider.getWebSocketContainer();
+        EventSocket clientSocket = new EventSocket();
+        Session session = client.connectToServer(clientSocket, server.getWsUri().resolve("/app/echo"));
+        session.getBasicRemote().sendText("trigger onMessage -> onError -> onClose");
+        session.close();
+        assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));
+
+        ClassLoader webAppClassLoader = webapp.getClassLoader();
+        assertThat(event, getClassLoader(event), is(webAppClassLoader));
+    }
+}

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
@@ -357,7 +357,7 @@ public class WebSocketCoreSession implements IncomingFrames, FrameHandler.CoreSe
             Throwable cause = closeStatus.getCause();
             try
             {
-                handler.onError(cause, errorCallback);
+                handle(() -> handler.onError(cause, errorCallback));
             }
             catch (Throwable e)
             {

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
@@ -77,7 +77,7 @@ public class WebSocketCoreSession implements IncomingFrames, FrameHandler.CoreSe
     private long maxTextMessageSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
     private Duration idleTimeout = WebSocketConstants.DEFAULT_IDLE_TIMEOUT;
     private Duration writeTimeout = WebSocketConstants.DEFAULT_WRITE_TIMEOUT;
-    private final ContextHandler context;
+    private final ContextHandler contextHandler;
 
     public WebSocketCoreSession(FrameHandler handler, Behavior behavior, Negotiated negotiated)
     {
@@ -85,14 +85,24 @@ public class WebSocketCoreSession implements IncomingFrames, FrameHandler.CoreSe
         this.behavior = behavior;
         this.negotiated = negotiated;
         this.demanding = handler.isDemanding();
-        this.context = (behavior == Behavior.SERVER) ? ContextHandler.getCurrentContext().getContextHandler() : null;
+
+        if (behavior == Behavior.SERVER)
+        {
+            ContextHandler.Context context = ContextHandler.getCurrentContext();
+            this.contextHandler = (context != null) ? context.getContextHandler() : null;
+        }
+        else
+        {
+            this.contextHandler = null;
+        }
+
         negotiated.getExtensions().initialize(new IncomingAdaptor(), new OutgoingAdaptor(), this);
     }
 
     private void handle(Runnable runnable)
     {
-        if (context != null)
-            context.handle(runnable);
+        if (contextHandler != null)
+            contextHandler.handle(runnable);
         else
             runnable.run();
     }

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketMapping.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketMapping.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.websocket.servlet;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -263,39 +264,30 @@ public class WebSocketMapping implements Dumpable, LifeCycle.Listener
             if (servletContext == null)
                 throw new IllegalStateException("null servletContext from request");
 
-            ClassLoader loader = servletContext.getClassLoader();
-            ClassLoader old = Thread.currentThread().getContextClassLoader();
+            ServletUpgradeRequest upgradeRequest = new ServletUpgradeRequest(negotiation);
+            ServletUpgradeResponse upgradeResponse = new ServletUpgradeResponse(negotiation);
 
-            try
+            AtomicReference<Object> result = new AtomicReference<>();
+            ((ContextHandler.Context)servletContext).getContextHandler().handle(() ->
+                result.set(creator.createWebSocket(upgradeRequest, upgradeResponse)));
+            Object websocketPojo = result.get();
+
+            // Handling for response forbidden (and similar paths)
+            if (upgradeResponse.isCommitted())
+                return null;
+
+            if (websocketPojo == null)
             {
-                Thread.currentThread().setContextClassLoader(loader);
-
-                ServletUpgradeRequest upgradeRequest = new ServletUpgradeRequest(negotiation);
-                ServletUpgradeResponse upgradeResponse = new ServletUpgradeResponse(negotiation);
-
-                Object websocketPojo = creator.createWebSocket(upgradeRequest, upgradeResponse);
-
-                // Handling for response forbidden (and similar paths)
-                if (upgradeResponse.isCommitted())
-                    return null;
-
-                if (websocketPojo == null)
-                {
-                    // no creation, sorry
-                    upgradeResponse.sendError(SC_SERVICE_UNAVAILABLE, "WebSocket Endpoint Creation Refused");
-                    return null;
-                }
-
-                FrameHandler frameHandler = factory.newFrameHandler(websocketPojo, upgradeRequest, upgradeResponse);
-                if (frameHandler != null)
-                    return frameHandler;
-
+                // no creation, sorry
+                upgradeResponse.sendError(SC_SERVICE_UNAVAILABLE, "WebSocket Endpoint Creation Refused");
                 return null;
             }
-            finally
-            {
-                Thread.currentThread().setContextClassLoader(old);
-            }
+
+            FrameHandler frameHandler = factory.newFrameHandler(websocketPojo, upgradeRequest, upgradeResponse);
+            if (frameHandler != null)
+                return frameHandler;
+
+            return null;
         }
 
         @Override


### PR DESCRIPTION
**Issue #4401**

- `WebSocketCoreSession` now updates the context classloader before invoking application code.
- `JavaxWebSocketConfiguration` now protectAndExposes `JavaxWebSocketClientContainerProvider`
so it can be discovered by the `ServiceLoader` in a webapp.

This fixes the last test which is still failing on cometd 6.0.x.