### PR TITLE
Issue #847 - deprecate asyncWriteTimeout in the jetty websocket API

### DIFF
--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketPolicy.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketPolicy.java
@@ -188,6 +188,7 @@ public class WebSocketPolicy
      *
      * @return the timeout for async write operations. negative values indicate disabled timeout.
      */
+    @Deprecated
     public long getAsyncWriteTimeout()
     {
         return asyncWriteTimeout;

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -427,6 +427,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
      *
      * @return number of milliseconds for timeout of an attempted write operation
      */
+    @Deprecated
     public long getAsyncWriteTimeout()
     {
         return getPolicy().getAsyncWriteTimeout();


### PR DESCRIPTION
It was decided that the writeTimeout was not to be added back to the Jetty websocket API in jetty-10 (see #4344). So it should be deprecated in jetty-9.4 (there are setters for it in 9.4 but it is actually unimplemented).

Closes #847