### PR TITLE
Issue #4235 - communicate reason of OpenID auth failure to error page

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -434,8 +434,8 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             String redirectUri = URIUtil.addPaths(request.getContextPath(), _errorPage);
             if (message != null)
             {
-                String query = URIUtil.combineQueryParams(ERROR_PARAMETER + "=" + UrlEncoded.encodeString(message), _errorQuery);
-                redirectUri = URIUtil.addPaths(request.getContextPath(), _errorPath) + "?" + query;
+                String query = URIUtil.addQueries(ERROR_PARAMETER + "=" + UrlEncoded.encodeString(message), _errorQuery);
+                redirectUri = URIUtil.addPathQuery(URIUtil.addPaths(request.getContextPath(), _errorPath), query);
                 baseResponse.sendRedirect(getRedirectCode(baseRequest.getHttpVersion()), redirectUri);
             }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1305,6 +1305,28 @@ public class URIUtil
         return URI.create(buf.toString());
     }
 
+    /**
+     * Combine two query strings into one. Each query string should not contain the beginning '?' character, but
+     * may contain multiple parameters separated by the '{@literal &}' character.
+     * @param query1 the first query string.
+     * @param query2 the second query string.
+     * @return the combination of the two query strings.
+     */
+    public static String combineQueryParams(String query1, String query2)
+    {
+        StringBuilder queryBuilder = new StringBuilder();
+        if (!StringUtil.isEmpty(query1))
+        {
+            queryBuilder.append(query1);
+            if (!StringUtil.isEmpty(query2))
+                queryBuilder.append("&");
+        }
+
+        if (!StringUtil.isEmpty(query2))
+            queryBuilder.append(query2);
+        return queryBuilder.toString();
+    }
+
     public static URI getJarSource(URI uri)
     {
         try

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -714,6 +714,20 @@ public class URIUtil
         return buf.toString();
     }
 
+    /** Add a path and a query string
+     * @param path The path which may already contain contain a query
+     * @param query The query string or null if no query to be added
+     * @return The path with any non null query added after a '?' or '&amp;' as appropriate.
+     */
+    public static String addPathQuery(String path, String query)
+    {
+        if (query == null)
+            return path;
+        if (path.indexOf('?') >= 0)
+            return path + '&' + query;
+        return path + '?' + query;
+    }
+
     /**
      * Given a URI, attempt to get the last segment.
      * <p>
@@ -1312,19 +1326,13 @@ public class URIUtil
      * @param query2 the second query string.
      * @return the combination of the two query strings.
      */
-    public static String combineQueryParams(String query1, String query2)
+    public static String addQueries(String query1, String query2)
     {
-        StringBuilder queryBuilder = new StringBuilder();
-        if (!StringUtil.isEmpty(query1))
-        {
-            queryBuilder.append(query1);
-            if (!StringUtil.isEmpty(query2))
-                queryBuilder.append("&");
-        }
-
-        if (!StringUtil.isEmpty(query2))
-            queryBuilder.append(query2);
-        return queryBuilder.toString();
+        if (StringUtil.isEmpty(query1))
+            return query2;
+        if (StringUtil.isEmpty(query2))
+            return query1;
+        return query1 + '&' + query2;
     }
 
     public static URI getJarSource(URI uri)

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -730,6 +730,6 @@ public class URIUtilTest
     @MethodSource("addQueryParameterSource")
     public void testAddQueryParam(String param1, String param2, Matcher<String> matcher)
     {
-        assertThat(URIUtil.combineQueryParams(param1, param2), matcher);
+        assertThat(URIUtil.addQueries(param1, param2), matcher);
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -708,5 +709,27 @@ public class URIUtilTest
     public void testGetUriLastPathSegment(URI uri, String expectedName)
     {
         assertThat(URIUtil.getUriLastPathSegment(uri), is(expectedName));
+    }
+
+    public static Stream<Arguments> addQueryParameterSource()
+    {
+        final String newQueryParam = "newParam=11";
+        return Stream.of(
+            Arguments.of(null, newQueryParam, is(newQueryParam)),
+            Arguments.of(newQueryParam, null, is(newQueryParam)),
+            Arguments.of("", newQueryParam, is(newQueryParam)),
+            Arguments.of(newQueryParam, "", is(newQueryParam)),
+            Arguments.of("existingParam=3", newQueryParam, is("existingParam=3&" + newQueryParam)),
+            Arguments.of(newQueryParam, "existingParam=3", is(newQueryParam + "&existingParam=3")),
+            Arguments.of("existingParam1=value1&existingParam2=value2", newQueryParam, is("existingParam1=value1&existingParam2=value2&" + newQueryParam)),
+            Arguments.of(newQueryParam, "existingParam1=value1&existingParam2=value2", is(newQueryParam + "&existingParam1=value1&existingParam2=value2"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("addQueryParameterSource")
+    public void testAddQueryParam(String param1, String param2, Matcher<String> matcher)
+    {
+        assertThat(URIUtil.combineQueryParams(param1, param2), matcher);
     }
 }


### PR DESCRIPTION
**Issue #4235**

Make the ways errors are sent more consistent, now a utility method called `sendError` will either send a redirect to the error page if it was defined, otherwise it will send a 403 response. If a redirect was sent to the error page, a message may be given through the query parameter `error_description_jetty`. This has now been used in places where that logic was not being done previously.

The values `error` and `error_description` are already defined query parameters for OpenID Connect at 3.1.2.6.  Authentication Error Response at https://openid.net/specs/openid-connect-core-1_0.html. So I have defined this error reason to be a distinct parameter name `error_description_jetty`.