### PR TITLE
Issue #4645 - ForwardedRequestCustomizer now gives 400 response for bad port values

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -377,25 +377,18 @@ public class ForwardedRequestCustomizer implements Customizer
 
         // Do a single pass through the header fields as it is a more efficient single iteration.
         Forwarded forwarded = new Forwarded(request, config);
-        try
+        for (HttpField field : httpFields)
         {
-            for (HttpField field : httpFields)
+            try
             {
-                try
-                {
-                    MethodHandle handle = _handles.get(field.getName());
-                    if (handle != null)
-                        handle.invoke(forwarded, field);
-                }
-                catch (Throwable t)
-                {
-                    onError(field, t);
-                }
+                MethodHandle handle = _handles.get(field.getName());
+                if (handle != null)
+                    handle.invoke(forwarded, field);
             }
-        }
-        catch (Throwable e)
-        {
-            throw new RuntimeException(e);
+            catch (Throwable t)
+            {
+                onError(field, t);
+            }
         }
 
         if (forwarded._proto != null)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -639,19 +639,23 @@ public class ForwardedRequestCustomizer implements Customizer
         @SuppressWarnings("unused")
         public void handlePort(HttpField field)
         {
+            String port = getLeftMost(field.getValue());
+            if (StringUtil.isEmpty(port))
+                throw new IllegalArgumentException(field.getName() + " has empty value");
+
             if (!getForwardedPortAsAuthority())
             {
                 if (_for == null)
-                    _for = new PortSetHostPort(_request.getRemoteHost(), Integer.parseInt(getLeftMost(field.getValue())));
+                    _for = new PortSetHostPort(_request.getRemoteHost(), Integer.parseInt(port));
                 else if (_for instanceof PossiblyPartialHostPort && _for.getPort() <= 0)
-                    _for = new HostPort(HostPort.normalizeHost(_for.getHost()), Integer.parseInt(getLeftMost(field.getValue())));
+                    _for = new HostPort(HostPort.normalizeHost(_for.getHost()), Integer.parseInt(port));
             }
             else
             {
                 if (_host == null)
-                    _host = new PortSetHostPort(_request.getServerName(), Integer.parseInt(getLeftMost(field.getValue())));
+                    _host = new PortSetHostPort(_request.getServerName(), Integer.parseInt(port));
                 else if (_host instanceof PossiblyPartialHostPort && _host.getPort() <= 0)
-                    _host = new HostPort(HostPort.normalizeHost(_host.getHost()), Integer.parseInt(getLeftMost(field.getValue())));
+                    _host = new HostPort(HostPort.normalizeHost(_host.getHost()), Integer.parseInt(port));
             }
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -36,8 +36,6 @@ import org.eclipse.jetty.util.ArrayTrie;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.Trie;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
 
 import static java.lang.invoke.MethodType.methodType;
 
@@ -64,8 +62,6 @@ import static java.lang.invoke.MethodType.methodType;
  */
 public class ForwardedRequestCustomizer implements Customizer
 {
-    private static final Logger LOG = Log.getLogger(ForwardedRequestCustomizer.class);
-
     private HostPortHttpField _forcedHost;
     private boolean _proxyAsAuthority = false;
     private boolean _forwardedPortAsAuthority = true;
@@ -434,8 +430,7 @@ public class ForwardedRequestCustomizer implements Customizer
 
     protected void onError(HttpField field, Throwable t)
     {
-        LOG.warn("Exception while processing {}", field, t);
-        throw new BadMessageException("Bad header value for " + field.getName());
+        throw new BadMessageException("Bad header value for " + field.getName(), t);
     }
 
     protected String getLeftMost(String headerValue)

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -617,6 +618,25 @@ public class ForwardedRequestCustomizerTest
         assertThat("status", response.getStatus(), is(200));
 
         expectations.accept(actual);
+    }
+
+    @Test
+    public void testBadInput() throws Exception
+    {
+        Request request = new Request("Bad port value")
+            .headers(
+                "GET / HTTP/1.1",
+                "Host: myhost",
+                "X-Forwarded-Port: "
+            );
+
+        request.configure(customizer);
+
+        String rawRequest = request.getRawRequest((header) -> header);
+        System.out.println(rawRequest);
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat("status", response.getStatus(), is(400));
     }
 
     private static class Request

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
@@ -32,7 +32,7 @@ public class HostPort
     private final String _host;
     private final int _port;
 
-    public HostPort(String host, int port) throws IllegalArgumentException
+    public HostPort(String host, int port)
     {
         _host = host;
         _port = port;
@@ -61,7 +61,7 @@ public class HostPort
                 {
                     if (authority.charAt(close + 1) != ':')
                         throw new IllegalArgumentException("Bad IPv6 port");
-                    _port = StringUtil.toInt(authority, close + 2);
+                    _port = parsePort(authority.substring(close + 2));
                 }
                 else
                     _port = 0;
@@ -80,7 +80,7 @@ public class HostPort
                     else
                     {
                         _host = authority.substring(0, c);
-                        _port = StringUtil.toInt(authority, c + 1);
+                        _port = parsePort(authority.substring(c + 1));
                     }
                 }
                 else
@@ -103,10 +103,6 @@ public class HostPort
                 }
             };
         }
-        if (_host == null)
-            throw new IllegalArgumentException("Bad host");
-        if (_port < 0)
-            throw new IllegalArgumentException("Bad port");
     }
 
     /**
@@ -162,5 +158,24 @@ public class HostPort
 
         // normalize with [ ]
         return "[" + host + "]";
+    }
+
+    /**
+     * Parse a string representing a port validating it is a valid port value.
+     *
+     * @param rawPort the port string.
+     * @return the integer value for the port.
+     * @throws IllegalArgumentException
+     */
+    public static int parsePort(String rawPort) throws IllegalArgumentException
+    {
+        if (StringUtil.isEmpty(rawPort))
+            throw new IllegalArgumentException("Bad port");
+
+        int port = Integer.parseInt(rawPort);
+        if (port <= 0 || port > 65535)
+            throw new IllegalArgumentException("Bad port");
+
+        return port;
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
@@ -43,6 +43,7 @@ public class HostPortTest
             Arguments.of("[0::0::0::1]", "[0::0::0::1]", null),
             Arguments.of("[0::0::0::1]:80", "[0::0::0::1]", "80"),
             Arguments.of("0:1:2:3:4:5:6", "[0:1:2:3:4:5:6]", null),
+            Arguments.of("127.0.0.1:65535", "127.0.0.1", "65535"),
             // Localhost tests
             Arguments.of("localhost:80", "localhost", "80"),
             Arguments.of("127.0.0.1:80", "127.0.0.1", "80"),
@@ -79,7 +80,9 @@ public class HostPortTest
             "[0::0::0::0::1]:xxx",
             "host:-80",
             "127.0.0.1:-80",
-            "[0::0::0::0::1]:-80")
+            "[0::0::0::0::1]:-80",
+            "127.0.0.1:65536"
+            )
             .map(Arguments::of);
     }
 


### PR DESCRIPTION
**Issue #4645**

Replace the previous `NumberFormatException` with an `IllegalArgumentException` with a more descriptive error message.

It would also be possible to change the code to just return if we have an empty `X-Forwarded-Port` value, which would ignore it. I'm not sure if that would be more correct than throwing.