### PR TITLE
Issue #4641 added data rate grace period configuration

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -72,6 +72,7 @@ public class HttpConfiguration implements Dumpable
     private int _maxErrorDispatches = 10;
     private long _minRequestDataRate;
     private long _minResponseDataRate;
+    private long _minDataRateGracePeriod;
     private CookieCompliance _requestCookieCompliance = CookieCompliance.RFC6265;
     private CookieCompliance _responseCookieCompliance = CookieCompliance.RFC6265;
     private MultiPartFormDataCompliance _multiPartCompliance = MultiPartFormDataCompliance.LEGACY; // TODO change default in jetty-10
@@ -138,6 +139,7 @@ public class HttpConfiguration implements Dumpable
         _maxErrorDispatches = config._maxErrorDispatches;
         _minRequestDataRate = config._minRequestDataRate;
         _minResponseDataRate = config._minResponseDataRate;
+        _minDataRateGracePeriod = config._minDataRateGracePeriod;
         _requestCookieCompliance = config._requestCookieCompliance;
         _responseCookieCompliance = config._responseCookieCompliance;
         _multiPartCompliance = config._multiPartCompliance;
@@ -556,6 +558,23 @@ public class HttpConfiguration implements Dumpable
     }
 
     /**
+     * @return The grace period in milliseconds used when measuring minimum data rates or &lt;=0 for none
+     */
+    @ManagedAttribute("The data rate measurement grace period in milliseconds")
+    public long getMinDataRateGracePeriod()
+    {
+        return _minDataRateGracePeriod;
+    }
+
+    /**
+     * @param period The grace period in milliseconds used when measuring minimum data rates or &lt;=0 for none
+     */
+    public void setMinDataRateGracePeriod(long period)
+    {
+        _minDataRateGracePeriod = period;
+    }
+
+    /**
      * @return The CookieCompliance used for parsing request <code>Cookie</code> headers.
      * @see #getResponseCookieCompliance()
      */
@@ -671,6 +690,7 @@ public class HttpConfiguration implements Dumpable
             "maxErrorDispatches=" + _maxErrorDispatches,
             "minRequestDataRate=" + _minRequestDataRate,
             "minResponseDataRate=" + _minResponseDataRate,
+            "minDataRateGracePeriod=" + _minDataRateGracePeriod,
             "cookieCompliance=" + _requestCookieCompliance,
             "setRequestCookieCompliance=" + _responseCookieCompliance,
             "notifyRemoteAsyncErrors=" + _notifyRemoteAsyncErrors

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -283,8 +283,10 @@ public class HttpInput extends ServletInputStream implements Runnable
             long minRequestDataRate = _channelState.getHttpChannel().getHttpConfiguration().getMinRequestDataRate();
             if (minRequestDataRate > 0 && _firstByteTimeStamp != -1)
             {
+                long graceConfig =_channelState.getHttpChannel().getHttpConfiguration().getMinDataRateGracePeriod();
+                long grace = TimeUnit.MILLISECONDS.toNanos(Math.max(graceConfig, 0));
                 long period = System.nanoTime() - _firstByteTimeStamp;
-                if (period > 0)
+                if (period > grace)
                 {
                     long minimumData = minRequestDataRate * TimeUnit.NANOSECONDS.toMillis(period) / TimeUnit.SECONDS.toMillis(1);
                     if (_contentArrived < minimumData)


### PR DESCRIPTION
Added a configuration parameter in HttpConfiguration for data rate measurement grace period.

This is a rather cryptic and specialized configuration parameter, but since we do not want to change default behaviour (I think), having a configuration parameter with default value 0 seems like the safest approach.

Perhaps we want to actually have a default and change default behaviour when using the min rate feature?
Also: Perhaps we could choose better naming for this parameter?