### PR TITLE
Issue #4860 - NPE from HttpFields

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpField.java
@@ -40,7 +40,7 @@ public class HttpField
         if (_header != null && name == null)
             _name = _header.asString();
         else
-            _name = Objects.requireNonNull(name);
+            _name = Objects.requireNonNull(name, "name");
         _value = value;
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -303,14 +303,18 @@ public class HttpFields implements Iterable<HttpField>
      */
     public List<String> getValuesList(String name)
     {
-        final List<String> list = new ArrayList<>();
+        List<String> list = null;
         for (int i = 0; i < _size; i++)
         {
             HttpField f = _fields[i];
             if (f.getName().equalsIgnoreCase(name))
+            {
+                if (list == null)
+                    list = new ArrayList<>(size() - i);
                 list.add(f.getValue());
+            }
         }
-        return list;
+        return list == null ? Collections.emptyList() : list;
     }
 
     /**
@@ -711,7 +715,8 @@ public class HttpFields implements Iterable<HttpField>
 
     public void add(HttpHeader header, HttpHeaderValue value)
     {
-        add(header, value.toString());
+        if (value != null)
+            add(header, value.toString());
     }
 
     /**
@@ -966,8 +971,11 @@ public class HttpFields implements Iterable<HttpField>
      *
      * @param fields the fields to add
      */
+    @Deprecated
     public void add(HttpFields fields)
     {
+        // TODO this implementation doesn't do what the javadoc says and is really the same
+        // as addAll, which is renamed to add anyway in 10.
         if (fields == null)
             return;
 
@@ -1185,7 +1193,7 @@ public class HttpFields implements Iterable<HttpField>
         @Override
         public int nextIndex()
         {
-            return _cursor + 1;
+            return _cursor;
         }
 
         @Override
@@ -1199,16 +1207,22 @@ public class HttpFields implements Iterable<HttpField>
         {
             if (_current < 0)
                 throw new IllegalStateException();
-            _fields[_current] = field;
+            if (field == null)
+                remove();
+            else
+                _fields[_current] = field;
         }
 
         @Override
         public void add(HttpField field)
         {
-            _fields = Arrays.copyOf(_fields, _fields.length + 1);
-            System.arraycopy(_fields, _cursor, _fields, _cursor + 1, _size++);
-            _fields[_cursor++] = field;
-            _current = -1;
+            if (field != null)
+            {
+                _fields = Arrays.copyOf(_fields, _fields.length + 1);
+                System.arraycopy(_fields, _cursor, _fields, _cursor + 1, _size++);
+                _fields[_cursor++] = field;
+                _current = -1;
+            }
         }
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -636,7 +636,8 @@ public class HttpFields implements Iterable<HttpField>
             {
                 if (put)
                 {
-                    System.arraycopy(_fields, i + 1, _fields, i, --_size - i);
+                    _size--;
+                    System.arraycopy(_fields, i + 1, _fields, i, _size - i);
                 }
                 else
                 {
@@ -676,7 +677,7 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void put(HttpHeader header, String value)
     {
-        Objects.requireNonNull(header, "header");
+        Objects.requireNonNull(header, "header must not be null");
 
         if (value == null)
             remove(header);
@@ -692,7 +693,7 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void put(String name, List<String> list)
     {
-        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(name, "name must not be null");
 
         remove(name);
         if (list == null)
@@ -736,7 +737,7 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void add(HttpHeader header, String value)
     {
-        Objects.requireNonNull(header, "header");
+        Objects.requireNonNull(header, "header must not be null");
 
         if (value == null)
             throw new IllegalArgumentException("null value");
@@ -760,7 +761,8 @@ public class HttpFields implements Iterable<HttpField>
             if (f.getHeader() == name)
             {
                 removed = f;
-                System.arraycopy(_fields, i + 1, _fields, i, --_size - i);
+                _size--;
+                System.arraycopy(_fields, i + 1, _fields, i, _size - i);
             }
         }
         return removed;
@@ -781,7 +783,8 @@ public class HttpFields implements Iterable<HttpField>
             if (f.getName().equalsIgnoreCase(name))
             {
                 removed = f;
-                System.arraycopy(_fields, i + 1, _fields, i, --_size - i);
+                _size--;
+                System.arraycopy(_fields, i + 1, _fields, i, _size - i);
             }
         }
         return removed;
@@ -1229,8 +1232,9 @@ public class HttpFields implements Iterable<HttpField>
             if (field != null)
             {
                 _fields = Arrays.copyOf(_fields, _fields.length + 1);
-                System.arraycopy(_fields, _cursor, _fields, _cursor + 1, _size++);
+                System.arraycopy(_fields, _cursor, _fields, _cursor + 1, _size - _cursor);
                 _fields[_cursor++] = field;
+                _size++;
                 _current = -1;
             }
         }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.ToIntFunction;
@@ -675,6 +676,8 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void put(HttpHeader header, String value)
     {
+        Objects.requireNonNull(header, "header");
+
         if (value == null)
             remove(header);
         else
@@ -689,7 +692,12 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void put(String name, List<String> list)
     {
+        Objects.requireNonNull(name, "name");
+
         remove(name);
+        if (list == null)
+            return;
+
         for (String v : list)
         {
             if (v != null)
@@ -728,6 +736,8 @@ public class HttpFields implements Iterable<HttpField>
      */
     public void add(HttpHeader header, String value)
     {
+        Objects.requireNonNull(header, "header");
+
         if (value == null)
             throw new IllegalArgumentException("null value");
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpFieldTest
@@ -163,6 +164,12 @@ public class HttpFieldTest
         assertEquals("a", values[0]);
         assertEquals("x,\"p,q\",z", values[1]);
         assertEquals("c", values[2]);
+    }
+
+    @Test
+    public void testFieldNameNull()
+    {
+        assertThrows(NullPointerException.class, () -> new HttpField((String)null, null));
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpFieldsTest
 {
     @Test
-    public void testPut() throws Exception
+    public void testPut()
     {
         HttpFields header = new HttpFields();
 
@@ -72,7 +72,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testPutTo() throws Exception
+    public void testPutTo()
     {
         HttpFields header = new HttpFields();
 
@@ -93,7 +93,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGet() throws Exception
+    public void testGet()
     {
         HttpFields header = new HttpFields();
 
@@ -104,24 +104,21 @@ public class HttpFieldsTest
         assertEquals("value0", header.get("Name0"));
         assertEquals("value1", header.get("name1"));
         assertEquals("value1", header.get("Name1"));
-        assertEquals(null, header.get("Name2"));
+        assertNull(header.get("Name2"));
 
         assertEquals("value0", header.getField("name0").getValue());
         assertEquals("value0", header.getField("Name0").getValue());
         assertEquals("value1", header.getField("name1").getValue());
         assertEquals("value1", header.getField("Name1").getValue());
-        assertEquals(null, header.getField("Name2"));
+        assertNull(header.getField("Name2"));
 
         assertEquals("value0", header.getField(0).getValue());
         assertEquals("value1", header.getField(1).getValue());
-        assertThrows(NoSuchElementException.class, () ->
-        {
-            header.getField(2);
-        });
+        assertThrows(NoSuchElementException.class, () -> header.getField(2));
     }
 
     @Test
-    public void testGetValuesList() throws Exception
+    public void testGetValuesList()
     {
         HttpFields header = new HttpFields();
 
@@ -144,7 +141,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGetKnown() throws Exception
+    public void testGetKnown()
     {
         HttpFields header = new HttpFields();
 
@@ -157,12 +154,12 @@ public class HttpFieldsTest
         assertEquals("value0", header.getField(HttpHeader.CONNECTION).getValue());
         assertEquals("value1", header.getField(HttpHeader.ACCEPT).getValue());
 
-        assertEquals(null, header.getField(HttpHeader.AGE));
-        assertEquals(null, header.get(HttpHeader.AGE));
+        assertNull(header.getField(HttpHeader.AGE));
+        assertNull(header.get(HttpHeader.AGE));
     }
 
     @Test
-    public void testCRLF() throws Exception
+    public void testCRLF()
     {
         HttpFields header = new HttpFields();
 
@@ -181,7 +178,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testCachedPut() throws Exception
+    public void testCachedPut()
     {
         HttpFields header = new HttpFields();
 
@@ -201,7 +198,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testRePut() throws Exception
+    public void testRePut()
     {
         HttpFields header = new HttpFields();
 
@@ -235,13 +232,13 @@ public class HttpFieldsTest
         assertEquals(3, matches);
 
         e = header.getValues("name1");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value1");
-        assertEquals(false, e.hasMoreElements());
+        assertFalse(e.hasMoreElements());
     }
 
     @Test
-    public void testRemovePut() throws Exception
+    public void testRemovePut()
     {
         HttpFields header = new HttpFields(1);
 
@@ -275,11 +272,11 @@ public class HttpFieldsTest
         assertEquals(2, matches);
 
         e = header.getValues("name1");
-        assertEquals(false, e.hasMoreElements());
+        assertFalse(e.hasMoreElements());
     }
 
     @Test
-    public void testAdd() throws Exception
+    public void testAdd()
     {
         HttpFields fields = new HttpFields();
 
@@ -312,7 +309,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testAddAll() throws Exception
+    public void testAddAll()
     {
         HttpFields fields0 = new HttpFields();
         assertThat(fields0.size(), is(0));
@@ -369,7 +366,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGetValues() throws Exception
+    public void testGetValues()
     {
         HttpFields fields = new HttpFields();
 
@@ -379,37 +376,39 @@ public class HttpFieldsTest
         fields.add("name1", "\"value1C\",\tvalue1D");
 
         Enumeration<String> e = fields.getValues("name0");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0A,value0B");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0C,value0D");
-        assertEquals(false, e.hasMoreElements());
+        assertFalse(e.hasMoreElements());
 
+        //noinspection deprecation
         e = fields.getValues("name0", ",");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0A");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0B");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0C");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value0D");
-        assertEquals(false, e.hasMoreElements());
+        assertFalse(e.hasMoreElements());
 
+        //noinspection deprecation
         e = fields.getValues("name1", ",");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value1A");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value\t, 1B");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value1C");
-        assertEquals(true, e.hasMoreElements());
+        assertTrue(e.hasMoreElements());
         assertEquals(e.nextElement(), "value1D");
-        assertEquals(false, e.hasMoreElements());
+        assertFalse(e.hasMoreElements());
     }
 
     @Test
-    public void testAddCSV() throws Exception
+    public void testAddCSV()
     {
         HttpFields fields = new HttpFields();
         fields.addCSV(HttpHeader.CONNECTION);
@@ -433,7 +432,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGetCSV() throws Exception
+    public void testGetCSV()
     {
         HttpFields fields = new HttpFields();
 
@@ -449,7 +448,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testAddQuotedCSV() throws Exception
+    public void testAddQuotedCSV()
     {
         HttpFields fields = new HttpFields();
 
@@ -491,7 +490,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGetQualityCSV() throws Exception
+    public void testGetQualityCSV()
     {
         HttpFields fields = new HttpFields();
 
@@ -513,7 +512,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testGetQualityCSVHeader() throws Exception
+    public void testGetQualityCSVHeader()
     {
         HttpFields fields = new HttpFields();
 
@@ -535,7 +534,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testDateFields() throws Exception
+    public void testDateFields()
     {
         HttpFields fields = new HttpFields();
 
@@ -577,7 +576,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testNegDateFields() throws Exception
+    public void testNegDateFields()
     {
         HttpFields fields = new HttpFields();
 
@@ -595,7 +594,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testLongFields() throws Exception
+    public void testLongFields()
     {
         HttpFields header = new HttpFields();
 
@@ -607,47 +606,12 @@ public class HttpFieldsTest
         header.put("N2", "xx");
 
         long i1 = header.getLongField("I1");
-        try
-        {
-            header.getLongField("I2");
-            assertTrue(false);
-        }
-        catch (NumberFormatException e)
-        {
-            assertTrue(true);
-        }
+        assertThrows(NumberFormatException.class, () -> header.getLongField("I2"));
 
         long i3 = header.getLongField("I3");
-
-        try
-        {
-            header.getLongField("I4");
-            assertTrue(false);
-        }
-        catch (NumberFormatException e)
-        {
-            assertTrue(true);
-        }
-
-        try
-        {
-            header.getLongField("N1");
-            assertTrue(false);
-        }
-        catch (NumberFormatException e)
-        {
-            assertTrue(true);
-        }
-
-        try
-        {
-            header.getLongField("N2");
-            assertTrue(false);
-        }
-        catch (NumberFormatException e)
-        {
-            assertTrue(true);
-        }
+        assertThrows(NumberFormatException.class, () -> header.getLongField("I4"));
+        assertThrows(NumberFormatException.class, () -> header.getLongField("N1"));
+        assertThrows(NumberFormatException.class, () -> header.getLongField("N2"));
 
         assertEquals(42, i1);
         assertEquals(-44, i3);
@@ -659,7 +623,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testContains() throws Exception
+    public void testContains()
     {
         HttpFields header = new HttpFields();
 
@@ -739,7 +703,7 @@ public class HttpFieldsTest
         // previously caused a NPE in put.   If this test doesn't throw then it passes.
         HttpFields fields = new HttpFields();
         fields.add((HttpField)null);
-        fields.put((HttpField)null);
+        fields.put(null);
         fields.put("something", "else");
         ListIterator<HttpField> iter = fields.listIterator();
         iter.next();
@@ -754,7 +718,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testIteration() throws Exception
+    public void testIteration()
     {
         HttpFields header = new HttpFields();
         Iterator<HttpField> i = header.iterator();
@@ -845,7 +809,7 @@ public class HttpFieldsTest
     }
 
     @Test
-    public void testStream() throws Exception
+    public void testStream()
     {
         HttpFields header = new HttpFields();
         assertThat(header.stream().count(), is(0L));

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.http;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -697,6 +698,44 @@ public class HttpFieldsTest
     }
 
     @Test
+    public void testAddNullName()
+    {
+        HttpFields fields = new HttpFields();
+        assertThrows(NullPointerException.class, () -> fields.add((String)null, "bogus"));
+        assertThat(fields.size(), is(0));
+
+        assertThrows(NullPointerException.class, () -> fields.add((HttpHeader)null, "bogus"));
+        assertThat(fields.size(), is(0));
+    }
+
+    @Test
+    public void testPutNullName()
+    {
+        HttpFields fields = new HttpFields();
+        assertThrows(NullPointerException.class, () -> fields.put((String)null, "bogus"));
+        assertThat(fields.size(), is(0));
+
+        assertThrows(NullPointerException.class, () -> fields.put(null, (List<String>)null));
+        assertThat(fields.size(), is(0));
+
+        List<String> emptyList = new ArrayList<>();
+        assertThrows(NullPointerException.class, () -> fields.put(null, emptyList));
+        assertThat(fields.size(), is(0));
+
+        assertThrows(NullPointerException.class, () -> fields.put((HttpHeader)null, "bogus"));
+        assertThat(fields.size(), is(0));
+    }
+
+    @Test
+    public void testPutNullValueList()
+    {
+        HttpFields fields = new HttpFields();
+
+        fields.put("name", (List<String>)null);
+        assertThat(fields.size(), is(0));
+    }
+
+    @Test
     public void testPreventNullField()
     {
         // Attempt various ways that may have put a null field in the array that
@@ -710,15 +749,15 @@ public class HttpFieldsTest
         assertThat(fields.size(), is(1));
         ListIterator<HttpField> iter = fields.listIterator();
         iter.next();
-        iter.set(null);
+        iter.set(null); // set field to null - null entry in list now
         assertThat(fields.size(), is(0));
-        iter.add(null);
+        iter.add(null); // attempt to add null entry
         assertThat(fields.size(), is(0));
         fields.put("something", "other");
         assertThat(fields.size(), is(1));
         iter = fields.listIterator();
         iter.next();
-        iter.remove();
+        iter.remove(); // remove only entry
         assertThat(fields.size(), is(0));
         fields.put("something", "other");
         assertThat(fields.size(), is(1));

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -700,20 +700,28 @@ public class HttpFieldsTest
     public void testPreventNullField()
     {
         // Attempt various ways that may have put a null field in the array that
-        // previously caused a NPE in put.   If this test doesn't throw then it passes.
+        // previously caused a NPE in put.
         HttpFields fields = new HttpFields();
-        fields.add((HttpField)null);
-        fields.put(null);
+        fields.add((HttpField)null); // should not result in field being added
+        assertThat(fields.size(), is(0));
+        fields.put(null); // should not result in field being added
+        assertThat(fields.size(), is(0));
         fields.put("something", "else");
+        assertThat(fields.size(), is(1));
         ListIterator<HttpField> iter = fields.listIterator();
         iter.next();
         iter.set(null);
+        assertThat(fields.size(), is(0));
         iter.add(null);
+        assertThat(fields.size(), is(0));
         fields.put("something", "other");
+        assertThat(fields.size(), is(1));
         iter = fields.listIterator();
         iter.next();
         iter.remove();
+        assertThat(fields.size(), is(0));
         fields.put("something", "other");
+        assertThat(fields.size(), is(1));
         fields.clear();
     }
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -767,7 +767,7 @@ public class HttpFieldsTest
     @Test
     public void testIteration()
     {
-        HttpFields header = new HttpFields();
+        HttpFields header = new HttpFields(5);
         Iterator<HttpField> i = header.iterator();
         assertThat(i.hasNext(), is(false));
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -749,7 +749,7 @@ public class HttpFieldsTest
         assertThat(fields.size(), is(1));
         ListIterator<HttpField> iter = fields.listIterator();
         iter.next();
-        iter.set(null); // set field to null - null entry in list now
+        iter.set(null); // set field to null - should result in noop
         assertThat(fields.size(), is(0));
         iter.add(null); // attempt to add null entry
         assertThat(fields.size(), is(0));

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -432,8 +432,17 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                                 abort(x);
                             else
                             {
-                                _response.resetContent();
-                                sendResponseAndComplete();
+                                try
+                                {
+                                    _response.resetContent();
+                                    sendResponseAndComplete();
+                                }
+                                catch (Throwable t)
+                                {
+                                    if (x != t)
+                                        x.addSuppressed(t);
+                                    abort(x);
+                                }
                             }
                         }
                         finally


### PR DESCRIPTION
Fix handling of null fields in `HttpFields` for #4860 :
 + Added paranoid catch in `HttpChannel` so even if fix doesn't work we won't loop forever.
 + Fixed bug in iterator with nextIndex
 + Do not allow null fields to be set with list iterator
 + improved test coverage
