### PR TITLE
Fixes #4735 - Get env variables in PHP scripts served through FastCGI…

### DIFF
--- a/jetty-fcgi/fcgi-server/pom.xml
+++ b/jetty-fcgi/fcgi-server/pom.xml
@@ -14,6 +14,23 @@
     <bundle-symbolic-name>${project.groupId}.server</bundle-symbolic-name>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-alpn-java-server</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -49,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-alpn-java-server</artifactId>
+      <artifactId>jetty-alpn-openjdk8-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jetty-fcgi/fcgi-server/pom.xml
+++ b/jetty-fcgi/fcgi-server/pom.xml
@@ -14,10 +14,6 @@
     <bundle-symbolic-name>${project.groupId}.server</bundle-symbolic-name>
   </properties>
 
-  <build>
-    <plugins></plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -38,6 +34,7 @@
       <artifactId>jetty-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
@@ -52,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-alpn-server</artifactId>
+      <artifactId>jetty-alpn-java-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/proxy/FastCGIProxyServlet.java
+++ b/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/proxy/FastCGIProxyServlet.java
@@ -19,11 +19,14 @@
 package org.eclipse.jetty.fcgi.server.proxy;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -48,7 +51,7 @@ import org.eclipse.jetty.util.ProcessorUtils;
  * that is sent to the FastCGI server specified in the {@code proxyTo}
  * init-param.
  * <p>
- * This servlet accepts two additional init-params:
+ * This servlet accepts these additional {@code init-param}s:
  * <ul>
  * <li>{@code scriptRoot}, mandatory, that must be set to the directory where
  * the application that must be served via FastCGI is installed and corresponds to
@@ -62,6 +65,8 @@ import org.eclipse.jetty.util.ProcessorUtils;
  * </ul></li>
  * <li>{@code fastCGI.HTTPS}, optional, defaults to false, that specifies whether
  * to force the FastCGI {@code HTTPS} parameter to the value {@code on}</li>
+ * <li>{@code fastCGI.envNames}, optional, a comma separated list of environment variable
+ * names read via {@link System#getenv(String)} that are forwarded as FastCGI parameters.</li>
  * </ul>
  *
  * @see TryFilesFilter
@@ -73,6 +78,7 @@ public class FastCGIProxyServlet extends AsyncProxyServlet.Transparent
     public static final String ORIGINAL_URI_ATTRIBUTE_INIT_PARAM = "originalURIAttribute";
     public static final String ORIGINAL_QUERY_ATTRIBUTE_INIT_PARAM = "originalQueryAttribute";
     public static final String FASTCGI_HTTPS_INIT_PARAM = "fastCGI.HTTPS";
+    public static final String FASTCGI_ENV_NAMES_INIT_PARAM = "fastCGI.envNames";
 
     private static final String REMOTE_ADDR_ATTRIBUTE = FastCGIProxyServlet.class.getName() + ".remoteAddr";
     private static final String REMOTE_PORT_ATTRIBUTE = FastCGIProxyServlet.class.getName() + ".remotePort";
@@ -87,6 +93,7 @@ public class FastCGIProxyServlet extends AsyncProxyServlet.Transparent
     private String originalURIAttribute;
     private String originalQueryAttribute;
     private boolean fcgiHTTPS;
+    private Set<String> fcgiEnvNames;
 
     @Override
     public void init() throws ServletException
@@ -102,6 +109,15 @@ public class FastCGIProxyServlet extends AsyncProxyServlet.Transparent
         originalQueryAttribute = getInitParameter(ORIGINAL_QUERY_ATTRIBUTE_INIT_PARAM);
 
         fcgiHTTPS = Boolean.parseBoolean(getInitParameter(FASTCGI_HTTPS_INIT_PARAM));
+
+        fcgiEnvNames = Collections.emptySet();
+        String envNames = getInitParameter(FASTCGI_ENV_NAMES_INIT_PARAM);
+        if (envNames != null)
+        {
+            fcgiEnvNames = Stream.of(envNames.split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+        }
     }
 
     @Override
@@ -195,6 +211,13 @@ public class FastCGIProxyServlet extends AsyncProxyServlet.Transparent
 
     protected void customizeFastCGIHeaders(Request proxyRequest, HttpFields fastCGIHeaders)
     {
+        for (String envName : fcgiEnvNames)
+        {
+            String envValue = System.getenv(envName);
+            if (envValue != null)
+                fastCGIHeaders.put(envName, envValue);
+        }
+
         fastCGIHeaders.remove("HTTP_PROXY");
 
         fastCGIHeaders.put(FCGI.Headers.REMOTE_ADDR, (String)proxyRequest.getAttributes().get(REMOTE_ADDR_ATTRIBUTE));


### PR DESCRIPTION
…ProxyServlet.

Introduced fastCGI.envNames to specify a comma separated list of
environment variable names that are forwarded to the PHP process.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>

Closes #4735.