### PR TITLE
Issue #4577 - request getPathInfo() could be null in InetAccessHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -245,7 +245,8 @@ public class InetAccessHandler extends HandlerWrapper
     protected boolean isAllowed(InetAddress addr, Request baseRequest, HttpServletRequest request)
     {
         String connectorName = baseRequest.getHttpChannel().getConnector().getName();
-        return _set.test(new AccessTuple(connectorName, addr, baseRequest.getPathInfo()));
+        String path = baseRequest.getMetaData().getURI().getDecodedPath();
+        return _set.test(new AccessTuple(connectorName, addr, path));
     }
 
     @Override


### PR DESCRIPTION
**Issue #4577**

Use the same fix to replace `baseRequest.getPathInfo()` from PR #4580.