### PR TITLE
Issue #4383 - synchronize multiparts for cleanup from different thread

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -56,10 +56,10 @@ import org.eclipse.jetty.util.log.Logger;
  * <p>
  * Deleting the parts can be done from a different thread if the parts are parsed asynchronously.
  * Because of this we use the state to fail the parsing and coordinate which thread will delete any remaining parts.
- * The deletion of parts is done by the cleanup thread in all cases except the transition from ERROR->DELETED which
+ * The deletion of parts is done by the cleanup thread in all cases except the transition from ERROR-&gt;DELETED which
  * is done by the parsing thread.
  * </p>
- * <pre>
+ * <pre>{@code
  *                              deleteParts()
  *     +--------------------------------------------------------------+
  *     |                                                              |
@@ -69,7 +69,7 @@ import org.eclipse.jetty.util.log.Logger;
  *                      |                                             |
  *                      +----------------> ERROR ---------------------+
  *                        deleteParts()             parsing thread
- * </pre>
+ * }</pre>
  * @see <a href="https://tools.ietf.org/html/rfc7578">https://tools.ietf.org/html/rfc7578</a>
  */
 public class MultiPartFormInputStream

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -94,7 +94,7 @@ public class MultiPartFormInputStream
     private volatile boolean _deleteOnExit;
     private volatile boolean _writeFilesWithFilenames;
     private volatile int _bufferSize = 16 * 1024;
-    private volatile State state = State.UNPARSED;
+    private State state = State.UNPARSED;
 
     public class MultiPart implements Part
     {
@@ -356,7 +356,11 @@ public class MultiPartFormInputStream
      */
     public MultiPartFormInputStream(InputStream in, String contentType, MultipartConfigElement config, File contextTmpDir)
     {
+        // Must be a multipart request.
         _contentType = contentType;
+        if (_contentType == null || !_contentType.startsWith("multipart/form-data"))
+            throw new IllegalArgumentException("content type is not multipart/form-data");
+
         _contextTmpDir =  (contextTmpDir != null) ? contextTmpDir : new File(System.getProperty("java.io.tmpdir"));
         _config = (config != null) ? config : new MultipartConfigElement(_contextTmpDir.getAbsolutePath());
 
@@ -520,10 +524,6 @@ public class MultiPartFormInputStream
         MultiPartParser parser = null;
         try
         {
-            // if its not a multipart request, don't parse it
-            if (_contentType == null || !_contentType.startsWith("multipart/form-data"))
-                return;
-
             // sort out the location to which to write the files
             if (_config.getLocation() == null)
                 _tmpDir = _contextTmpDir;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -564,8 +564,8 @@ public class MultiPartFormInputStreamTest
         }).start();
 
         // The call to getParts should throw an error.
-        Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
-        assertThat(error.getMessage(), is("CLOSING"));
+        Throwable error = assertThrows(IOException.class, mpis::getParts);
+        assertThat(error.getMessage(), is("ERROR"));
 
         // There was no error with the cleanup.
         assertNull(cleanupError.get());
@@ -586,8 +586,8 @@ public class MultiPartFormInputStreamTest
         mpis.deleteParts();
 
         // The call to getParts should throw because we have already cleaned up the parts.
-        Throwable error = assertThrows(IllegalStateException.class, mpis::getParts);
-        assertThat(error.getMessage(), is("CLOSED"));
+        Throwable error = assertThrows(IOException.class, mpis::getParts);
+        assertThat(error.getMessage(), is("DELETED"));
 
         // Even though we called getParts() we never even created the tmp directory as we had already called deleteParts().
         assertFalse(_tmpDir.exists());

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -206,12 +206,10 @@ public class MultiPartFormInputStreamTest
         throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 50);
-        MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
-            "Content-type: text/plain",
-            config,
-            _tmpDir);
-        mpis.setDeleteOnExit(true);
-        assertTrue(mpis.getParts().isEmpty());
+        Throwable t = assertThrows(IllegalArgumentException.class, () ->
+            new MultiPartFormInputStream(new ByteArrayInputStream(_multi.getBytes()),
+                "Content-type: text/plain", config, _tmpDir));
+        assertThat(t.getMessage(), is("content type is not multipart/form-data"));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -563,7 +563,7 @@ public class MultiPartFormInputStreamTest
 
         // The call to getParts should throw an error.
         Throwable error = assertThrows(IOException.class, mpis::getParts);
-        assertThat(error.getMessage(), is("ERROR"));
+        assertThat(error.getMessage(), is("DELETING"));
 
         // There was no error with the cleanup.
         assertNull(cleanupError.get());


### PR DESCRIPTION
Signed-off-by: Lachlan Roberts <lachlan@webtide.com>

**Issue #4383**

Changes from #4388 for jetty-10.0.x after we decided to merge only the minimal NPE fix to jetty-9.4.x and bring the rest of the changes to 10.

This fixes issues caused when the parsing is done in a different thread to the part cleanup.