### PR TITLE
Let code like a org.eclipse.jetty.proxy.AsyncMiddleManServlet subclass

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -69,7 +69,7 @@ public class HttpRequest implements Request
     private final AtomicReference<Throwable> aborted = new AtomicReference<>();
     private final HttpClient client;
     private final HttpConversation conversation;
-    private final String host;
+    private String host;
     private final int port;
     private URI uri;
     private String scheme;
@@ -925,4 +925,15 @@ public class HttpRequest implements Request
     {
         return String.format("%s[%s %s %s]@%x", getClass().getSimpleName(), getMethod(), getPath(), getVersion(), hashCode());
     }
+    
+    /**
+     * Overrides the host name.
+     *
+     * @param host the new host name.
+     */
+    @Override
+    public void host(String host) {
+        this.host = host;
+    }
+
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -463,6 +463,13 @@ public interface Request
     Throwable getAbortCause();
 
     /**
+     * Overrides the host name.
+     *
+     * @param host the new host name.
+     */
+    void host(String host);
+
+    /**
      * Common, empty, super-interface for request listeners.
      */
     interface RequestListener extends EventListener


### PR DESCRIPTION
Let code like a `org.eclipse.jetty.proxy.AsyncMiddleManServlet` subclass override a client request host name.
