### PR TITLE
Issue #4572 Implemented TAG_PAD

### DIFF
--- a/jetty-slf4j-impl/src/main/java/org/eclipse/jetty/logging/StdErrAppender.java
+++ b/jetty-slf4j-impl/src/main/java/org/eclipse/jetty/logging/StdErrAppender.java
@@ -32,7 +32,7 @@ public class StdErrAppender implements JettyAppender
      * Configuration keys specific to the StdErrAppender
      */
     static final String NAME_CONDENSE_KEY = "org.eclipse.jetty.logging.appender.NAME_CONDENSE";
-    static final String THREAD_PADDING_KEY = "org.eclipse.jetty.logging.appender.THREAD_PADDING";
+    static final String TAG_PAD_KEY = "org.eclipse.jetty.logging.appender.TAG_PAD";
     static final String MESSAGE_ESCAPE_KEY = "org.eclipse.jetty.logging.appender.MESSAGE_ESCAPE";
     static final String ZONEID_KEY = "org.eclipse.jetty.logging.appender.ZONE_ID";
     private static final String EOL = System.lineSeparator();
@@ -52,7 +52,7 @@ public class StdErrAppender implements JettyAppender
     /**
      * The fixed size of the thread name to use for output
      */
-    private final int threadPadding;
+    private final String tagPadding;
 
     /**
      * The stream to write logging events to.
@@ -88,7 +88,16 @@ public class StdErrAppender implements JettyAppender
 
         this.condensedNames = config.getBoolean(NAME_CONDENSE_KEY, true);
         this.escapedMessages = config.getBoolean(MESSAGE_ESCAPE_KEY, true);
-        this.threadPadding = config.getInt(THREAD_PADDING_KEY, -1);
+        int padding = config.getInt(TAG_PAD_KEY, -1);
+        if (padding <= 0)
+            this.tagPadding = null;
+        else
+        {
+            StringBuilder b = new StringBuilder(padding);
+            while (b.length() < padding)
+                b.append(' ');
+            this.tagPadding = b.toString();
+        }
     }
 
     @Override
@@ -116,9 +125,15 @@ public class StdErrAppender implements JettyAppender
         return escapedMessages;
     }
 
+    @Deprecated
     public int getThreadPadding()
     {
-        return threadPadding;
+        return 0;
+    }
+
+    public int getTagPadding()
+    {
+        return tagPadding == null ? 0 : tagPadding.length();
     }
 
     public PrintStream getStream()
@@ -143,23 +158,24 @@ public class StdErrAppender implements JettyAppender
 
         // Logger Name
         builder.append(':');
-        if (condensedNames)
-        {
-            builder.append(logger.getCondensedName());
-        }
-        else
-        {
-            builder.append(logger.getName());
-        }
+        String name = condensedNames ? logger.getCondensedName() : logger.getName();
+        builder.append(name);
 
         // Thread Name
         builder.append(':');
-        builder.append(threadName); // TODO: support TAG_PAD configuration
-        builder.append(':');
+        builder.append(threadName);
+        builder.append(":");
+
+        // Padding
+        if (tagPadding == null)
+            builder.append(' ');
+        else
+        {
+            int tagLen = name.length() + threadName.length() + 2;
+            builder.append(tagPadding, 0, Math.max(1, tagPadding.length() - tagLen));
+        }
 
         // Message
-        builder.append(' ');
-
         FormattingTuple ft = MessageFormatter.arrayFormat(message, argumentArray);
         appendEscaped(builder, ft.getMessage());
         if (cause == null)

--- a/jetty-slf4j-impl/src/test/java/org/eclipse/jetty/logging/JettyLoggerConfigurationTest.java
+++ b/jetty-slf4j-impl/src/test/java/org/eclipse/jetty/logging/JettyLoggerConfigurationTest.java
@@ -34,7 +34,7 @@ public class JettyLoggerConfigurationTest
         Properties props = new Properties();
         props.setProperty(StdErrAppender.MESSAGE_ESCAPE_KEY, "false");
         props.setProperty(StdErrAppender.NAME_CONDENSE_KEY, "false");
-        props.setProperty(StdErrAppender.THREAD_PADDING_KEY, "10");
+        props.setProperty(StdErrAppender.TAG_PAD_KEY, "10");
         props.setProperty("com.mortbay.LEVEL", "WARN");
         props.setProperty("com.mortbay.STACKS", "false");
 
@@ -43,7 +43,7 @@ public class JettyLoggerConfigurationTest
 
         assertFalse(appender.isEscapedMessages());
         assertFalse(appender.isCondensedNames());
-        assertEquals(appender.getThreadPadding(), 10);
+        assertEquals(appender.getTagPadding(), 10);
 
         JettyLevel level = config.getLevel("com.mortbay");
         assertEquals(JettyLevel.WARN, level);


### PR DESCRIPTION
Implemented the TAG_PAD configuration for jetty log appender.

There was a half implementation for thread name padding, but that is not sufficient to align the log output.  Tag padding works on the combined thread and logger name.
