### PR TITLE
fix websocket JPMS warnings and build issues

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/module-info.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/module-info.java
@@ -29,7 +29,8 @@ module org.eclipse.jetty.websocket.core.common
     exports org.eclipse.jetty.websocket.core.internal to org.eclipse.jetty.websocket.core.client, org.eclipse.jetty.websocket.core.server, org.eclipse.jetty.util;
 
     requires org.eclipse.jetty.http;
-    requires org.eclipse.jetty.io;
+    requires transitive org.eclipse.jetty.io;
+    requires transitive org.eclipse.jetty.util;
     requires org.slf4j;
 
     uses Extension;

--- a/jetty-websocket/websocket-util/src/main/java/module-info.java
+++ b/jetty-websocket/websocket-util/src/main/java/module-info.java
@@ -21,8 +21,6 @@ module org.eclipse.jetty.websocket.util
     exports org.eclipse.jetty.websocket.util;
     exports org.eclipse.jetty.websocket.util.messages;
 
-    requires org.eclipse.jetty.util;
-    requires org.slf4j;
-    requires org.eclipse.jetty.io;
     requires transitive org.eclipse.jetty.websocket.core.common;
+    requires org.slf4j;
 }


### PR DESCRIPTION
Fixes the test failure and other websocket JPMS warnings:
```
[ERROR] There was an error in the forked processsuperclass access check failed: class org.eclipse.jetty.websocket.common.TestableLeakTrackingBufferPool (in module org.eclipse.jetty.websocket.jetty.common) cannot access class org.eclipse.jetty.io.LeakTrackingByteBufferPool (in module org.eclipse.jetty.io) because module org.eclipse.jetty.websocket.jetty.common does not read module org.eclipse.jetty.io
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked processsuperclass access check failed: class org.eclipse.jetty.websocket.common.TestableLeakTrackingBufferPool (in module org.eclipse.jetty.websocket.jetty.common) cannot access class org.eclipse.jetty.io.LeakTrackingByteBufferPool (in module org.eclipse.jetty.io) because module org.eclipse.jetty.websocket.jetty.common does not read module org.eclipse.jetty.io
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:675)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:285)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:248)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1217)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1063)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:889)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:956)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
```