### PR TITLE
Issue #4505 Ensure get/setInitParam with null arg throws NPE

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
@@ -1288,6 +1288,15 @@ public class ServletContextHandler extends ContextHandler
         }
 
         @Override
+        public String getInitParameter(String name)
+        {
+            //since servlet spec 4.0
+            if (name == null)
+                throw new NullPointerException();
+            return super.getInitParameter(name);
+        }
+
+        @Override
         public boolean setInitParameter(String name, String value)
         {
             if (!isStarting())
@@ -1295,6 +1304,10 @@ public class ServletContextHandler extends ContextHandler
 
             if (!_enabled)
                 throw new UnsupportedOperationException();
+
+            //since servlet spec 4.0
+            if (name == null)
+                throw new NullPointerException();
 
             return super.setInitParameter(name, value);
         }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -1291,8 +1292,7 @@ public class ServletContextHandler extends ContextHandler
         public String getInitParameter(String name)
         {
             //since servlet spec 4.0
-            if (name == null)
-                throw new NullPointerException();
+            Objects.requireNonNull(name);
             return super.getInitParameter(name);
         }
 
@@ -1306,8 +1306,7 @@ public class ServletContextHandler extends ContextHandler
                 throw new UnsupportedOperationException();
 
             //since servlet spec 4.0
-            if (name == null)
-                throw new NullPointerException();
+            Objects.requireNonNull(name);
 
             return super.setInitParameter(name, value);
         }

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -87,6 +87,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -97,6 +98,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -468,6 +470,46 @@ public class ServletContextHandlerTest
     {
         _server.stop();
         _server.join();
+    }
+    
+    @Test
+    public void testInitParams() throws Exception
+    {
+        //Test get/setInitParam with null throws NPE
+        ServletContextHandler root = new ServletContextHandler(_server, "/", ServletContextHandler.SESSIONS);
+        _server.setHandler(root);
+        ListenerHolder initialListener = new ListenerHolder();
+        initialListener.setListener(new ServletContextListener()
+        {
+            public void contextInitialized(ServletContextEvent sce)
+            {
+                sce.getServletContext().setInitParameter("foo", "bar");
+                assertEquals("bar", root.getServletContext().getInitParameter("foo"));
+                assertThrows(NullPointerException.class, 
+                    new Executable()
+                    {
+                        @Override
+                        public void execute() throws Throwable
+                        {
+                            sce.getServletContext().setInitParameter(null, "bad");
+                        }
+                    }
+                );
+                assertThrows(NullPointerException.class,
+                    new Executable()
+                    {
+                        @Override
+                        public void execute() throws Throwable
+                        {
+                            sce.getServletContext().getInitParameter(null);
+                        }
+                    }
+                );
+            }
+        });
+        
+        root.getServletHandler().addListener(initialListener);
+        _server.start();
     }
     
     @Test

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -484,26 +484,12 @@ public class ServletContextHandlerTest
             public void contextInitialized(ServletContextEvent sce)
             {
                 sce.getServletContext().setInitParameter("foo", "bar");
-                assertEquals("bar", root.getServletContext().getInitParameter("foo"));
+                assertEquals("bar", sce.getServletContext().getInitParameter("foo"));
                 assertThrows(NullPointerException.class, 
-                    new Executable()
-                    {
-                        @Override
-                        public void execute() throws Throwable
-                        {
-                            sce.getServletContext().setInitParameter(null, "bad");
-                        }
-                    }
+                    () ->  sce.getServletContext().setInitParameter(null, "bad")
                 );
                 assertThrows(NullPointerException.class,
-                    new Executable()
-                    {
-                        @Override
-                        public void execute() throws Throwable
-                        {
-                            sce.getServletContext().getInitParameter(null);
-                        }
-                    }
+                    () -> sce.getServletContext().getInitParameter(null)
                 );
             }
         });


### PR DESCRIPTION
Implement throw of NPE if key arg to get/setInitParam is null, as per servlet spec.

Closes #4505 