### PR TITLE
Issue #4606 - fixing formatTick use of `now`

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/DateCache.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/DateCache.java
@@ -239,7 +239,7 @@ public class DateCache
         // recheck the tick, to save multiple formats
         if (tick == null || tick._seconds != seconds)
         {
-            String s = ZonedDateTime.ofInstant(Instant.now(), _zoneId).format(_tzFormat);
+            String s = ZonedDateTime.ofInstant(Instant.ofEpochMilli(now), _zoneId).format(_tzFormat);
             _tick = new Tick(seconds, s);
             tick = _tick;
         }


### PR DESCRIPTION
Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>