### PR TITLE
Avoid large allocations of temporary buffers in BuferUtil

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -553,12 +553,10 @@ public class BufferUtil
         }
         else
         {
-            byte[] bytes = null;
+            byte[] bytes = new byte[Math.min(buffer.remaining(), TEMP_BUFFER_SIZE)];
             while (buffer.hasRemaining())
             {
                 int byteCountToWrite = Math.min(buffer.remaining(), TEMP_BUFFER_SIZE);
-                if (bytes == null)
-                    bytes = new byte[byteCountToWrite];
                 buffer.get(bytes, 0, byteCountToWrite);
                 out.write(bytes, 0, byteCountToWrite);
             }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -553,10 +553,12 @@ public class BufferUtil
         }
         else
         {
-            byte[] bytes = new byte[TEMP_BUFFER_SIZE];
+            byte[] bytes = null;
             while (buffer.hasRemaining())
             {
                 int byteCountToWrite = Math.min(buffer.remaining(), TEMP_BUFFER_SIZE);
+                if (bytes == null)
+                    bytes = new byte[byteCountToWrite];
                 buffer.get(bytes, 0, byteCountToWrite);
                 out.write(bytes, 0, byteCountToWrite);
             }


### PR DESCRIPTION
Hi, Jetty Maintainers! 

We have recently noticed that our jetty instances suffer from a large number of young GC pauses. The allocation profiler pointed out that a large number of allocations is occurring in `BufferUtil#writeTo`. 

<img width="1191" alt="Screen Shot 2020-07-15 at 2 07 06 pm" src="https://user-images.githubusercontent.com/1780970/87502264-80704900-c6a4-11ea-8761-3017f7ab1ac1.png">


In our use-case, we're receiving a large number of WebSocket messages from many connections but most of them are very small, typically tiny keep-alive frames. The change in this PR can help to avoid allocating 4K temporary arrays when only a few bytes need to be copied. This could potentially be optimised even further with a specialised implementation for [`o.e.j.u.ByteArrayOutputStream2`](https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-util/src/main/java/org/eclipse/jetty/util/ByteArrayOutputStream2.java), however, the change won't be as simple. 

Additionally, I ran [`o.e.j.u.BufferUtilTest#testWriteToMicrobenchmark`](https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java#L241) with `capacity = 1024, iterations = 1000` and it showed a measurable difference in the number of young gc cycles.

_Before:_
```
2020-07-15 13:21:50.986:WARN:oeju.BufferUtilTest:main: overall average: 3ms

[0.500s][info   ][gc,heap,exit ] Heap
[0.500s][info   ][gc,heap,exit ]  garbage-first heap   total 2097152K, used 79872K [0x0000000780000000, 0x0000000800000000)
[0.500s][info   ][gc,heap,exit ]   region size 1024K, 79 young (80896K), 0 survivors (0K)
[0.500s][info   ][gc,heap,exit ]  Metaspace       used 12797K, capacity 13316K, committed 13696K, reserved 1060864K
[0.500s][info   ][gc,heap,exit ]   class space    used 1321K, capacity 1537K, committed 1664K, reserved 1048576K
```

_After:_
```
2020-07-15 13:20:21.798:WARN:oeju.BufferUtilTest:main: overall average: 2ms

[0.497s][info   ][gc,heap,exit ] Heap
[0.497s][info   ][gc,heap,exit ]  garbage-first heap   total 2097152K, used 50176K [0x0000000780000000, 0x0000000800000000)
[0.497s][info   ][gc,heap,exit ]   region size 1024K, 50 young (51200K), 0 survivors (0K)
[0.497s][info   ][gc,heap,exit ]  Metaspace       used 12788K, capacity 13316K, committed 13696K, reserved 1060864K
[0.497s][info   ][gc,heap,exit ]   class space    used 1321K, capacity 1537K, committed 1664K, reserved 1048576K
```


As a reference, previous a similar change was introduced in https://github.com/eclipse/jetty.project/pull/4561. I'm also happy to open a separate PR for the `10.0.x` branch if it sounds good to you. 

