### PR TITLE
Fixes #4542 Root pathspec mapping pathInfo

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecGroup.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecGroup.java
@@ -39,7 +39,7 @@ public enum PathSpecGroup
      *
      * <pre>
      *   ""           - servlet spec       (Root Servlet)
-     *   null         - servlet spec       (Root Servlet)
+     *   null         - legacy             (Root Servlet)
      * </pre>
      *
      * Note: there is no known uri-template spec variant of this kind of path spec

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -167,7 +167,6 @@ public class ServletPathSpec extends PathSpec
     @Override
     public String getPathInfo(String path)
     {
-        // Path Info only valid for PREFIX_GLOB types
         switch (group)
         {
             case ROOT:

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -168,16 +168,19 @@ public class ServletPathSpec extends PathSpec
     public String getPathInfo(String path)
     {
         // Path Info only valid for PREFIX_GLOB types
-        if (group == PathSpecGroup.PREFIX_GLOB)
+        switch (group)
         {
-            if (path.length() == (specLength - 2))
-            {
-                return null;
-            }
-            return path.substring(specLength - 2);
-        }
+            case ROOT:
+                return path;
 
-        return null;
+            case PREFIX_GLOB:
+                if (path.length() == (specLength - 2))
+                    return null;
+                return path.substring(specLength - 2);
+
+            default:
+                return null;
+        }
     }
 
     @Override
@@ -185,35 +188,27 @@ public class ServletPathSpec extends PathSpec
     {
         switch (group)
         {
+            case ROOT:
+                return "";
+
             case EXACT:
                 if (pathSpec.equals(path))
-                {
                     return path;
-                }
-                else
-                {
-                    return null;
-                }
+                return null;
+
             case PREFIX_GLOB:
                 if (isWildcardMatch(path))
-                {
                     return path.substring(0, specLength - 2);
-                }
-                else
-                {
-                    return null;
-                }
+                return null;
+
             case SUFFIX_GLOB:
                 if (path.regionMatches(path.length() - (specLength - 1), pathSpec, 1, specLength - 1))
-                {
                     return path;
-                }
-                else
-                {
-                    return null;
-                }
+                return null;
+
             case DEFAULT:
                 return path;
+
             default:
                 return null;
         }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -62,6 +62,7 @@ public class PathMappingsTest
     {
         PathMappings<String> p = new PathMappings<>();
 
+        p.put(new ServletPathSpec(""), "root");
         p.put(new ServletPathSpec("/"), "default");
         p.put(new ServletPathSpec("/animal/bird/*"), "birds");
         p.put(new ServletPathSpec("/animal/fish/*"), "fishes");
@@ -75,7 +76,8 @@ public class PathMappingsTest
         assertMatch(p, "/animal/bird/eagle", "birds");
         assertMatch(p, "/animal/fish/bass/sea", "fishes");
         assertMatch(p, "/animal/peccary/javalina/evolution", "animals");
-        assertMatch(p, "/", "default");
+        assertMatch(p, "/", "root");
+        assertMatch(p, "/other", "default");
         assertMatch(p, "/animal/bird/eagle/chat", "animalChat");
         assertMatch(p, "/animal/bird/penguin/chat", "animalChat");
         assertMatch(p, "/animal/fish/trout/cam", "animalCam");

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/ServletPathSpecTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/ServletPathSpecTest.java
@@ -117,7 +117,8 @@ public class ServletPathSpecTest
         assertEquals(null, new ServletPathSpec("/Foo/*").getPathInfo("/Foo"), "pathInfo prefix");
         assertEquals(null, new ServletPathSpec("*.ext").getPathInfo("/Foo/bar.ext"), "pathInfo suffix");
         assertEquals(null, new ServletPathSpec("/").getPathInfo("/Foo/bar.ext"), "pathInfo default");
-
+        assertEquals("/", new ServletPathSpec("").getPathInfo("/"), "pathInfo root");
+        assertEquals("", new ServletPathSpec("").getPathInfo(""), "pathInfo root");
         assertEquals("/xxx/zzz", new ServletPathSpec("/*").getPathInfo("/xxx/zzz"), "pathInfo default");
     }
 
@@ -146,7 +147,8 @@ public class ServletPathSpecTest
         assertEquals("/Foo", new ServletPathSpec("/Foo/*").getPathMatch("/Foo"), "pathMatch prefix");
         assertEquals("/Foo/bar.ext", new ServletPathSpec("*.ext").getPathMatch("/Foo/bar.ext"), "pathMatch suffix");
         assertEquals("/Foo/bar.ext", new ServletPathSpec("/").getPathMatch("/Foo/bar.ext"), "pathMatch default");
-
+        assertEquals("", new ServletPathSpec("").getPathMatch("/"), "pathInfo root");
+        assertEquals("", new ServletPathSpec("").getPathMatch(""), "pathInfo root");
         assertEquals("", new ServletPathSpec("/*").getPathMatch("/xxx/zzz"), "pathMatch default");
     }
 


### PR DESCRIPTION
#4542 
For the "" root pathspec, the pathinfo should always be the full path and the matched path is ""

Signed-off-by: Greg Wilkins <gregw@webtide.com>