### PR TITLE
Channel recycling h2

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -544,9 +544,9 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
                 stream = newLocalStream(frame, frameOut);
                 stream.setListener(listener);
                 ControlEntry entry = new ControlEntry(frameOut[0], stream, new StreamPromiseCallback(promise, stream));
+                stream.process(new PrefaceFrame(), Callback.NOOP);
                 queued = flusher.append(entry);
             }
-            stream.process(new PrefaceFrame(), Callback.NOOP);
             // Iterate outside the synchronized block.
             if (queued)
                 flusher.iterate();

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/HeadersFrame.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/HeadersFrame.java
@@ -41,6 +41,11 @@ public class HeadersFrame extends Frame
         this(0, metaData, priority, endStream);
     }
 
+    public HeadersFrame(int streamId, PriorityFrame priority, HeadersFrame other)
+    {
+        this(streamId, other.getMetaData(), priority, other.isEndStream());
+    }
+
     /**
      * <p>Creates a new {@code HEADERS} frame with the specified stream {@code id}.</p>
      * <p>{@code HEADERS} frames with a specific stream {@code id} are typically used

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/PriorityFrame.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/PriorityFrame.java
@@ -41,6 +41,11 @@ public class PriorityFrame extends Frame
         this.exclusive = exclusive;
     }
 
+    public PriorityFrame(int streamId, PriorityFrame other)
+    {
+        this(streamId, other.getParentStreamId(), other.getWeight(), other.isExclusive());
+    }
+
     public int getStreamId()
     {
         return streamId;

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/PushPromiseFrame.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/frames/PushPromiseFrame.java
@@ -26,6 +26,16 @@ public class PushPromiseFrame extends Frame
     private final int promisedStreamId;
     private final MetaData.Request metaData;
 
+    public PushPromiseFrame(int streamId, MetaData.Request metaData)
+    {
+        this(streamId, 0, metaData);
+    }
+
+    public PushPromiseFrame(int promisedStreamId, PushPromiseFrame frame)
+    {
+        this(frame.getStreamId(), promisedStreamId, frame.getMetaData());
+    }
+
     public PushPromiseFrame(int streamId, int promisedStreamId, MetaData.Request metaData)
     {
         super(FrameType.PUSH_PROMISE);

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnection.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnection.java
@@ -94,7 +94,7 @@ public class HTTP2ServerConnection extends HTTP2Connection
     private final AtomicLong totalResponses = new AtomicLong();
     private final ServerSessionListener listener;
     private final HttpConfiguration httpConfig;
-    private boolean recycleHttpChannels;
+    private boolean recycleHttpChannels = true;
 
     public HTTP2ServerConnection(ByteBufferPool byteBufferPool, Executor executor, EndPoint endPoint, HttpConfiguration httpConfig, ServerParser parser, ISession session, int inputBufferSize, ServerSessionListener listener)
     {

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpTransportOverHTTP2.java
@@ -265,7 +265,7 @@ public class HttpTransportOverHTTP2 implements HttpTransport
         if (LOG.isDebugEnabled())
             LOG.debug("HTTP/2 Push {}", request);
 
-        stream.push(new PushPromiseFrame(stream.getId(), 0, request), new Promise<>()
+        stream.push(new PushPromiseFrame(stream.getId(), request), new Promise<>()
         {
             @Override
             public void succeeded(Stream pushStream)


### PR DESCRIPTION
Re-enable recycling of http2 channels; solve the race condition (see #3673) while relieving lock contention (see #2188).