### PR TITLE
Issue #4828 Buffer Corruption

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -305,7 +305,7 @@ public class ErrorHandler extends AbstractHandler
                 // TODO error page may cause a BufferOverflow.  In which case we try
                 // TODO again with stacks disabled. If it still overflows, it is
                 // TODO written without a body.
-                ByteBuffer buffer = baseRequest.getResponse().getHttpOutput().acquireBuffer();
+                ByteBuffer buffer = baseRequest.getResponse().getHttpOutput().getBuffer();
                 ByteBufferOutputStream out = new ByteBufferOutputStream(buffer);
                 PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, charset));
 


### PR DESCRIPTION
For #4828 Buffer Corruption:
 + improve synchronization around `releaseBuffer`
 + improve synchronization around `acquireBuffer`
 + made `acquireBuffer` private.

Signed-off-by: Greg Wilkins <gregw@webtide.com>