### PR TITLE
Implement forward/include/async params for HttpServletMapping

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
@@ -60,6 +60,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
                 baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, baseRequest.getAttribute(RequestDispatcher.FORWARD_SERVLET_PATH));
                 baseRequest.setAttribute(AsyncContext.ASYNC_PATH_INFO, baseRequest.getAttribute(RequestDispatcher.FORWARD_PATH_INFO));
                 baseRequest.setAttribute(AsyncContext.ASYNC_QUERY_STRING, baseRequest.getAttribute(RequestDispatcher.FORWARD_QUERY_STRING));
+                baseRequest.setAttribute(AsyncContext.ASYNC_MAPPING, baseRequest.getAttribute(RequestDispatcher.FORWARD_MAPPING));
             }
             else
             {
@@ -68,6 +69,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
                 baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, baseRequest.getServletPath());
                 baseRequest.setAttribute(AsyncContext.ASYNC_PATH_INFO, baseRequest.getPathInfo());
                 baseRequest.setAttribute(AsyncContext.ASYNC_QUERY_STRING, baseRequest.getQueryString());
+                baseRequest.setAttribute(AsyncContext.ASYNC_MAPPING, baseRequest.getHttpServletMapping());
             }
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -27,6 +27,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -108,7 +109,7 @@ public class Dispatcher implements RequestDispatcher
                 attr._servletPath = null; // set by ServletHandler
                 attr._pathInfo = _pathInContext;
                 attr._query = _uri.getQuery();
-
+                attr._mapping = null; //set by ServletHandler
                 if (attr._query != null)
                     baseRequest.mergeQueryParameters(baseRequest.getQueryString(), attr._query, false);
                 baseRequest.setAttributes(attr);
@@ -147,6 +148,7 @@ public class Dispatcher implements RequestDispatcher
         final String old_context_path = baseRequest.getContextPath();
         final String old_servlet_path = baseRequest.getServletPath();
         final String old_path_info = baseRequest.getPathInfo();
+        final HttpServletMapping old_mapping = baseRequest.getHttpServletMapping();
 
         final MultiMap<String> old_query_params = baseRequest.getQueryParameters();
         final Attributes old_attr = baseRequest.getAttributes();
@@ -175,6 +177,7 @@ public class Dispatcher implements RequestDispatcher
                     attr._requestURI = (String)old_attr.getAttribute(FORWARD_REQUEST_URI);
                     attr._contextPath = (String)old_attr.getAttribute(FORWARD_CONTEXT_PATH);
                     attr._servletPath = (String)old_attr.getAttribute(FORWARD_SERVLET_PATH);
+                    attr._mapping = (HttpServletMapping)old_attr.getAttribute(FORWARD_MAPPING);
                 }
                 else
                 {
@@ -183,6 +186,7 @@ public class Dispatcher implements RequestDispatcher
                     attr._requestURI = old_uri.getPath();
                     attr._contextPath = old_context_path;
                     attr._servletPath = old_servlet_path;
+                    attr._mapping = old_mapping;
                 }
 
                 HttpURI uri = new HttpURI(old_uri.getScheme(), old_uri.getHost(), old_uri.getPort(),
@@ -261,6 +265,7 @@ public class Dispatcher implements RequestDispatcher
         String _servletPath;
         String _pathInfo;
         String _query;
+        HttpServletMapping _mapping;
 
         ForwardAttributes(Attributes attributes)
         {
@@ -282,6 +287,8 @@ public class Dispatcher implements RequestDispatcher
                     return _contextPath;
                 if (key.equals(FORWARD_QUERY_STRING))
                     return _query;
+                if (key.equals(FORWARD_MAPPING))
+                    return _mapping;
             }
 
             if (key.startsWith(__INCLUDE_PREFIX))
@@ -312,6 +319,7 @@ public class Dispatcher implements RequestDispatcher
                 set.add(FORWARD_REQUEST_URI);
                 set.add(FORWARD_SERVLET_PATH);
                 set.add(FORWARD_CONTEXT_PATH);
+                set.add(FORWARD_MAPPING);
                 if (_query != null)
                     set.add(FORWARD_QUERY_STRING);
                 else
@@ -336,7 +344,8 @@ public class Dispatcher implements RequestDispatcher
                     _contextPath = (String)value;
                 else if (key.equals(FORWARD_QUERY_STRING))
                     _query = (String)value;
-
+                else if (key.equals(FORWARD_MAPPING))
+                    _mapping = (HttpServletMapping)value;
                 else if (value == null)
                     _attr.removeAttribute(key);
                 else
@@ -376,6 +385,7 @@ public class Dispatcher implements RequestDispatcher
         String _servletPath;
         String _pathInfo;
         String _query;
+        HttpServletMapping _mapping;
 
         IncludeAttributes(Attributes attributes)
         {
@@ -397,6 +407,8 @@ public class Dispatcher implements RequestDispatcher
                     return _query;
                 if (key.equals(INCLUDE_REQUEST_URI))
                     return _requestURI;
+                if (key.equals(INCLUDE_MAPPING))
+                    return _mapping;
             }
             else if (key.startsWith(__INCLUDE_PREFIX))
                 return null;
@@ -425,6 +437,7 @@ public class Dispatcher implements RequestDispatcher
                 set.add(INCLUDE_REQUEST_URI);
                 set.add(INCLUDE_SERVLET_PATH);
                 set.add(INCLUDE_CONTEXT_PATH);
+                set.add(INCLUDE_MAPPING);
                 if (_query != null)
                     set.add(INCLUDE_QUERY_STRING);
                 else
@@ -449,6 +462,8 @@ public class Dispatcher implements RequestDispatcher
                     _contextPath = (String)value;
                 else if (key.equals(INCLUDE_QUERY_STRING))
                     _query = (String)value;
+                else if (key.equals(INCLUDE_MAPPING))
+                    _mapping = (HttpServletMapping)value;
                 else if (value == null)
                     _attr.removeAttribute(key);
                 else

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -142,33 +142,6 @@ public class Request implements HttpServletRequest
 {
     public static final String __MULTIPART_CONFIG_ELEMENT = "org.eclipse.jetty.multipartConfig";
 
-    public static final HttpServletMapping __NULL_MAPPING = new HttpServletMapping()
-    {
-        @Override
-        public String getMatchValue()
-        {
-            return "";
-        }
-
-        @Override
-        public String getPattern()
-        {
-            return "";
-        }
-
-        @Override
-        public String getServletName()
-        {
-            return "";
-        }
-
-        @Override
-        public MappingMatch getMappingMatch()
-        {
-            return null;
-        }
-    };
-
     private static final Logger LOG = Log.getLogger(Request.class);
     private static final Collection<Locale> __defaultLocale = Collections.singleton(Locale.getDefault());
     private static final int INPUT_NONE = 0;
@@ -219,9 +192,6 @@ public class Request implements HttpServletRequest
     
     public static HttpServletMapping getServletMapping(PathSpec pathSpec, String servletPath, String servletName)
     {
-        if (pathSpec == null || servletPath == null)
-            return __NULL_MAPPING;
-
         final MappingMatch match;
         final String mapping;
         if (pathSpec instanceof ServletPathSpec)
@@ -266,21 +236,21 @@ public class Request implements HttpServletRequest
             @Override
             public String getMatchValue()
             {
-                return mapping;
+                return (mapping == null ? "" : mapping);
             }
 
             @Override
             public String getPattern()
             {
                 if (pathSpec != null)
-                    pathSpec.toString();
-                return null;
+                    return pathSpec.getDeclaration();
+                return "";
             }
 
             @Override
             public String getServletName()
             {
-                return servletName;
+                return (servletName == null ? "" : servletName);
             }
 
             @Override
@@ -288,6 +258,14 @@ public class Request implements HttpServletRequest
             {
                 return match;
             }
+
+            @Override
+            public String toString()
+            {
+                return "HttpServletMapping{matchValue=" + getMatchValue() + 
+                    ", pattern=" + getPattern() + ", servletName=" + getServletName() + 
+                    ", mappingMatch=" + getMappingMatch() + "}";
+            }    
         };
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AsyncDelayHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AsyncDelayHandler.java
@@ -52,6 +52,7 @@ public class AsyncDelayHandler extends HandlerWrapper
         Object asyncQueryString = null;
         Object asyncRequestUri = null;
         Object asyncServletPath = null;
+        Object asyncHttpServletMapping = null;
 
         // Is this request a restarted one?
         boolean restart = false;
@@ -72,6 +73,8 @@ public class AsyncDelayHandler extends HandlerWrapper
             baseRequest.setAttribute(AsyncContext.ASYNC_REQUEST_URI, null);
             asyncServletPath = baseRequest.getAttribute(AsyncContext.ASYNC_SERVLET_PATH);
             baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, null);
+            asyncHttpServletMapping = baseRequest.getAttribute(AsyncContext.ASYNC_MAPPING);
+            baseRequest.setAttribute(AsyncContext.ASYNC_MAPPING, null);
         }
 
         // Should we handle this request now?
@@ -101,6 +104,7 @@ public class AsyncDelayHandler extends HandlerWrapper
                 baseRequest.setAttribute(AsyncContext.ASYNC_QUERY_STRING, asyncQueryString);
                 baseRequest.setAttribute(AsyncContext.ASYNC_REQUEST_URI, asyncRequestUri);
                 baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, asyncServletPath);
+                baseRequest.setAttribute(AsyncContext.ASYNC_MAPPING, asyncHttpServletMapping);
             }
 
             // signal the request is leaving the handler

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,6 +43,7 @@ import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
@@ -49,6 +51,7 @@ import javax.servlet.http.Part;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.http.tools.HttpTester;
 import org.eclipse.jetty.server.LocalConnector.LocalEndPoint;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -1411,6 +1414,69 @@ public class RequestTest
     }
 
     @Test
+    public void testHttpServletMapping() throws Exception
+    {
+        String request = "GET / HTTP/1.1\n" +
+            "Host: whatever\n" +
+            "Connection: close\n" +
+            "\n";
+        
+        _server.stop();
+        PathMappingHandler handler = new PathMappingHandler(null, null, null);
+        _server.setHandler(handler);
+        _server.start();
+        String response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=, pattern=, servletName=, mappingMatch=null}"));
+        _server.stop();
+        
+        ServletPathSpec spec = new ServletPathSpec("");
+        handler = new PathMappingHandler(spec, spec.getPathMatch("foo"), "Something");
+        _server.setHandler(handler);
+        _server.start();
+        response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=, pattern=, servletName=Something, mappingMatch=CONTEXT_ROOT}"));
+        _server.stop();
+        
+        spec = new ServletPathSpec("/");
+        handler = new PathMappingHandler(spec, "", "Default");
+        _server.setHandler(handler);
+        _server.start();
+        response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=/, pattern=/, servletName=Default, mappingMatch=DEFAULT}"));
+        _server.stop();
+        
+        spec = new ServletPathSpec("/foo/*");
+        handler = new PathMappingHandler(spec, spec.getPathMatch("/foo/bar"), "BarServlet");
+        _server.setHandler(handler);
+        _server.start();
+        response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=/foo, pattern=/foo/*, servletName=BarServlet, mappingMatch=PATH}"));
+        _server.stop();
+
+        spec = new ServletPathSpec("*.jsp");
+        handler = new PathMappingHandler(spec, spec.getPathMatch("/foo/bar.jsp"), "JspServlet");
+        _server.setHandler(handler);
+        _server.start();
+        response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=/foo/bar, pattern=*.jsp, servletName=JspServlet, mappingMatch=EXTENSION}"));
+        _server.stop();
+        
+        spec = new ServletPathSpec("/catalog");
+        handler = new PathMappingHandler(spec, spec.getPathMatch("/catalog"), "CatalogServlet");
+        _server.setHandler(handler);
+        _server.start();
+        response = _connector.getResponse(request);
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertThat("Response body content", response, containsString("HttpServletMapping{matchValue=catalog, pattern=/catalog, servletName=CatalogServlet, mappingMatch=EXACT}"));
+        _server.stop();
+    }
+    
+    @Test
     public void testCookies() throws Exception
     {
         final ArrayList<Cookie> cookies = new ArrayList<>();
@@ -1914,5 +1980,69 @@ public class RequestTest
                 response.sendError(500);
             }
         }
+    }
+
+    private class TestUserIdentityScope implements UserIdentity.Scope
+    {
+        private ContextHandler _handler;
+        private String _contextPath;
+        private String _name;
+        
+        public TestUserIdentityScope(ContextHandler handler, String contextPath, String name)
+        {
+            _handler = handler;
+            _contextPath = contextPath;
+            _name = name;
+        }
+        
+        @Override
+        public ContextHandler getContextHandler()
+        {
+            return _handler;
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            return _contextPath;
+        }
+
+        @Override
+        public String getName()
+        {
+            return _name;
+        }
+
+        @Override
+        public Map<String, String> getRoleRefMap()
+        {
+            return null;
+        }
+    }
+
+    private class PathMappingHandler extends AbstractHandler
+    {
+        private ServletPathSpec _spec;
+        private String _servletPath;
+        private String _servletName;
+        
+        public PathMappingHandler(ServletPathSpec spec, String servletPath, String servletName)
+        {
+            _spec = spec;
+            _servletPath = servletPath;
+            _servletName = servletName;
+        }
+        
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+        {
+            ((Request)request).setHandled(true);
+            baseRequest.setServletPath(_servletPath);
+            baseRequest.setPathSpec(_spec);
+            if (_servletName != null)
+                baseRequest.setUserIdentityScope(new TestUserIdentityScope(null, null, _servletName));
+            HttpServletMapping mapping = baseRequest.getHttpServletMapping();
+            response.getWriter().println(mapping);
+        }   
     }
 }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -449,6 +449,7 @@ public class ServletHandler extends ScopedHandler
                 {
                     baseRequest.setAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH, servletPath);
                     baseRequest.setAttribute(RequestDispatcher.INCLUDE_PATH_INFO, pathInfo);
+                    baseRequest.setAttribute(RequestDispatcher.INCLUDE_MAPPING, Request.getServletMapping(pathSpec, servletPath, servletHolder.getName()));
                 }
                 else
                 {

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncContextTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/AsyncContextTest.java
@@ -27,6 +27,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -224,6 +225,10 @@ public class AsyncContextTest
         assertThat("query string attr is correct", responseBody, containsString("async:run:attr:queryString:dispatch=true"));
         assertThat("context path attr is correct", responseBody, containsString("async:run:attr:contextPath:/ctx"));
         assertThat("request uri attr is correct", responseBody, containsString("async:run:attr:requestURI:/ctx/servletPath"));
+        assertThat("http servlet mapping matchValue is correct", responseBody, containsString("async:run:attr:mapping:matchValue:servletPath"));
+        assertThat("http servlet mapping pattern is correct", responseBody, containsString("async:run:attr:mapping:pattern:/servletPath"));
+        assertThat("http servlet mapping servletName is correct", responseBody, containsString("async:run:attr:mapping:servletName:"));
+        assertThat("http servlet mapping mappingMatch is correct", responseBody, containsString("async:run:attr:mapping:mappingMatch:EXACT"));
     }
 
     @Test
@@ -257,6 +262,10 @@ public class AsyncContextTest
         assertThat("async run attr query string", responseBody, containsString("async:run:attr:queryString:dispatch=true"));
         assertThat("async run context path", responseBody, containsString("async:run:attr:contextPath:/ctx"));
         assertThat("async run request uri has correct encoding", responseBody, containsString("async:run:attr:requestURI:/ctx/test/hello%2fthere"));
+        assertThat("http servlet mapping matchValue is correct", responseBody, containsString("async:run:attr:mapping:matchValue:/test"));
+        assertThat("http servlet mapping pattern is correct", responseBody, containsString("async:run:attr:mapping:pattern:/test/*"));
+        assertThat("http servlet mapping servletName is correct", responseBody, containsString("async:run:attr:mapping:servletName:"));
+        assertThat("http servlet mapping mappingMatch is correct", responseBody, containsString("async:run:attr:mapping:mappingMatch:PATH"));
     }
 
     @Test
@@ -296,6 +305,10 @@ public class AsyncContextTest
         assertThat("query string attr is correct", responseBody, containsString("async:run:attr:queryString:dispatch=true&queryStringWithEncoding=space%20space"));
         assertThat("context path attr is correct", responseBody, containsString("async:run:attr:contextPath:/ctx"));
         assertThat("request uri attr is correct", responseBody, containsString("async:run:attr:requestURI:/ctx/path%20with%20spaces/servletPath"));
+        assertThat("http servlet mapping matchValue is correct", responseBody, containsString("async:run:attr:mapping:matchValue:path with spaces/servletPath"));
+        assertThat("http servlet mapping pattern is correct", responseBody, containsString("async:run:attr:mapping:pattern:/path with spaces/servletPath"));
+        assertThat("http servlet mapping servletName is correct", responseBody, containsString("async:run:attr:mapping:servletName:"));
+        assertThat("http servlet mapping mappingMatch is correct", responseBody, containsString("async:run:attr:mapping:mappingMatch:EXACT"));
     }
 
     @Test
@@ -338,6 +351,10 @@ public class AsyncContextTest
         assertThat("query string attr is correct", responseBody, containsString("async:run:attr:queryString:dispatch=true"));
         assertThat("context path attr is correct", responseBody, containsString("async:run:attr:contextPath:/ctx"));
         assertThat("request uri attr is correct", responseBody, containsString("async:run:attr:requestURI:/ctx/servletPath"));
+        assertThat("http servlet mapping matchValue is correct", responseBody, containsString("async:run:attr:mapping:matchValue:servletPath"));
+        assertThat("http servlet mapping pattern is correct", responseBody, containsString("async:run:attr:mapping:pattern:/servletPath"));
+        assertThat("http servlet mapping servletName is correct", responseBody, containsString("async:run:attr:mapping:servletName:"));
+        assertThat("http servlet mapping mappingMatch is correct", responseBody, containsString("async:run:attr:mapping:mappingMatch:EXACT"));
     }
 
     @Test
@@ -687,6 +704,14 @@ public class AsyncContextTest
                 _context.getResponse().getOutputStream().print("async:run:attr:queryString:" + req.getAttribute(AsyncContext.ASYNC_QUERY_STRING) + "\n");
                 _context.getResponse().getOutputStream().print("async:run:attr:contextPath:" + req.getAttribute(AsyncContext.ASYNC_CONTEXT_PATH) + "\n");
                 _context.getResponse().getOutputStream().print("async:run:attr:requestURI:" + req.getAttribute(AsyncContext.ASYNC_REQUEST_URI) + "\n");
+                HttpServletMapping mapping = (HttpServletMapping)req.getAttribute(AsyncContext.ASYNC_MAPPING);
+                if (mapping != null)
+                {
+                    _context.getResponse().getOutputStream().print("async:run:attr:mapping:matchValue:" + mapping.getMatchValue() + "\n");
+                    _context.getResponse().getOutputStream().print("async:run:attr:mapping:pattern:" + mapping.getPattern() + "\n");
+                    _context.getResponse().getOutputStream().print("async:run:attr:mapping:servletName:" + mapping.getServletName() + "\n");
+                    _context.getResponse().getOutputStream().print("async:run:attr:mapping:mappingMatch:" + mapping.getMappingMatch() + "\n");
+                }
             }
             catch (IOException e)
             {

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DispatcherTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DispatcherTest.java
@@ -41,6 +41,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.ServletResponseWrapper;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
@@ -728,9 +729,12 @@ public class DispatcherTest
             assertEquals("/ForwardServlet", request.getAttribute(Dispatcher.FORWARD_SERVLET_PATH));
             assertEquals(null, request.getAttribute(Dispatcher.FORWARD_PATH_INFO));
             assertEquals("do=assertforward&do=more&test=1", request.getAttribute(Dispatcher.FORWARD_QUERY_STRING));
-
+            HttpServletMapping fwdMapping = (HttpServletMapping)request.getAttribute(Dispatcher.FORWARD_MAPPING);
+            assertNotNull(fwdMapping);
+            assertEquals("/ForwardServlet", fwdMapping.getMatchValue());
+            
             List<String> expectedAttributeNames = Arrays.asList(Dispatcher.FORWARD_REQUEST_URI, Dispatcher.FORWARD_CONTEXT_PATH,
-                Dispatcher.FORWARD_SERVLET_PATH, Dispatcher.FORWARD_QUERY_STRING);
+                Dispatcher.FORWARD_SERVLET_PATH, Dispatcher.FORWARD_QUERY_STRING, Dispatcher.FORWARD_MAPPING);
             List<String> requestAttributeNames = Collections.list(request.getAttributeNames());
             assertTrue(requestAttributeNames.containsAll(expectedAttributeNames));
 
@@ -760,9 +764,12 @@ public class DispatcherTest
             assertEquals("/ForwardServlet", request.getAttribute(Dispatcher.FORWARD_SERVLET_PATH));
             assertEquals(null, request.getAttribute(Dispatcher.FORWARD_PATH_INFO));
             assertEquals("do=assertforward&foreign=%d2%e5%ec%ef%e5%f0%e0%f2%f3%f0%e0&test=1", request.getAttribute(Dispatcher.FORWARD_QUERY_STRING));
+            HttpServletMapping fwdMapping = (HttpServletMapping)request.getAttribute(Dispatcher.FORWARD_MAPPING);
+            assertNotNull(fwdMapping);
+            assertEquals("/ForwardServlet", fwdMapping.getMatchValue());
 
             List<String> expectedAttributeNames = Arrays.asList(Dispatcher.FORWARD_REQUEST_URI, Dispatcher.FORWARD_CONTEXT_PATH,
-                Dispatcher.FORWARD_SERVLET_PATH, Dispatcher.FORWARD_QUERY_STRING);
+                Dispatcher.FORWARD_SERVLET_PATH, Dispatcher.FORWARD_QUERY_STRING, Dispatcher.FORWARD_MAPPING);
             List<String> requestAttributeNames = Collections.list(request.getAttributeNames());
             assertTrue(requestAttributeNames.containsAll(expectedAttributeNames));
 
@@ -806,9 +813,12 @@ public class DispatcherTest
             assertEquals("/AssertIncludeServlet", request.getAttribute(Dispatcher.INCLUDE_SERVLET_PATH));
             assertEquals(null, request.getAttribute(Dispatcher.INCLUDE_PATH_INFO));
             assertEquals("do=end&do=the", request.getAttribute(Dispatcher.INCLUDE_QUERY_STRING));
+            HttpServletMapping incMapping = (HttpServletMapping)request.getAttribute(Dispatcher.INCLUDE_MAPPING);
+            assertNotNull(incMapping);
+            assertEquals("/AssertIncludeServlet", incMapping.getMatchValue());
 
             List expectedAttributeNames = Arrays.asList(Dispatcher.INCLUDE_REQUEST_URI, Dispatcher.INCLUDE_CONTEXT_PATH,
-                Dispatcher.INCLUDE_SERVLET_PATH, Dispatcher.INCLUDE_QUERY_STRING);
+                Dispatcher.INCLUDE_SERVLET_PATH, Dispatcher.INCLUDE_QUERY_STRING, Dispatcher.INCLUDE_MAPPING);
             List requestAttributeNames = Collections.list(request.getAttributeNames());
             assertTrue(requestAttributeNames.containsAll(expectedAttributeNames));
 
@@ -836,17 +846,23 @@ public class DispatcherTest
             assertEquals("/ForwardServlet", request.getAttribute(Dispatcher.FORWARD_SERVLET_PATH));
             assertEquals("/forwardpath", request.getAttribute(Dispatcher.FORWARD_PATH_INFO));
             assertEquals("do=include", request.getAttribute(Dispatcher.FORWARD_QUERY_STRING));
+            HttpServletMapping fwdMapping = (HttpServletMapping)request.getAttribute(Dispatcher.FORWARD_MAPPING);
+            assertNotNull(fwdMapping);
+            assertEquals("/ForwardServlet", fwdMapping.getMatchValue());
 
             assertEquals("/context/AssertForwardIncludeServlet/assertpath", request.getAttribute(Dispatcher.INCLUDE_REQUEST_URI));
             assertEquals("/context", request.getAttribute(Dispatcher.INCLUDE_CONTEXT_PATH));
             assertEquals("/AssertForwardIncludeServlet", request.getAttribute(Dispatcher.INCLUDE_SERVLET_PATH));
             assertEquals("/assertpath", request.getAttribute(Dispatcher.INCLUDE_PATH_INFO));
             assertEquals("do=end", request.getAttribute(Dispatcher.INCLUDE_QUERY_STRING));
+            HttpServletMapping incMapping = (HttpServletMapping)request.getAttribute(Dispatcher.INCLUDE_MAPPING);
+            assertNotNull(incMapping);
+            assertEquals("/AssertForwardIncludeServlet", incMapping.getMatchValue());     
 
             List expectedAttributeNames = Arrays.asList(Dispatcher.FORWARD_REQUEST_URI, Dispatcher.FORWARD_CONTEXT_PATH, Dispatcher.FORWARD_SERVLET_PATH,
-                Dispatcher.FORWARD_PATH_INFO, Dispatcher.FORWARD_QUERY_STRING,
+                Dispatcher.FORWARD_PATH_INFO, Dispatcher.FORWARD_QUERY_STRING, Dispatcher.FORWARD_MAPPING,
                 Dispatcher.INCLUDE_REQUEST_URI, Dispatcher.INCLUDE_CONTEXT_PATH, Dispatcher.INCLUDE_SERVLET_PATH,
-                Dispatcher.INCLUDE_PATH_INFO, Dispatcher.INCLUDE_QUERY_STRING);
+                Dispatcher.INCLUDE_PATH_INFO, Dispatcher.INCLUDE_QUERY_STRING, Dispatcher.INCLUDE_MAPPING);
             List requestAttributeNames = Collections.list(request.getAttributeNames());
             assertTrue(requestAttributeNames.containsAll(expectedAttributeNames));
 
@@ -874,15 +890,19 @@ public class DispatcherTest
             assertEquals(null, request.getAttribute(Dispatcher.INCLUDE_SERVLET_PATH));
             assertEquals(null, request.getAttribute(Dispatcher.INCLUDE_PATH_INFO));
             assertEquals(null, request.getAttribute(Dispatcher.INCLUDE_QUERY_STRING));
+            assertEquals(null, request.getAttribute(Dispatcher.INCLUDE_MAPPING));
 
             assertEquals("/context/IncludeServlet/includepath", request.getAttribute(Dispatcher.FORWARD_REQUEST_URI));
             assertEquals("/context", request.getAttribute(Dispatcher.FORWARD_CONTEXT_PATH));
             assertEquals("/IncludeServlet", request.getAttribute(Dispatcher.FORWARD_SERVLET_PATH));
             assertEquals("/includepath", request.getAttribute(Dispatcher.FORWARD_PATH_INFO));
             assertEquals("do=forward", request.getAttribute(Dispatcher.FORWARD_QUERY_STRING));
+            HttpServletMapping fwdMapping = (HttpServletMapping)request.getAttribute(Dispatcher.FORWARD_MAPPING);
+            assertNotNull(fwdMapping);
+            assertEquals("/IncludeServlet", fwdMapping.getMatchValue());
 
             List expectedAttributeNames = Arrays.asList(Dispatcher.FORWARD_REQUEST_URI, Dispatcher.FORWARD_CONTEXT_PATH, Dispatcher.FORWARD_SERVLET_PATH,
-                Dispatcher.FORWARD_PATH_INFO, Dispatcher.FORWARD_QUERY_STRING);
+                Dispatcher.FORWARD_PATH_INFO, Dispatcher.FORWARD_QUERY_STRING, Dispatcher.FORWARD_MAPPING);
             List requestAttributeNames = Collections.list(request.getAttributeNames());
             assertTrue(requestAttributeNames.containsAll(expectedAttributeNames));
 


### PR DESCRIPTION
Closes #4507 

Implementing the request attributes for HttpServletMapping; corrected the implementation of the value of the "pattern" field; added tests for the new FORWARD, INCLUDE, ASYNC attributes.