### PR TITLE
Issue #4890 - Do not index large HTTP2 Fields

### DIFF
--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -324,7 +324,7 @@ public class HpackEncoder
             // Unknown field entry, so we will have to send literally, but perhaps add an index.
             final boolean indexed;
 
-            // Do we know it's name?
+            // Do we know its name?
             HttpHeader header = field.getHeader();
 
             // Select encoding strategy
@@ -342,7 +342,6 @@ public class HpackEncoder
                     if (_debug)
                         encoding = indexed ? "PreEncodedIdx" : "PreEncoded";
                 }
-                // has the custom header name been seen before and will it fit in dynamic table?
                 else if (name == null && fieldSize < _context.getMaxDynamicTableSize())
                 {
                     // unknown name and value that will fit in dynamic table, so let's index
@@ -356,7 +355,7 @@ public class HpackEncoder
                 }
                 else
                 {
-                    // known custom name, but unknown value.
+                    // Known name, but different value.
                     // This is probably a custom field with changing value, so don't index.
                     indexed = false;
                     encodeName(buffer, (byte)0x00, 4, field.getName(), null);

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -395,9 +395,9 @@ public class HpackEncoder
                             (huffman ? "HuffV" : "LitV") +
                             (neverIndex ? "!!Idx" : "!Idx");
                 }
-                else if (fieldSize >= _context.getMaxDynamicTableSize() || header == HttpHeader.CONTENT_LENGTH && field.getValue().length() > 2)
+                else if (fieldSize >= _context.getMaxDynamicTableSize() || header == HttpHeader.CONTENT_LENGTH && field.getIntValue() != 0)
                 {
-                    // Non indexed if field too large or a content length for 3 digits or more
+                    // The field is too large or a non zero content length, so do not index.
                     indexed = false;
                     encodeName(buffer, (byte)0x00, 4, header.asString(), name);
                     encodeValue(buffer, true, field.getValue());

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -394,7 +394,7 @@ public class HpackEncoder
                             (huffman ? "HuffV" : "LitV") +
                             (neverIndex ? "!!Idx" : "!Idx");
                 }
-                else if (fieldSize >= _context.getMaxDynamicTableSize() || header == HttpHeader.CONTENT_LENGTH && field.getIntValue() != 0)
+                else if (fieldSize >= _context.getMaxDynamicTableSize() || header == HttpHeader.CONTENT_LENGTH && !"0".equals(field.getValue()))
                 {
                     // The field is too large or a non zero content length, so do not index.
                     indexed = false;

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.util.BufferUtil;
@@ -167,6 +168,28 @@ public class HpackEncoderTest
             largeName.append(filler, 0, Math.min(filler.length(), ctx.getMaxDynamicTableSize() - largeName.length()));
         pos = BufferUtil.flipToFill(buffer);
         encoder.encode(buffer, new HttpField(largeName.toString(), "Value"));
+        BufferUtil.flipToFlush(buffer, pos);
+        assertThat(ctx.getDynamicTableSize(), Matchers.is(dynamicTableSize));
+    }
+
+    @Test
+    public void testIndexContentLength()
+    {
+        HpackEncoder encoder = new HpackEncoder(38 * 5);
+        HpackContext ctx = encoder.getHpackContext();
+
+        ByteBuffer buffer = BufferUtil.allocate(4096);
+
+        // Index zero content length
+        int pos = BufferUtil.flipToFill(buffer);
+        encoder.encode(buffer, new HttpField(HttpHeader.CONTENT_LENGTH, "0"));
+        BufferUtil.flipToFlush(buffer, pos);
+        int dynamicTableSize = ctx.getDynamicTableSize();
+        assertThat(dynamicTableSize, Matchers.greaterThan(0));
+
+        // Do not index non zero content length
+        pos = BufferUtil.flipToFill(buffer);
+        encoder.encode(buffer, new HttpField(HttpHeader.CONTENT_LENGTH, "42"));
         BufferUtil.flipToFlush(buffer, pos);
         assertThat(ctx.getDynamicTableSize(), Matchers.is(dynamicTableSize));
     }

--- a/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
+++ b/jetty-http2/http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackEncoderTest.java
@@ -162,9 +162,9 @@ public class HpackEncoderTest
 
         // Do not index big field
         StringBuilder largeName = new StringBuilder("largeName-");
-        String X = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        String filler = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
         while (largeName.length() < ctx.getMaxDynamicTableSize())
-            largeName.append(X, 0, Math.min(X.length(), ctx.getMaxDynamicTableSize()-largeName.length()));
+            largeName.append(filler, 0, Math.min(filler.length(), ctx.getMaxDynamicTableSize() - largeName.length()));
         pos = BufferUtil.flipToFill(buffer);
         encoder.encode(buffer, new HttpField(largeName.toString(), "Value"));
         BufferUtil.flipToFlush(buffer, pos);


### PR DESCRIPTION
Fixes #4890. Do not index encode fields larger than the dynamic table.