### PR TITLE
Update startup-unix-service.adoc

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/startup/startup-unix-service.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/startup/startup-unix-service.adoc
@@ -221,6 +221,7 @@ Next we need to make the Unix System aware that we have a new Jetty Service that
 # cp /opt/jetty/jetty-distribution-{VERSION}/bin/jetty.sh /etc/init.d/jetty
 # echo "JETTY_HOME=/opt/jetty/jetty-distribution-{VERSION}" > /etc/default/jetty
 # echo "JETTY_BASE=/opt/web/mybase" >> /etc/default/jetty
+# echo "JETTY_USER=jetty" >> /etc/default/jetty
 # echo "TMPDIR=/opt/jetty/temp" >> /etc/default/jetty
 ....
 


### PR DESCRIPTION
JETTY_USER variable need to be set for the init script to run as 'jetty' instead of root
Signed-off-by: Binh Trinh <beango@gmail.com>