### PR TITLE
Issue #4907 - close websocket suspendState if close frame is received

### DIFF
--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -204,16 +204,10 @@ public class JettyWebSocketFrameHandler implements FrameHandler
                 default:
                     throw new IllegalStateException();
             }
-        }
 
-        // If we have received a close frame, set state to closed to disallow suspends and resumes.
-        byte opCode = frame.getOpCode();
-        if (opCode == OpCode.CLOSE)
-        {
-            synchronized (this)
-            {
+            // If we have received a close frame, set state to closed to disallow further suspends and resumes.
+            if (frame.getOpCode() == OpCode.CLOSE)
                 state = SuspendState.CLOSED;
-            }
         }
 
         // Send to raw frame handling on user side (eg: WebSocketFrameListener)
@@ -247,7 +241,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
             callback::failed
         );
 
-        switch (opCode)
+        switch (frame.getOpCode())
         {
             case OpCode.CLOSE:
                 onCloseFrame(frame, callback);

--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -296,7 +296,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
     {
         synchronized (this)
         {
-            // We are now closed and cannot suspend or resume
+            // We are now closed and cannot suspend or resume.
             state = SuspendState.CLOSED;
         }
 
@@ -311,6 +311,15 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         {
             callback.failed(new ClosedChannelException());
             return;
+        }
+
+        // If we have received the final close frame set state to closed to disallow suspends and resumes.
+        if (!session.getCoreSession().isOutputOpen())
+        {
+            synchronized (this)
+            {
+                state = SuspendState.CLOSED;
+            }
         }
 
         try


### PR DESCRIPTION
**Closes #4907**

Fixes flaky test `SuspendResumeTest.testSuspendAfterClose()`.

If a close frame is received we must close the suspend state so any subsequent calls to `suspend()` and `resume()` will throw `IllegalStateException`.

The transition to the close state must be done both when receiving a close frame before the `WebSocketFrameListener` is called, and in the case when we never received a close frame but the connection has been closed.