### PR TITLE
Jetty 9.4.x #5053 secure random

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/DigestAuthentication.java
@@ -22,10 +22,10 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.client.HttpClient;
@@ -46,6 +46,7 @@ import org.eclipse.jetty.util.TypeUtil;
  */
 public class DigestAuthentication extends AbstractAuthentication
 {
+    private static final SecureRandom random = new SecureRandom();
     private final String user;
     private final String password;
 
@@ -216,7 +217,6 @@ public class DigestAuthentication extends AbstractAuthentication
 
         private String newClientNonce()
         {
-            Random random = new Random();
             byte[] bytes = new byte[8];
             random.nextBytes(bytes);
             return toHexString(bytes);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/MultiPartContentProvider.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/MultiPartContentProvider.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -69,6 +70,7 @@ public class MultiPartContentProvider extends AbstractTypedContentProvider imple
     private static final Logger LOG = Log.getLogger(MultiPartContentProvider.class);
     private static final byte[] COLON_SPACE_BYTES = new byte[]{':', ' '};
     private static final byte[] CR_LF_BYTES = new byte[]{'\r', '\n'};
+    private static final Random random = new SecureRandom();
 
     private final List<Part> parts = new ArrayList<>();
     private final ByteBuffer firstBoundary;
@@ -99,7 +101,6 @@ public class MultiPartContentProvider extends AbstractTypedContentProvider imple
 
     private static String makeBoundary()
     {
-        Random random = new Random();
         StringBuilder builder = new StringBuilder("JettyHttpClientBoundary");
         int length = builder.length();
         while (builder.length() < length + 16)

--- a/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/PlusConfiguration.java
+++ b/jetty-plus/src/main/java/org/eclipse/jetty/plus/webapp/PlusConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.plus.webapp;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -39,6 +40,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
 public class PlusConfiguration extends AbstractConfiguration
 {
     private static final Logger LOG = Log.getLogger(PlusConfiguration.class);
+    private static final Random __random = new SecureRandom();
 
     private Integer _key;
 
@@ -99,8 +101,7 @@ public class PlusConfiguration extends AbstractConfiguration
     {
         try (ThreadClassLoaderScope scope = new ThreadClassLoaderScope(wac.getClassLoader()))
         {
-            Random random = new Random();
-            _key = random.nextInt();
+            _key = __random.nextInt();
             Context context = new InitialContext();
             Context compCtx = (Context)context.lookup("java:comp");
             compCtx.addToEnvironment(NamingContext.LOCK_PROPERTY, _key);

--- a/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/masks/RandomMasker.java
+++ b/jetty-websocket/websocket-client/src/main/java/org/eclipse/jetty/websocket/client/masks/RandomMasker.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.websocket.client.masks;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.eclipse.jetty.websocket.common.WebSocketFrame;
@@ -28,7 +29,7 @@ public class RandomMasker implements Masker
 
     public RandomMasker()
     {
-        this(new Random());
+        this(new SecureRandom());
     }
 
     public RandomMasker(Random random)


### PR DESCRIPTION
Replace uses of Random with SecureRandom for #5053
We do not believe any of these uses of Random represent any security vulnerability, but we are making this
change for an abundance of caution and to avoid warnings from 3rd party scanning tools.