### PR TITLE
Issue #4603 - avoid NPE during websocket HTTP/2 upgrade

### DIFF
--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
@@ -314,6 +314,9 @@ public class HttpTransportOverHTTP2 implements HttpTransport
         return transportCallback.onIdleTimeout(failure);
     }
 
+    /**
+     * @return true if error sent, false if upgraded or aborted.
+     */
     boolean prepareUpgrade()
     {
         HttpChannelOverHTTP2 channel = (HttpChannelOverHTTP2)stream.getAttachment();

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
@@ -320,12 +320,16 @@ public class HttpTransportOverHTTP2 implements HttpTransport
         Request request = channel.getRequest();
         if (request.getHttpInput().hasContent())
             return channel.sendErrorOrAbort("Unexpected content in CONNECT request");
+
         Connection connection = (Connection)request.getAttribute(UPGRADE_CONNECTION_ATTRIBUTE);
+        if (connection == null)
+            return channel.sendErrorOrAbort("No UPGRADE_CONNECTION_ATTRIBUTE available");
+
         EndPoint endPoint = connection.getEndPoint();
         endPoint.upgrade(connection);
         stream.setAttachment(endPoint);
-        // Only now that we have switched the attachment,
-        // we can demand DATA frames to process them.
+
+        // Only now that we have switched the attachment, we can demand DATA frames to process them.
         stream.demand(1);
 
         if (LOG.isDebugEnabled())
@@ -340,21 +344,6 @@ public class HttpTransportOverHTTP2 implements HttpTransport
         Object attachment = stream.getAttachment();
         if (attachment instanceof HttpChannelOverHTTP2)
         {
-            // TODO: we used to "fake" a 101 response to upgrade the endpoint
-            //  but we don't anymore, so this code should be deleted.
-            HttpChannelOverHTTP2 channel = (HttpChannelOverHTTP2)attachment;
-            if (channel.getResponse().getStatus() == HttpStatus.SWITCHING_PROTOCOLS_101)
-            {
-                Connection connection = (Connection)channel.getRequest().getAttribute(UPGRADE_CONNECTION_ATTRIBUTE);
-                EndPoint endPoint = connection.getEndPoint();
-                // TODO: check that endPoint implements HTTP2Channel.
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Tunnelling DATA frames through {}", endPoint);
-                endPoint.upgrade(connection);
-                stream.setAttachment(endPoint);
-                return;
-            }
-
             // If the stream is not closed, it is still reading the request content.
             // Send a reset to the other end so that it stops sending data.
             if (!stream.isClosed())
@@ -366,6 +355,7 @@ public class HttpTransportOverHTTP2 implements HttpTransport
 
             // Consume the existing queued data frames to
             // avoid stalling the session flow control.
+            HttpChannelOverHTTP2 channel = (HttpChannelOverHTTP2)attachment;
             channel.consumeInput();
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -490,7 +490,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                                 break;
                         }
 
-                        // Check if an update is done (if so, do not close)
+                        // If an upgrade is attempted and failed with sendError call, then do not close here.
                         if (checkAndPrepareUpgrade())
                             break;
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -490,7 +490,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                                 break;
                         }
 
-                        // If an upgrade is attempted and failed with sendError call, then do not close here.
+                        // If send error is called we need to break.
                         if (checkAndPrepareUpgrade())
                             break;
 
@@ -527,6 +527,10 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         return !suspended;
     }
 
+    /**
+     * @param message the error message.
+     * @return true if we have sent an error, false if we have aborted.
+     */
     public boolean sendErrorOrAbort(String message)
     {
         try

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -479,7 +479,6 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
         if (LOG.isDebugEnabled())
             LOG.debug("Upgrade from {} to {}", getEndPoint().getConnection(), upgradeConnection);
         getRequest().setAttribute(HttpTransport.UPGRADE_CONNECTION_ATTRIBUTE, upgradeConnection);
-        getResponse().setStatus(HttpStatus.SWITCHING_PROTOCOLS_101);
         getHttpTransport().onCompleted();
         return true;
     }

--- a/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
+++ b/jetty-websocket/websocket-core/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
@@ -160,12 +160,12 @@ public abstract class AbstractHandshaker implements Handshaker
 
         coreSession.setWebSocketConnection(connection);
 
+        baseRequest.setHandled(true);
         Response baseResponse = baseRequest.getResponse();
         prepareResponse(baseResponse, negotiation);
         if (httpConfig.getSendServerVersion())
             baseResponse.getHttpFields().put(SERVER_VERSION);
         baseResponse.flushBuffer();
-        baseRequest.setHandled(true);
 
         baseRequest.setAttribute(HttpTransport.UPGRADE_CONNECTION_ATTRIBUTE, connection);
 


### PR DESCRIPTION
**Issue #4603**

If no `UPGRADE_CONNECTION_ATTRIBUTE` is set when `prepareUpgrade()` is called we should do a sendErrorOrAbort on the channel.