### PR TITLE
Fixes #3185 - Bundle-RequiredExecutionEnvironment: JavaSE-11 for Jett…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
             <instructions>
               <Bundle-SymbolicName>${bundle-symbolic-name}</Bundle-SymbolicName>
               <Bundle-Description>Jetty module for ${project.name}</Bundle-Description>
-              <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+              <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
               <Bundle-DocURL>${jetty.url}</Bundle-DocURL>
               <Bundle-Vendor>Eclipse Jetty Project</Bundle-Vendor>
               <Bundle-Classpath>.</Bundle-Classpath>


### PR DESCRIPTION
…y 10.0.x.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>

Closes #3185.