### PR TITLE
Reset trailers on recycled response

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -132,6 +132,7 @@ public class Response implements HttpServletResponse
         _out.recycle();
         _fields.clear();
         _encodingFrom = EncodingFrom.NOT_SET;
+        _trailers = null;
     }
 
     public HttpOutput getHttpOutput()
@@ -1080,6 +1081,7 @@ public class Response implements HttpServletResponse
         _mimeType = null;
         _characterEncoding = null;
         _encodingFrom = EncodingFrom.NOT_SET;
+        _trailers = null;
 
         // Clear all response headers
         _fields.clear();

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpTrailersTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpTrailersTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,7 +41,6 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpTrailersTest extends AbstractTest<TransportScenario>
 {
@@ -80,13 +81,11 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
     {
         String trailerName = "Trailer";
         String trailerValue = "value";
-        scenario.start(new AbstractHandler()
+        scenario.start(new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                jettyRequest.setHandled(true);
-
                 // Read the content first.
                 ServletInputStream input = jettyRequest.getInputStream();
                 while (true)
@@ -119,13 +118,11 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
     public void testEmptyRequestTrailers(Transport transport) throws Exception
     {
         init(transport);
-        scenario.start(new AbstractHandler()
+        scenario.start(new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                jettyRequest.setHandled(true);
-
                 // Read the content first.
                 ServletInputStream input = jettyRequest.getInputStream();
                 while (true)
@@ -166,16 +163,15 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
 
     private void testResponseTrailers(byte[] content) throws Exception
     {
-        final AtomicBoolean once = new AtomicBoolean(false);
+        AtomicBoolean once = new AtomicBoolean();
         String trailerName = "Trailer";
         String trailerValue = "value";
-        scenario.start(new AbstractHandler()
+        scenario.start(new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                jettyRequest.setHandled(true);
-                Response jettyResponse = (Response)response;
+                Response jettyResponse = jettyRequest.getResponse();
 
                 if (once.compareAndSet(false, true))
                 {
@@ -211,7 +207,7 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
         assertEquals(HttpStatus.OK_200, response.getStatus());
         assertNull(failure.get());
 
-        // subsequent requests should not have trailers
+        // Subsequent requests should not have trailers.
         response = scenario.client.newRequest(scenario.newURI())
             .onResponseSuccess(r ->
             {
@@ -237,16 +233,13 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
     public void testEmptyResponseTrailers(Transport transport) throws Exception
     {
         init(transport);
-        scenario.start(new AbstractHandler()
+        scenario.start(new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
             {
-                jettyRequest.setHandled(true);
-
                 HttpFields trailers = new HttpFields();
-
-                Response jettyResponse = (Response)response;
+                Response jettyResponse = jettyRequest.getResponse();
                 jettyResponse.setTrailers(() -> trailers);
             }
         });
@@ -282,17 +275,15 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
         String trailerName = "Trailer";
         String trailerValue = "value";
         init(transport);
-        scenario.start(new AbstractHandler()
+        scenario.start(new EmptyServerHandler()
         {
             @Override
-            public void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                jettyRequest.setHandled(true);
-
                 HttpFields trailers = new HttpFields();
                 trailers.put(trailerName, trailerValue);
 
-                Response jettyResponse = (Response)response;
+                Response jettyResponse = jettyRequest.getResponse();
                 jettyResponse.setTrailers(() -> trailers);
 
                 // Write a large content
@@ -327,5 +318,47 @@ public class HttpTrailersTest extends AbstractTest<TransportScenario>
         HttpFields trailers = httpResponse.getTrailers();
         assertNotNull(trailers);
         assertEquals(trailerValue, trailers.get(trailerName));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TransportProvider.class)
+    public void testResponseResetAlsoResetsTrailers(Transport transport) throws Exception
+    {
+        init(transport);
+        scenario.start(new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                Response jettyResponse = jettyRequest.getResponse();
+                HttpFields trailers = new HttpFields();
+                trailers.put("name", "value");
+                jettyResponse.setTrailers(() -> trailers);
+                // Fill some other response field.
+                response.setHeader("name", "value");
+                response.setStatus(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                response.getWriter();
+
+                // Reset the response.
+                response.reset();
+                // Must not throw because we have called
+                // getWriter() above, since we have reset().
+                response.getOutputStream();
+            }
+        });
+
+        CountDownLatch latch = new CountDownLatch(1);
+        scenario.client.newRequest(scenario.newURI())
+            .timeout(5, TimeUnit.SECONDS)
+            .send(result ->
+            {
+                HttpResponse response = (HttpResponse)result.getResponse();
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertNull(response.getTrailers());
+                assertNull(response.getHeaders().get("name"));
+                latch.countDown();
+            });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
Whilst investigating #4711 for jetty-10, it was noticed that trailers are not nulled on recycled Response instances, nor on reset.

Signed-off-by: Greg Wilkins <gregw@webtide.com>