### PR TITLE
Issue #4873 - fix timeout on ExecutorThreadPool.join()

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
@@ -302,7 +302,7 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
     @Override
     public void join() throws InterruptedException
     {
-        _executor.awaitTermination(getStopTimeout(), TimeUnit.MILLISECONDS);
+        _executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/AbstractThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/AbstractThreadPoolTest.java
@@ -18,7 +18,11 @@
 
 package org.eclipse.jetty.util.thread;
 
+import java.time.Duration;
+
 import org.eclipse.jetty.util.ProcessorUtils;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.ThreadPool.SizedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -26,6 +30,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractThreadPoolTest
@@ -86,5 +92,27 @@ public abstract class AbstractThreadPoolTest
         }
 
         assertThat(pool.getMaxThreads(), Matchers.is(3));
+    }
+
+    @Test
+    public void testJoinWithStopTimeout()
+    {
+        // ThreadPool must be an implement ContainerLifeCycle for this test to be valid.
+        SizedThreadPool threadPool = newPool(3);
+        if (!(threadPool instanceof ContainerLifeCycle))
+            return;
+
+        final long stopTimeout = 100;
+        ((ContainerLifeCycle)threadPool).setStopTimeout(100);
+        LifeCycle.start(threadPool);
+
+        // Verify that join does not timeout after waiting twice the stopTimeout.
+        assertThrows(Throwable.class, () ->
+            assertTimeoutPreemptively(Duration.ofMillis(stopTimeout * 2), threadPool::join)
+        );
+
+        // After stopping the ThreadPool join should unblock.
+        LifeCycle.stop(threadPool);
+        assertTimeoutPreemptively(Duration.ofMillis(stopTimeout), threadPool::join);
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ExecutorThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ExecutorThreadPoolTest.java
@@ -18,13 +18,7 @@
 
 package org.eclipse.jetty.util.thread;
 
-import java.time.Duration;
-
 import org.eclipse.jetty.util.thread.ThreadPool.SizedThreadPool;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ExecutorThreadPoolTest extends AbstractThreadPoolTest
 {
@@ -32,23 +26,5 @@ public class ExecutorThreadPoolTest extends AbstractThreadPoolTest
     protected SizedThreadPool newPool(int max)
     {
         return new ExecutorThreadPool(max);
-    }
-
-    @Test
-    public void testJoin() throws Exception
-    {
-        final long stopTimeout = 100;
-        ExecutorThreadPool executorThreadPool = new ExecutorThreadPool(10);
-        executorThreadPool.setStopTimeout(stopTimeout);
-        executorThreadPool.start();
-
-        // Verify that join does not timeout after waiting twice the stopTimeout.
-        assertThrows(Throwable.class, () ->
-            assertTimeoutPreemptively(Duration.ofMillis(stopTimeout * 2), executorThreadPool::join)
-        );
-
-        // After stopping the ThreadPool join should unblock.
-        executorThreadPool.stop();
-        assertTimeoutPreemptively(Duration.ofMillis(stopTimeout), executorThreadPool::join);
     }
 }


### PR DESCRIPTION
see issue #4873