### PR TITLE
Issue #4520 Reinstate throw of UnreadableSessionDataException

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -747,7 +747,8 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
                 }
                 catch (Exception e)
                 {
-                    LOG.warn("Passivation of idle session {} failed", session.getId(), e);
+                    LOG.warn("Passivation of idle session {} failed", session.getId());
+                    LOG.warn(e);
                 }
             }
         }
@@ -844,7 +845,8 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         }
         catch (Exception e)
         {
-            LOG.warn("Save of new session {} failed", id, e);
+            LOG.warn("Save of new session {} failed", id);
+            LOG.warn(e);
         }
         return session;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -341,7 +341,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
     protected Session getAndEnter(String id, boolean enter) throws Exception
     {
         Session session = null;
-        final AtomicReference<Exception> exception = new AtomicReference<Exception>();
+        AtomicReference<Exception> exception = new AtomicReference<Exception>();
 
         session = doComputeIfAbsent(id, k ->
         {
@@ -367,7 +367,6 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             }
             catch (Exception e)
             {
-                LOG.warn("Error loading session {}", id, e);
                 exception.set(e);
                 return null;
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.server.session;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 
@@ -334,12 +335,13 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
      * 
      * @param id The session to retrieve
      * @param enter if true, the usage count of the session will be incremented
-     * @return
-     * @throws Exception
+     * @return the session if it exists, null otherwise
+     * @throws Exception if the session cannot be loaded
      */
     protected Session getAndEnter(String id, boolean enter) throws Exception
     {
         Session session = null;
+        final AtomicReference<Exception> exception = new AtomicReference<Exception>();
 
         session = doComputeIfAbsent(id, k ->
         {
@@ -366,10 +368,15 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
             catch (Exception e)
             {
                 LOG.warn("Error loading session {}", id, e);
+                exception.set(e);
                 return null;
             }
         });
 
+        Exception ex = exception.get();
+        if (ex != null)
+            throw ex;
+            
         if (session != null)
         {
             try (Lock lock = session.lock())

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionIdManager.java
@@ -303,12 +303,13 @@ public class DefaultSessionIdManager extends ContainerLifeCycle implements Sessi
             }
 
             if (LOG.isDebugEnabled())
-                LOG.debug("Checked {}, in use:", id, inUse);
+                LOG.debug("Checked {}, in use: {}", id, inUse);
             return inUse;
         }
         catch (Exception e)
         {
-            LOG.warn("Problem checking if id {} is in use", id, e);
+            LOG.warn("Problem checking if id {} is in use", id);
+            LOG.warn(e);
             return false;
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/FileSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/FileSessionDataStore.java
@@ -258,7 +258,8 @@ public class FileSessionDataStore extends AbstractSessionDataStore
         }
         catch (NumberFormatException e)
         {
-            LOG.warn("Not valid session filename {}", p.getFileName(), e);
+            LOG.warn("Not valid session filename {}", p.getFileName());
+            LOG.warn(e);
         }
     }
 
@@ -299,7 +300,8 @@ public class FileSessionDataStore extends AbstractSessionDataStore
                 }
                 catch (Exception x)
                 {
-                    LOG.warn("Unable to delete unrestorable file {} for session {}", filename, id, x);
+                    LOG.warn("Unable to delete unrestorable file {} for session {}", filename, id);
+                    LOG.warn(x);
                 }
             }
             throw e;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
@@ -865,7 +865,8 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
                         }
                         catch (Exception e)
                         {
-                            LOG.warn("{} Problem checking if potentially expired session {} exists in db", _context.getWorkerName(), k, e);
+                            LOG.warn("{} Problem checking if potentially expired session {} exists in db", _context.getWorkerName(), k);
+                            LOG.warn(e);
                         }
                     }
                 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
@@ -88,7 +88,7 @@ public class NullSessionCache extends AbstractSessionCache
     @Override
     public void setEvictionPolicy(int evictionTimeout)
     {
-        LOG.warn("Ignoring eviction setting:" + evictionTimeout);
+        LOG.warn("Ignoring eviction setting: {}", evictionTimeout);
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -928,7 +928,7 @@ public class SessionHandler extends ScopedHandler
         }
         catch (UnreadableSessionDataException e)
         {
-            LOG.warn(e);
+            LOG.warn("Error loading session {}", id, e);
             try
             {
                 //tell id mgr to remove session from all other contexts

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -916,7 +916,8 @@ public class SessionHandler extends ScopedHandler
                     }
                     catch (Exception e)
                     {
-                        LOG.warn("Invalidating session {} found to be expired when requested", id, e);
+                        LOG.warn("Invalidating session {} found to be expired when requested", id);
+                        LOG.warn(e);
                     }
 
                     return null;
@@ -928,7 +929,8 @@ public class SessionHandler extends ScopedHandler
         }
         catch (UnreadableSessionDataException e)
         {
-            LOG.warn("Error loading session {}", id, e);
+            LOG.warn("Error loading session {}", id);
+            LOG.warn(e);
             try
             {
                 //tell id mgr to remove session from all other contexts
@@ -936,7 +938,8 @@ public class SessionHandler extends ScopedHandler
             }
             catch (Exception x)
             {
-                LOG.warn("Error cross-context invalidating unreadable session {}", id, x);
+                LOG.warn("Error cross-context invalidating unreadable session {}", id);
+                LOG.warn(x);
             }
             return null;
         }
@@ -1211,7 +1214,7 @@ public class SessionHandler extends ScopedHandler
                         }
                         catch (Exception e)
                         {
-                            LOG.warn("Session listener threw exception", e);
+                            LOG.warn(e);
                         }
                         //call the attribute removed listeners and finally mark it as invalid
                         session.finishInvalidate();

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SessionEvictionFailureTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/SessionEvictionFailureTest.java
@@ -32,6 +32,8 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.StacklessLogging;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -177,7 +179,7 @@ public class SessionEvictionFailureTest
             int port1 = server.getPort();
             HttpClient client = new HttpClient();
             client.start();
-            try
+            try (StacklessLogging stackless = new StacklessLogging(Log.getLogger("org.eclipse.jetty.server.session")))
             {
                 String url = "http://localhost:" + port1 + contextPath + servletMapping;
 


### PR DESCRIPTION
The fix for issue #3913 accidentally removed the throw of an UnreadableSessionDataException from AbstractSessionCache.get() method (the implementation of get() was changed to eventually use a lambda expression and the throw was therefore omitted).  The missing throw meant that a session that could not be read from the session data store was treated as not existing rather than existing and being unusable.  If the session is unusable the previous behaviour was to invalidate it and delete it in the store across all contexts. 

This omission came to light in issue #4520, where a flaky database connection was throwing an exception when trying to read existing session data when a request accessed the session. As null was returned rather than an exception, it seemed as if the session merely didn't exist. When application code later in the request handling asked to create a session, normal practise is to be able to use that same id, if that id is already in use (this is part of cross-context dispatch). As the faulty session had not been detected and deleted, it looked like the same id could be re-used causing a primary key clash.

Closes #4520 