### PR TITLE
Issue #4861 - reduce garbage created by the async request attributes

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -118,17 +118,17 @@ class AsyncAttributes extends Attributes.Wrapper
         super.clearAttributes();
     }
 
-    public void applyToAttributes(Attributes attributes)
+    public static void applyAsyncAttributes(Attributes attributes, String requestURI, String contextPath, String servletPath, String pathInfo, String queryString)
     {
-        if (_requestURI != null)
-            attributes.setAttribute(AsyncContext.ASYNC_REQUEST_URI, _requestURI);
-        if (_contextPath != null)
-            attributes.setAttribute(AsyncContext.ASYNC_CONTEXT_PATH, _contextPath);
-        if (_servletPath != null)
-            attributes.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, _servletPath);
-        if (_pathInfo != null)
-            attributes.setAttribute(AsyncContext.ASYNC_PATH_INFO, _pathInfo);
-        if (_queryString != null)
-            attributes.setAttribute(AsyncContext.ASYNC_QUERY_STRING, _queryString);
+        if (requestURI != null)
+            attributes.setAttribute(AsyncContext.ASYNC_REQUEST_URI, requestURI);
+        if (contextPath != null)
+            attributes.setAttribute(AsyncContext.ASYNC_CONTEXT_PATH, contextPath);
+        if (servletPath != null)
+            attributes.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, servletPath);
+        if (pathInfo != null)
+            attributes.setAttribute(AsyncContext.ASYNC_PATH_INFO, pathInfo);
+        if (queryString != null)
+            attributes.setAttribute(AsyncContext.ASYNC_QUERY_STRING, queryString);
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -26,28 +26,27 @@ import org.eclipse.jetty.util.Attributes;
 
 class AsyncAttributes extends Attributes.Wrapper
 {
-    /**
-     * Async dispatch attribute name prefix.
-     */
-    public static final String __ASYNC_PREFIX = "javax.servlet.async.";
-
     private String _requestURI;
     private String _contextPath;
     private String _servletPath;
     private String _pathInfo;
-    private String _query;
+    private String _queryString;
 
-    AsyncAttributes(Attributes attributes)
+    public AsyncAttributes(Attributes attributes, String requestUri, String contextPath, String servletPath, String pathInfo, String queryString)
     {
         super(attributes);
+
+        // TODO: make fields final in jetty-10 and NOOP when one of these attributes is set.
+        _requestURI = requestUri;
+        _contextPath = contextPath;
+        _servletPath = servletPath;
+        _pathInfo = pathInfo;
+        _queryString = queryString;
     }
 
     @Override
     public Object getAttribute(String key)
     {
-        if (!key.startsWith(__ASYNC_PREFIX))
-            return super.getAttribute(key);
-
         switch (key)
         {
             case AsyncContext.ASYNC_REQUEST_URI:
@@ -59,7 +58,7 @@ class AsyncAttributes extends Attributes.Wrapper
             case AsyncContext.ASYNC_PATH_INFO:
                 return _pathInfo;
             case AsyncContext.ASYNC_QUERY_STRING:
-                return _query;
+                return _queryString;
             default:
                 return super.getAttribute(key);
         }
@@ -68,13 +67,7 @@ class AsyncAttributes extends Attributes.Wrapper
     @Override
     public Set<String> getAttributeNameSet()
     {
-        HashSet<String> set = new HashSet<>();
-        for (String name : _attributes.getAttributeNameSet())
-        {
-            if (!name.startsWith(__ASYNC_PREFIX))
-                set.add(name);
-        }
-
+        Set<String> set = new HashSet<>(super.getAttributeNameSet());
         if (_requestURI != null)
             set.add(AsyncContext.ASYNC_REQUEST_URI);
         if (_contextPath != null)
@@ -83,18 +76,14 @@ class AsyncAttributes extends Attributes.Wrapper
             set.add(AsyncContext.ASYNC_SERVLET_PATH);
         if (_pathInfo != null)
             set.add(AsyncContext.ASYNC_PATH_INFO);
-        if (_query != null)
+        if (_queryString != null)
             set.add(AsyncContext.ASYNC_QUERY_STRING);
-
         return set;
     }
 
     @Override
     public void setAttribute(String key, Object value)
     {
-        if (!key.startsWith(__ASYNC_PREFIX))
-            super.setAttribute(key, value);
-
         switch (key)
         {
             case AsyncContext.ASYNC_REQUEST_URI:
@@ -110,10 +99,11 @@ class AsyncAttributes extends Attributes.Wrapper
                 _pathInfo = (String)value;
                 break;
             case AsyncContext.ASYNC_QUERY_STRING:
-                _query = (String)value;
+                _queryString = (String)value;
                 break;
             default:
                 super.setAttribute(key, value);
+                break;
         }
     }
 
@@ -124,7 +114,21 @@ class AsyncAttributes extends Attributes.Wrapper
         _contextPath = null;
         _servletPath = null;
         _pathInfo = null;
-        _query = null;
+        _queryString = null;
         super.clearAttributes();
+    }
+
+    public void applyToAttributes(Attributes attributes)
+    {
+        if (_requestURI != null)
+            attributes.setAttribute(AsyncContext.ASYNC_REQUEST_URI, _requestURI);
+        if (_contextPath != null)
+            attributes.setAttribute(AsyncContext.ASYNC_CONTEXT_PATH, _contextPath);
+        if (_servletPath != null)
+            attributes.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, _servletPath);
+        if (_pathInfo != null)
+            attributes.setAttribute(AsyncContext.ASYNC_PATH_INFO, _pathInfo);
+        if (_queryString != null)
+            attributes.setAttribute(AsyncContext.ASYNC_QUERY_STRING, _queryString);
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -1,0 +1,130 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.AsyncContext;
+
+import org.eclipse.jetty.util.Attributes;
+
+class AsyncAttributes extends Attributes.Wrapper
+{
+    /**
+     * Async dispatch attribute name prefix.
+     */
+    public static final String __ASYNC_PREFIX = "javax.servlet.async.";
+
+    private String _requestURI;
+    private String _contextPath;
+    private String _servletPath;
+    private String _pathInfo;
+    private String _query;
+
+    AsyncAttributes(Attributes attributes)
+    {
+        super(attributes);
+    }
+
+    @Override
+    public Object getAttribute(String key)
+    {
+        if (!key.startsWith(__ASYNC_PREFIX))
+            return super.getAttribute(key);
+
+        switch (key)
+        {
+            case AsyncContext.ASYNC_REQUEST_URI:
+                return _requestURI;
+            case AsyncContext.ASYNC_CONTEXT_PATH:
+                return _contextPath;
+            case AsyncContext.ASYNC_SERVLET_PATH:
+                return _servletPath;
+            case AsyncContext.ASYNC_PATH_INFO:
+                return _pathInfo;
+            case AsyncContext.ASYNC_QUERY_STRING:
+                return _query;
+            default:
+                return super.getAttribute(key);
+        }
+    }
+
+    @Override
+    public Set<String> getAttributeNameSet()
+    {
+        HashSet<String> set = new HashSet<>();
+        for (String name : _attributes.getAttributeNameSet())
+        {
+            if (!name.startsWith(__ASYNC_PREFIX))
+                set.add(name);
+        }
+
+        if (_requestURI != null)
+            set.add(AsyncContext.ASYNC_REQUEST_URI);
+        if (_contextPath != null)
+            set.add(AsyncContext.ASYNC_CONTEXT_PATH);
+        if (_servletPath != null)
+            set.add(AsyncContext.ASYNC_SERVLET_PATH);
+        if (_pathInfo != null)
+            set.add(AsyncContext.ASYNC_PATH_INFO);
+        if (_query != null)
+            set.add(AsyncContext.ASYNC_QUERY_STRING);
+
+        return set;
+    }
+
+    @Override
+    public void setAttribute(String key, Object value)
+    {
+        if (!key.startsWith(__ASYNC_PREFIX))
+            super.setAttribute(key, value);
+
+        switch (key)
+        {
+            case AsyncContext.ASYNC_REQUEST_URI:
+                _requestURI = (String)value;
+                break;
+            case AsyncContext.ASYNC_CONTEXT_PATH:
+                _contextPath = (String)value;
+                break;
+            case AsyncContext.ASYNC_SERVLET_PATH:
+                _servletPath = (String)value;
+                break;
+            case AsyncContext.ASYNC_PATH_INFO:
+                _pathInfo = (String)value;
+                break;
+            case AsyncContext.ASYNC_QUERY_STRING:
+                _query = (String)value;
+                break;
+            default:
+                super.setAttribute(key, value);
+        }
+    }
+
+    @Override
+    public void clearAttributes()
+    {
+        _requestURI = null;
+        _contextPath = null;
+        _servletPath = null;
+        _pathInfo = null;
+        _query = null;
+        super.clearAttributes();
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContextEvent.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.server;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
-import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -32,7 +31,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
 {
     private final Context _context;
     private final AsyncContextState _asyncContext;
-    private volatile HttpChannelState _state;
+    private final HttpChannelState _state;
     private ServletContext _dispatchContext;
     private String _dispatchPath;
     private volatile Scheduler.Task _timeoutTask;
@@ -45,31 +44,9 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         _asyncContext = asyncContext;
         _state = state;
 
-        // If we haven't been async dispatched before
-        if (baseRequest.getAttribute(AsyncContext.ASYNC_REQUEST_URI) == null)
-        {
-            // We are setting these attributes during startAsync, when the spec implies that
-            // they are only available after a call to AsyncContext.dispatch(...);
-
-            // have we been forwarded before?
-            String uri = (String)baseRequest.getAttribute(RequestDispatcher.FORWARD_REQUEST_URI);
-            if (uri != null)
-            {
-                baseRequest.setAttribute(AsyncContext.ASYNC_REQUEST_URI, uri);
-                baseRequest.setAttribute(AsyncContext.ASYNC_CONTEXT_PATH, baseRequest.getAttribute(RequestDispatcher.FORWARD_CONTEXT_PATH));
-                baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, baseRequest.getAttribute(RequestDispatcher.FORWARD_SERVLET_PATH));
-                baseRequest.setAttribute(AsyncContext.ASYNC_PATH_INFO, baseRequest.getAttribute(RequestDispatcher.FORWARD_PATH_INFO));
-                baseRequest.setAttribute(AsyncContext.ASYNC_QUERY_STRING, baseRequest.getAttribute(RequestDispatcher.FORWARD_QUERY_STRING));
-            }
-            else
-            {
-                baseRequest.setAttribute(AsyncContext.ASYNC_REQUEST_URI, baseRequest.getRequestURI());
-                baseRequest.setAttribute(AsyncContext.ASYNC_CONTEXT_PATH, baseRequest.getContextPath());
-                baseRequest.setAttribute(AsyncContext.ASYNC_SERVLET_PATH, baseRequest.getServletPath());
-                baseRequest.setAttribute(AsyncContext.ASYNC_PATH_INFO, baseRequest.getPathInfo());
-                baseRequest.setAttribute(AsyncContext.ASYNC_QUERY_STRING, baseRequest.getQueryString());
-            }
-        }
+        // We are setting these attributes during startAsync, when the spec implies that
+        // they are only available after a call to AsyncContext.dispatch(...);
+        baseRequest.setAsyncAttributes();
     }
 
     public ServletContext getSuspendedContext()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -330,24 +330,25 @@ public class Dispatcher implements RequestDispatcher
                 {
                     case FORWARD_PATH_INFO:
                         _pathInfo = (String)value;
-                        return;
+                        break;
                     case FORWARD_REQUEST_URI:
                         _requestURI = (String)value;
-                        return;
+                        break;
                     case FORWARD_SERVLET_PATH:
                         _servletPath = (String)value;
-                        return;
+                        break;
                     case FORWARD_CONTEXT_PATH:
                         _contextPath = (String)value;
-                        return;
+                        break;
                     case FORWARD_QUERY_STRING:
                         _query = (String)value;
-                        return;
+                        break;
                     default:
                         if (value == null)
                             _attributes.removeAttribute(key);
                         else
                             _attributes.setAttribute(key, value);
+                        break;
                 }
             }
             else if (value == null)
@@ -452,24 +453,25 @@ public class Dispatcher implements RequestDispatcher
                 {
                     case INCLUDE_PATH_INFO:
                         _pathInfo = (String)value;
-                        return;
+                        break;
                     case INCLUDE_REQUEST_URI:
                         _requestURI = (String)value;
-                        return;
+                        break;
                     case INCLUDE_SERVLET_PATH:
                         _servletPath = (String)value;
-                        return;
+                        break;
                     case INCLUDE_CONTEXT_PATH:
                         _contextPath = (String)value;
-                        return;
+                        break;
                     case INCLUDE_QUERY_STRING:
                         _query = (String)value;
-                        return;
+                        break;
                     default:
                         if (value == null)
                             _attributes.removeAttribute(key);
                         else
                             _attributes.setAttribute(key, value);
+                        break;
                 }
             }
             else if (value == null)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1868,10 +1868,13 @@ public class Request implements HttpServletRequest
         _asyncNotSupportedSource = null;
         _handled = false;
         _attributes = Attributes.unwrap(_attributes);
-        if (ServletAttributes.class.equals(_attributes.getClass()))
-            _attributes.clearAttributes();
-        else
-            _attributes = new ServletAttributes();
+        if (_attributes != null)
+        {
+            if (ServletAttributes.class.equals(_attributes.getClass()))
+                _attributes.clearAttributes();
+            else
+                _attributes = null;
+        }
         _contentType = null;
         _characterEncoding = null;
         _contextPath = null;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
@@ -1,0 +1,64 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.Set;
+
+import org.eclipse.jetty.util.Attributes;
+import org.eclipse.jetty.util.AttributesMap;
+
+public class ServletAttributes implements Attributes
+{
+    private final Attributes _attributes;
+
+    public ServletAttributes()
+    {
+        _attributes = new AsyncAttributes(new AttributesMap());
+    }
+
+    @Override
+    public void removeAttribute(String name)
+    {
+        _attributes.removeAttribute(name);
+    }
+
+    @Override
+    public void setAttribute(String name, Object attribute)
+    {
+        _attributes.setAttribute(name, attribute);
+    }
+
+    @Override
+    public Object getAttribute(String name)
+    {
+        return _attributes.getAttribute(name);
+    }
+
+    @Override
+    public Set<String> getAttributeNameSet()
+    {
+        return _attributes.getAttributeNameSet();
+    }
+
+    @Override
+    public void clearAttributes()
+    {
+        _attributes.clearAttributes();
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
@@ -28,9 +28,9 @@ public class ServletAttributes implements Attributes
     private final Attributes _attributes = new AttributesMap();
     private AsyncAttributes _asyncAttributes;
 
-    public void setAsyncAttributes(AsyncAttributes attributes)
+    public void setAsyncAttributes(String requestURI, String contextPath, String servletPath, String pathInfo, String queryString)
     {
-        _asyncAttributes = attributes;
+        _asyncAttributes = new AsyncAttributes(_attributes, requestURI, contextPath, servletPath, pathInfo, queryString);
     }
 
     private Attributes getAttributes()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
@@ -25,40 +25,59 @@ import org.eclipse.jetty.util.AttributesMap;
 
 public class ServletAttributes implements Attributes
 {
-    private final Attributes _attributes;
+    private final Attributes _attributes = new AttributesMap();
+    private AsyncAttributes _asyncAttributes;
 
-    public ServletAttributes()
+    public void setAsyncAttributes(AsyncAttributes attributes)
     {
-        _attributes = new AsyncAttributes(new AttributesMap());
+        _asyncAttributes = attributes;
     }
 
     @Override
     public void removeAttribute(String name)
     {
-        _attributes.removeAttribute(name);
+        if (_asyncAttributes == null)
+            _attributes.removeAttribute(name);
+        else
+            _asyncAttributes.removeAttribute(name);
     }
 
     @Override
     public void setAttribute(String name, Object attribute)
     {
-        _attributes.setAttribute(name, attribute);
+        if (_asyncAttributes == null)
+            _attributes.setAttribute(name, attribute);
+        else
+            _asyncAttributes.setAttribute(name, attribute);
     }
 
     @Override
     public Object getAttribute(String name)
     {
-        return _attributes.getAttribute(name);
+        if (_asyncAttributes == null)
+            return _attributes.getAttribute(name);
+        else
+            return _asyncAttributes.getAttribute(name);
     }
 
     @Override
     public Set<String> getAttributeNameSet()
     {
-        return _attributes.getAttributeNameSet();
+        if (_asyncAttributes == null)
+            return _attributes.getAttributeNameSet();
+        else
+            return _asyncAttributes.getAttributeNameSet();
     }
 
     @Override
     public void clearAttributes()
     {
-        _attributes.clearAttributes();
+        if (_asyncAttributes == null)
+            _attributes.clearAttributes();
+        else
+        {
+            _asyncAttributes.clearAttributes();
+            _asyncAttributes = null;
+        }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServletAttributes.java
@@ -33,51 +33,39 @@ public class ServletAttributes implements Attributes
         _asyncAttributes = attributes;
     }
 
+    private Attributes getAttributes()
+    {
+        return (_asyncAttributes == null) ? _attributes : _asyncAttributes;
+    }
+
     @Override
     public void removeAttribute(String name)
     {
-        if (_asyncAttributes == null)
-            _attributes.removeAttribute(name);
-        else
-            _asyncAttributes.removeAttribute(name);
+        getAttributes().removeAttribute(name);
     }
 
     @Override
     public void setAttribute(String name, Object attribute)
     {
-        if (_asyncAttributes == null)
-            _attributes.setAttribute(name, attribute);
-        else
-            _asyncAttributes.setAttribute(name, attribute);
+        getAttributes().setAttribute(name, attribute);
     }
 
     @Override
     public Object getAttribute(String name)
     {
-        if (_asyncAttributes == null)
-            return _attributes.getAttribute(name);
-        else
-            return _asyncAttributes.getAttribute(name);
+        return getAttributes().getAttribute(name);
     }
 
     @Override
     public Set<String> getAttributeNameSet()
     {
-        if (_asyncAttributes == null)
-            return _attributes.getAttributeNameSet();
-        else
-            return _asyncAttributes.getAttributeNameSet();
+        return getAttributes().getAttributeNameSet();
     }
 
     @Override
     public void clearAttributes()
     {
-        if (_asyncAttributes == null)
-            _attributes.clearAttributes();
-        else
-        {
-            _asyncAttributes.clearAttributes();
-            _asyncAttributes = null;
-        }
+        getAttributes().clearAttributes();
+        _asyncAttributes = null;
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/AttributesMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/AttributesMap.java
@@ -111,8 +111,7 @@ public class AttributesMap implements Attributes, Dumpable
         if (attrs instanceof AttributesMap)
             return Collections.enumeration(((AttributesMap)attrs).keySet());
 
-        List<String> names = new ArrayList<>();
-        names.addAll(Collections.list(attrs.getAttributeNames()));
+        List<String> names = new ArrayList<>(Collections.list(attrs.getAttributeNames()));
         return Collections.enumeration(names);
     }
 


### PR DESCRIPTION
**Issue #4861**

Reduce garbage produced by creating the `ConcurrentHashMap` of `AttributesMap` when going async. In `Request` we now use `ServletAttributes` as the intial `Attributes` instance which can still be subsequently wrapped by forwards and includes, this will store the async mapping attributes as local variables instead of using the `AttributesMap`.

The `HttpServletMapping` needs to be added back to `AsyncAttributes` when this is merged to 10.