### PR TITLE
Refactor CrossOriginFilter with small perf improvements

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.Filter;
@@ -157,8 +159,10 @@ public class CrossOriginFilter implements Filter
     private boolean anyOriginAllowed;
     private boolean anyTimingOriginAllowed;
     private boolean anyHeadersAllowed;
-    private List<String> allowedOrigins = new ArrayList<String>();
-    private List<String> allowedTimingOrigins = new ArrayList<String>();
+    private Set<String> allowedOrigins = new HashSet<String>();
+    private List<Pattern> allowedOriginPatterns = new ArrayList<Pattern>();
+    private Set<String> allowedTimingOrigins = new HashSet<String>();
+    private List<Pattern> allowedTimingOriginPatterns = new ArrayList<Pattern>();
     private List<String> allowedMethods = new ArrayList<String>();
     private List<String> allowedHeaders = new ArrayList<String>();
     private List<String> exposedHeaders = new ArrayList<String>();
@@ -172,8 +176,8 @@ public class CrossOriginFilter implements Filter
         String allowedOriginsConfig = config.getInitParameter(ALLOWED_ORIGINS_PARAM);
         String allowedTimingOriginsConfig = config.getInitParameter(ALLOWED_TIMING_ORIGINS_PARAM);
 
-        anyOriginAllowed = generateAllowedOrigins(allowedOrigins, allowedOriginsConfig, DEFAULT_ALLOWED_ORIGINS);
-        anyTimingOriginAllowed = generateAllowedOrigins(allowedTimingOrigins, allowedTimingOriginsConfig, DEFAULT_ALLOWED_TIMING_ORIGINS);
+        anyOriginAllowed = generateAllowedOrigins(allowedOrigins, allowedOriginPatterns, allowedOriginsConfig, DEFAULT_ALLOWED_ORIGINS);
+        anyTimingOriginAllowed = generateAllowedOrigins(allowedTimingOrigins, allowedTimingOriginPatterns, allowedTimingOriginsConfig, DEFAULT_ALLOWED_TIMING_ORIGINS);
 
         String allowedMethodsConfig = config.getInitParameter(ALLOWED_METHODS_PARAM);
         if (allowedMethodsConfig == null)
@@ -235,7 +239,7 @@ public class CrossOriginFilter implements Filter
         }
     }
 
-    private boolean generateAllowedOrigins(List<String> allowedOriginStore, String allowedOriginsConfig, String defaultOrigin)
+    private boolean generateAllowedOrigins(Set<String> allowedOriginStore, List<Pattern> allowedOriginPatternStore, String allowedOriginsConfig, String defaultOrigin)
     {
         if (allowedOriginsConfig == null)
             allowedOriginsConfig = defaultOrigin;
@@ -247,7 +251,11 @@ public class CrossOriginFilter implements Filter
                 if (ANY_ORIGIN.equals(allowedOrigin))
                 {
                     allowedOriginStore.clear();
+                    allowedOriginPatternStore.clear();
                     return true;
+                }
+                else if (allowedOrigin.contains("*")) {
+                    allowedOriginPatternStore.add(Pattern.compile(parseAllowedWildcardOriginToRegex(allowedOrigin)));
                 }
                 else
                 {
@@ -270,7 +278,7 @@ public class CrossOriginFilter implements Filter
         // Is it a cross origin request ?
         if (origin != null && isEnabled(request))
         {
-            if (anyOriginAllowed || originMatches(allowedOrigins, origin))
+            if (anyOriginAllowed || originMatches(allowedOrigins, allowedOriginPatterns, origin))
             {
                 if (isSimpleRequest(request))
                 {
@@ -292,7 +300,7 @@ public class CrossOriginFilter implements Filter
                     handleSimpleResponse(request, response, origin);
                 }
 
-                if (anyTimingOriginAllowed || originMatches(allowedTimingOrigins, origin))
+                if (anyTimingOriginAllowed || originMatches(allowedTimingOrigins, allowedTimingOriginPatterns, origin))
                 {
                     response.setHeader(TIMING_ALLOW_ORIGIN_HEADER, origin);
                 }
@@ -330,7 +338,7 @@ public class CrossOriginFilter implements Filter
         return true;
     }
 
-    private boolean originMatches(List<String> allowedOrigins, String originList)
+    private boolean originMatches(Set<String> allowedOrigins, List<Pattern> allowedOriginPatterns, String originList)
     {
         if (originList.trim().length() == 0)
             return false;
@@ -341,28 +349,16 @@ public class CrossOriginFilter implements Filter
             if (origin.trim().length() == 0)
                 continue;
 
-            for (String allowedOrigin : allowedOrigins)
+            if (allowedOrigins.contains(origin))
+                return true;
+
+            for (Pattern allowedOrigin : allowedOriginPatterns)
             {
-                if (allowedOrigin.contains("*"))
-                {
-                    Matcher matcher = createMatcher(origin, allowedOrigin);
-                    if (matcher.matches())
-                        return true;
-                }
-                else if (allowedOrigin.equals(origin))
-                {
+                if (allowedOrigin.matcher(origin).matches())
                     return true;
-                }
             }
         }
         return false;
-    }
-
-    private Matcher createMatcher(String origin, String allowedOrigin)
-    {
-        String regex = parseAllowedWildcardOriginToRegex(allowedOrigin);
-        Pattern pattern = Pattern.compile(regex);
-        return pattern.matcher(origin);
     }
 
     private String parseAllowedWildcardOriginToRegex(String allowedOrigin)
@@ -507,7 +503,11 @@ public class CrossOriginFilter implements Filter
     public void destroy()
     {
         anyOriginAllowed = false;
+        anyTimingOriginAllowed = false;
         allowedOrigins.clear();
+        allowedOriginPatterns.clear();
+        allowedTimingOrigins.clear();
+        allowedTimingOriginPatterns.clear();
         allowedMethods.clear();
         allowedHeaders.clear();
         preflightMaxAge = 0;

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/CrossOriginFilter.java
@@ -254,7 +254,8 @@ public class CrossOriginFilter implements Filter
                     allowedOriginPatternStore.clear();
                     return true;
                 }
-                else if (allowedOrigin.contains("*")) {
+                else if (allowedOrigin.contains("*"))
+                {
                     allowedOriginPatternStore.add(Pattern.compile(parseAllowedWildcardOriginToRegex(allowedOrigin)));
                 }
                 else


### PR DESCRIPTION
Hi maintainers,

I've made a small change to split the list of origins into a set of origins (for exact match) and a list of patterns (for pattern match). This way for exact match we can check if the set contains the origin (instead of iterating through the list) and only iterate through the origins for pattern matching. 

This change also creates patterns during the init phase, instead of creating a new Pattern object during each request

Functionality remains unchanged. Not sure if any tests need to be added, but do let me know if any specific tests are required.

Force pushed for adding signoff