### PR TITLE
Issue #4496 Update paxexam for osgi tests

### DIFF
--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.13.100</version>
+      <version>3.15.100</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update to 3.15.100 from 3.13.100. Only used for osgi unit tests.

Closes #4496 