### PR TITLE
Issue #4752 Call HttpSessionListener.sessionCreated in order listeners were added.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -279,7 +279,8 @@ public class SessionHandler extends ScopedHandler
     }
 
     /**
-     * Call the session lifecycle listeners
+     * Call the session lifecycle listeners in
+     * the reverse order they were added.
      *
      * @param session the session on which to call the lifecycle listeners
      */
@@ -310,7 +311,8 @@ public class SessionHandler extends ScopedHandler
     }
 
     /**
-     * Call the session lifecycle listeners
+     * Call the session lifecycle listeners in the order
+     * they were added.
      *
      * @param session the session on which to call the lifecycle listeners
      */
@@ -322,9 +324,9 @@ public class SessionHandler extends ScopedHandler
         if (_sessionListeners != null)
         {
             HttpSessionEvent event = new HttpSessionEvent(session);
-            for (int i = _sessionListeners.size() - 1; i >= 0; i--)
+            for (HttpSessionListener  l : _sessionListeners)
             {
-                _sessionListeners.get(i).sessionCreated(event);
+                l.sessionCreated(event);
             }
         }
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/session/SessionHandlerTest.java
@@ -22,9 +22,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import javax.servlet.SessionTrackingMode;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
 
+import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SessionHandlerTest
@@ -35,7 +40,64 @@ public class SessionHandlerTest
         SessionHandler sessionHandler = new SessionHandler();
         sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)));
         sessionHandler.setSessionTrackingModes(Collections.singleton(SessionTrackingMode.SSL));
-        assertThrows(IllegalArgumentException.class,() ->
-            sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.SSL, SessionTrackingMode.URL))));
+        assertThrows(IllegalArgumentException.class, () -> sessionHandler.setSessionTrackingModes(new HashSet<>(Arrays.asList(SessionTrackingMode.SSL, SessionTrackingMode.URL))));
+    }
+
+    @Test
+    public void testSessionListenerOrdering()
+        throws Exception
+    {
+        final StringBuffer result = new StringBuffer();
+
+        class Listener1 implements HttpSessionListener
+        {
+
+            @Override
+            public void sessionCreated(HttpSessionEvent se)
+            {
+                result.append("Listener1 create;");
+            }
+
+            @Override
+            public void sessionDestroyed(HttpSessionEvent se)
+            {
+                result.append("Listener1 destroy;");
+            }
+        }
+
+        class Listener2 implements HttpSessionListener
+        {
+
+            @Override
+            public void sessionCreated(HttpSessionEvent se)
+            {
+                result.append("Listener2 create;");
+            }
+
+            @Override
+            public void sessionDestroyed(HttpSessionEvent se)
+            {
+                result.append("Listener2 destroy;");
+            }
+
+        }
+
+        Server server = new Server();
+        SessionHandler sessionHandler = new SessionHandler();
+        try
+        {
+            sessionHandler.addEventListener(new Listener1());
+            sessionHandler.addEventListener(new Listener2());
+            sessionHandler.setServer(server);
+            sessionHandler.start();
+            Session session = new Session(sessionHandler, new SessionData("aa", "_", "0.0", 0, 0, 0, 0));
+            sessionHandler.callSessionCreatedListeners(session);
+            sessionHandler.callSessionDestroyedListeners(session);
+            assertEquals("Listener1 create;Listener2 create;Listener2 destroy;Listener1 destroy;", result.toString());
+        }
+        finally
+        {
+            sessionHandler.stop();
+        }
     }
 }


### PR DESCRIPTION
Closes #4752 

Ensure HttpSessionListener.sessionCreated is called in order listeners were added. HttpSessionListener.sessionDestroyed remains in reverse order.