### PR TITLE
Issue #4662 Ensure contextDestroyed called after filters and servlets destroyed

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -27,6 +27,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -445,6 +448,22 @@ public class ContextHandlerTest
         assertThat(connector.getResponse("GET /foo/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo'"));
         assertThat(connector.getResponse("GET /foo/bar/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo/bar'"));
     }
+    
+    @Test
+    public void testContextInitializationDestruction() throws Exception
+    {
+        Server server = new Server();
+        ContextHandlerCollection contexts = new ContextHandlerCollection();
+        server.setHandler(contexts);
+
+        ContextHandler noServlets = new ContextHandler(contexts, "/noservlets");
+        TestServletContextListener listener = new TestServletContextListener();
+        noServlets.addEventListener(listener);
+        server.start();
+        assertEquals(1, listener.initialized);
+        server.stop();
+        assertEquals(1, listener.destroyed);
+    }
 
     @Test
     public void testContextVirtualGetContext() throws Exception
@@ -838,6 +857,24 @@ public class ContextHandlerTest
             response.setHeader("Connection", "close");
             PrintWriter writer = response.getWriter();
             writer.println("ctx='" + request.getContextPath() + "'");
+        }
+    }
+    
+    private static class TestServletContextListener implements ServletContextListener
+    {
+        public int initialized = 0;
+        public int destroyed = 0;
+        
+        @Override
+        public void contextInitialized(ServletContextEvent sce)
+        {
+            initialized++;
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent sce)
+        {
+            destroyed++;
         }
     }
 }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
@@ -307,6 +308,9 @@ public class ServletHandler extends ScopedHandler
         _servlets = shs;
         ServletMapping[] sms = (ServletMapping[])LazyList.toArray(servletMappings, ServletMapping.class);
         _servletMappings = sms;
+        
+        if (_contextHandler != null)
+            _contextHandler.contextDestroyed();
 
         //Retain only Listeners added via jetty apis (is Source.EMBEDDED)
         List<ListenerHolder> listenerHolders = new ArrayList<>();
@@ -733,30 +737,40 @@ public class ServletHandler extends ScopedHandler
     public void initialize()
         throws Exception
     {
-        _initialized = true;
-        
         MultiException mx = new MultiException();
 
-        Stream.concat(Stream.concat(
-            Arrays.stream(_filters),
-            Arrays.stream(_servlets).sorted()),
-            Arrays.stream(_listeners))
-            .forEach(h ->
+        Consumer<BaseHolder<?>> c = h ->
+        {
+            try
             {
-                try
+                if (!h.isStarted())
                 {
-                    if (!h.isStarted())
-                    {
-                        h.start();
-                        h.initialize();
-                    }
+                    h.start();
+                    h.initialize();
                 }
-                catch (Throwable e)
-                {
-                    LOG.debug(Log.EXCEPTION, e);
-                    mx.add(e);
-                }
-            });
+            }
+            catch (Throwable e)
+            {
+                LOG.debug(Log.EXCEPTION, e);
+                mx.add(e);
+            }
+        };
+        
+        //Start the listeners so we can call them
+        Arrays.stream(_listeners).forEach(c);
+        
+        //call listeners contextInitialized
+        if (_contextHandler != null)
+            _contextHandler.contextInitialized();
+        
+        //Only set initialized true AFTER the listeners have been called
+        _initialized = true;
+            
+        //Start the filters then the servlets
+        Stream.concat(
+            Arrays.stream(_filters),
+            Arrays.stream(_servlets).sorted())
+            .forEach(c);
 
         mx.ifExceptionThrow();
     }

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -538,6 +538,41 @@ public class ServletContextHandlerTest
     }
     
     @Test
+    public void testContextInitializationDestruction() throws Exception
+    {
+        Server server = new Server();
+        ContextHandlerCollection contexts = new ContextHandlerCollection();
+        server.setHandler(contexts);
+
+        ServletContextHandler root = new ServletContextHandler(contexts, "/");
+        class TestServletContextListener implements ServletContextListener
+        {
+            public int initialized = 0;
+            public int destroyed = 0;
+            
+            @Override
+            public void contextInitialized(ServletContextEvent sce)
+            {
+                initialized++;
+            }
+
+            @Override
+            public void contextDestroyed(ServletContextEvent sce)
+            {
+                destroyed++;
+            }
+        }
+        
+        TestServletContextListener listener = new TestServletContextListener();
+        root.addEventListener(listener);
+        server.start();
+        server.stop();
+        assertEquals(1, listener.initialized);
+        server.stop();
+        assertEquals(1, listener.destroyed);
+    }
+    
+    @Test
     public void testListenersFromContextListener() throws Exception
     {
         ContextHandlerCollection contexts = new ContextHandlerCollection();

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletLifeCycleTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletLifeCycleTest.java
@@ -60,8 +60,8 @@ public class ServletLifeCycleTest
         context.getObjectFactory().addDecorator(new TestDecorator());
 
         ServletHandler sh = context.getServletHandler();
-        sh.addListener(new ListenerHolder(TestListener.class));
-        context.addEventListener(context.getServletContext().createListener(TestListener2.class));
+        sh.addListener(new ListenerHolder(TestListener.class)); //added directly to ServletHandler
+        context.addEventListener(context.getServletContext().createListener(TestListener2.class));//create,decorate and add listener to context - no holder!
 
         sh.addFilterWithMapping(TestFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         sh.addFilterWithMapping(new FilterHolder(context.getServletContext().createFilter(TestFilter2.class)), "/*", EnumSet.of(DispatcherType.REQUEST));
@@ -110,8 +110,6 @@ public class ServletLifeCycleTest
         server.stop();
 
         assertThat(events, Matchers.contains(
-            "contextDestroyed class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestListener",
-            "contextDestroyed class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestListener2",
             "destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestFilter2",
             "Destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestFilter2",
             "destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestFilter",
@@ -122,6 +120,8 @@ public class ServletLifeCycleTest
             "destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestServlet2",
             "Destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestServlet",
             "destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestServlet",
+            "contextDestroyed class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestListener",
+            "contextDestroyed class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestListener2",
             "Destroy class org.eclipse.jetty.servlet.ServletLifeCycleTest$TestListener"
         ));
 


### PR DESCRIPTION
Closes #4662 

After  #4083 we called the ServletContextListeners.contextDestroyed too early, before the filters and servlets were destroyed.  This PR fixes that, and also reworks the initialization sequence of the filters/servlets/listeners so that the context starting and stopping code is more symmetrical.