### PR TITLE
Issue #4894 use schema and/or catalog name when creating sessions table

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/sessions/session-configuration-jdbc.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/sessions/session-configuration-jdbc.adoc
@@ -85,6 +85,16 @@ db-connection-type=datasource
 #jetty.session.jdbc.schema.maxIntervalColumn=maxInterval
 #jetty.session.jdbc.schema.mapColumn=map
 #jetty.session.jdbc.schema.table=JettySessions
+# Optional name of the schema used to identify where the session table is defined in the database: 
+#  "" - empty string, no schema name 
+#  "INFERRED" - special string meaning infer from the current db connection
+#  name - a string defined by the user
+#jetty.session.jdbc.schema.schemaName
+# Optional name of the catalog used to identify where the session table is defined in the database: 
+#  "" - empty string, no catalog name
+#  "INFERRED" - special string meaning infer from the current db connection
+#  name - a string defined by the user
+#jetty.session.jdbc.schema.catalogName
 ----
 
 jetty.session.gracePeriod.seconds::
@@ -111,4 +121,14 @@ jetty.session.jdbc.driverUrl::
 Url of the database which includes the driver type, host name and port, service name and any specific attributes unique to the database, such as a username.
 As an example, here is a mysql connection with the username appended: `jdbc:mysql://127.0.0.1:3306/sessions?user=sessionsadmin`.
 
-The `jetty.sessionTableSchema` values represent the names for the columns in the JDBC database and can be changed to suit your environment.
+The `jetty.session.jdbc.schema.*` values represent the names of the table and columns in the JDBC database used to store sessions and can be changed to suit your environment.
+
+There are also two special, optional properties: `jetty.session.jdbc.schema.schemaName` and `jetty.session.jdbc.schema.catalogName`.
+The exact meaning of these two properties is dependent on your database vendor, but can broadly be described as further scoping for the session table name.
+See https://en.wikipedia.org/wiki/Database_schema and https://en.wikipedia.org/wiki/Database_catalog.
+These extra scoping names can come into play at startup time when jetty determines if the session table already exists, or otherwise creates it on-the-fly.
+If you have employed either of these concepts when you pre-created the session table, or you want to ensure that jetty uses them when it auto-creates the session table, then you have two options: either set them explicitly, or let jetty infer them from a database connection (obtained using either a Datasource or Driver according to the `db-connection-type` you have configured).
+To set them explicitly, uncomment and supply appropriate values for the `jetty.session.jdbc.schema.schemaName` and/or `jetty.session.jdbc.schema.catalogName` properties.
+To allow jetty to infer them from a database connection, use the special string `INFERRED` instead.
+If you leave them blank or commented out, then the sessions table will not be scoped by schema or catalog name.
+

--- a/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
@@ -54,6 +54,12 @@
 			<Set name="mapColumn">
 				<Property name="jetty.session.jdbc.schema.mapColumn" default="map" />
 			</Set>
+            <Set name="schemaName">
+                <Property name="jetty.session.jdbc.schema.schemaName" />
+            </Set>
+            <Set name="catalogName">
+                <Property name="jetty.session.jdbc.schema.catalogName" />
+            </Set>
 			<Set name="tableName">
 				<Property name="jetty.session.jdbc.schema.table" default="JettySessions" />
 			</Set>

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -55,3 +55,14 @@ db-connection-type=datasource
 #jetty.session.jdbc.schema.maxIntervalColumn=maxInterval
 #jetty.session.jdbc.schema.mapColumn=map
 #jetty.session.jdbc.schema.table=JettySessions
+# Optional name of the schema used to identify where the session table is defined in the database: 
+#  "" - empty string, no schema name 
+#  "INFERRED" - special string meaning infer from the current db connection
+#  name - a string defined by the user
+#jetty.session.jdbc.schema.schemaName
+# Optional name of the catalog used to identify where the session table is defined in the database: 
+#  "" - empty string, no catalog name
+#  "INFERRED" - special string meaning infer from the current db connection
+#  name - a string defined by the user
+#jetty.session.jdbc.schema.catalogName
+


### PR DESCRIPTION
Closes #4894 

When jetty jdbc session store starts up, it will check for the existence of the session table and create it if it doesn't exist.  For the creation check, it uses the java.sql.DatabaseMetaData.getTables(catalog,schemaPattern, tablePattern, tabletypes) call. We have been passing in null as the catalog, and a value for schemaPattern only if  the user specified a schemaName in the JDBCSessionDataStore.SessionTableSchema configuration.

According to #4894, for some database types, if you have configured more than one 'database' for a given installation, and a session table of the same name should exist in both, then jetty will actually only create the table in one of the databases. For example, the OP has a mysql installation with 2 databases defined 'databaseA' and 'databaseB'. WebappA will use 'databaseA', and is thus configured with a jdbc url of jdbc:mysql://localhost:3306/databaseA,  and WebappB will use 'databaseB', and is thus configured with jdbc url of jdbc:mysql://localhost:3306/databaseB.  Depending which one starts first, the JettySessions table will either be created in databaseA or databaseB instead of both. It seems that this is being caused by defaulting either the catalog or schema to null in the DatabaseMetaData.getTables call. 

This fix tries to maintain the current behaviour, which is by default passing in 'null' as both the catalog and schema names in DatabaseMetaData.getTables call.
It adds in the ability for the user to completely explicitly specify the catalog name and schema name.
It also adds in the ability for the name of the catalog and schema to be grabbed out of the existing connection to the database.