### PR TITLE
Fixes #4787 - Make org.eclipse.jetty.client.HttpRequest's host name w…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -69,12 +69,12 @@ public class HttpRequest implements Request
     private final AtomicReference<Throwable> aborted = new AtomicReference<>();
     private final HttpClient client;
     private final HttpConversation conversation;
-    private final String host;
-    private final int port;
-    private URI uri;
     private String scheme;
+    private String host;
+    private int port;
     private String path;
     private String query;
+    private URI uri;
     private String method = HttpMethod.GET.asString();
     private HttpVersion version = HttpVersion.HTTP_1_1;
     private long idleTimeout = -1;
@@ -136,9 +136,25 @@ public class HttpRequest implements Request
     }
 
     @Override
+    public Request host(String host)
+    {
+        this.host = host;
+        this.uri = null;
+        return this;
+    }
+
+    @Override
     public int getPort()
     {
         return port;
+    }
+
+    @Override
+    public Request port(int port)
+    {
+        this.port = port;
+        this.uri = null;
+        return this;
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -51,25 +51,38 @@ import org.eclipse.jetty.util.Fields;
 public interface Request
 {
     /**
-     * @return the scheme of this request, such as "http" or "https"
+     * @return the URI scheme of this request, such as "http" or "https"
      */
     String getScheme();
 
     /**
-     * @param scheme the scheme of this request, such as "http" or "https"
+     * @param scheme the URI scheme of this request, such as "http" or "https"
      * @return this request object
      */
     Request scheme(String scheme);
 
     /**
-     * @return the host of this request, such as "127.0.0.1" or "google.com"
+     * @return the URI host of this request, such as "127.0.0.1" or "google.com"
      */
     String getHost();
 
     /**
-     * @return the port of this request such as 80 or 443
+     * @param host the URI host of this request, such as "127.0.0.1" or "google.com"
+     * @return this request object
+     */
+    Request host(String host);
+
+    /**
+     * @return the URI port of this request such as 80 or 443
      */
     int getPort();
+
+    /**
+     *
+     * @param port the URI port of this request such as 80 or 443
+     * @return this request object
+     */
+    Request port(int port);
 
     /**
      * @return the method of this request, such as GET or POST, as a String
@@ -89,26 +102,26 @@ public interface Request
     Request method(String method);
 
     /**
-     * @return the path of this request, such as "/" or "/path" - without the query
+     * @return the URI path of this request, such as "/" or "/path" - without the query
      * @see #getQuery()
      */
     String getPath();
 
     /**
-     * Specifies the path - and possibly the query - of this request.
+     * Specifies the URI path - and possibly the query - of this request.
      * If the query part is specified, parameter values must be properly
      * {@link URLEncoder#encode(String, String) UTF-8 URL encoded}.
      * For example, if the value for parameter "currency" is the euro symbol &euro; then the
      * query string for this parameter must be "currency=%E2%82%AC".
      * For transparent encoding of parameter values, use {@link #param(String, String)}.
      *
-     * @param path the path of this request, such as "/" or "/path?param=1"
+     * @param path the URI path of this request, such as "/" or "/path?param=1"
      * @return this request object
      */
     Request path(String path);
 
     /**
-     * @return the query string of this request such as "param=1"
+     * @return the URI query string of this request such as "param=1"
      * @see #getPath()
      * @see #getParams()
      */
@@ -131,12 +144,12 @@ public interface Request
     Request version(HttpVersion version);
 
     /**
-     * @return the query parameters of this request
+     * @return the URI query parameters of this request
      */
     Fields getParams();
 
     /**
-     * Adds a query parameter with the given name and value.
+     * Adds a URI query parameter with the given name and value.
      * The value is {@link URLEncoder#encode(String, String) UTF-8 URL encoded}.
      *
      * @param name the name of the query parameter

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
@@ -133,6 +133,26 @@ public class HttpClientURITest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
+    public void testHostPort(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        Request request = client.newRequest("domain.com", 80)
+            .scheme(scenario.getScheme())
+            .host("localhost")
+            .port(connector.getLocalPort())
+            .timeout(1, TimeUnit.SECONDS);
+
+        assertEquals("localhost", request.getHost());
+        assertEquals(connector.getLocalPort(), request.getPort());
+
+        ContentResponse response = request.send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
     public void testPath(Scenario scenario) throws Exception
     {
         final String path = "/path";


### PR DESCRIPTION
…ritable.

For some historical reason, host and port were not mutable after the request
was created. Since many other key parameters are mutable (e.g. the scheme)
it makes sense to make host and port mutable too.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>

Closes #4787.