### PR TITLE
Start a mongo instance for testing using docker via java code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
           agent { node { label 'linux' } }
           steps {
             timeout(time: 120, unit: 'MINUTES') {
-              mavenBuild("jdk8", "-T3 -Pmongodb clean install", "maven3", true)
+              mavenBuild("jdk8", "-T3 clean install", "maven3", true)
               // Collect up the jacoco execution results (only on main build)
               jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                   exclusionPattern: '' +
@@ -45,7 +45,7 @@ pipeline {
           agent { node { label 'linux' } }
           steps {
             timeout(time: 120, unit: 'MINUTES') {
-              mavenBuild("jdk11", "-T3 -Pmongodb clean install", "maven3", true)
+              mavenBuild("jdk11", "-T3 clean install", "maven3", true)
               warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
               junit testResults: '**/target/surefire-reports/*.xml,**/target/invoker-reports/TEST*.xml'
             }
@@ -56,7 +56,7 @@ pipeline {
           agent { node { label 'linux' } }
           steps {
             timeout(time: 120, unit: 'MINUTES') {
-              mavenBuild("jdk14", "-T3 -Pmongodb clean install", "maven3", true)
+              mavenBuild("jdk14", "-T3 clean install", "maven3", true)
               warnings consoleParsers: [[parserName: 'Maven'], [parserName: 'Java']]
               junit testResults: '**/target/surefire-reports/*.xml,**/target/invoker-reports/TEST*.xml'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ def mavenBuild(jdk, cmdline, mvnName, junitPublishDisabled) {
       mavenOpts: mavenOpts,
       mavenLocalRepo: localRepo) {
     // Some common Maven command line + provided command line
-    sh "mvn -Pci -V -B -e -Dmaven.test.failure.ignore=true -Djetty.testtracker.log=true $cmdline -Dunix.socket.tmp=" + env.JENKINS_HOME
+    sh "mvn -Premote-session-tests -Pci -V -B -e -Dmaven.test.failure.ignore=true -Djetty.testtracker.log=true $cmdline -Dunix.socket.tmp=" + env.JENKINS_HOME
   }
 }
 

--- a/jetty-util/src/main/config/modules/slf4j-api.mod
+++ b/jetty-util/src/main/config/modules/slf4j-api.mod
@@ -16,7 +16,7 @@ maven://org.slf4j/slf4j-api/${slf4j.version}|lib/slf4j/slf4j-api-${slf4j.version
 lib/slf4j/slf4j-api-${slf4j.version}.jar
 
 [ini]
-slf4j.version?=1.7.25
+slf4j.version?=1.7.30
 jetty.webapp.addServerClasses+=,${jetty.base.uri}/lib/slf4j/
 
 [license]

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-support.version>1.4</build-support.version>
     <checkstyle.version>8.20</checkstyle.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <log4j2.version>2.11.2</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
     <logback.version>1.2.3</logback.version>
@@ -32,7 +32,7 @@
     <jmh.version>1.21</jmh.version>
     <jmhjar.name>benchmarks</jmhjar.name>
     <tycho-version>1.4.0</tycho-version>
-    <junit.version>5.5.1</junit.version>
+    <junit.version>5.6.2</junit.version>
     <maven.version>3.6.0</maven.version>
     <maven.resolver.version>1.3.1</maven.resolver.version>
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
@@ -1079,6 +1079,16 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>1.14.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>1.14.1</version>
       </dependency>
       <!-- Old Deps -->
       <dependency>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -116,10 +116,7 @@
     <profile>
       <id>ci</id>
       <activation>
-        <property>
-          <name>mongodb.enabled</name>
-          <value>true</value>
-        </property>
+        <file><exists>/var/run/docker.sock</exists></file>
       </activation>
       <build>
         <plugins>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -114,9 +114,13 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>ci</id>
+      <id>remote-session-tests</id>
       <activation>
-        <file><exists>/var/run/docker.sock</exists></file>
+<!--        <file><exists>/var/run/docker.sock</exists></file>-->
+        <property>
+          <name>mongo.enabled</name>
+          <value>true</value>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -117,7 +117,6 @@
     <profile>
       <id>remote-session-tests</id>
       <activation>
-<!--        <file><exists>/var/run/docker.sock</exists></file>-->
         <property>
           <name>mongo.enabled</name>
           <value>true</value>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.sessions.mongo</bundle-symbolic-name>
     <embedmongo.host>localhost</embedmongo.host>
+    <!-- if changing this version please update default in MongoTestHelper you will get thanks from Eclipse IDE users -->
     <mongo.docker.version>2.2.7</mongo.docker.version>
   </properties>
   <build>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.sessions.mongo</bundle-symbolic-name>
     <embedmongo.host>localhost</embedmongo.host>
+    <mongo.docker.version>2.2.7</mongo.docker.version>
   </properties>
   <build>
     <plugins>
@@ -95,10 +96,25 @@
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>
-      <id>mongodb</id>
+      <id>ci</id>
       <activation>
         <property>
           <name>mongodb.enabled</name>
@@ -112,50 +128,10 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemPropertyVariables>
-                <embedmongoPort>${embedmongo.port}</embedmongoPort>
-                <embedmongoHost>${embedmongo.host}</embedmongoHost>
+                <mongo.docker.version>${mongo.docker.version}</mongo.docker.version>
               </systemPropertyVariables>
               <skipTests>false</skipTests>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>com.github.joelittlejohn.embedmongo</groupId>
-            <artifactId>embedmongo-maven-plugin</artifactId>
-            <version>0.4.1</version>
-            <configuration>
-              <!--port>37017</port-->
-              <!-- allocates a random port and overrides embedmongo.port -->
-              <randomPort>true</randomPort>
-
-              <databaseDirectory>${project.build.directory}/mongotest</databaseDirectory>
-
-              <!-- optional (file|console|none), default console -->
-              <logging>file</logging>
-              <!-- optional, can be used when logging=file, default is ./embedmongo.log -->
-              <logFile>${project.build.directory}/embedmongo.log</logFile>
-              <!--optional, one of wiredTiger or mmapv1 (default is mmapv1) -->
-              <!--storageEngine>wiredTiger</storageEngine-->
-              <!-- optional, skips this plugin entirely, use on the command line like -Dembedmongo.skip -->
-              <skip>false</skip>
-              <downloadPath>https://jenkins.webtide.net/userContent/</downloadPath>
-              <version>2.2.1</version>
-            </configuration>
-            <executions>
-              <execution>
-                <id>start</id>
-                <phase>process-test-classes</phase>
-                <goals>
-                  <goal>start</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>stop</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>stop</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStoreTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStoreTest.java
@@ -42,15 +42,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
 {
+
     @BeforeEach
-    public void beforeClass() throws Exception
+    public void beforeEach() throws Exception
     {
         MongoTestHelper.dropCollection();
         MongoTestHelper.createCollection();
     }
 
     @AfterEach
-    public void afterClass() throws Exception
+    public void afterEach() throws Exception
     {
         MongoTestHelper.dropCollection();
     }

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoTestHelper.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoTestHelper.java
@@ -52,7 +52,7 @@ public class MongoTestHelper
     public static final String COLLECTION_NAME = "testsessions";
 
     static GenericContainer mongo =
-        new GenericContainer("mongo:" + System.getProperty("mongo.docker.version"))
+        new GenericContainer("mongo:" + System.getProperty("mongo.docker.version", "2.2.7"))
             .withLogConsumer(new Slf4jLogConsumer(MONGO_LOG));
 
     static MongoClient mongoClient;

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoTestHelper.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/nosql/mongodb/MongoTestHelper.java
@@ -32,8 +32,10 @@ import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
 import org.eclipse.jetty.server.session.SessionData;
 import org.eclipse.jetty.util.ClassLoadingObjectInputStream;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,39 +46,71 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class MongoTestHelper
 {
-    private static final Logger LOG = Log.getLogger(MongoTestHelper.class);
-    static int __workers = 0;
+    private static final Logger LOG = LoggerFactory.getLogger(MongoTestHelper.class);
+    private static final Logger MONGO_LOG = LoggerFactory.getLogger("org.eclipse.jetty.nosql.mongodb.MongoLogs");
     public static final String DB_NAME = "HttpSessions";
     public static final String COLLECTION_NAME = "testsessions";
 
-    static MongoClient _mongoClient;
+    static GenericContainer mongo =
+        new GenericContainer("mongo:" + System.getProperty("mongo.docker.version"))
+            .withLogConsumer(new Slf4jLogConsumer(MONGO_LOG));
 
-    static
+    static MongoClient mongoClient;
+
+    public static void startMongo()
     {
         try
         {
-            _mongoClient =
-                new MongoClient(System.getProperty("embedmongo.host"), Integer.getInteger("embedmongoPort"));
+            long start = System.currentTimeMillis();
+            mongo.start();
+            String containerIpAddress =  mongo.getContainerIpAddress();
+            int mongoPort = mongo.getMappedPort(27017);
+            LOG.info("Mongo container started for {}:{} - {}ms", containerIpAddress, mongoPort,
+                     System.currentTimeMillis() - start);
+            System.setProperty("embedmongoHost", containerIpAddress);
+            System.setProperty("embedmongoPort", Integer.toString(mongoPort));
         }
-        catch (UnknownHostException e)
+        catch (Exception e)
         {
-            e.printStackTrace();
+            LOG.error(e.getMessage(), e);
+            throw new RuntimeException(e);
         }
     }
 
-    public static void dropCollection() throws MongoException, UnknownHostException
+    public static void stopMongo()
     {
-        _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME).drop();
+        mongo.stop();
+        mongoClient = null;
+    }
+
+    public static MongoClient getMongoClient() throws UnknownHostException
+    {
+        boolean restart = false;
+        if (mongo == null || !mongo.isRunning())
+        {
+            startMongo();
+            restart = true;
+        }
+        if (mongoClient == null || restart)
+        {
+            mongoClient = new MongoClient(System.getProperty("embedmongoHost"), Integer.getInteger("embedmongoPort"));
+        }
+        return mongoClient;
+    }
+
+    public static void dropCollection() throws Exception
+    {
+        getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME).drop();
     }
 
     public static void createCollection() throws UnknownHostException, MongoException
     {
-        _mongoClient.getDB(DB_NAME).createCollection(COLLECTION_NAME, null);
+        getMongoClient().getDB(DB_NAME).createCollection(COLLECTION_NAME, null);
     }
 
     public static DBCollection getCollection() throws UnknownHostException, MongoException
     {
-        return _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        return getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
     }
 
     public static MongoSessionDataStoreFactory newSessionDataStoreFactory()
@@ -92,7 +126,7 @@ public class MongoTestHelper
     public static boolean checkSessionExists(String id)
         throws Exception
     {
-        DBCollection collection = _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        DBCollection collection = getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
 
         DBObject fields = new BasicDBObject();
         fields.put(MongoSessionDataStore.EXPIRY, 1);
@@ -109,7 +143,7 @@ public class MongoTestHelper
     public static boolean checkSessionPersisted(SessionData data)
         throws Exception
     {
-        DBCollection collection = _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        DBCollection collection = getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
 
         DBObject fields = new BasicDBObject();
 
@@ -117,7 +151,7 @@ public class MongoTestHelper
         if (sessionDocument == null)
             return false; //doesn't exist
 
-        LOG.info("{}", sessionDocument);
+        LOG.debug("{}", sessionDocument);
 
         Boolean valid = (Boolean)sessionDocument.get(MongoSessionDataStore.VALID);
 
@@ -183,7 +217,7 @@ public class MongoTestHelper
                                                Map<String, Object> attributes)
         throws Exception
     {
-        DBCollection collection = _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        DBCollection collection = getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
 
         // Form query for upsert
         BasicDBObject key = new BasicDBObject(MongoSessionDataStore.ID, id);
@@ -193,7 +227,7 @@ public class MongoTestHelper
         boolean upsert = false;
         BasicDBObject sets = new BasicDBObject();
 
-        Object version = new Long(1);
+        Object version = 1L;
 
         // New session
 
@@ -232,7 +266,7 @@ public class MongoTestHelper
         throws Exception
     {
 
-        DBCollection collection = _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        DBCollection collection = getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
 
         // Form query for upsert
         BasicDBObject key = new BasicDBObject(MongoSessionDataStore.ID, id);
@@ -242,7 +276,7 @@ public class MongoTestHelper
         boolean upsert = false;
         BasicDBObject sets = new BasicDBObject();
 
-        Object version = new Long(1);
+        Object version = 1L;
 
         // New session
         upsert = true;
@@ -278,7 +312,7 @@ public class MongoTestHelper
         throws Exception
     {
         //make old-style session to test if we can retrieve it
-        DBCollection collection = _mongoClient.getDB(DB_NAME).getCollection(COLLECTION_NAME);
+        DBCollection collection = getMongoClient().getDB(DB_NAME).getCollection(COLLECTION_NAME);
 
         // Form query for upsert
         BasicDBObject key = new BasicDBObject(MongoSessionDataStore.ID, id);
@@ -288,7 +322,7 @@ public class MongoTestHelper
         boolean upsert = false;
         BasicDBObject sets = new BasicDBObject();
 
-        Object version = new Long(1);
+        Object version = 1L;
 
         // New session
         upsert = true;

--- a/tests/test-sessions/test-mongodb-sessions/src/test/resources/simplelogger.properties
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/resources/simplelogger.properties
@@ -1,0 +1,3 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.log.org.eclipse.jetty.nosql.mongodb.MongoLogs=error
+org.slf4j.simpleLogger.log.org.eclipse.jetty.nosql.mongodb.MongoTestHelper=info


### PR DESCRIPTION
If @janbartel like it I can make changes for other external stuff we use such infinispan, memcache, hazelcast (remote mode) etc...
This simply avoid to start an external instance of any product (even in this case we can test different version of mongo using `-Dmongo.docker.version=x.x.x` as long as the tag is available here https://hub.docker.com/_/mongo?tab=tags 
ATM those tests were activated only with a profile I wonder if it should per default now?