### PR TITLE
Fixes #4904 - WebsocketClient creates more connections than needed.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -37,13 +37,12 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
 {
     private static final Logger LOG = Log.getLogger(AbstractConnectionPool.class);
 
-    private final AtomicBoolean closed = new AtomicBoolean();
-
     /**
      * The connectionCount encodes both the total connections plus the pending connection counts, so both can be atomically changed.
      * The bottom 32 bits represent the total connections and the top 32 bits represent the pending connections.
      */
     private final AtomicBiInteger connections = new AtomicBiInteger();
+    private final AtomicBoolean closed = new AtomicBoolean();
     private final HttpDestination destination;
     private final int maxConnections;
     private final Callback requester;
@@ -102,6 +101,15 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
         return acquire(true);
     }
 
+    /**
+     * <p>Returns an idle connection, if available;
+     * if an idle connection is not available, and the given {@code create} parameter is {@code true},
+     * then schedules the opening of a new connection;
+     * otherwise returns {@code null}.</p>
+     *
+     * @param create whether to schedule the opening of a connection if no idle connections are available
+     * @return an idle connection or {@code null} if no idle connections are available
+     */
     protected Connection acquire(boolean create)
     {
         Connection connection = activate();
@@ -114,6 +122,16 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
         return connection;
     }
 
+    /**
+     * <p>Schedules the opening of a new connection.</p>
+     * <p>Whether a new connection is scheduled for opening is determined by the {@code maxPending} parameter:
+     * if {@code maxPending} is greater than the current number of connections scheduled for opening,
+     * then this method returns without scheduling the opening of a new connection;
+     * if {@code maxPending} is negative, a new connection is always scheduled for opening.</p>
+     *
+     * @param maxPending the max desired number of connections scheduled for opening,
+     * or a negative number to always trigger the opening of a new connection
+     */
     protected void tryCreate(int maxPending)
     {
         while (true)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -44,13 +44,13 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
      * The bottom 32 bits represent the total connections and the top 32 bits represent the pending connections.
      */
     private final AtomicBiInteger connections = new AtomicBiInteger();
-    private final Destination destination;
+    private final HttpDestination destination;
     private final int maxConnections;
     private final Callback requester;
 
     protected AbstractConnectionPool(Destination destination, int maxConnections, Callback requester)
     {
-        this.destination = destination;
+        this.destination = (HttpDestination)destination;
         this.maxConnections = maxConnections;
         this.requester = requester;
     }
@@ -102,7 +102,7 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
         Connection connection = activate();
         if (connection == null)
         {
-            tryCreate(-1);
+            tryCreate(destination.getQueuedRequestCount());
             connection = activate();
         }
         return connection;

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -99,10 +99,16 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
     @Override
     public Connection acquire()
     {
+        return acquire(true);
+    }
+
+    protected Connection acquire(boolean create)
+    {
         Connection connection = activate();
         if (connection == null)
         {
-            tryCreate(destination.getQueuedRequestCount());
+            if (create)
+                tryCreate(destination.getQueuedRequestCount());
             connection = activate();
         }
         return connection;

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -104,11 +104,13 @@ public abstract class AbstractConnectionPool implements ConnectionPool, Dumpable
     /**
      * <p>Returns an idle connection, if available;
      * if an idle connection is not available, and the given {@code create} parameter is {@code true},
-     * then schedules the opening of a new connection;
+     * then schedules the opening of a new connection, if possible within the configuration of this
+     * connection pool (for example, if it does not exceed the max connection count);
      * otherwise returns {@code null}.</p>
      *
      * @param create whether to schedule the opening of a connection if no idle connections are available
      * @return an idle connection or {@code null} if no idle connections are available
+     * @see #tryCreate(int)
      */
     protected Connection acquire(boolean create)
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -228,7 +228,7 @@ public abstract class HttpConnection implements Connection
             }
             else
             {
-                // Association may fail for example if the application
+                // Association may fail, for example if the application
                 // aborted the request, so we must release the channel.
                 channel.release();
                 result = new SendFailure(new HttpRequestException("Could not associate request to connection", request), false);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -228,6 +228,8 @@ public abstract class HttpConnection implements Connection
             }
             else
             {
+                // Association may fail for example if the application
+                // aborted the request, so we must release the channel.
                 channel.release();
                 result = new SendFailure(new HttpRequestException("Could not associate request to connection", request), false);
             }
@@ -242,6 +244,8 @@ public abstract class HttpConnection implements Connection
         }
         else
         {
+            // This connection has been timed out by another thread
+            // that will take care of removing it from the pool.
             return new SendFailure(new TimeoutException(), true);
         }
     }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -475,6 +475,11 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         return removed;
     }
 
+    /**
+     * @param connection the connection to remove
+     * @deprecated use {@link #remove(Connection)} instead
+     */
+    @Deprecated
     public void close(Connection connection)
     {
         remove(connection);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -465,16 +465,14 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         {
             tryRemoveIdleDestination();
         }
-        else
+        else if (removed)
         {
-            // We need to execute queued requests
-            // even if this connection was removed.
+            // Process queued requests that may be waiting.
             // We may create a connection that is not
             // needed, but it will eventually idle timeout.
-            if (removed)
-                process(true);
+            process(true);
         }
-        return connectionPool.remove(connection);
+        return removed;
     }
 
     public void close(Connection connection)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -452,12 +452,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
 
     public boolean remove(Connection connection)
     {
-        return connectionPool.remove(connection);
-    }
-
-    public void close(Connection connection)
-    {
-        boolean removed = remove(connection);
+        boolean removed = connectionPool.remove(connection);
 
         if (getHttpExchanges().isEmpty())
         {
@@ -465,12 +460,19 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         }
         else
         {
-            // We need to execute queued requests even if this connection failed.
-            // We may create a connection that is not needed, but it will eventually
-            // idle timeout, so no worries.
+            // We need to execute queued requests
+            // even if this connection was removed.
+            // We may create a connection that is not
+            // needed, but it will eventually idle timeout.
             if (removed)
                 process(true);
         }
+        return connectionPool.remove(connection);
+    }
+
+    public void close(Connection connection)
+    {
+        remove(connection);
     }
 
     /**

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
@@ -66,13 +66,21 @@ public class MultiplexConnectionPool extends AbstractConnectionPool implements C
         {
             int queuedRequests = destination.getQueuedRequestCount();
             int maxMultiplex = getMaxMultiplex();
-            int maxPending = queuedRequests / maxMultiplex;
-            if (maxPending * maxMultiplex != queuedRequests)
-                ++maxPending;
+            int maxPending = ceilDiv(queuedRequests, maxMultiplex);
             tryCreate(maxPending);
             connection = activate();
         }
         return connection;
+    }
+
+    /**
+     * @param a the dividend
+     * @param b the divisor
+     * @return the ceiling of the algebraic quotient
+     */
+    private static int ceilDiv(int a, int b)
+    {
+        return (a + b - 1) / b;
     }
 
     protected void lock()

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
@@ -64,7 +64,11 @@ public class MultiplexConnectionPool extends AbstractConnectionPool implements C
         Connection connection = activate();
         if (connection == null)
         {
-            int maxPending = 1 + destination.getQueuedRequestCount() / getMaxMultiplex();
+            int queuedRequests = destination.getQueuedRequestCount();
+            int maxMultiplex = getMaxMultiplex();
+            int maxPending = queuedRequests / maxMultiplex;
+            if (maxPending * maxMultiplex != queuedRequests)
+                ++maxPending;
             tryCreate(maxPending);
             connection = activate();
         }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
@@ -69,6 +69,13 @@ public class RoundRobinConnectionPool extends AbstractConnectionPool implements 
         }
     }
 
+    /**
+     * <p>Returns an idle connection, if available, following a round robin algorithm;
+     * otherwise it always tries to create a new connection, up until the max connection count.</p>
+     *
+     * @param create this parameter is ignored and assumed to be always {@code true}
+     * @return an idle connection or {@code null} if no idle connections are available
+     */
     @Override
     protected Connection acquire(boolean create)
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
@@ -70,6 +70,14 @@ public class RoundRobinConnectionPool extends AbstractConnectionPool implements 
     }
 
     @Override
+    protected Connection acquire(boolean create)
+    {
+        // The nature of this connection pool is such that a
+        // connection must always be present in the next slot.
+        return super.acquire(true);
+    }
+
+    @Override
     protected void onCreated(Connection connection)
     {
         synchronized (this)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
@@ -180,7 +180,7 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements Connec
     {
         if (closed.compareAndSet(false, true))
         {
-            getHttpDestination().close(this);
+            getHttpDestination().remove(this);
             abort(failure);
             channel.destroy();
             getEndPoint().shutdownOutput();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/BufferingResponseListener.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/BufferingResponseListener.java
@@ -119,9 +119,10 @@ public abstract class BufferingResponseListener extends Listener.Adapter
         int length = content.remaining();
         if (length > BufferUtil.space(buffer))
         {
-            int requiredCapacity = buffer == null ? length : buffer.capacity() + length;
-            if (requiredCapacity > maxLength)
+            int remaining = buffer == null ? 0 : buffer.remaining();
+            if (remaining + length > maxLength)
                 response.abort(new IllegalArgumentException("Buffering capacity " + maxLength + " exceeded"));
+            int requiredCapacity = buffer == null ? length : buffer.capacity() + length;
             int newCapacity = Math.min(Integer.highestOneBit(requiredCapacity) << 1, maxLength);
             buffer = BufferUtil.ensureCapacity(buffer, newCapacity);
         }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -19,7 +19,7 @@
 package org.eclipse.jetty.client;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -27,11 +27,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Destination;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.util.BytesContentProvider;
@@ -43,51 +43,51 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.SocketAddressResolver;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled // Disabled by @gregw on issue #2540 - commit 621b946b10884e7308eacca241dcf8b5d6f6cff2
 public class ConnectionPoolTest
 {
     private Server server;
     private ServerConnector connector;
     private HttpClient client;
 
-    public static Stream<Arguments> pools()
+    public static Stream<ConnectionPoolFactory> pools()
     {
-        List<Object[]> pools = new ArrayList<>();
-        pools.add(new Object[]{
-            DuplexConnectionPool.class,
-            (ConnectionPool.Factory)
-                destination -> new DuplexConnectionPool(destination, 8, destination)
-        });
-        pools.add(new Object[]{
-            RoundRobinConnectionPool.class,
-            (ConnectionPool.Factory)
-                destination -> new RoundRobinConnectionPool(destination, 8, destination)
-        });
-        return pools.stream().map(Arguments::of);
+        return Stream.of(
+            new ConnectionPoolFactory("duplex", destination -> new DuplexConnectionPool(destination, 8, destination)),
+            new ConnectionPoolFactory("round-robin", destination -> new RoundRobinConnectionPool(destination, 8, destination)),
+            new ConnectionPoolFactory("multiplex", destination -> new MultiplexConnectionPool(destination, 8, destination, 1))
+        );
     }
 
-    private void start(final ConnectionPool.Factory factory, Handler handler) throws Exception
+    private void start(ConnectionPool.Factory factory, Handler handler) throws Exception
+    {
+        startServer(handler);
+        startClient(factory);
+    }
+
+    private void startClient(ConnectionPool.Factory factory) throws Exception
+    {
+        HttpClientTransport transport = new HttpClientTransportOverHTTP(1);
+        transport.setConnectionPoolFactory(factory);
+        client = new HttpClient(transport, null);
+        client.start();
+    }
+
+    private void startServer(Handler handler) throws Exception
     {
         server = new Server();
         connector = new ServerConnector(server);
         server.addConnector(connector);
         server.setHandler(handler);
-
-        HttpClientTransport transport = new HttpClientTransportOverHTTP(1);
-        transport.setConnectionPoolFactory(factory);
         server.start();
-
-        client = new HttpClient(transport, null);
-        client.start();
     }
 
     @AfterEach
@@ -111,14 +111,14 @@ public class ConnectionPoolTest
         }
     }
 
-    @ParameterizedTest(name = "[{index}] {0}")
+    @ParameterizedTest
     @MethodSource("pools")
-    public void test(Class<? extends ConnectionPool> connectionPoolClass, ConnectionPool.Factory factory) throws Exception
+    public void test(ConnectionPoolFactory factory) throws Exception
     {
-        start(factory, new EmptyServerHandler()
+        start(factory.factory, new EmptyServerHandler()
         {
             @Override
-            protected void service(String target, org.eclipse.jetty.server.Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void service(String target, org.eclipse.jetty.server.Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 switch (HttpMethod.fromString(request.getMethod()))
                 {
@@ -231,6 +231,76 @@ public class ConnectionPoolTest
         catch (Throwable x)
         {
             failures.add(x);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    public void testQueuedRequestsDontOpenTooManyConnections(ConnectionPoolFactory factory) throws Exception
+    {
+        start(factory.factory, new EmptyServerHandler());
+
+        long delay = 1000;
+        client.setSocketAddressResolver(new SocketAddressResolver.Sync()
+        {
+            @Override
+            public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+            {
+                client.getExecutor().execute(() ->
+                {
+                    try
+                    {
+                        Thread.sleep(delay);
+                        super.resolve(host, port, promise);
+                    }
+                    catch (InterruptedException x)
+                    {
+                        promise.failed(x);
+                    }
+                });
+            }
+        });
+
+        CountDownLatch latch = new CountDownLatch(2);
+        client.newRequest("localhost", connector.getLocalPort())
+            .path("/one")
+            .send(result ->
+            {
+                if (result.isSucceeded())
+                    latch.countDown();
+            });
+        Thread.sleep(delay / 2);
+        client.newRequest("localhost", connector.getLocalPort())
+            .path("/two")
+            .send(result ->
+            {
+                if (result.isSucceeded())
+                    latch.countDown();
+            });
+
+        assertTrue(latch.await(2 * delay, TimeUnit.MILLISECONDS));
+        List<Destination> destinations = client.getDestinations();
+        assertEquals(1, destinations.size());
+        HttpDestination destination = (HttpDestination)destinations.get(0);
+        AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
+        assertEquals(2, connectionPool.getConnectionCount());
+    }
+
+    private static class ConnectionPoolFactory
+    {
+        private final String name;
+        private final ConnectionPool.Factory factory;
+
+        private ConnectionPoolFactory(String name, ConnectionPool.Factory factory)
+        {
+            this.name = name;
+            this.factory = factory;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
         }
     }
 }

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
@@ -248,7 +248,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements Connec
     {
         if (closed.compareAndSet(false, true))
         {
-            getHttpDestination().close(this);
+            getHttpDestination().remove(this);
 
             abort(failure);
 

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -148,7 +148,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         if (closed.compareAndSet(false, true))
         {
-            getHttpDestination().close(this);
+            getHttpDestination().remove(this);
 
             abort(failure);
 


### PR DESCRIPTION
Fixed connection pool's `acquire()` methods to correctly take into account the number of queued requests.

Also fixed a collateral bug in `BufferingResponseListener` - wrong calculation of the max content length.

Restored `ConnectionPoolTest` that was disabled in #2540, cleaned it up, and let it run for hours without failures.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>