### PR TITLE
only include jetty-slf4j-impl jar once in jetty-home

### DIFF
--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -145,7 +145,7 @@
                 org.eclipse.jetty.orbit,org.eclipse.jetty.http2,org.eclipse.jetty.websocket,org.eclipse.jetty.fcgi,org.eclipse.jetty.toolchain,org.apache.taglibs
               </excludeGroupIds>
               <excludeArtifactIds>
-                jetty-all,apache-jsp,apache-jstl,jetty-start,jetty-spring
+                jetty-all,apache-jsp,apache-jstl,jetty-start,jetty-spring,jetty-slf4j-impl
               </excludeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib</outputDirectory>


### PR DESCRIPTION
I noticed that we had `jetty-slf4j-impl-10.0.0-SNAPSHOT.jar` in jetty-home at both
`lib/`  and `lib/logging/`

This change excludes it from the `lib` directory.