### PR TITLE
restore old ServletPathMapping even for include dispatch types

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -410,7 +410,7 @@ public class Dispatcher implements RequestDispatcher
                     case INCLUDE_CONTEXT_PATH:
                     {
                         ContextHandler.Context context = _baseRequest.getContext();
-                        return context == null ? null : context.getContextHandler().getContextPathEncoded();
+                        return context == null ? null : context.getContextHandler().getRequestContextPath();
                     }
                     case INCLUDE_QUERY_STRING:
                         return _query;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -794,14 +794,7 @@ public class Request implements HttpServletRequest
         if (context == null)
             return null;
 
-        // For some reason the spec requires the context path to be encoded (unlike getServletPath).
-        String contextPath = context.getContextHandler().getContextPathEncoded();
-
-        // For the root context, the spec requires that the empty string is returned instead of the leading '/'
-        // which is included in the pathInContext
-        if (URIUtil.SLASH.equals(contextPath))
-            return "";
-        return contextPath;
+        return context.getContextHandler().getRequestContextPath();
     }
 
     /** Get the path in the context.

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -439,8 +439,6 @@ public class ServletHandler extends ScopedHandler
         // Get the base requests
         final ServletPathMapping old_servlet_path_mapping = baseRequest.getServletPathMapping();
 
-        DispatcherType type = baseRequest.getDispatcherType();
-
         ServletHolder servletHolder = null;
         UserIdentity.Scope oldScope = null;
 
@@ -472,8 +470,7 @@ public class ServletHandler extends ScopedHandler
             if (oldScope != null)
                 baseRequest.setUserIdentityScope(oldScope);
 
-            if (!(DispatcherType.INCLUDE.equals(type)))
-                baseRequest.setServletPathMapping(old_servlet_path_mapping);
+            baseRequest.setServletPathMapping(old_servlet_path_mapping);
         }
     }
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/IncludedServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/IncludedServletTest.java
@@ -42,7 +42,6 @@ import org.eclipse.jetty.toolchain.test.IO;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -108,12 +107,13 @@ public class IncludedServletTest
 
         private void dumpAttrs(String tag, HttpServletRequest req, ServletOutputStream out) throws IOException
         {
-            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_CONTEXT_PATH,
-                req.getAttribute(RequestDispatcher.INCLUDE_CONTEXT_PATH)));
-            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_SERVLET_PATH,
-                req.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH)));
-            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_PATH_INFO,
-                req.getAttribute(RequestDispatcher.INCLUDE_PATH_INFO)));
+            String contextPath = (String)req.getAttribute(RequestDispatcher.INCLUDE_CONTEXT_PATH);
+            String servletPath = (String)req.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
+            String pathInfo = (String)req.getAttribute(RequestDispatcher.INCLUDE_PATH_INFO);
+
+            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_CONTEXT_PATH, contextPath));
+            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_SERVLET_PATH, servletPath));
+            out.println(String.format("%s: %s='%s'", tag, RequestDispatcher.INCLUDE_PATH_INFO, pathInfo));
         }
     }
 
@@ -221,7 +221,6 @@ public class IncludedServletTest
         }
     }
 
-    @Disabled // TODO: complete merge of PR #5058.
     @Test
     public void testIncludeAttributes() throws IOException
     {


### PR DESCRIPTION
Always restore the old `ServletPathMapping` in the `ServletHandler`, even for include dispatch type.

This was causing the `IncludedServletTest.testIncludeAttributes()` to fail, which was merged from PR #5058.