### PR TITLE
Fix NPE in HouseKeeper.stopScavenging

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/HouseKeeper.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/HouseKeeper.java
@@ -158,7 +158,7 @@ public class HouseKeeper extends AbstractLifeCycle
                 LOG.info("{} Stopped scavenging", _sessionIdManager.getWorkerName());
             }
             _task = null;
-            if (_ownScheduler)
+            if (_ownScheduler && _scheduler != null)
             {
                 _scheduler.stop();
                 _scheduler = null;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/HouseKeeper.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/HouseKeeper.java
@@ -160,6 +160,7 @@ public class HouseKeeper extends AbstractLifeCycle
             _task = null;
             if (_ownScheduler && _scheduler != null)
             {
+                _ownScheduler = false;
                 _scheduler.stop();
                 _scheduler = null;
             }


### PR DESCRIPTION
HouseKeeper.stopScavenging throws NPE when called twice.

To reproduce this issue, call `setIntervalSec(0)` before shutting down the server.

```java
Server server = new Server(8080);
server.setSessionIdManager(new DefaultSessionIdManager(server));
server.start();
server.getSessionIdManager().getSessionHouseKeeper().setIntervalSec(0L);
server.stop();
```

Signed-off-by: Hirotaka Ikoma <hikoma@gmail.com>