### PR TITLE
Issue #4737 Ensure lifecycle callbacks happen for run-as and non async servlets

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
@@ -462,8 +462,9 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
         //classes are unknown outside the ServletHolder
         Servlet unwrapped = servlet;
         while (WrapperServlet.class.isAssignableFrom(unwrapped.getClass()))
-            unwrapped = ((WrapperServlet)unwrapped).unwrap();
+            unwrapped = ((WrapperServlet)unwrapped).getWrappedServlet();
         getServletHandler().destroyServlet(unwrapped);
+        //destroy the wrapped servlet, in case there is special behaviour
         servlet.destroy();
     }
 
@@ -1314,7 +1315,7 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
         /**
          * @return the original servlet
          */
-        public Servlet unwrap()
+        public Servlet getWrappedServlet()
         {
             return _servlet;
         }


### PR DESCRIPTION
Closes #4737 

Need to unwrap RunAsServlet and NotAsyncServlet before calling ServletHandler.destroyServlet(Servlet) because these wrapper classnames are unknown outside of the ServletHolder, in particular to the LifeCycleCallbackCollection, which contains the maps of postConstruct and preDestroy methods to call based on the name of the class.