### PR TITLE
Fix #4461 HttpOutput Aggregation

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -1696,16 +1696,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 return Action.SCHEDULED;
             }
 
-            // all content written, but if we have not yet signaled completion,
-            // then we need to do so
-            if (_last && !_completed)
-            {
-                // TODO How can this ever happen?
-                _completed = true;
-                channelWrite(BufferUtil.EMPTY_BUFFER, true, this);
-                return Action.SCHEDULED;
-            }
-
             if (LOG.isDebugEnabled() && _completed)
                 LOG.debug("EOF of {}", this);
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -1628,7 +1628,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         private final ByteBuffer _buffer;
         private final ByteBuffer _slice;
         private final int _len;
-        volatile boolean _completed;
+        private boolean _completed;
 
         AsyncWrite(byte[] b, int off, int len, boolean last)
         {
@@ -1696,10 +1696,11 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 return Action.SCHEDULED;
             }
 
-            // all content written, but if we have not yet signal completion, we
-            // need to do so
+            // all content written, but if we have not yet signaled completion,
+            // then we need to do so
             if (_last && !_completed)
             {
+                // TODO How can this ever happen?
                 _completed = true;
                 channelWrite(BufferUtil.EMPTY_BUFFER, true, this);
                 return Action.SCHEDULED;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -381,7 +381,7 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
                         int len = slice.remaining();
                         _crc.update(array, off, len);
                         _deflater.setInput(array, off, len);  // TODO use ByteBuffer API in Jetty-10
-                        BufferUtil.clear(slice);
+                        slice.position(slice.position() + len);
                         if (_last && BufferUtil.isEmpty(_content))
                             _deflater.finish();
                     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -826,29 +826,6 @@ public class HttpOutputTest
             baseRequest.setHandled(true);
             HttpOutput out = (HttpOutput) response.getOutputStream();
 
-            // Add clearing interceptor to simulate behaviour of GzipHandler
-            HttpOutput.Interceptor interceptor = out.getInterceptor();
-            out.setInterceptor(new Interceptor()
-            {
-                @Override
-                public void write(ByteBuffer content, boolean last, Callback callback)
-                {
-                    interceptor.write(content, last, Callback.from(()->BufferUtil.clear(content), callback));
-                }
-
-                @Override
-                public Interceptor getNextInterceptor()
-                {
-                    return interceptor;
-                }
-
-                @Override
-                public boolean isOptimizedForDirectBuffers()
-                {
-                    return interceptor.isOptimizedForDirectBuffers();
-                }
-            });
-
             int bufferSize = baseRequest.getHttpChannel().getHttpConfiguration().getOutputBufferSize();
             int commitSize = baseRequest.getHttpChannel().getHttpConfiguration().getOutputAggregationSize();
             char fill = 'A';


### PR DESCRIPTION
This is an alternative to #4465 that fixes #4461 and the discovered issue of not aggregating due to an empty at capacity buffer.

+ Added tests to check that aggregation continues after first flush of an aggregated buffer (this triggers both #4461 and the discovered bug of not aggregating because of empty at capacity aggregate buffer).
+ Added getAggregateSize method that does a compact to avoid empty at capacity aggregate buffer
+ Call onWriteComplete if residue of an overflow aggregation can itself be aggregated.

Signed-off-by: Greg Wilkins <gregw@webtide.com>

Closes #4461