### PR TITLE
Issue #4819 - Workarounds for old (pre API 24) Android SDKs

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -1413,7 +1413,15 @@ public class SslContextFactory extends AbstractLifeCycle implements Dumpable
     public void customize(SSLEngine sslEngine)
     {
         SSLParameters sslParams = sslEngine.getSSLParameters();
-        sslParams.setEndpointIdentificationAlgorithm(_endpointIdentificationAlgorithm);
+        try
+        {
+            // Method introduced on introduced on Android API 24.
+            sslParams.setEndpointIdentificationAlgorithm(_endpointIdentificationAlgorithm);
+        }
+        catch (NoSuchMethodError ignored)
+        {
+            // ignore failure on old Android API revisions.
+        }
         sslEngine.setSSLParameters(sslParams);
 
         if (getWantClientAuth())


### PR DESCRIPTION
There's a number of SSL/TLS related API calls that we use in Jetty 9.2.x that are not available in older versions of Android.

These are a set of workarounds to not crash when those APIs are not present in the JVM runtime.
