### PR TITLE
Issue #4504 Forwarded Host and Server

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -397,10 +397,20 @@ public class ForwardedRequestCustomizer implements Customizer
                 request.setSecure(true);
         }
 
-        if (forwarded._host != null)
+        if (forwarded._server != null && forwarded._host instanceof PortSetHostPort)
+        {
+            httpFields.put(new HostPortHttpField(forwarded._server, forwarded._host.getPort()));
+            request.setAuthority(forwarded._server, forwarded._host.getPort());
+        }
+        else if (forwarded._host != null)
         {
             httpFields.put(new HostPortHttpField(forwarded._host));
             request.setAuthority(forwarded._host.getHost(), forwarded._host.getPort());
+        }
+        else if (forwarded._server != null)
+        {
+            httpFields.put(new HostPortHttpField(forwarded._server));
+            request.setAuthority(forwarded._server, 0);
         }
 
         if (forwarded._for != null)
@@ -546,6 +556,7 @@ public class ForwardedRequestCustomizer implements Customizer
         String _proto;
         HostPort _for;
         HostPort _host;
+        String _server;
 
         public Forwarded(Request request, HttpConfiguration config)
         {
@@ -598,7 +609,7 @@ public class ForwardedRequestCustomizer implements Customizer
         {
             if (getProxyAsAuthority())
                 return;
-            handleHost(field);
+            _server = getLeftMost(field.getValue());
         }
 
         @SuppressWarnings("unused")

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -412,6 +412,34 @@ public class ForwardedRequestCustomizerTest
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
+            Arguments.of(new Request("X-Forwarded-* (Server before Host)")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: myhost",
+                        "X-Forwarded-Proto: https",
+                        "X-Forwarded-Server: fw.example.com",
+                        "X-Forwarded-Host: www.example.com",
+                        "X-Forwarded-Port: 4333",
+                        "X-Forwarded-For: 8.5.4.3:2222"
+                    ),
+                new Expectations()
+                    .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .requestURL("https://www.example.com:4333/")
+                    .remoteAddr("8.5.4.3").remotePort(2222)
+            ),
+            Arguments.of(new Request("X-Forwarded-* (Server and Port)")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: myhost",
+                        "X-Forwarded-Server: fw.example.com",
+                        "X-Forwarded-Port: 4333",
+                        "X-Forwarded-For: 8.5.4.3:2222"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("fw.example.com").serverPort(4333)
+                    .requestURL("http://fw.example.com:4333/")
+                    .remoteAddr("8.5.4.3").remotePort(2222)
+            ),
 
             // =================================================================
             // Mixed Behavior


### PR DESCRIPTION
Fixes #4504 
`X-Forwarded-Host` now has precedence over `X-Forwarded-Server` and the outcome is no longer header order dependent.
Also handle the ultra weird edge case of a `X-Forwarded-Server` and `X-Forwarded-Port`