### PR TITLE
Issue #4985 - fix NPE related to use of Attributes.Wrapper getAttributeNameSet() Jetty 10

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -31,7 +31,6 @@ class AsyncAttributes extends Attributes.Wrapper
     private final ServletPathMapping _mapping;
     private final String _queryString;
 
-
     private final String _servletPath;
     private final String _pathInfo;
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncAttributes.java
@@ -28,16 +28,20 @@ class AsyncAttributes extends Attributes.Wrapper
 {
     private final String _requestURI;
     private final String _contextPath;
-    private final String _pathInContext;
-    private ServletPathMapping _mapping;
+    private final ServletPathMapping _mapping;
     private final String _queryString;
+
+
+    private final String _servletPath;
+    private final String _pathInfo;
 
     public AsyncAttributes(Attributes attributes, String requestUri, String contextPath, String pathInContext, ServletPathMapping mapping, String queryString)
     {
         super(attributes);
         _requestURI = requestUri;
         _contextPath = contextPath;
-        _pathInContext = pathInContext;
+        _servletPath = mapping == null ? null : mapping.getServletPath();
+        _pathInfo = mapping == null ? pathInContext : mapping.getPathInfo();
         _mapping = mapping;
         _queryString = queryString;
     }
@@ -52,9 +56,9 @@ class AsyncAttributes extends Attributes.Wrapper
             case AsyncContext.ASYNC_CONTEXT_PATH:
                 return _contextPath;
             case AsyncContext.ASYNC_SERVLET_PATH:
-                return _mapping == null ? null : _mapping.getServletPath();
+                return _servletPath;
             case AsyncContext.ASYNC_PATH_INFO:
-                return _mapping == null ? _pathInContext : _mapping.getPathInfo();
+                return _pathInfo;
             case AsyncContext.ASYNC_QUERY_STRING:
                 return _queryString;
             case AsyncContext.ASYNC_MAPPING:
@@ -68,12 +72,18 @@ class AsyncAttributes extends Attributes.Wrapper
     public Set<String> getAttributeNameSet()
     {
         Set<String> set = new HashSet<>(super.getAttributeNameSet());
-        set.add(AsyncContext.ASYNC_REQUEST_URI);
-        set.add(AsyncContext.ASYNC_CONTEXT_PATH);
-        set.add(AsyncContext.ASYNC_SERVLET_PATH);
-        set.add(AsyncContext.ASYNC_PATH_INFO);
-        set.add(AsyncContext.ASYNC_QUERY_STRING);
-        set.add(AsyncContext.ASYNC_MAPPING);
+        if (_requestURI != null)
+            set.add(AsyncContext.ASYNC_REQUEST_URI);
+        if (_contextPath != null)
+            set.add(AsyncContext.ASYNC_CONTEXT_PATH);
+        if (_servletPath != null)
+            set.add(AsyncContext.ASYNC_SERVLET_PATH);
+        if (_pathInfo != null)
+            set.add(AsyncContext.ASYNC_PATH_INFO);
+        if (_queryString != null)
+            set.add(AsyncContext.ASYNC_QUERY_STRING);
+        if (_mapping != null)
+            set.add(AsyncContext.ASYNC_MAPPING);
         return set;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -26,6 +26,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -439,7 +440,7 @@ public class Dispatcher implements RequestDispatcher
             String pathInfo = (String)getAttribute(INCLUDE_PATH_INFO);
             String servletPath = (String)getAttribute(INCLUDE_SERVLET_PATH);
             String contextPath = (String)getAttribute(INCLUDE_CONTEXT_PATH);
-            String includeMapping = (String)getAttribute(INCLUDE_MAPPING);
+            HttpServletMapping includeMapping = (HttpServletMapping)getAttribute(INCLUDE_MAPPING);
 
             if (_named == null)
             {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -244,7 +244,8 @@ public class Dispatcher implements RequestDispatcher
     {
         private final String _requestURI;
         private final String _contextPath;
-        private final String _pathInContext;
+        private final String _servletPath;
+        private final String _pathInfo;
         private final ServletPathMapping _servletPathMapping;
         private final String _query;
 
@@ -253,9 +254,11 @@ public class Dispatcher implements RequestDispatcher
             super(attributes);
             _requestURI = requestURI;
             _contextPath = contextPath;
-            _pathInContext = pathInContext;
             _servletPathMapping = mapping;
             _query = query;
+
+            _pathInfo = _servletPathMapping == null ? pathInContext : _servletPathMapping.getPathInfo();
+            _servletPath = _servletPathMapping == null ? null : _servletPathMapping.getServletPath();
         }
 
         @Override
@@ -266,11 +269,11 @@ public class Dispatcher implements RequestDispatcher
                 switch (key)
                 {
                     case FORWARD_PATH_INFO:
-                        return _servletPathMapping == null ? _pathInContext : _servletPathMapping.getPathInfo();
+                        return _pathInfo;
                     case FORWARD_REQUEST_URI:
                         return _requestURI;
                     case FORWARD_SERVLET_PATH:
-                        return _servletPathMapping == null ? null : _servletPathMapping.getServletPath();
+                        return _servletPath;
                     case FORWARD_CONTEXT_PATH:
                         return _contextPath;
                     case FORWARD_QUERY_STRING:
@@ -302,12 +305,18 @@ public class Dispatcher implements RequestDispatcher
 
             if (_named == null)
             {
-                set.add(FORWARD_PATH_INFO);
-                set.add(FORWARD_REQUEST_URI);
-                set.add(FORWARD_SERVLET_PATH);
-                set.add(FORWARD_CONTEXT_PATH);
-                set.add(FORWARD_MAPPING);
-                set.add(FORWARD_QUERY_STRING);
+                if (_pathInfo != null)
+                    set.add(FORWARD_PATH_INFO);
+                if (_requestURI != null)
+                    set.add(FORWARD_REQUEST_URI);
+                if (_servletPath != null)
+                    set.add(FORWARD_SERVLET_PATH);
+                if (_contextPath != null)
+                    set.add(FORWARD_CONTEXT_PATH);
+                if (_servletPathMapping != null)
+                    set.add(FORWARD_MAPPING);
+                if (_query != null)
+                    set.add(FORWARD_QUERY_STRING);
             }
 
             return set;
@@ -426,14 +435,26 @@ public class Dispatcher implements RequestDispatcher
                     set.add(name);
             }
 
+            // We can't assign these in the constructor because the ServletPathMapping hasn't been set by the ServletHandler.
+            String pathInfo = (String)getAttribute(INCLUDE_PATH_INFO);
+            String servletPath = (String)getAttribute(INCLUDE_SERVLET_PATH);
+            String contextPath = (String)getAttribute(INCLUDE_CONTEXT_PATH);
+            String includeMapping = (String)getAttribute(INCLUDE_MAPPING);
+
             if (_named == null)
             {
-                set.add(INCLUDE_PATH_INFO);
-                set.add(INCLUDE_REQUEST_URI);
-                set.add(INCLUDE_SERVLET_PATH);
-                set.add(INCLUDE_CONTEXT_PATH);
-                set.add(INCLUDE_MAPPING);
-                set.add(INCLUDE_QUERY_STRING);
+                if (pathInfo != null)
+                    set.add(INCLUDE_PATH_INFO);
+                if (_requestURI != null)
+                    set.add(INCLUDE_REQUEST_URI);
+                if (servletPath != null)
+                    set.add(INCLUDE_SERVLET_PATH);
+                if (contextPath != null)
+                    set.add(INCLUDE_CONTEXT_PATH);
+                if (includeMapping != null)
+                    set.add(INCLUDE_MAPPING);
+                if (_query != null)
+                    set.add(INCLUDE_QUERY_STRING);
             }
 
             return set;


### PR DESCRIPTION
Merge the changes from PR #5004 to Jetty 10

Had to do things a bit differently due to conflicts due to the `ServletPathMapping` changes.

In `IncludeAttributes.getAttributeNameSet()` we now actually call `getAttribute()` to check if each field is null. We can't assign these fields in the constructor as the `ServletPathMapping` isn't set until the request goes through the `ServletHandler`.