### PR TITLE
Issue #5043 - allow anonymous WebSocketListener / Endpoint classes to be used

### DIFF
--- a/jetty-websocket/websocket-javax-client/src/main/java/org/eclipse/jetty/websocket/javax/client/internal/JavaxWebSocketClientFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-javax-client/src/main/java/org/eclipse/jetty/websocket/javax/client/internal/JavaxWebSocketClientFrameHandlerFactory.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.websocket.javax.client.internal;
 
 import javax.websocket.ClientEndpoint;
-import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 
 import org.eclipse.jetty.websocket.javax.common.JavaxWebSocketContainer;
@@ -49,7 +48,7 @@ public class JavaxWebSocketClientFrameHandlerFactory extends JavaxWebSocketFrame
     public JavaxWebSocketFrameHandlerMetadata getMetadata(Class<?> endpointClass, EndpointConfig endpointConfig)
     {
         if (javax.websocket.Endpoint.class.isAssignableFrom(endpointClass))
-            return createEndpointMetadata((Class<? extends Endpoint>)endpointClass, endpointConfig);
+            return createEndpointMetadata(endpointConfig);
 
         if (endpointClass.getAnnotation(ClientEndpoint.class) == null)
             return null;

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandlerFactory.java
@@ -250,20 +250,20 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         }
     }
 
-    protected JavaxWebSocketFrameHandlerMetadata createEndpointMetadata(Class<? extends Endpoint> endpointClass, EndpointConfig endpointConfig)
+    protected JavaxWebSocketFrameHandlerMetadata createEndpointMetadata(EndpointConfig endpointConfig)
     {
         JavaxWebSocketFrameHandlerMetadata metadata = new JavaxWebSocketFrameHandlerMetadata(endpointConfig);
-        MethodHandles.Lookup lookup = getApplicationMethodHandleLookup(endpointClass);
+        MethodHandles.Lookup lookup = getServerMethodHandleLookup();
 
-        Method openMethod = ReflectUtils.findMethod(endpointClass, "onOpen", Session.class, EndpointConfig.class);
+        Method openMethod = ReflectUtils.findMethod(Endpoint.class, "onOpen", Session.class, EndpointConfig.class);
         MethodHandle open = toMethodHandle(lookup, openMethod);
         metadata.setOpenHandler(open, openMethod);
 
-        Method closeMethod = ReflectUtils.findMethod(endpointClass, "onClose", Session.class, CloseReason.class);
+        Method closeMethod = ReflectUtils.findMethod(Endpoint.class, "onClose", Session.class, CloseReason.class);
         MethodHandle close = toMethodHandle(lookup, closeMethod);
         metadata.setCloseHandler(close, closeMethod);
 
-        Method errorMethod = ReflectUtils.findMethod(endpointClass, "onError", Session.class, Throwable.class);
+        Method errorMethod = ReflectUtils.findMethod(Endpoint.class, "onError", Session.class, Throwable.class);
         MethodHandle error = toMethodHandle(lookup, errorMethod);
         metadata.setErrorHandler(error, errorMethod);
 

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/DummyFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/DummyFrameHandlerFactory.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.websocket.javax.common;
 
 import javax.websocket.ClientEndpoint;
 import javax.websocket.ClientEndpointConfig;
-import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 
 import org.eclipse.jetty.websocket.util.InvokerUtils;
@@ -43,7 +42,7 @@ public class DummyFrameHandlerFactory extends JavaxWebSocketFrameHandlerFactory
     {
         if (javax.websocket.Endpoint.class.isAssignableFrom(endpointClass))
         {
-            return createEndpointMetadata((Class<? extends Endpoint>)endpointClass, endpointConfig);
+            return createEndpointMetadata(endpointConfig);
         }
 
         if (endpointClass.getAnnotation(ClientEndpoint.class) == null)

--- a/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerFrameHandlerFactory.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.websocket.javax.server.internal;
 
-import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.server.ServerEndpoint;
 
@@ -42,7 +41,7 @@ public class JavaxWebSocketServerFrameHandlerFactory extends JavaxWebSocketClien
     public JavaxWebSocketFrameHandlerMetadata getMetadata(Class<?> endpointClass, EndpointConfig endpointConfig)
     {
         if (javax.websocket.Endpoint.class.isAssignableFrom(endpointClass))
-            return createEndpointMetadata((Class<? extends Endpoint>)endpointClass, endpointConfig);
+            return createEndpointMetadata(endpointConfig);
 
         ServerEndpoint anno = endpointClass.getAnnotation(ServerEndpoint.class);
         if (anno == null)

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxOnCloseTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxOnCloseTest.java
@@ -50,11 +50,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JavaxOnCloseTest
 {
-    private static BlockingArrayQueue<OnCloseEndpoint> serverEndpoints = new BlockingArrayQueue<>();
+    private static final BlockingArrayQueue<OnCloseEndpoint> serverEndpoints = new BlockingArrayQueue<>();
 
     private Server server;
     private ServerConnector connector;
-    private JavaxWebSocketClientContainer client = new JavaxWebSocketClientContainer();
+    private final JavaxWebSocketClientContainer client = new JavaxWebSocketClientContainer();
 
     @ServerEndpoint("/")
     public static class OnCloseEndpoint extends EventSocket
@@ -84,7 +84,7 @@ public class JavaxOnCloseTest
     @ClientEndpoint
     public static class BlockingClientEndpoint extends EventSocket
     {
-        private CountDownLatch blockInClose = new CountDownLatch(1);
+        private final CountDownLatch blockInClose = new CountDownLatch(1);
 
         public void unBlockClose()
         {

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/EndpointEchoTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/EndpointEchoTest.java
@@ -115,7 +115,6 @@ public class EndpointEchoTest
     @Test
     public void testEchoAnonymousInstance() throws Exception
     {
-
         CountDownLatch openLatch = new CountDownLatch(1);
         CountDownLatch closeLatch = new CountDownLatch(1);
         BlockingQueue<String> textMessages = new BlockingArrayQueue<>();

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/EndpointEchoTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/client/EndpointEchoTest.java
@@ -18,13 +18,18 @@
 
 package org.eclipse.jetty.websocket.javax.tests.client;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.websocket.CloseReason;
 import javax.websocket.ContainerProvider;
+import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 
+import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.websocket.javax.common.JavaxWebSocketSession;
 import org.eclipse.jetty.websocket.javax.tests.LocalServer;
 import org.eclipse.jetty.websocket.javax.tests.WSEndpointTracker;
@@ -35,6 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EndpointEchoTest
 {
@@ -104,5 +110,47 @@ public class EndpointEchoTest
 
         session.close();
         endpoint.awaitCloseEvent("Client");
+    }
+
+    @Test
+    public void testEchoAnonymousInstance() throws Exception
+    {
+
+        CountDownLatch openLatch = new CountDownLatch(1);
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        BlockingQueue<String> textMessages = new BlockingArrayQueue<>();
+        Endpoint clientEndpoint = new Endpoint()
+        {
+            @Override
+            public void onOpen(Session session, EndpointConfig config)
+            {
+                // Cannot replace this with a lambda or it breaks ReflectUtils.findGenericClassFor().
+                session.addMessageHandler(new MessageHandler.Whole<String>()
+                {
+                    @Override
+                    public void onMessage(String message)
+                    {
+                        textMessages.add(message);
+                    }
+                });
+                openLatch.countDown();
+            }
+
+            @Override
+            public void onClose(Session session, CloseReason closeReason)
+            {
+                closeLatch.countDown();
+            }
+        };
+
+        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+        Session session = container.connectToServer(clientEndpoint, null, server.getWsUri().resolve("/echo/text"));
+        assertTrue(openLatch.await(5, TimeUnit.SECONDS));
+        session.getBasicRemote().sendText("Echo");
+
+        String resp = textMessages.poll(1, TimeUnit.SECONDS);
+        assertThat("Response echo", resp, is("Echo"));
+        session.close();
+        assertTrue(closeLatch.await(5, TimeUnit.SECONDS));
     }
 }

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/listeners/WebSocketListenerTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/listeners/WebSocketListenerTest.java
@@ -21,6 +21,8 @@ package org.eclipse.jetty.websocket.tests.listeners;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,13 +30,18 @@ import java.util.stream.Stream;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.tests.EchoSocket;
 import org.eclipse.jetty.websocket.tests.EventSocket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -60,6 +67,8 @@ public class WebSocketListenerTest
         contextHandler.setContextPath("/");
         JettyWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
         {
+            container.addMapping("/echo", (req, res) -> new EchoSocket());
+
             for (Class<?> c : getClassListFromArguments(TextListeners.getTextListeners()))
             {
                 container.addMapping("/text/" + c.getSimpleName(), (req, res) -> construct(c));
@@ -123,6 +132,46 @@ public class WebSocketListenerTest
         assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
         assertThat(clientEndpoint.closeCode, is(StatusCode.NORMAL));
         assertThat(clientEndpoint.closeReason, is("standard close"));
+    }
+
+    @Test
+    public void testAnonymousListener() throws Exception
+    {
+        CountDownLatch openLatch = new CountDownLatch(1);
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        BlockingQueue<String> textMessages = new BlockingArrayQueue<>();
+        WebSocketListener clientEndpoint = new WebSocketListener() {
+            @Override
+            public void onWebSocketConnect(Session session)
+            {
+                openLatch.countDown();
+            }
+
+            @Override
+            public void onWebSocketText(String message)
+            {
+                textMessages.add(message);
+            }
+
+            @Override
+            public void onWebSocketClose(int statusCode, String reason)
+            {
+                closeLatch.countDown();
+            }
+        };
+
+        Session session = client.connect(clientEndpoint, serverUri.resolve("/echo")).get(5, TimeUnit.SECONDS);
+        assertTrue(openLatch.await(5, TimeUnit.SECONDS));
+
+        // Send and receive echo on client.
+        String payload = "hello world";
+        session.getRemote().sendString(payload);
+        String echoMessage = textMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(echoMessage, is(payload));
+
+        // Close normally.
+        session.close(StatusCode.NORMAL, "standard close");
+        assertTrue(closeLatch.await(5, TimeUnit.SECONDS));
     }
 
     private List<Class<?>> getClassListFromArguments(Stream<Arguments> stream)

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/listeners/WebSocketListenerTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/listeners/WebSocketListenerTest.java
@@ -140,7 +140,8 @@ public class WebSocketListenerTest
         CountDownLatch openLatch = new CountDownLatch(1);
         CountDownLatch closeLatch = new CountDownLatch(1);
         BlockingQueue<String> textMessages = new BlockingArrayQueue<>();
-        WebSocketListener clientEndpoint = new WebSocketListener() {
+        WebSocketListener clientEndpoint = new WebSocketListener()
+        {
             @Override
             public void onWebSocketConnect(Session session)
             {


### PR DESCRIPTION
**Issue #5043**

The `MethodHandle`s for the Endpoint metadata should use the actual interface with the methods rather than the `endpointClass` which may be private.

This is different for annotated Endpoint classes which must be public as we need to discover the annotated methods.