### PR TITLE
Issue #5062 - fix flaky test KeyStoreScannerTest.testKeystoreRemoval()

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/KeyStoreScanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/KeyStoreScanner.java
@@ -104,6 +104,16 @@ public class KeyStoreScanner extends ContainerLifeCycle implements Scanner.Discr
             reload();
     }
 
+    @ManagedOperation(value = "Scan for changes in the SSL Keystore", impact = "ACTION")
+    public void scan()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("scanning");
+
+        _scanner.scan();
+        _scanner.scan();
+    }
+
     @ManagedOperation(value = "Reload the SSL Keystore", impact = "ACTION")
     public void reload()
     {


### PR DESCRIPTION
**Closes #5062**

KeyStoreScannerTest now uses manual scanning to avoid timing issues.