### PR TITLE
Issue #4673 - fix MultiPart parsing for content split in boundary

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/SearchPattern.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/SearchPattern.java
@@ -36,9 +36,9 @@ import java.util.Arrays;
  */
 public class SearchPattern
 {
-    static final int alphabetSize = 256;
-    private int[] table;
-    private byte[] pattern;
+    private static final int ALPHABET_SIZE = 256;
+    private final int[] table = new int[ALPHABET_SIZE];
+    private final byte[] pattern;
 
     /**
      * Produces a SearchPattern instance which can be used
@@ -70,16 +70,11 @@ public class SearchPattern
     private SearchPattern(byte[] pattern)
     {
         this.pattern = pattern;
-
         if (pattern.length == 0)
             throw new IllegalArgumentException("Empty Pattern");
 
         //Build up the pre-processed table for this pattern.
-        table = new int[alphabetSize];
-        for (int i = 0; i < table.length; ++i)
-        {
-            table[i] = pattern.length;
-        }
+        Arrays.fill(table, pattern.length);
         for (int i = 0; i < pattern.length - 1; ++i)
         {
             table[0xff & pattern[i]] = pattern.length - 1 - i;
@@ -97,7 +92,7 @@ public class SearchPattern
      */
     public int match(byte[] data, int offset, int length)
     {
-        validate(data, offset, length);
+        validateArgs(data, offset, length);
 
         int skip = offset;
         while (skip <= offset + length - pattern.length)
@@ -125,7 +120,7 @@ public class SearchPattern
      */
     public int endsWith(byte[] data, int offset, int length)
     {
-        validate(data, offset, length);
+        validateArgs(data, offset, length);
 
         int skip = (pattern.length <= length) ? (offset + length - pattern.length) : offset;
         while (skip < offset + length)
@@ -136,10 +131,8 @@ public class SearchPattern
                     return (offset + length - skip);
             }
 
-            if (skip + pattern.length - 1 < data.length)
-                skip += table[0xff & data[skip + pattern.length - 1]];
-            else
-                skip++;
+            // We can't use the pre-processed table as we are not matching on the full pattern.
+            skip++;
         }
 
         return 0;
@@ -157,10 +150,9 @@ public class SearchPattern
      */
     public int startsWith(byte[] data, int offset, int length, int matched)
     {
-        validate(data, offset, length);
+        validateArgs(data, offset, length);
 
         int matchedCount = 0;
-
         for (int i = 0; i < pattern.length - matched && i < length; i++)
         {
             if (data[offset + i] == pattern[i + matched])
@@ -180,7 +172,7 @@ public class SearchPattern
      * @param offset The offset within the data to start the search
      * @param length The length of the data to search
      */
-    private void validate(byte[] data, int offset, int length)
+    private void validateArgs(byte[] data, int offset, int length)
     {
         if (offset < 0)
             throw new IllegalArgumentException("offset was negative");

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/SearchPatternTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/SearchPatternTest.java
@@ -32,10 +32,10 @@ public class SearchPatternTest
     @Test
     public void testBasicSearch()
     {
-        byte[] p1 = new String("truth").getBytes(StandardCharsets.US_ASCII);
-        byte[] p2 = new String("evident").getBytes(StandardCharsets.US_ASCII);
-        byte[] p3 = new String("we").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String("we hold these truths to be self evident").getBytes(StandardCharsets.US_ASCII);
+        byte[] p1 = "truth".getBytes(StandardCharsets.US_ASCII);
+        byte[] p2 = "evident".getBytes(StandardCharsets.US_ASCII);
+        byte[] p3 = "we".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = "we hold these truths to be self evident".getBytes(StandardCharsets.US_ASCII);
 
         // Testing Compiled Pattern p1 "truth"
         SearchPattern sp1 = SearchPattern.compile(p1);
@@ -65,8 +65,8 @@ public class SearchPatternTest
     @Test
     public void testDoubleMatch()
     {
-        byte[] p = new String("violent").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String("These violent delights have violent ends.").getBytes(StandardCharsets.US_ASCII);
+        byte[] p = "violent".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = "These violent delights have violent ends.".getBytes(StandardCharsets.US_ASCII);
         SearchPattern sp = SearchPattern.compile(p);
         assertEquals(6, sp.match(d, 0, d.length));
         assertEquals(-1, sp.match(d, 6, p.length - 1));
@@ -113,8 +113,8 @@ public class SearchPatternTest
     @Test
     public void testAlmostMatch()
     {
-        byte[] p = new String("violent").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String("vio lent violen v iolent violin vioviolenlent viiolent").getBytes(StandardCharsets.US_ASCII);
+        byte[] p = "violent".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = "vio lent violen v iolent violin vioviolenlent viiolent".getBytes(StandardCharsets.US_ASCII);
         SearchPattern sp = SearchPattern.compile(p);
         assertEquals(-1, sp.match(d, 0, d.length));
     }
@@ -123,14 +123,14 @@ public class SearchPatternTest
     public void testOddSizedPatterns()
     {
         // Test Large Pattern
-        byte[] p = new String("pneumonoultramicroscopicsilicovolcanoconiosis").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String("pneumon").getBytes(StandardCharsets.US_ASCII);
+        byte[] p = "pneumonoultramicroscopicsilicovolcanoconiosis".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = "pneumon".getBytes(StandardCharsets.US_ASCII);
         SearchPattern sp = SearchPattern.compile(p);
         assertEquals(-1, sp.match(d, 0, d.length));
 
         // Test Single Character Pattern
-        p = new String("s").getBytes(StandardCharsets.US_ASCII);
-        d = new String("the cake is a lie").getBytes(StandardCharsets.US_ASCII);
+        p = "s".getBytes(StandardCharsets.US_ASCII);
+        d = "the cake is a lie".getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(10, sp.match(d, 0, d.length));
     }
@@ -138,30 +138,36 @@ public class SearchPatternTest
     @Test
     public void testEndsWith()
     {
-        byte[] p = new String("pneumonoultramicroscopicsilicovolcanoconiosis").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String("pneumonoultrami").getBytes(StandardCharsets.US_ASCII);
+        byte[] p = "pneumonoultramicroscopicsilicovolcanoconiosis".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = "pneumonoultrami".getBytes(StandardCharsets.US_ASCII);
         SearchPattern sp = SearchPattern.compile(p);
         assertEquals(15, sp.endsWith(d, 0, d.length));
 
-        p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        d = new String("abcdefghijklmnopqrstuvwxyzabcdefghijklmno").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmno".getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(0, sp.match(d, 0, d.length));
         assertEquals(-1, sp.match(d, 1, d.length - 1));
         assertEquals(15, sp.endsWith(d, 0, d.length));
 
-        p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        d = new String("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(0, sp.match(d, 0, d.length));
         assertEquals(26, sp.match(d, 1, d.length - 1));
         assertEquals(26, sp.endsWith(d, 0, d.length));
 
         //test no match
-        p = new String("hello world").getBytes(StandardCharsets.US_ASCII);
-        d = new String("there is definitely no match in here").getBytes(StandardCharsets.US_ASCII);
+        p = "hello world".getBytes(StandardCharsets.US_ASCII);
+        d = "there is definitely no match in here".getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(0, sp.endsWith(d, 0, d.length));
+
+        //Test with range on array.
+        p = "abcde".getBytes(StandardCharsets.US_ASCII);
+        d = "?abc00000".getBytes(StandardCharsets.US_ASCII);
+        sp = SearchPattern.compile(p);
+        assertEquals(3, sp.endsWith(d, 0, 4));
     }
 
     @Test
@@ -178,39 +184,54 @@ public class SearchPatternTest
 
     private void testStartsWith(String offset)
     {
-        byte[] p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        byte[] d = new String(offset + "ijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
+        byte[] p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        byte[] d = (offset + "ijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
         SearchPattern sp = SearchPattern.compile(p);
         assertEquals(18 + offset.length(), sp.match(d, offset.length(), d.length - offset.length()));
         assertEquals(-1, sp.match(d, offset.length() + 19, d.length - 19 - offset.length()));
         assertEquals(26, sp.startsWith(d, offset.length(), d.length - offset.length(), 8));
 
-        p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        d = new String(offset + "ijklmnopqrstuvwxyNOMATCH").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        d = (offset + "ijklmnopqrstuvwxyNOMATCH").getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(0, sp.startsWith(d, offset.length(), d.length - offset.length(), 8));
 
-        p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        d = new String(offset + "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        d = (offset + "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(26, sp.startsWith(d, offset.length(), d.length - offset.length(), 0));
 
         //test no match
-        p = new String("hello world").getBytes(StandardCharsets.US_ASCII);
-        d = new String(offset + "there is definitely no match in here").getBytes(StandardCharsets.US_ASCII);
+        p = "hello world".getBytes(StandardCharsets.US_ASCII);
+        d = (offset + "there is definitely no match in here").getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(0, sp.startsWith(d, offset.length(), d.length - offset.length(), 0));
 
         //test large pattern small buffer
-        p = new String("abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.US_ASCII);
-        d = new String(offset + "mnopqrs").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.US_ASCII);
+        d = (offset + "mnopqrs").getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(19, sp.startsWith(d, offset.length(), d.length - offset.length(), 12));
 
         //partial pattern
-        p = new String("abcdef").getBytes(StandardCharsets.US_ASCII);
-        d = new String(offset + "cde").getBytes(StandardCharsets.US_ASCII);
+        p = "abcdef".getBytes(StandardCharsets.US_ASCII);
+        d = (offset + "cde").getBytes(StandardCharsets.US_ASCII);
         sp = SearchPattern.compile(p);
         assertEquals(5, sp.startsWith(d, offset.length(), d.length - offset.length(), 2));
+    }
+
+    @Test
+    public void testExampleFrom4673()
+    {
+        SearchPattern pattern = SearchPattern.compile("\r\n------WebKitFormBoundaryhXfFAMfUnUKhmqT8".getBytes(StandardCharsets.US_ASCII));
+        byte[] data = new byte[]{118,97,108,117,101,49,
+                                 '\r','\n','-','-','-','-',
+                                 0,0,0,0,0,0,0,0,0,0,
+                                 0,0,0,0,0,0,0,0,0,0,
+                                 0,0,0,0,0,0,0,0,0,0};
+        int length = 12;
+
+        int partialMatch = pattern.endsWith(data, 0, length);
+        System.err.println("match1: " + partialMatch);
     }
 }


### PR DESCRIPTION
**Issue #4673**

If MultiPart content is parsed from different reads split over the boundary string, then the parser can sometimes think that the next part is content of the previous part.

The problem was in the implementation trying to use the table from the Boyer–Moore–Horspool algorithm for `SearchPattern.endsWith()`. This is a different situation to `SearchPattern.match()` as we are not matching on the whole pattern so the pre-processed table cannot be used in the same way.