### PR TITLE
Use HTTPS instead of HTTP to download SNAPSHOT Deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2018,7 +2018,7 @@
         <repository>
           <id>jetty-snapshots</id>
           <name>jetty-snapshots</name>
-          <url>http://oss.sonatype.org/content/repositories/jetty-snapshots</url>
+          <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
           <snapshots>
             <enabled>true</enabled>
           </snapshots>


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)
[Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)

This vulnerability was found with the CodeQL Query contributed as part of my contribution to the GitHub Security Lab Bug Bounty Program. https://github.com/github/security-lab/issues/21