### PR TITLE
Issue #4985 - fix NPE related to use of Attributes.Wrapper getAttributeNameSet()

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -26,6 +26,8 @@ import org.eclipse.jetty.util.Attributes;
 
 class AsyncAttributes extends Attributes.Wrapper
 {
+    public static final String __ASYNC_PREFIX = "javax.servlet.async.";
+
     private String _requestURI;
     private String _contextPath;
     private String _servletPath;
@@ -67,7 +69,11 @@ class AsyncAttributes extends Attributes.Wrapper
     @Override
     public Set<String> getAttributeNameSet()
     {
-        Set<String> set = new HashSet<>(super.getAttributeNameSet());
+        Set<String> set = new HashSet<>();
+        super.getAttributeNameSet().stream()
+            .filter(name -> !name.startsWith(__ASYNC_PREFIX))
+            .forEach(set::add);
+
         if (_requestURI != null)
             set.add(AsyncContext.ASYNC_REQUEST_URI);
         if (_contextPath != null)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -298,7 +298,7 @@ public class Dispatcher implements RequestDispatcher
         {
             HashSet<String> set = new HashSet<>();
             super.getAttributeNameSet().stream()
-                .filter(name -> !name.startsWith(__INCLUDE_PREFIX)) // TODO: why does this filter the __INCLUDE_PREFIX as well?
+                .filter(name -> !name.startsWith(__INCLUDE_PREFIX))
                 .filter(name -> !name.startsWith(__FORWARD_PREFIX))
                 .forEach(set::add);
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -253,11 +253,11 @@ public class Dispatcher implements RequestDispatcher
 
     private class ForwardAttributes extends Attributes.Wrapper
     {
-        String _requestURI;
-        String _contextPath;
-        String _servletPath;
-        String _pathInfo;
-        String _query;
+        private String _requestURI;
+        private String _contextPath;
+        private String _servletPath;
+        private String _pathInfo;
+        private String _query;
 
         ForwardAttributes(Attributes attributes)
         {
@@ -286,6 +286,7 @@ public class Dispatcher implements RequestDispatcher
                 }
             }
 
+            // TODO: should this be __FORWARD_PREFIX?
             if (key.startsWith(__INCLUDE_PREFIX))
                 return null;
 
@@ -296,26 +297,23 @@ public class Dispatcher implements RequestDispatcher
         public Set<String> getAttributeNameSet()
         {
             HashSet<String> set = new HashSet<>();
-            for (String name : _attributes.getAttributeNameSet())
-            {
-                if (!name.startsWith(__INCLUDE_PREFIX) &&
-                    !name.startsWith(__FORWARD_PREFIX))
-                    set.add(name);
-            }
+            super.getAttributeNameSet().stream()
+                .filter(name -> !name.startsWith(__INCLUDE_PREFIX)) // TODO: why does this filter the __INCLUDE_PREFIX as well?
+                .filter(name -> !name.startsWith(__FORWARD_PREFIX))
+                .forEach(set::add);
 
             if (_named == null)
             {
                 if (_pathInfo != null)
                     set.add(FORWARD_PATH_INFO);
-                else
-                    set.remove(FORWARD_PATH_INFO);
-                set.add(FORWARD_REQUEST_URI);
-                set.add(FORWARD_SERVLET_PATH);
-                set.add(FORWARD_CONTEXT_PATH);
+                if (_requestURI != null)
+                    set.add(FORWARD_REQUEST_URI);
+                if (_servletPath != null)
+                    set.add(FORWARD_SERVLET_PATH);
+                if (_contextPath != null)
+                    set.add(FORWARD_CONTEXT_PATH);
                 if (_query != null)
                     set.add(FORWARD_QUERY_STRING);
-                else
-                    set.remove(FORWARD_QUERY_STRING);
             }
 
             return set;
@@ -378,11 +376,11 @@ public class Dispatcher implements RequestDispatcher
 
     private class IncludeAttributes extends Attributes.Wrapper
     {
-        String _requestURI;
-        String _contextPath;
-        String _servletPath;
-        String _pathInfo;
-        String _query;
+        private String _requestURI;
+        private String _contextPath;
+        private String _servletPath;
+        private String _pathInfo;
+        private String _query;
 
         IncludeAttributes(Attributes attributes)
         {
@@ -420,25 +418,22 @@ public class Dispatcher implements RequestDispatcher
         public Set<String> getAttributeNameSet()
         {
             HashSet<String> set = new HashSet<>();
-            for (String name : _attributes.getAttributeNameSet())
-            {
-                if (!name.startsWith(__INCLUDE_PREFIX))
-                    set.add(name);
-            }
+            super.getAttributeNameSet().stream()
+                .filter(name -> !name.startsWith(__INCLUDE_PREFIX))
+                .forEach(set::add);
 
             if (_named == null)
             {
                 if (_pathInfo != null)
                     set.add(INCLUDE_PATH_INFO);
-                else
-                    set.remove(INCLUDE_PATH_INFO);
-                set.add(INCLUDE_REQUEST_URI);
-                set.add(INCLUDE_SERVLET_PATH);
-                set.add(INCLUDE_CONTEXT_PATH);
+                if (_requestURI != null)
+                    set.add(INCLUDE_REQUEST_URI);
+                if (_servletPath != null)
+                    set.add(INCLUDE_SERVLET_PATH);
+                if (_contextPath != null)
+                    set.add(INCLUDE_CONTEXT_PATH);
                 if (_query != null)
                     set.add(INCLUDE_QUERY_STRING);
-                else
-                    set.remove(INCLUDE_QUERY_STRING);
             }
 
             return set;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyCustomizer.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.server;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.servlet.ServletRequest;
 
 import org.eclipse.jetty.io.EndPoint;
@@ -66,14 +65,18 @@ public class ProxyCustomizer implements HttpConfiguration.Customizer
 
     private static class ProxyAttributes extends Attributes.Wrapper
     {
-        private final InetSocketAddress remoteAddress;
-        private final InetSocketAddress localAddress;
+        private final String _remoteAddress;
+        private final String _localAddress;
+        private final int _remotePort;
+        private final int _localPort;
 
         private ProxyAttributes(InetSocketAddress remoteAddress, InetSocketAddress localAddress, Attributes attributes)
         {
             super(attributes);
-            this.remoteAddress = remoteAddress;
-            this.localAddress = localAddress;
+            _remoteAddress = remoteAddress.getAddress().getHostAddress();
+            _localAddress = localAddress.getAddress().getHostAddress();
+            _remotePort = remoteAddress.getPort();
+            _localPort = localAddress.getPort();
         }
 
         @Override
@@ -82,13 +85,13 @@ public class ProxyCustomizer implements HttpConfiguration.Customizer
             switch (name)
             {
                 case REMOTE_ADDRESS_ATTRIBUTE_NAME:
-                    return remoteAddress.getAddress().getHostAddress();
+                    return _remoteAddress;
                 case REMOTE_PORT_ATTRIBUTE_NAME:
-                    return remoteAddress.getPort();
+                    return _remotePort;
                 case LOCAL_ADDRESS_ATTRIBUTE_NAME:
-                    return localAddress.getAddress().getHostAddress();
+                    return _localAddress;
                 case LOCAL_PORT_ATTRIBUTE_NAME:
-                    return localAddress.getPort();
+                    return _localPort;
                 default:
                     return super.getAttribute(name);
             }
@@ -98,9 +101,14 @@ public class ProxyCustomizer implements HttpConfiguration.Customizer
         public Set<String> getAttributeNameSet()
         {
             Set<String> names = new HashSet<>(_attributes.getAttributeNameSet());
-            names.add(REMOTE_ADDRESS_ATTRIBUTE_NAME);
+            names.remove(REMOTE_ADDRESS_ATTRIBUTE_NAME);
+            names.remove(LOCAL_ADDRESS_ATTRIBUTE_NAME);
+
+            if (_remoteAddress != null)
+                names.add(REMOTE_ADDRESS_ATTRIBUTE_NAME);
+            if (_localAddress != null)
+                names.add(LOCAL_ADDRESS_ATTRIBUTE_NAME);
             names.add(REMOTE_PORT_ATTRIBUTE_NAME);
-            names.add(LOCAL_ADDRESS_ATTRIBUTE_NAME);
             names.add(LOCAL_PORT_ATTRIBUTE_NAME);
             return names;
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -319,47 +319,51 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
         private final Request _request;
         private final SSLSession _session;
 
+        private X509Certificate[] _certs;
+        private String _cipherSuite;
+        private Integer _keySize;
+        private String _sessionId;
+        private String _sessionAttribute;
+
         public SslAttributes(Request request, SSLSession sslSession, Attributes attributes)
         {
             super(attributes);
             this._request = request;
             this._session = sslSession;
+
+            try
+            {
+                _certs = getSslSessionData().getCerts();
+                _cipherSuite = _session.getCipherSuite();
+                _keySize = getSslSessionData().getKeySize();
+                _sessionId = getSslSessionData().getIdStr();
+                _sessionAttribute = getSslSessionAttribute();
+            }
+            catch (Exception e)
+            {
+                LOG.warn("Unable to get secure details ", e);
+            }
         }
 
         @Override
         public Object getAttribute(String name)
         {
-            Object value = _attributes.getAttribute(name);
-            if (value != null)
-                return value;
-            try
+            switch (name)
             {
-                switch (name)
-                {
-                    case JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE:
-                        return getSslSessionData().getCerts();
-
-                    case JAVAX_SERVLET_REQUEST_CIPHER_SUITE:
-                        return _session.getCipherSuite();
-
-                    case JAVAX_SERVLET_REQUEST_KEY_SIZE:
-                        return getSslSessionData().getKeySize();
-
-                    case JAVAX_SERVLET_REQUEST_SSL_SESSION_ID:
-                        return getSslSessionData().getIdStr();
-
-                    default:
-                        String sessionAttribute = getSslSessionAttribute();
-                        if (!StringUtil.isEmpty(sessionAttribute) && sessionAttribute.equals(name))
-                            return _session;
-                }
+                case JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE:
+                    return _certs;
+                case JAVAX_SERVLET_REQUEST_CIPHER_SUITE:
+                    return _cipherSuite;
+                case JAVAX_SERVLET_REQUEST_KEY_SIZE:
+                    return _keySize;
+                case JAVAX_SERVLET_REQUEST_SSL_SESSION_ID:
+                    return _sessionId;
+                default:
+                    if (!StringUtil.isEmpty(_sessionAttribute) && _sessionAttribute.equals(name))
+                        return _session;
             }
-            catch (Exception e)
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Unable to get secure details ", e);
-            }
-            return null;
+
+            return _attributes.getAttribute(name);
         }
 
         /**
@@ -391,13 +395,22 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
         public Set<String> getAttributeNameSet()
         {
             Set<String> names = new HashSet<>(_attributes.getAttributeNameSet());
-            names.add(JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE);
-            names.add(JAVAX_SERVLET_REQUEST_CIPHER_SUITE);
-            names.add(JAVAX_SERVLET_REQUEST_KEY_SIZE);
-            names.add(JAVAX_SERVLET_REQUEST_SSL_SESSION_ID);
-            String sessionAttribute = getSslSessionAttribute();
-            if (!StringUtil.isEmpty(sessionAttribute))
-                names.add(sessionAttribute);
+            names.remove(JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE);
+            names.remove(JAVAX_SERVLET_REQUEST_CIPHER_SUITE);
+            names.remove(JAVAX_SERVLET_REQUEST_KEY_SIZE);
+            names.remove(JAVAX_SERVLET_REQUEST_SSL_SESSION_ID);
+
+            if (_certs != null)
+                names.add(JAVAX_SERVLET_REQUEST_X_509_CERTIFICATE);
+            if (_cipherSuite != null)
+                names.add(JAVAX_SERVLET_REQUEST_CIPHER_SUITE);
+            if (_keySize != null)
+                names.add(JAVAX_SERVLET_REQUEST_KEY_SIZE);
+            if (_sessionId != null)
+                names.add(JAVAX_SERVLET_REQUEST_SSL_SESSION_ID);
+            if (!StringUtil.isEmpty(_sessionAttribute))
+                names.add(_sessionAttribute);
+
             return names;
         }
     }


### PR DESCRIPTION
**Issue #4985**

This PR tries to prevent any of the `Attributes.Wrapper` implementations from returning a value in `getAttributeNameSet()` that corresponds to a null attribute when `getAttribute()` is called with the name.

For each `Attributes.Wrapper` we now do the following:
- Ensure that if the value is set to null, we do not add the corresponding attribute name to the set.
- Don't determine attribute values lazily as we won't know whether its null or not.
- Ensure that any conflicting attributes from the wrapped `Attributes` are removed.

@mpetzold has tested this branch and it seems to have fixed the NPE originally reported
see https://github.com/eclipse/jetty.project/issues/4985#issuecomment-650237509
> The NPE is gone. However, I still have a problem with the WebSocket connection of Vaadin / Atmosphere. This may be something else or related configuration.
