### PR TITLE
Issue #4621 - excluding jetty-jaspi from jetty-all

### DIFF
--- a/aggregates/jetty-all/pom.xml
+++ b/aggregates/jetty-all/pom.xml
@@ -150,11 +150,15 @@
       <artifactId>jetty-util</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--
+      Cannot be included.
+      It requires javax.security.auth.message which cannot legally be included in jetty-all
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jaspi</artifactId>
       <version>${project.version}</version>
     </dependency>
+     -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jndi</artifactId>


### PR DESCRIPTION
+ Jaspi cannot be included in jetty-all because
  it requires javax.security.auth.message
  which cannot legally be included in jetty-all

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>