### PR TITLE
the "DO NOT EDIT" comment in .mod files should start with '#'

### DIFF
--- a/apache-jsp/src/main/config/modules/apache-jsp.mod
+++ b/apache-jsp/src/main/config/modules/apache-jsp.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables use of the apache implementation of JSP

--- a/apache-jstl/src/main/config/modules/apache-jstl.mod
+++ b/apache-jstl/src/main/config/modules/apache-jstl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the apache version of JSTL

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Selects an ALPN (Application Layer Protocol Negotiation) implementation by java version.

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-10.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-10.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-9

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-11.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-11.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-9

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-12.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-12.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-13.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-13.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-14.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-14.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-15.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-15.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [depend]
 alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-8.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-8.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides ALPN support for JDK 8, using the Jetty ALPN Agent.

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-9.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-9.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides support for ALPN based on JDK 9+ APIs.

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the ALPN (Application Layer Protocol Negotiation) TLS extension.

--- a/jetty-annotations/src/main/config/modules/annotations.mod
+++ b/jetty-annotations/src/main/config/modules/annotations.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables Annotation scanning for deployed webapplications.

--- a/jetty-client/src/main/config/modules/client.mod
+++ b/jetty-client/src/main/config/modules/client.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds the Jetty HTTP client to the server classpath.

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables webapplication deployment from the webapps directory.

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.mod
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables Deployer to apply common configuration to all webapp deployments

--- a/jetty-fcgi/fcgi-server/src/main/config/modules/fcgi.mod
+++ b/jetty-fcgi/fcgi-server/src/main/config/modules/fcgi.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds the FastCGI implementation to the classpath.

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables GCloud Datastore API and implementation

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Control GCloud API classpath

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/session-store-gcloud.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/session-store-gcloud.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables GCloudDatastore session management.

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables session data store in an embedded Hazelcast Map

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables session data store in a remote Hazelcast Map

--- a/jetty-home/src/main/resources/modules/conscrypt.mod
+++ b/jetty-home/src/main/resources/modules/conscrypt.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Installs the Conscrypt JSSE provider

--- a/jetty-home/src/main/resources/modules/hawtio.mod
+++ b/jetty-home/src/main/resources/modules/hawtio.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Deploys the Hawtio console as a webapplication.

--- a/jetty-home/src/main/resources/modules/jamon.mod
+++ b/jetty-home/src/main/resources/modules/jamon.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Deploys the JAMon webapplication

--- a/jetty-home/src/main/resources/modules/jminix.mod
+++ b/jetty-home/src/main/resources/modules/jminix.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Deploys the Jminix JMX Console within the server

--- a/jetty-home/src/main/resources/modules/jolokia.mod
+++ b/jetty-home/src/main/resources/modules/jolokia.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Deploys the Jolokia console as a web application.

--- a/jetty-home/src/main/resources/modules/jsp.mod
+++ b/jetty-home/src/main/resources/modules/jsp.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables JSP for all webapplications deployed on the server.

--- a/jetty-home/src/main/resources/modules/jstl.mod
+++ b/jetty-home/src/main/resources/modules/jstl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables JSTL for all webapplications deployed on the server

--- a/jetty-home/src/main/resources/modules/stop.mod
+++ b/jetty-home/src/main/resources/modules/stop.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 This module causes jetty to stop immediately after starting. This is good for testing configuration and/or precompiling quickstart webapps

--- a/jetty-http2/http2-server/src/main/config/modules/http2.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables HTTP2 protocol support on the TLS(SSL) Connector,

--- a/jetty-http2/http2-server/src/main/config/modules/http2c.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2c.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the HTTP2C protocol on the HTTP Connector

--- a/jetty-jaas/src/main/config/modules/jaas.mod
+++ b/jetty-jaas/src/main/config/modules/jaas.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable JAAS for deployed webapplications.

--- a/jetty-jaspi/src/main/config/modules/jaspi.mod
+++ b/jetty-jaspi/src/main/config/modules/jaspi.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable JASPI authentication for deployed webapplications.

--- a/jetty-jmx/src/main/config/modules/jmx-remote.mod
+++ b/jetty-jmx/src/main/config/modules/jmx-remote.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables remote RMI access to JMX

--- a/jetty-jmx/src/main/config/modules/jmx.mod
+++ b/jetty-jmx/src/main/config/modules/jmx.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables JMX instrumentation for server beans and 

--- a/jetty-jndi/src/main/jndi-config/modules/jndi.mod
+++ b/jetty-jndi/src/main/jndi-config/modules/jndi.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds the Jetty JNDI implementation to the classpath.

--- a/jetty-jndi/src/main/jndi-config/modules/mail.mod
+++ b/jetty-jndi/src/main/jndi-config/modules/mail.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds the javax.mail implementation to the classpath.

--- a/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/modules/testmod.mod
+++ b/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/modules/testmod.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables test setup

--- a/jetty-maven-plugin/src/main/resources/maven.mod
+++ b/jetty-maven-plugin/src/main/resources/maven.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables an unassembled maven webapp to run in a jetty distro

--- a/jetty-memcached/jetty-memcached-sessions/src/main/config/modules/sessions/session-data-cache/xmemcached.mod
+++ b/jetty-memcached/jetty-memcached-sessions/src/main/config/modules/sessions/session-data-cache/xmemcached.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Memcache cache for SessionData

--- a/jetty-nosql/src/main/config/modules/session-store-mongo.mod
+++ b/jetty-nosql/src/main/config/modules/session-store-mongo.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables NoSql session management with a MongoDB driver.

--- a/jetty-nosql/src/main/config/modules/sessions/mongo/address.mod
+++ b/jetty-nosql/src/main/config/modules/sessions/mongo/address.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Server/port address connections for session storage

--- a/jetty-nosql/src/main/config/modules/sessions/mongo/uri.mod
+++ b/jetty-nosql/src/main/config/modules/sessions/mongo/uri.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 MongoURI connections for session storage

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds OpenId Connect authentication.

--- a/jetty-overlay-deployer/src/main/config/modules/overlay.mod
+++ b/jetty-overlay-deployer/src/main/config/modules/overlay.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable the jetty overlay deployer that allows

--- a/jetty-plus/src/main/plus-config/modules/plus.mod
+++ b/jetty-plus/src/main/plus-config/modules/plus.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables JNDI and resource injection for webapplications 

--- a/jetty-plus/src/main/plus-config/modules/transactions.mod
+++ b/jetty-plus/src/main/plus-config/modules/transactions.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Puts javax.transaction api on the classpath  

--- a/jetty-proxy/src/main/config/modules/proxy.mod
+++ b/jetty-proxy/src/main/config/modules/proxy.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable the Jetty Proxy, that allows the server to act

--- a/jetty-quickstart/src/main/config/modules/quickstart.mod
+++ b/jetty-quickstart/src/main/config/modules/quickstart.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the Jetty Quickstart module for rapid

--- a/jetty-rewrite/src/main/config/modules/rewrite-compactpath.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite-compactpath.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Add a rule to the rewrite module to compact paths so that double slashes

--- a/jetty-rewrite/src/main/config/modules/rewrite-customizer.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite-customizer.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a rewrite Rules container as a request customizer on

--- a/jetty-rewrite/src/main/config/modules/rewrite.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the jetty-rewrite handler.  Specific rewrite

--- a/jetty-security/src/main/config/modules/security.mod
+++ b/jetty-security/src/main/config/modules/security.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds servlet standard security handling to the classpath.

--- a/jetty-server/src/main/config/modules/acceptratelimit.mod
+++ b/jetty-server/src/main/config/modules/acceptratelimit.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable a server wide accept rate limit

--- a/jetty-server/src/main/config/modules/bytebufferpool.mod
+++ b/jetty-server/src/main/config/modules/bytebufferpool.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configures the ByteBufferPool used by ServerConnectors.

--- a/jetty-server/src/main/config/modules/connectionlimit.mod
+++ b/jetty-server/src/main/config/modules/connectionlimit.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable a server wide connection limit

--- a/jetty-server/src/main/config/modules/continuation.mod
+++ b/jetty-server/src/main/config/modules/continuation.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables support for Continuation style asynchronous

--- a/jetty-server/src/main/config/modules/customrequestlog.mod
+++ b/jetty-server/src/main/config/modules/customrequestlog.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a format string style request log.

--- a/jetty-server/src/main/config/modules/debug.mod
+++ b/jetty-server/src/main/config/modules/debug.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the DebugListener to generate additional 

--- a/jetty-server/src/main/config/modules/debuglog.mod
+++ b/jetty-server/src/main/config/modules/debuglog.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Deprecated Debug Log using the DebugHandle.

--- a/jetty-server/src/main/config/modules/ext.mod
+++ b/jetty-server/src/main/config/modules/ext.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds all jar files discovered in $JETTY_HOME/lib/ext

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable GzipHandler for dynamic gzip compression

--- a/jetty-server/src/main/config/modules/home-base-warning.mod
+++ b/jetty-server/src/main/config/modules/home-base-warning.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Generates a warning that server has been run from $JETTY_HOME

--- a/jetty-server/src/main/config/modules/http-forwarded.mod
+++ b/jetty-server/src/main/config/modules/http-forwarded.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds a forwarded request customizer to the HTTP Connector

--- a/jetty-server/src/main/config/modules/http.mod
+++ b/jetty-server/src/main/config/modules/http.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables an HTTP connector on the server.

--- a/jetty-server/src/main/config/modules/inetaccess.mod
+++ b/jetty-server/src/main/config/modules/inetaccess.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable the InetAccessHandler to apply a include/exclude

--- a/jetty-server/src/main/config/modules/ipaccess.mod
+++ b/jetty-server/src/main/config/modules/ipaccess.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable the ipaccess handler to apply a white/black list

--- a/jetty-server/src/main/config/modules/jdbc.mod
+++ b/jetty-server/src/main/config/modules/jdbc.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [jpms]
 add-modules: java.sql

--- a/jetty-server/src/main/config/modules/jvm.mod
+++ b/jetty-server/src/main/config/modules/jvm.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 A noop module that creates an ini template useful for

--- a/jetty-server/src/main/config/modules/logback-access.mod
+++ b/jetty-server/src/main/config/modules/logback-access.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables logback request log.

--- a/jetty-server/src/main/config/modules/lowresources.mod
+++ b/jetty-server/src/main/config/modules/lowresources.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a low resource monitor on the server

--- a/jetty-server/src/main/config/modules/proxy-protocol-ssl.mod
+++ b/jetty-server/src/main/config/modules/proxy-protocol-ssl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the Proxy Protocol on the TLS(SSL) Connector.

--- a/jetty-server/src/main/config/modules/proxy-protocol.mod
+++ b/jetty-server/src/main/config/modules/proxy-protocol.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the Proxy Protocol on the HTTP Connector.

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a NCSA style request log.

--- a/jetty-server/src/main/config/modules/resources.mod
+++ b/jetty-server/src/main/config/modules/resources.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds the $JETTY_HOME/resources and/or $JETTY_BASE/resources

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the core Jetty server on the classpath.

--- a/jetty-server/src/main/config/modules/session-cache-hash.mod
+++ b/jetty-server/src/main/config/modules/session-cache-hash.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable first level session cache. If this module is not enabled, sessions will

--- a/jetty-server/src/main/config/modules/session-cache-null.mod
+++ b/jetty-server/src/main/config/modules/session-cache-null.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 A trivial SessionCache that does not actually cache sessions.

--- a/jetty-server/src/main/config/modules/session-store-cache.mod
+++ b/jetty-server/src/main/config/modules/session-store-cache.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables caching of SessionData in front of a SessionDataStore.

--- a/jetty-server/src/main/config/modules/session-store-file.mod
+++ b/jetty-server/src/main/config/modules/session-store-file.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables session persistent storage in files.

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables JDBC persistent/distributed session storage.

--- a/jetty-server/src/main/config/modules/sessions.mod
+++ b/jetty-server/src/main/config/modules/sessions.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 The session management. By enabling this module, it allows 

--- a/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 JDBC Datasource connections for session storage

--- a/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 JDBC Driver connections for session storage

--- a/jetty-server/src/main/config/modules/ssl.mod
+++ b/jetty-server/src/main/config/modules/ssl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a TLS(SSL) Connector on the server.

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable detailed statistics collection for the server,

--- a/jetty-server/src/main/config/modules/threadpool.mod
+++ b/jetty-server/src/main/config/modules/threadpool.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the Server thread pool.

--- a/jetty-servlet/src/main/config/modules/servlet.mod
+++ b/jetty-servlet/src/main/config/modules/servlet.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables standard Servlet handling.

--- a/jetty-servlets/src/main/config/modules/servlets.mod
+++ b/jetty-servlets/src/main/config/modules/servlets.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Puts a collection of jetty utility servlets and filters

--- a/jetty-spring/src/main/config/modules/spring.mod
+++ b/jetty-spring/src/main/config/modules/spring.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable spring configuration processing so all jetty style 

--- a/jetty-start/src/test/resources/dist-home/modules/main.mod
+++ b/jetty-start/src/test/resources/dist-home/modules/main.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Example of a module

--- a/jetty-unixsocket/src/main/config/modules/unixsocket-forwarded.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket-forwarded.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds a forwarded request customizer to the HTTP configuration used

--- a/jetty-unixsocket/src/main/config/modules/unixsocket-http.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket-http.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds an HTTP protocol support to the Unix Domain Socket connector.

--- a/jetty-unixsocket/src/main/config/modules/unixsocket-http2c.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket-http2c.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds an HTTP2C connetion factory to the Unix Domain Socket Connector

--- a/jetty-unixsocket/src/main/config/modules/unixsocket-proxy-protocol.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket-proxy-protocol.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables the proxy protocol on the Unix Domain Socket Connector 

--- a/jetty-unixsocket/src/main/config/modules/unixsocket-secure.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket-secure.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable a secure request customizer on the HTTP Configuration

--- a/jetty-unixsocket/src/main/config/modules/unixsocket.mod
+++ b/jetty-unixsocket/src/main/config/modules/unixsocket.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enables a Unix Domain Socket Connector that can receive

--- a/jetty-util/src/main/config/modules/console-capture.mod
+++ b/jetty-util/src/main/config/modules/console-capture.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Redirects JVMs console stderr and stdout to a log file,

--- a/jetty-util/src/main/config/modules/jcl-slf4j.mod
+++ b/jetty-util/src/main/config/modules/jcl-slf4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a Java Commons Logging (JCL) binding to SLF4J logging. 

--- a/jetty-util/src/main/config/modules/jul-impl.mod
+++ b/jetty-util/src/main/config/modules/jul-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configures the Java Util Logging mechanism

--- a/jetty-util/src/main/config/modules/jul-slf4j.mod
+++ b/jetty-util/src/main/config/modules/jul-slf4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a Java Util Logging binding to SLF4J logging.

--- a/jetty-util/src/main/config/modules/log4j-impl.mod
+++ b/jetty-util/src/main/config/modules/log4j-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a Log4j v1.2 API and implementation.  

--- a/jetty-util/src/main/config/modules/log4j2-api.mod
+++ b/jetty-util/src/main/config/modules/log4j2-api.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides the Log4j v2 API

--- a/jetty-util/src/main/config/modules/log4j2-impl.mod
+++ b/jetty-util/src/main/config/modules/log4j2-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a Log4j v2 implementation. 

--- a/jetty-util/src/main/config/modules/log4j2-slf4j.mod
+++ b/jetty-util/src/main/config/modules/log4j2-slf4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a Log4j v2 binding to SLF4J logging.  

--- a/jetty-util/src/main/config/modules/logback-impl.mod
+++ b/jetty-util/src/main/config/modules/logback-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides the logback core implementation

--- a/jetty-util/src/main/config/modules/logging-jetty.mod
+++ b/jetty-util/src/main/config/modules/logging-jetty.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging mechanism.

--- a/jetty-util/src/main/config/modules/logging-jul.mod
+++ b/jetty-util/src/main/config/modules/logging-jul.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging to use Java Util Logging (jul)

--- a/jetty-util/src/main/config/modules/logging-log4j.mod
+++ b/jetty-util/src/main/config/modules/logging-log4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging to use Log4j Logging

--- a/jetty-util/src/main/config/modules/logging-log4j2.mod
+++ b/jetty-util/src/main/config/modules/logging-log4j2.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging to use log4j version 2

--- a/jetty-util/src/main/config/modules/logging-logback.mod
+++ b/jetty-util/src/main/config/modules/logging-logback.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging to use Logback Logging. 

--- a/jetty-util/src/main/config/modules/logging-slf4j.mod
+++ b/jetty-util/src/main/config/modules/logging-slf4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Configure jetty logging to use slf4j.

--- a/jetty-util/src/main/config/modules/slf4j-api.mod
+++ b/jetty-util/src/main/config/modules/slf4j-api.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides SLF4J API.  Requires a slf4j implementation (eg slf4j-simple-impl)

--- a/jetty-util/src/main/config/modules/slf4j-jul.mod
+++ b/jetty-util/src/main/config/modules/slf4j-jul.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Java Util Logging (JUL) logging.

--- a/jetty-util/src/main/config/modules/slf4j-log4j.mod
+++ b/jetty-util/src/main/config/modules/slf4j-log4j.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a SLF4J binding to the Log4j v1.2 API logging.

--- a/jetty-util/src/main/config/modules/slf4j-log4j2.mod
+++ b/jetty-util/src/main/config/modules/slf4j-log4j2.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Log4j v2 logging.

--- a/jetty-util/src/main/config/modules/slf4j-logback.mod
+++ b/jetty-util/src/main/config/modules/slf4j-logback.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Logback logging.

--- a/jetty-util/src/main/config/modules/slf4j-simple-impl.mod
+++ b/jetty-util/src/main/config/modules/slf4j-simple-impl.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Provides SLF4J simple logging implementation.

--- a/jetty-webapp/src/main/config/modules/webapp.mod
+++ b/jetty-webapp/src/main/config/modules/webapp.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Adds support for servlet specification webapplication to the server

--- a/jetty-websocket/javax-websocket-server-impl/src/main/config/modules/websocket.mod
+++ b/jetty-websocket/javax-websocket-server-impl/src/main/config/modules/websocket.mod
@@ -1,4 +1,4 @@
-DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
 Enable websockets for deployed web applications


### PR DESCRIPTION
In a discussion on PR https://github.com/eclipse/jetty.project/pull/5042#discussion_r454302453, @joakime has said that all these "DO NOT EDIT" comments in the .mod files should start with `#`. 