### PR TITLE
Issue #4965 - WINDOW_UPDATE for locally failed stream should not clos…

### DIFF
--- a/jetty-http2/http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientSession.java
+++ b/jetty-http2/http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientSession.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
-import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.generator.Generator;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
@@ -116,17 +115,6 @@ public class HTTP2ClientSession extends HTTP2Session
                     onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_headers_frame");
             }
         }
-    }
-
-    @Override
-    protected void onResetForUnknownStream(ResetFrame frame)
-    {
-        int streamId = frame.getStreamId();
-        boolean closed = isClientStream(streamId) ? isLocalStreamClosed(streamId) : isRemoteStreamClosed(streamId);
-        if (closed)
-            notifyReset(this, frame);
-        else
-            onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_rst_stream_frame");
     }
 
     @Override

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/AbstractFlowControlStrategy.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/AbstractFlowControlStrategy.java
@@ -199,18 +199,22 @@ public abstract class AbstractFlowControlStrategy implements FlowControlStrategy
 
     protected void onSessionUnstalled(ISession session)
     {
-        sessionStallTime.addAndGet(System.nanoTime() - sessionStall.getAndSet(0));
+        long stallTime = System.nanoTime() - sessionStall.getAndSet(0);
+        sessionStallTime.addAndGet(stallTime);
         if (LOG.isDebugEnabled())
-            LOG.debug("Session unstalled {}", session);
+            LOG.debug("Session unstalled after {} ms {}", TimeUnit.NANOSECONDS.toMillis(stallTime), session);
     }
 
     protected void onStreamUnstalled(IStream stream)
     {
         Long time = streamsStalls.remove(stream);
         if (time != null)
-            streamsStallTime.addAndGet(System.nanoTime() - time);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Stream unstalled {}", stream);
+        {
+            long stallTime = System.nanoTime() - time;
+            streamsStallTime.addAndGet(stallTime);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stream unstalled after {} ms {}", TimeUnit.NANOSECONDS.toMillis(stallTime), stream);
+        }
     }
 
     @ManagedAttribute(value = "The time, in milliseconds, that the session flow control has stalled", readonly = true)

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/BufferingFlowControlStrategy.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/BufferingFlowControlStrategy.java
@@ -112,7 +112,7 @@ public class BufferingFlowControlStrategy extends AbstractFlowControlStrategy
                 session.updateRecvWindow(level);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Data consumed, {} bytes, updated session recv window by {}/{} for {}", length, level, maxLevel, session);
-                session.frames(null, Callback.NOOP, new WindowUpdateFrame(0, level), Frame.EMPTY_ARRAY);
+                sendWindowUpdate(null, session, new WindowUpdateFrame(0, level));
             }
             else
             {
@@ -146,7 +146,7 @@ public class BufferingFlowControlStrategy extends AbstractFlowControlStrategy
                         stream.updateRecvWindow(level);
                         if (LOG.isDebugEnabled())
                             LOG.debug("Data consumed, {} bytes, updated stream recv window by {}/{} for {}", length, level, maxLevel, stream);
-                        session.frames(stream, Callback.NOOP, new WindowUpdateFrame(stream.getId(), level), Frame.EMPTY_ARRAY);
+                        sendWindowUpdate(stream, session, new WindowUpdateFrame(stream.getId(), level));
                     }
                     else
                     {
@@ -156,6 +156,11 @@ public class BufferingFlowControlStrategy extends AbstractFlowControlStrategy
                 }
             }
         }
+    }
+
+    protected void sendWindowUpdate(IStream stream, ISession session, WindowUpdateFrame frame)
+    {
+        session.frames(stream, Callback.NOOP, frame, Frame.EMPTY_ARRAY);
     }
 
     @Override

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -256,13 +256,21 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             // We must enlarge the session flow control window,
             // otherwise other requests will be stalled.
             flowControl.onDataConsumed(this, null, flowControlLength);
-            boolean local = (streamId & 1) == (localStreamIds.get() & 1);
-            boolean closed = local ? isLocalStreamClosed(streamId) : isRemoteStreamClosed(streamId);
-            if (closed)
+            if (isStreamClosed(streamId))
                 reset(new ResetFrame(streamId, ErrorCode.STREAM_CLOSED_ERROR.code), callback);
             else
                 onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_data_frame", callback);
         }
+    }
+
+    private boolean isStreamClosed(int streamId)
+    {
+        return isLocalStream(streamId) ? isLocalStreamClosed(streamId) : isRemoteStreamClosed(streamId);
+    }
+
+    private boolean isLocalStream(int streamId)
+    {
+        return (streamId & 1) == (localStreamIds.get() & 1);
     }
 
     protected boolean isLocalStreamClosed(int streamId)
@@ -303,7 +311,13 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         }
     }
 
-    protected abstract void onResetForUnknownStream(ResetFrame frame);
+    protected void onResetForUnknownStream(ResetFrame frame)
+    {
+        if (isStreamClosed(frame.getStreamId()))
+            notifyReset(this, frame);
+        else
+            onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_rst_stream_frame");
+    }
 
     @Override
     public void onSettings(SettingsFrame frame)
@@ -480,7 +494,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             }
             else
             {
-                if (!isRemoteStreamClosed(streamId))
+                if (!isStreamClosed(streamId))
                     onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_window_update_frame");
             }
         }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -653,10 +653,11 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
     @Override
     public String toString()
     {
-        return String.format("%s@%x#%d{sendWindow=%s,recvWindow=%s,reset=%b/%b,%s,age=%d,attachment=%s}",
+        return String.format("%s@%x#%d@%x{sendWindow=%s,recvWindow=%s,reset=%b/%b,%s,age=%d,attachment=%s}",
             getClass().getSimpleName(),
             hashCode(),
             getId(),
+            session.hashCode(),
             sendWindow,
             recvWindow,
             localReset,

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerSession.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerSession.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.Frame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
-import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.frames.WindowUpdateFrame;
 import org.eclipse.jetty.http2.generator.Generator;
@@ -138,17 +137,6 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
                 onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_headers_frame");
             }
         }
-    }
-
-    @Override
-    protected void onResetForUnknownStream(ResetFrame frame)
-    {
-        int streamId = frame.getStreamId();
-        boolean closed = isClientStream(streamId) ? isRemoteStreamClosed(streamId) : isLocalStreamClosed(streamId);
-        if (closed)
-            notifyReset(this, frame);
-        else
-            onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_rst_stream_frame");
     }
 
     @Override


### PR DESCRIPTION
…e the HTTP/2 session.

Improved HTTP2Session.onWindowUpdate() code to correctly check whether
the stream is already closed, and if so, just drop the WINDOW_UPDATE.
Refactored onResetForUnknownStream() to base class.
Other small refactorings to improve logging.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>