### PR TITLE
Issue #5018 - add request timeout onto websocket ClientUpgradeRequest

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
@@ -100,7 +100,7 @@ public class ClientTimeoutTest
         client.setMaxIdleTimeout(timeout);
         Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()));
 
-        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout + 200, TimeUnit.MILLISECONDS));
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout * 2, TimeUnit.MILLISECONDS));
         assertThat(executionException.getCause(), instanceOf(UpgradeException.class));
         UpgradeException upgradeException = (UpgradeException)executionException.getCause();
         assertThat(upgradeException.getCause(), instanceOf(TimeoutException.class));
@@ -112,10 +112,10 @@ public class ClientTimeoutTest
         EventSocket clientSocket = new EventSocket();
         long timeout = 1000;
         ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
-        upgradeRequest.timeout(timeout, TimeUnit.MILLISECONDS);
+        upgradeRequest.setTimeout(timeout, TimeUnit.MILLISECONDS);
         Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()), upgradeRequest);
 
-        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout + 200, TimeUnit.MILLISECONDS));
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout * 2, TimeUnit.MILLISECONDS));
         assertThat(executionException.getCause(), instanceOf(UpgradeException.class));
         UpgradeException upgradeException = (UpgradeException)executionException.getCause();
         assertThat(upgradeException.getCause(), instanceOf(TimeoutException.class));

--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
@@ -1,0 +1,123 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests.client;
+
+import java.util.EnumSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.servlet.DispatcherType;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.UpgradeException;
+import org.eclipse.jetty.websocket.api.util.WSURI;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.NativeWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
+import org.eclipse.jetty.websocket.tests.EventSocket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ClientTimeoutTest
+{
+    private Server server;
+    private WebSocketClient client;
+    private final CountDownLatch createEndpoint = new CountDownLatch(1);
+
+    @BeforeEach
+    public void start() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+
+        NativeWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+        {
+            container.addMapping("/", (req, res) ->
+            {
+                try
+                {
+                    createEndpoint.await(5, TimeUnit.SECONDS);
+                    return new EventSocket.EchoSocket();
+                }
+                catch (InterruptedException e)
+                {
+                    throw new IllegalStateException(e);
+                }
+            });
+        });
+        contextHandler.addFilter(WebSocketUpgradeFilter.class, "/", EnumSet.of(DispatcherType.REQUEST));
+        server.start();
+
+        client = new WebSocketClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        createEndpoint.countDown();
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testWebSocketClientTimeout() throws Exception
+    {
+        EventSocket clientSocket = new EventSocket();
+        long timeout = 1000;
+        client.setMaxIdleTimeout(timeout);
+        Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()));
+
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout + 200, TimeUnit.MILLISECONDS));
+        assertThat(executionException.getCause(), instanceOf(UpgradeException.class));
+        UpgradeException upgradeException = (UpgradeException)executionException.getCause();
+        assertThat(upgradeException.getCause(), instanceOf(TimeoutException.class));
+    }
+
+    @Test
+    public void testClientUpgradeRequestTimeout() throws Exception
+    {
+        EventSocket clientSocket = new EventSocket();
+        long timeout = 1000;
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        upgradeRequest.timeout(timeout, TimeUnit.MILLISECONDS);
+        Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()), upgradeRequest);
+
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout + 200, TimeUnit.MILLISECONDS));
+        assertThat(executionException.getCause(), instanceOf(UpgradeException.class));
+        UpgradeException upgradeException = (UpgradeException)executionException.getCause();
+        assertThat(upgradeException.getCause(), instanceOf(TimeoutException.class));
+    }
+}

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpField;
@@ -68,6 +69,7 @@ public class ClientUpgradeRequest extends UpgradeRequestAdapter
 
     private final String key;
     private Object localEndpoint;
+    private long timeout;
 
     public ClientUpgradeRequest()
     {
@@ -177,6 +179,27 @@ public class ClientUpgradeRequest extends UpgradeRequestAdapter
 
             super.setParameterMap(pmap);
         }
+    }
+
+    /**
+     * @param timeout the total timeout for the request/response conversation of the WebSocket handshake;
+     * use zero or a negative value to disable the timeout
+     * @param unit the timeout unit
+     * @return this request object
+     */
+    public ClientUpgradeRequest timeout(long timeout, TimeUnit unit)
+    {
+        this.timeout = unit.toMillis(timeout);
+        return this;
+    }
+
+    /**
+     * @return the total timeout for this request, in milliseconds;
+     * zero or negative if the timeout is disabled
+     */
+    public long getTimeout()
+    {
+        return timeout;
     }
 
     public void setLocalEndpoint(Object websocket)

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -185,12 +185,10 @@ public class ClientUpgradeRequest extends UpgradeRequestAdapter
      * @param timeout the total timeout for the request/response conversation of the WebSocket handshake;
      * use zero or a negative value to disable the timeout
      * @param unit the timeout unit
-     * @return this request object
      */
-    public ClientUpgradeRequest timeout(long timeout, TimeUnit unit)
+    public void setTimeout(long timeout, TimeUnit unit)
     {
         this.timeout = unit.toMillis(timeout);
-        return this;
     }
 
     /**

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -375,7 +375,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
         init();
 
         WebSocketUpgradeRequest wsReq = new WebSocketUpgradeRequest(this, httpClient, request);
-        wsReq.timeout(request.getTimeout() , TimeUnit.MILLISECONDS);
+        wsReq.timeout(request.getTimeout(), TimeUnit.MILLISECONDS);
         wsReq.setUpgradeListener(upgradeListener);
         return wsReq.sendAsync();
     }

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.client.HttpClient;
@@ -374,7 +375,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketCont
         init();
 
         WebSocketUpgradeRequest wsReq = new WebSocketUpgradeRequest(this, httpClient, request);
-
+        wsReq.timeout(request.getTimeout() , TimeUnit.MILLISECONDS);
         wsReq.setUpgradeListener(upgradeListener);
         return wsReq.sendAsync();
     }


### PR DESCRIPTION
**Issue #5018** 

Add setter and getter for request timeout on the `ClientUpgradeRequest` in the same style as the methods on`org.eclipse.jetty.client.api.Request`.