### PR TITLE
Issue #4921

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartWebApp.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartWebApp.java
@@ -120,7 +120,29 @@ public class QuickStartWebApp extends WebAppContext
     {
         _generateOrigin = generateOrigin;
     }
-
+    
+    /**
+     * Never call any listeners unless we are fully
+     * starting the webapp.
+     */
+    @Override
+    public void contextInitialized() throws Exception
+    {
+        if (_startWebapp)
+            super.contextInitialized();
+    }
+    
+    /**
+     * Never call any listeners unless we are fully
+     * starting the webapp.
+     */
+    @Override
+    public void contextDestroyed() throws Exception
+    {
+        if (_startWebapp)
+            super.contextDestroyed();
+    }
+    
     @Override
     protected void startWebapp() throws Exception
     {

--- a/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/FooContextListener.java
+++ b/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/FooContextListener.java
@@ -34,21 +34,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class FooContextListener implements ServletContextListener
 {
+    static int ___initialized;
+    static int __destroyed;
+
     @Override
     public void contextInitialized(ServletContextEvent sce)
     {
+        ++___initialized;
+
         ServletRegistration defaultRego = sce.getServletContext().getServletRegistration("default");
         Collection<String> mappings = defaultRego.getMappings();
         assertThat("/", is(in(mappings)));
 
-        Set<String> otherMappings = sce.getServletContext().getServletRegistration("foo").addMapping("/");
-        assertTrue(otherMappings.isEmpty());
-        Collection<String> fooMappings = sce.getServletContext().getServletRegistration("foo").getMappings();
-        assertThat("/", is(in(fooMappings)));
+        ServletRegistration rego = sce.getServletContext().getServletRegistration("foo");
+        if (rego != null)
+        {
+            Set<String> otherMappings = rego.addMapping("/");
+            assertTrue(otherMappings.isEmpty());
+            Collection<String> fooMappings = rego.getMappings();
+            assertThat("/", is(in(fooMappings)));
+        }
     }
 
     @Override
     public void contextDestroyed(ServletContextEvent sce)
     {
+        ++__destroyed;
     }
 }

--- a/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/TestQuickStart.java
+++ b/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/TestQuickStart.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.servlet.ListenerHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +70,7 @@ public class TestQuickStart
         fooHolder.setName("foo");
         quickstart.getServletHandler().addServlet(fooHolder);
         ListenerHolder lholder = new ListenerHolder();
-        lholder.setListener(new FooContextListener());
+        lholder.setClassName("org.eclipse.jetty.quickstart.FooContextListener");
         quickstart.getServletHandler().addListener(lholder);
         server.setHandler(quickstart);
         server.start();
@@ -91,5 +92,51 @@ public class TestQuickStart
         assertNotNull(sh);
         assertEquals("foo", sh.getName());
         server.stop();
+    }
+    
+    @Test
+    public void testListenersNotCalledInPreConfigure() throws Exception
+    {
+        File quickstartXml = new File(webInf, "quickstart-web.xml");
+        assertFalse(quickstartXml.exists());
+        
+        Server server = new Server();
+        
+        QuickStartWebApp quickstart = new QuickStartWebApp();
+
+        //add a listener directly to the ContextHandler so it is there when we start -
+        //if you add them to the ServletHandler (like StandardDescriptorProcessor does)
+        //then they are not added to the ContextHandler in a pre-generate.
+        quickstart.addEventListener(new FooContextListener());
+        quickstart.setResourceBase(testDir.getAbsolutePath());
+        quickstart.setPreconfigure(true);
+        quickstart.setGenerateOrigin(true);
+        server.setHandler(quickstart);
+        server.start();
+        server.stop();
+        assertTrue(quickstartXml.exists());
+        assertEquals(0, FooContextListener.___initialized);
+    }
+    
+    @Test
+    public void testListenersCalledIfGenerateWithStart() throws Exception
+    {
+        File quickstartXml = new File(webInf, "quickstart-web.xml");
+        assertFalse(quickstartXml.exists());
+        
+        Server server = new Server();
+        
+        QuickStartWebApp quickstart = new QuickStartWebApp();
+        quickstart.setAutoPreconfigure(true); //generate AND start the webapp
+
+        //add a listener directly to the ContextHandler so it is there when we start
+        quickstart.addEventListener(new FooContextListener());
+        quickstart.setResourceBase(testDir.getAbsolutePath());
+        quickstart.setGenerateOrigin(true);
+        server.setHandler(quickstart);
+        server.start();
+        server.stop();
+        assertTrue(quickstartXml.exists());
+        assertEquals(1, FooContextListener.___initialized);
     }
 }


### PR DESCRIPTION
Closes #4921 

Ensure that context listeners are never called by quickstart _unless_ we are fully starting the webapp (ie generating quickstart and then starting the webapp).