### PR TITLE
Issue #4936 response buffer corruption

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -441,8 +441,6 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
                 _parser.close();
         }
 
-        // Not in a race here with onFillable, because it has given up control before calling handle.
-        // in a slight race with #completed, but not sure what to do with that anyway.
         _generator.reset();
 
         // if we are not called from the onfillable thread, schedule completion

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -19,8 +19,10 @@
 package org.eclipse.jetty.server;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
+import java.net.Socket;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,18 +35,21 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class LargeHeaderTest
 {
     private Server server;
-    private LocalConnector connector;
 
     @BeforeEach
     public void setup() throws Exception
@@ -54,7 +59,8 @@ public class LargeHeaderTest
         HttpConfiguration config = new HttpConfiguration();
         HttpConnectionFactory http = new HttpConnectionFactory(config);
 
-        connector = new LocalConnector(server, http, null);
+        ServerConnector connector = new ServerConnector(server, http);
+        connector.setPort(0);
         connector.setIdleTimeout(5000);
         server.addConnector(connector);
 
@@ -67,7 +73,7 @@ public class LargeHeaderTest
             {
                 byte[] bytes = new byte[8 * 1024];
                 Arrays.fill(bytes, (byte)'X');
-                largeHeaderValue = "LargeHeaderOver8k-" + new String(bytes, StandardCharsets.ISO_8859_1) + "_Z_";
+                largeHeaderValue = "LargeHeaderOver8k-" + new String(bytes, UTF_8) + "_Z_";
             }
 
             @Override
@@ -94,24 +100,34 @@ public class LargeHeaderTest
     @Test
     public void testLargeHeader() throws Exception
     {
+        final Logger CLIENTLOG = Log.getLogger(LargeHeaderTest.class).getLogger(".client");
         ExecutorService executorService = Executors.newFixedThreadPool(8);
 
+        int localPort = server.getURI().getPort();
         String rawRequest = "GET / HTTP/1.1\r\n" +
-            "Host: localhost\r\n" +
+            "Host: localhost:" + localPort + "\r\n" +
             "\r\n";
 
         for (int i = 0; i < 500; ++i)
         {
             executorService.submit(() ->
             {
-                try
+                try (Socket client = new Socket("localhost", localPort);
+                     OutputStream output = client.getOutputStream();
+                     InputStream input = client.getInputStream())
                 {
-                    HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+                    output.write(rawRequest.getBytes(UTF_8));
+                    output.flush();
+
+                    String rawResponse = IO.toString(input, UTF_8);
+
+                    CLIENTLOG.info("rawResponse[{}]=[{}]", rawResponse.length(), rawResponse);
+                    HttpTester.Response response = HttpTester.parseResponse(rawResponse);
                     assertThat(response.getStatus(), is(500));
                 }
                 catch (Throwable t)
                 {
-                    t.printStackTrace();
+                    CLIENTLOG.warn("Client Issue", t);
                 }
             });
         }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -1,0 +1,121 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class LargeHeaderTest
+{
+    private Server server;
+    private LocalConnector connector;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        server = new Server();
+
+        HttpConfiguration config = new HttpConfiguration();
+        HttpConnectionFactory http = new HttpConnectionFactory(config);
+
+        connector = new LocalConnector(server, http, null);
+        connector.setIdleTimeout(5000);
+        server.addConnector(connector);
+
+        server.setErrorHandler(new ErrorHandler());
+
+        server.setHandler(new AbstractHandler()
+        {
+            final String largeHeaderValue;
+
+            {
+                byte[] bytes = new byte[8 * 1024];
+                Arrays.fill(bytes, (byte)'X');
+                largeHeaderValue = "LargeHeaderOver8k-" + new String(bytes, StandardCharsets.ISO_8859_1) + "_Z_";
+            }
+
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
+                response.setHeader("LongStr", largeHeaderValue);
+                PrintWriter writer = response.getWriter();
+                writer.write("<html><h1>FOO</h1></html>");
+                writer.flush();
+                response.flushBuffer();
+                baseRequest.setHandled(true);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    public void teardown()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testLargeHeader() throws Exception
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+
+        String rawRequest = "GET / HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "\r\n";
+
+        for (int i = 0; i < 500; ++i)
+        {
+            executorService.submit(() ->
+            {
+                try
+                {
+                    HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+                    assertThat(response.getStatus(), is(500));
+                }
+                catch (Throwable t)
+                {
+                    t.printStackTrace();
+                }
+            });
+        }
+
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
Closes #4936
If the response buffer is too large, the header buffer was released
but not nulled, then an exception thrown, which again released the
not nulled buffer.  The buffer thus ends up in the buffer pool twice!
