### PR TITLE
Issue #4550 XmlConfiguration argument matching

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -60,6 +60,22 @@ public class TypeUtil
 
     private static final HashMap<String, Class<?>> name2Class = new HashMap<>();
 
+    private static final Map<Class<?>, Class<?>> __unbox;
+
+    static
+    {
+        Map<Class<?>, Class<?>> unbox = new HashMap<>();
+        unbox.put(int.class, Integer.class);
+        unbox.put(long.class, Long.class);
+        unbox.put(byte.class, Byte.class);
+        unbox.put(char.class, Character.class);
+        unbox.put(float.class, Float.class);
+        unbox.put(double.class, Double.class);
+        unbox.put(short.class, Long.class);
+        unbox.put(boolean.class, Boolean.class);
+        __unbox = Collections.unmodifiableMap(unbox);
+    }
+
     static
     {
         name2Class.put("boolean", java.lang.Boolean.TYPE);
@@ -726,5 +742,16 @@ public class TypeUtil
             return MODULE_LOCATION.getModuleLocation(clazz);
         }
         return null;
+    }
+
+    public static boolean isUnboxable(Class<?> type, Object arg)
+    {
+        if (!type.isPrimitive())
+            return false;
+        if (arg == null)
+            return true;
+
+        Class<?> c = __unbox.get(type);
+        return arg.getClass() == __unbox.get(type);
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -60,22 +60,6 @@ public class TypeUtil
 
     private static final HashMap<String, Class<?>> name2Class = new HashMap<>();
 
-    private static final Map<Class<?>, Class<?>> __unbox;
-
-    static
-    {
-        Map<Class<?>, Class<?>> unbox = new HashMap<>();
-        unbox.put(boolean.class, Boolean.class);
-        unbox.put(byte.class, Byte.class);
-        unbox.put(char.class, Character.class);
-        unbox.put(short.class, Short.class);
-        unbox.put(int.class, Integer.class);
-        unbox.put(long.class, Long.class);
-        unbox.put(float.class, Float.class);
-        unbox.put(double.class, Double.class);
-        __unbox = Collections.unmodifiableMap(unbox);
-    }
-
     static
     {
         name2Class.put("boolean", java.lang.Boolean.TYPE);
@@ -742,15 +726,5 @@ public class TypeUtil
             return MODULE_LOCATION.getModuleLocation(clazz);
         }
         return null;
-    }
-
-    public static boolean isUnboxable(Class<?> type, Object arg)
-    {
-        if (!type.isPrimitive())
-            return false;
-        if (arg == null)
-            return true;
-
-        return __unbox.get(type) == arg.getClass();
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -752,6 +752,7 @@ public class TypeUtil
             return true;
 
         Class<?> c = __unbox.get(type);
-        return arg.getClass() == __unbox.get(type);
+        Class<?> ac = arg.getClass();
+        return ac == __unbox.get(type) || (Number.class.isAssignableFrom(c) && Number.class.isAssignableFrom(ac));
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -65,14 +65,14 @@ public class TypeUtil
     static
     {
         Map<Class<?>, Class<?>> unbox = new HashMap<>();
-        unbox.put(int.class, Integer.class);
-        unbox.put(long.class, Long.class);
+        unbox.put(boolean.class, Boolean.class);
         unbox.put(byte.class, Byte.class);
         unbox.put(char.class, Character.class);
+        unbox.put(short.class, Short.class);
+        unbox.put(int.class, Integer.class);
+        unbox.put(long.class, Long.class);
         unbox.put(float.class, Float.class);
         unbox.put(double.class, Double.class);
-        unbox.put(short.class, Long.class);
-        unbox.put(boolean.class, Boolean.class);
         __unbox = Collections.unmodifiableMap(unbox);
     }
 
@@ -751,8 +751,6 @@ public class TypeUtil
         if (arg == null)
             return true;
 
-        Class<?> c = __unbox.get(type);
-        Class<?> ac = arg.getClass();
-        return ac == __unbox.get(type) || (Number.class.isAssignableFrom(c) && Number.class.isAssignableFrom(ac));
+        return __unbox.get(type) == arg.getClass();
     }
 }

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -117,8 +117,6 @@ public class XmlConfiguration
             else
             {
                 // Rank by assignability of the arguments
-                // This is only a rough guide that will favour call(String) vs call(Object),
-                // but it will not resolve call(String, Object) vs call (Object, String)
                 for (int i = 0; i < count; i++)
                 {
                     Class<?> t1 = p1[i].getType();
@@ -126,9 +124,12 @@ public class XmlConfiguration
                     if (t1 != t2)
                     {
                         if (t1.isAssignableFrom(t2))
-                            compare++;
+                            compare = 1;
                         else if (t2.isAssignableFrom(t1))
-                            compare--;
+                            compare = -1;
+                        else
+                            compare = t1.getName().compareTo(t2.getName());
+                        break;
                     }
                 }
             }
@@ -1803,16 +1804,6 @@ public class XmlConfiguration
                     args = arguments.toArray(new Object[0]);
                 }
 
-                // Check assignable
-                Parameter[] params = executable.getParameters();
-                for (int i = 0; i < args.length; i++)
-                {
-                    if (args[i] != null &&
-                        !params[i].getType().isAssignableFrom(args[i].getClass()) &&
-                        !TypeUtil.isUnboxable(params[i].getType(), args[i]))
-                        return null;
-                }
-
                 return args;
             }
         }
@@ -1835,9 +1826,8 @@ public class XmlConfiguration
             }
         }
 
-        for (int i = 0; i < node.size(); i++)
+        for (Object o : node)
         {
-            Object o = node.get(i);
             if (!(o instanceof XmlParser.Node))
                 continue;
             XmlParser.Node n = (XmlParser.Node)o;

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -126,7 +126,7 @@ public class XmlConfiguration
                         if (compare == 0)
                         {
                             // favour primitive type over reference
-                            compare = Boolean.compare(t2.isPrimitive(), t1.isPrimitive());
+                            compare = Boolean.compare(!t1.isPrimitive(), !t2.isPrimitive());
                             if (compare == 0)
                                 // Use name to avoid non determinant sorting
                                 compare = t1.getName().compareTo(t2.getName());

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/AnnotatedTestConfiguration.java
@@ -92,6 +92,21 @@ public class AnnotatedTestConfiguration
         this.third = theRest.length > 1 ? theRest[1] : null;
     }
 
+    public void call(Integer value)
+    {
+        this.first = String.valueOf(value);
+    }
+
+    public void call(String value)
+    {
+        this.second = value;
+    }
+
+    public <E> void call(E value)
+    {
+        this.third = String.valueOf(value);
+    }
+
     public String getFirst()
     {
         return first;

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/TestConfiguration.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/TestConfiguration.java
@@ -54,6 +54,7 @@ public class TestConfiguration extends HashMap<String, Object>
     private Set set;
     private ConstructorArgTestClass constructorArgTestClass;
     public Map map;
+    public Double number;
 
     public TestConfiguration()
     {
@@ -63,6 +64,16 @@ public class TestConfiguration extends HashMap<String, Object>
     public TestConfiguration(@Name("name") String n)
     {
         name = n;
+    }
+
+    public void setNumber(Object value)
+    {
+        testObject = value;
+    }
+
+    public void setNumber(double value)
+    {
+        number = value;
     }
 
     public void setTest(Object value)

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -614,6 +614,10 @@ public class XmlConfigurationTest
         {
         }
 
+        public void call(int o)
+        {
+        }
+
         public void call(Object o)
         {
         }
@@ -639,6 +643,7 @@ public class XmlConfigurationTest
         Collections.sort(methods, XmlConfiguration.EXECUTABLE_COMPARATOR);
         assertThat(methods, Matchers.contains(
             TestOrder.class.getMethod("call"),
+            TestOrder.class.getMethod("call", int.class),
             TestOrder.class.getMethod("call", String.class),
             TestOrder.class.getMethod("call", Object.class),
             TestOrder.class.getMethod("call", String[].class),
@@ -854,6 +859,45 @@ public class XmlConfigurationTest
         assertEquals("one", atc.getFirst(), "first parameter not wired correctly");
         assertNull(atc.getSecond());
         assertNull(atc.getThird());
+    }
+
+    public static class NumberTypeProvider implements ArgumentsProvider
+    {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context)
+        {
+            return Stream.of(
+                "byte",
+                "int",
+                // "char",
+                "short",
+                "long",
+                "float",
+                "double",
+                "Byte",
+                "Integer",
+                // "Character",
+                "Short",
+                "Long",
+                "Float",
+                "Double"
+            ).map(Arguments::of);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(NumberTypeProvider.class)
+    public void testCallNumberConversion(String type) throws Exception
+    {
+        XmlConfiguration xmlConfiguration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+                " <Call name=\"setNumber\">" +
+                "  <Arg type=\"" + type + "\">42</Arg>" +
+                " </Call>" +
+                "</Configure>");
+
+        TestConfiguration tc = (TestConfiguration)xmlConfiguration.configure();
+        assertEquals(42.0D, tc.number);
     }
 
     @Test

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +45,9 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.log.StdErrLog;
 import org.eclipse.jetty.util.resource.PathResource;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -602,6 +606,67 @@ public class XmlConfigurationTest
         assertEquals("arg1", atc.getNested().getFirst(), "nested first parameter not wired correctly");
         assertEquals("arg2", atc.getNested().getSecond(), "nested second parameter not wired correctly");
         assertEquals("arg3", atc.getNested().getThird(), "nested third parameter not wired correctly");
+    }
+
+    private static class TestOrder
+    {
+        public void call()
+        {
+        }
+
+        public void call(Object o)
+        {
+        }
+
+        public void call(String s)
+        {
+        }
+
+        public void call(String... ss)
+        {
+        }
+
+        public void call(String s, String... ss)
+        {
+        }
+    }
+
+    @RepeatedTest(10)
+    public void testMethodOrdering() throws Exception
+    {
+        List<Method> methods = Arrays.stream(TestOrder.class.getMethods()).filter(m -> "call".equals(m.getName())).collect(Collectors.toList());
+        Collections.shuffle(methods);
+        Collections.sort(methods, XmlConfiguration.EXECUTABLE_COMPARATOR);
+        assertThat(methods, Matchers.contains(
+            TestOrder.class.getMethod("call"),
+            TestOrder.class.getMethod("call", String.class),
+            TestOrder.class.getMethod("call", Object.class),
+            TestOrder.class.getMethod("call", String[].class),
+            TestOrder.class.getMethod("call", String.class, String[].class)
+        ));
+    }
+
+    @Test
+    public void testOverloadedCall() throws Exception
+    {
+        XmlConfiguration xmlConfiguration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.AnnotatedTestConfiguration\">" +
+                "  <Call name=\"call\">" +
+                "    <Arg type=\"int\">1</Arg>" +
+                "  </Call>" +
+                "  <Call name=\"call\">" +
+                "    <Arg>2</Arg>" +
+                "  </Call>" +
+                "  <Call name=\"call\">" +
+                "    <Arg type=\"Long\">3</Arg>" +
+                "  </Call>" +
+                "</Configure>");
+
+        AnnotatedTestConfiguration atc = (AnnotatedTestConfiguration)xmlConfiguration.configure();
+
+        assertEquals("1", atc.getFirst());
+        assertEquals("2", atc.getSecond());
+        assertEquals("3", atc.getThird());
     }
 
     @Test

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.xml.sax.SAXException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -861,32 +862,25 @@ public class XmlConfigurationTest
         assertNull(atc.getThird());
     }
 
-    public static class NumberTypeProvider implements ArgumentsProvider
+    public static List<String> typeTestData()
     {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context)
-        {
-            return Stream.of(
-                "byte",
-                "int",
-                // "char",
-                "short",
-                "long",
-                "float",
-                "double",
-                "Byte",
-                "Integer",
-                // "Character",
-                "Short",
-                "Long",
-                "Float",
-                "Double"
-            ).map(Arguments::of);
-        }
+        return Arrays.asList(
+            "byte",
+            "int",
+            "short",
+            "long",
+            "float",
+            "double",
+            "Byte",
+            "Integer",
+            "Short",
+            "Long",
+            "Float",
+            "Double");
     }
 
     @ParameterizedTest
-    @ArgumentsSource(NumberTypeProvider.class)
+    @MethodSource("typeTestData")
     public void testCallNumberConversion(String type) throws Exception
     {
         XmlConfiguration xmlConfiguration = asXmlConfiguration(


### PR DESCRIPTION
Improve #4550 argument matching by:
 + rejecting obviously non matches (with allowance for unboxing)
 + sorting methods so that derived arguments are tried before more generic (eg String before Object)

Signed-off-by: Greg Wilkins <gregw@webtide.com>