### PR TITLE
Improve keystore exception message when keystore is not valid

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateUtils.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateUtils.java
@@ -47,7 +47,7 @@ public class CertificateUtils
             }
 
             if (!store.exists())
-                throw new IllegalStateException("no valid keystore");
+                throw new IllegalStateException(store.getName() + " is not a valid keystore");
 
             try (InputStream inStream = store.getInputStream())
             {

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
@@ -217,7 +217,7 @@ public class SslContextFactoryTest
                 cf.setTrustStorePath("/foo");
                 cf.start();
             });
-            assertThat(x.getMessage(), containsString("no valid keystore"));
+            assertThat(x.getMessage(), equalTo("/foo is not a valid keystore"));
         }
     }
 


### PR DESCRIPTION
It took me two days to find out why my keystore should not be valid due to this misleading error message. I thought it was the wrong format or the wrong password, but it was the absolute path :laughing: