### PR TITLE
Issue #4671 - fix NPE from CustomRequestLog logRequestCookie

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -1029,12 +1029,16 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
 
     private static void logRequestCookie(String arg, StringBuilder b, Request request, Response response)
     {
-        for (Cookie c : request.getCookies())
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null)
         {
-            if (arg.equals(c.getName()))
+            for (Cookie c : cookies)
             {
-                b.append(c.getValue());
-                return;
+                if (arg.equals(c.getName()))
+                {
+                    b.append(c.getValue());
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
**Issue #4671**

A null check is needed so a NPE will not be thrown if the request to be logged has no cookies.