### PR TITLE
Issue #4888 - Request getSession() now returns existing cached session if found

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1604,7 +1604,7 @@ public class Request implements HttpServletRequest
         if (_sessionHandler == null)
             throw new IllegalStateException("No SessionManager");
 
-        _session = _sessionHandler.newHttpSession(this);
+        _session = _sessionHandler.newHttpSession(this, true);
         HttpCookie cookie = _sessionHandler.getSessionCookie(_session, getContextPath(), isSecure());
         if (cookie != null)
             _channel.getResponse().replaceCookie(cookie);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java
@@ -130,6 +130,18 @@ public interface SessionCache extends LifeCycle
     void add(String id, Session session) throws Exception;
 
     /**
+     * Adds a new Session to the cache if absent.
+     * If a session already exists in the cache for the given id then the existing Session is returned
+     * and the new Session is not added
+     *
+     * @param id
+     * @param session
+     * @throws Exception
+     * @return the existing Session object or null if one already exists for the given id
+     */
+    Session addIfAbsent(String id, Session session) throws Exception;
+
+    /**
      * Get an existing Session. If necessary, the cache will load the data for
      * the session from the configured SessionDataStore.
      *

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateSessionCacheTest.java
@@ -1,0 +1,131 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server.session;
+
+import javax.servlet.http.HttpSession;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DuplicateSessionCacheTest
+{
+    private Server server;
+    private HttpClient client;
+
+    ServletContextHandler contextHandler;
+
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        // Default session behavior
+        contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        contextHandler.addServlet(DefaultServlet.class, "/");
+
+        HandlerList handlers = new HandlerList();
+        handlers.addHandler(contextHandler);
+        handlers.addHandler(new DefaultHandler());
+
+        server.setHandler(handlers);
+        server.start();
+    }
+
+    @AfterEach
+    public void stopServerAndClient()
+    {
+        LifeCycle.stop(server);
+        LifeCycle.stop(client);
+    }
+
+    @BeforeEach
+    public void startClient() throws Exception
+    {
+        client = new HttpClient();
+        client.start();
+    }
+
+    @Test
+    public void testNewSessionUseExistingTrue() throws Exception
+    {
+
+        //Create a new session and get the Id
+        Request request1 = new Request(null, null);
+        HttpSession session1 = contextHandler.getSessionHandler().newHttpSession(request1);
+        String id =  session1.getId();
+
+        //Re-use the same session id and try and create a new session
+        //With version 9.4.20 this would work but return a new session which is not ideal if one exists
+        //After version 9.4.21 this would throw an exception
+        //With the commit this test is included in now the existing session will be returned
+        Request request2 = new Request(null, null);
+        request2.setRequestedSessionId(id);
+        HttpSession session2 = contextHandler.getSessionHandler().newHttpSession(request2,true);
+
+        //Verify the two returned sessions are the same
+        assertTrue(session1 == session2);
+        assertEquals(id, session1.getId());
+    }
+
+    @Test
+    public void testUseExistingCachedFalse() throws Exception
+    {
+        //Create a new session and get the Id
+        Request request1 = new Request(null, null);
+        HttpSession session1 = contextHandler.getSessionHandler().newHttpSession(request1);
+        String id =  session1.getId();
+
+        //Should return null because a session exists and useExisting is false
+        Request request2 = new Request(null, null);
+        request2.setRequestedSessionId(id);
+        assertNull(contextHandler.getSessionHandler().newHttpSession(request2, false));
+    }
+
+    @Test
+    public void testNewHttpSessionOriginalMethod() throws Exception
+    {
+        //Create a new session and get the Id
+        Request request1 = new Request(null, null);
+        HttpSession session1 = contextHandler.getSessionHandler().newHttpSession(request1);
+        String id =  session1.getId();
+
+        //Should return null because a session exists
+        Request request2 = new Request(null, null);
+        request2.setRequestedSessionId(id);
+        assertNull(contextHandler.getSessionHandler().newHttpSession(request2));
+    }
+}


### PR DESCRIPTION
Instead of logging and exception and returning null, if an existing
Session is found in the session cache when attempting to add a new
session then the existing session is used instead and returned