### PR TITLE
Issue #4541 Large response header

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.HttpRequestException;
 import org.eclipse.jetty.client.HttpSender;
 import org.eclipse.jetty.client.api.ContentProvider;
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpGenerator;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MetaData;
@@ -35,6 +36,8 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
+
+import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 
 public class HttpSenderOverHTTP extends HttpSender
 {
@@ -224,6 +227,10 @@ public class HttpSenderOverHTTP extends HttpSender
                     {
                         headerBuffer = httpClient.getByteBufferPool().acquire(httpClient.getRequestBufferSize(), false);
                         break;
+                    }
+                    case HEADER_OVERFLOW:
+                    {
+                        throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Request header too large");
                     }
                     case NEED_CHUNK:
                     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpSenderOverHTTP.java
@@ -230,6 +230,8 @@ public class HttpSenderOverHTTP extends HttpSender
                     }
                     case HEADER_OVERFLOW:
                     {
+                        httpClient.getByteBufferPool().release(headerBuffer);
+                        headerBuffer = null;
                         throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Request header too large");
                     }
                     case NEED_CHUNK:

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -445,7 +445,8 @@ public class HttpGenerator
                 }
                 catch (BufferOverflowException e)
                 {
-                    throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large", e);
+                    LOG.ignore(e);
+                    return Result.NEED_HEADER;
                 }
                 catch (Exception e)
                 {

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -74,6 +74,7 @@ public class HttpGenerator
         NEED_CHUNK,             // Need a small chunk buffer of CHUNK_SIZE
         NEED_INFO,              // Need the request/response metadata info 
         NEED_HEADER,            // Need a buffer to build HTTP headers into
+        HEADER_OVERFLOW,        // The header buffer overflowed
         NEED_CHUNK_TRAILER,     // Need a large chunk buffer for last chunk and trailers
         FLUSH,                  // The buffers previously generated should be flushed 
         CONTINUE,               // Continue generating the message
@@ -262,7 +263,8 @@ public class HttpGenerator
                 }
                 catch (BufferOverflowException e)
                 {
-                    throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Request header too large", e);
+                    LOG.ignore(e);
+                    return Result.HEADER_OVERFLOW;
                 }
                 catch (Exception e)
                 {
@@ -446,7 +448,7 @@ public class HttpGenerator
                 catch (BufferOverflowException e)
                 {
                     LOG.ignore(e);
-                    return Result.NEED_HEADER;
+                    return Result.HEADER_OVERFLOW;
                 }
                 catch (Exception e)
                 {

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpGeneratorClientTest
@@ -120,6 +121,42 @@ public class HttpGeneratorClientTest
         assertThat(out, Matchers.not(Matchers.containsString("Content-Length")));
         assertThat(out, Matchers.containsString("Empty:"));
         assertThat(out, Matchers.not(Matchers.containsString("Null:")));
+    }
+
+    @Test
+    public void testHeaderOverflow() throws Exception
+    {
+        HttpGenerator gen = new HttpGenerator();
+
+        Info info = new Info("GET", "/index.html");
+        info.getFields().add("Host", "localhost");
+        info.getFields().add("Field", "SomeWhatLongValue");
+        info.setHttpVersion(HttpVersion.HTTP_1_0);
+
+        HttpGenerator.Result result = gen.generateRequest(info, null, null, null, true);
+        assertEquals(HttpGenerator.Result.NEED_HEADER, result);
+
+        ByteBuffer header = BufferUtil.allocate(16);
+        result = gen.generateRequest(info, header, null, null, true);
+        assertEquals(HttpGenerator.Result.HEADER_OVERFLOW, result);
+
+        header = BufferUtil.allocate(2048);
+        result = gen.generateRequest(info, header, null, null, true);
+        assertEquals(HttpGenerator.Result.FLUSH, result);
+        assertEquals(HttpGenerator.State.COMPLETING, gen.getState());
+        assertFalse(gen.isChunking());
+        String out = BufferUtil.toString(header);
+        BufferUtil.clear(header);
+
+        result = gen.generateResponse(null, false, null, null, null, false);
+        assertEquals(HttpGenerator.Result.SHUTDOWN_OUT, result);
+        assertEquals(HttpGenerator.State.END, gen.getState());
+        assertFalse(gen.isChunking());
+
+        assertEquals(0, gen.getContentPrepared());
+        assertThat(out, Matchers.containsString("GET /index.html HTTP/1.0"));
+        assertThat(out, Matchers.not(Matchers.containsString("Content-Length")));
+        assertThat(out, Matchers.containsString("Field: SomeWhatLongValue"));
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
@@ -155,6 +155,12 @@ public class HttpGeneratorServerHTTPTest
                         header = BufferUtil.allocate(2048);
                         continue;
 
+                    case HEADER_OVERFLOW:
+                        if (header.capacity() >= 8192)
+                            throw new BadMessageException(500, "Header too large");
+                        header = BufferUtil.allocate(8192);
+                        continue;
+
                     case NEED_CHUNK:
                         chunk = BufferUtil.allocate(HttpGenerator.CHUNK_SIZE);
                         continue;

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpTester.java
@@ -451,6 +451,12 @@ public class HttpTester
                             header = BufferUtil.allocate(8192);
                             continue;
 
+                        case HEADER_OVERFLOW:
+                            if (header.capacity() >= 32 * 1024)
+                                throw new BadMessageException(500, "Header too large");
+                            header = BufferUtil.allocate(32 * 1024);
+                            continue;
+
                         case NEED_CHUNK:
                             chunk = BufferUtil.allocate(HttpGenerator.CHUNK_SIZE);
                             continue;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -763,9 +763,10 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
 
                     case HEADER_OVERFLOW:
                     {
-                        if (_header.capacity() >= _config.getResponseHeaderSize())
-                            throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
+                        int capacity = _header.capacity();
                         _bufferPool.release(_header);
+                        if (capacity >= _config.getResponseHeaderSize())
+                            throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
                         _header = _bufferPool.acquire(_config.getResponseHeaderSize(), HEADER_BUFFER_DIRECT);
                         continue;
                     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -757,19 +757,16 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
 
                     case NEED_HEADER:
                     {
-                        int size;
-                        if (_header == null)
-                        {
-                            size = Math.min(_config.getResponseHeaderSize(), _config.getOutputBufferSize());
-                        }
-                        else
-                        {
-                            if (_header.capacity() >= _config.getResponseHeaderSize())
-                                throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
-                            size = _config.getResponseHeaderSize();
-                            _bufferPool.release(_header);
-                        }
-                        _header = _bufferPool.acquire(size, HEADER_BUFFER_DIRECT);
+                        _header = _bufferPool.acquire(Math.min(_config.getResponseHeaderSize(), _config.getOutputBufferSize()), HEADER_BUFFER_DIRECT);
+                        continue;
+                    }
+
+                    case HEADER_OVERFLOW:
+                    {
+                        if (_header.capacity() >= _config.getResponseHeaderSize())
+                            throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
+                        _bufferPool.release(_header);
+                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), HEADER_BUFFER_DIRECT);
                         continue;
                     }
                     case NEED_CHUNK:

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -25,6 +25,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpGenerator;
@@ -46,6 +47,8 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+
+import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 
 /**
  * <p>A {@link Connection} that handles the HTTP protocol.</p>
@@ -754,8 +757,19 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
 
                     case NEED_HEADER:
                     {
-                        _header = _bufferPool.acquire(_config.getResponseHeaderSize(), HEADER_BUFFER_DIRECT);
-
+                        int size;
+                        if (_header == null)
+                        {
+                            size = Math.min(_config.getResponseHeaderSize(), _config.getOutputBufferSize());
+                        }
+                        else
+                        {
+                            if (_header.capacity() >= _config.getResponseHeaderSize())
+                                throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
+                            size = _config.getResponseHeaderSize();
+                            _bufferPool.release(_header);
+                        }
+                        _header = _bufferPool.acquire(size, HEADER_BUFFER_DIRECT);
                         continue;
                     }
                     case NEED_CHUNK:


### PR DESCRIPTION
Fix #4541 by initially allocated a header buffer of `min(_config.getResponseHeaderSize(), _config.getOutputBufferSize())`
Only allocate a buffer of `getResponseHeaderSize` if an overflow results.

This should have no effect on the majority of responses where `getOutputBufferSize` is greater than `getResponseHeaderSize` other than the cost of a min operation.

Signed-off-by: Greg Wilkins <gregw@webtide.com>

Closes #4541 