### PR TITLE
Issue #4895 SessionCache flushOnResponseCommit with invalid session

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionCache.java
@@ -479,7 +479,7 @@ public abstract class AbstractSessionCache extends ContainerLifeCycle implements
         {
             //only write the session out at this point if the attributes changed. If only
             //the lastAccess/expiry time changed defer the write until the last request exits
-            if (session.getSessionData().isDirty() && _flushOnResponseCommit)
+            if (session.isValid() && session.getSessionData().isDirty() && _flushOnResponseCommit)
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Flush session {} on response commit", session);

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/RemoveSessionTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/RemoveSessionTest.java
@@ -54,6 +54,7 @@ public class RemoveSessionTest
         String servletMapping = "/server";
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
+        cacheFactory.setFlushOnResponseCommit(true);
         cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
 
@@ -93,6 +94,9 @@ public class RemoveSessionTest
                 assertEquals(0, ((DefaultSessionCache)m.getSessionCache()).getSessionsCurrent());
                 assertEquals(1, ((DefaultSessionCache)m.getSessionCache()).getSessionsMax());
                 assertEquals(1, ((DefaultSessionCache)m.getSessionCache()).getSessionsTotal());
+                
+                //check the session is no longer in the cache
+                assertFalse(((AbstractSessionCache)m.getSessionCache()).contains(TestServer.extractSessionId(sessionCookie)));
 
                 //check the session is not persisted any more
                 assertFalse(m.getSessionCache().getSessionDataStore().exists(TestServer.extractSessionId(sessionCookie)));
@@ -125,7 +129,8 @@ public class RemoveSessionTest
             String action = request.getParameter("action");
             if ("create".equals(action))
             {
-                request.getSession(true);
+                HttpSession s = request.getSession(true);
+                s.setAttribute("foo", "bar");
             }
             else if ("delete".equals(action))
             {


### PR DESCRIPTION
Closes #4895 

See issue for problem description. Fix is simple: ensure we never try and write out an invalid session when AbstractSessionCache.setFlushOnResponseCommit is true.