### PR TITLE
Issue #5048 - Review temporary buffer usage

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/CompressedContentFormat.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/CompressedContentFormat.java
@@ -50,7 +50,12 @@ public class CompressedContentFormat
         if (_extension == null && ccf._extension != null)
             return false;
 
-        return _encoding.equalsIgnoreCase(ccf._encoding) && _extension.equalsIgnoreCase(ccf._extension);
+        return equalsIgnoreCase(_encoding, ccf._encoding) && equalsIgnoreCase(_extension, ccf._extension);
+    }
+
+    private static boolean equalsIgnoreCase(String a, String b)
+    {
+        return (a == null) ? (b == null) : a.equalsIgnoreCase(b);
     }
 
     public static boolean tagEquals(String etag, String tag)

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/CompressedContentFormat.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/CompressedContentFormat.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.http;
 
+import org.eclipse.jetty.util.StringUtil;
+
 public class CompressedContentFormat
 {
     public static final CompressedContentFormat GZIP = new CompressedContentFormat("gzip", ".gz");
@@ -44,18 +46,9 @@ public class CompressedContentFormat
     {
         if (!(o instanceof CompressedContentFormat))
             return false;
+
         CompressedContentFormat ccf = (CompressedContentFormat)o;
-        if (_encoding == null && ccf._encoding != null)
-            return false;
-        if (_extension == null && ccf._extension != null)
-            return false;
-
-        return equalsIgnoreCase(_encoding, ccf._encoding) && equalsIgnoreCase(_extension, ccf._extension);
-    }
-
-    private static boolean equalsIgnoreCase(String a, String b)
-    {
-        return (a == null) ? (b == null) : a.equalsIgnoreCase(b);
+        return StringUtil.equalsIgnoreCase(_encoding, ccf._encoding) && StringUtil.equalsIgnoreCase(_extension, ccf._extension);
     }
 
     public static boolean tagEquals(String etag, String tag)

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPoolUtil.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPoolUtil.java
@@ -1,0 +1,63 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.resource.Resource;
+
+public class ByteBufferPoolUtil
+{
+    public static ByteBuffer resourceToBuffer(Resource resource, boolean direct, ByteBufferPool bufferPool) throws IOException
+    {
+        long len = resource.length();
+        if (len < 0)
+            throw new IllegalArgumentException("invalid resource: " + resource + " len=" + len);
+
+        if (len > Integer.MAX_VALUE)
+        {
+            // This method cannot handle resources of this size.
+            return null;
+        }
+
+        int ilen = (int)len;
+        ByteBuffer buffer;
+        if (bufferPool != null)
+            buffer = bufferPool.acquire(ilen, direct);
+        else
+            buffer = direct ? BufferUtil.allocateDirect(ilen) : BufferUtil.allocate(ilen);
+
+        int pos = BufferUtil.flipToFill(buffer);
+        if (resource.getFile() != null)
+            BufferUtil.readFrom(resource.getFile(), buffer);
+        else
+        {
+            try (InputStream is = resource.getInputStream())
+            {
+                BufferUtil.readFrom(is, ilen, buffer);
+            }
+        }
+        BufferUtil.flipToFlush(buffer, pos);
+
+        return buffer;
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -193,9 +193,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         // Is the content in the parent cache?
         if (_parent != null)
         {
-            HttpContent httpContent = _parent.getContent(pathInContext, maxBufferSize);
-            if (httpContent != null)
-                return httpContent;
+            return _parent.getContent(pathInContext, maxBufferSize);
         }
 
         return null;
@@ -582,7 +580,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
                     buffer = _indirectBuffer.get();
                 }
             }
-            return buffer == null ? null : buffer.asReadOnlyBuffer();
+            return buffer;
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -255,7 +255,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
                 {
                     String compressedPathInContext = pathInContext + format._extension;
                     CachedHttpContent compressedContent = _cache.get(compressedPathInContext);
-                    if (compressedContent == null || compressedContent.isValid())
+                    if (compressedContent == null || !compressedContent.isValid())
                     {
                         compressedContent = null;
                         Resource compressedResource = _factory.getResource(compressedPathInContext);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -74,7 +74,7 @@ public class ResourceService
     private boolean _acceptRanges = true;
     private boolean _dirAllowed = true;
     private boolean _redirectWelcome = false;
-    private CompressedContentFormat[] _precompressedFormats = new CompressedContentFormat[0];
+    private CompressedContentFormat[] _precompressedFormats = CompressedContentFormat.NONE;
     private String[] _preferredEncodingOrder = new String[0];
     private final Map<String, List<String>> _preferredEncodingOrderCache = new ConcurrentHashMap<>();
     private int _encodingCacheSize = 100;
@@ -197,8 +197,8 @@ public class ResourceService
     public boolean doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException
     {
-        String servletPath = null;
-        String pathInfo = null;
+        String servletPath;
+        String pathInfo;
         Enumeration<String> reqRanges = null;
         boolean included = request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI) != null;
         if (included)
@@ -578,7 +578,7 @@ public class ResourceService
             {
                 //Get jetty's Response impl
                 String mdlm = content.getLastModifiedValue();
-                if (mdlm != null && ifms.equals(mdlm))
+                if (ifms.equals(mdlm))
                 {
                     sendStatus(response, HttpServletResponse.SC_NOT_MODIFIED, content::getETagValue);
                     return false;
@@ -621,7 +621,7 @@ public class ResourceService
             return;
         }
 
-        byte[] data = null;
+        byte[] data;
         String base = URIUtil.addEncodedPaths(request.getRequestURI(), URIUtil.SLASH);
         String dir = resource.getListHTML(base, pathInContext.length() > 1, request.getQueryString());
         if (dir == null)
@@ -674,10 +674,10 @@ public class ResourceService
                 content.getResource().writeTo(out, 0, content_length);
             }
             // else if we can't do a bypass write because of wrapping
-            else if (written || !(out instanceof HttpOutput))
+            else if (written)
             {
                 // write normally
-                putHeaders(response, content, written ? -1 : 0);
+                putHeaders(response, content, -1);
                 ByteBuffer buffer = content.getIndirectBuffer();
                 if (buffer != null)
                     BufferUtil.writeTo(buffer, out);
@@ -764,7 +764,7 @@ public class ResourceService
             //  content-length header
             //
             putHeaders(response, content, -1);
-            String mimetype = (content == null ? null : content.getContentTypeValue());
+            String mimetype = content.getContentTypeValue();
             if (mimetype == null)
                 LOG.warn("Unknown mimetype for " + request.getRequestURI());
             MultiPartOutputStream multi = new MultiPartOutputStream(out);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.PreEncodedHttpField;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.ResourceContentFactory;
 import org.eclipse.jetty.server.ResourceService;
@@ -102,7 +103,8 @@ public class ResourceHandler extends HandlerWrapper implements ResourceFactory, 
         if (_mimeTypes == null)
             _mimeTypes = _context == null ? new MimeTypes() : _context.getMimeTypes();
 
-        _resourceService.setContentFactory(new ResourceContentFactory(this, _mimeTypes, _resourceService.getPrecompressedFormats()));
+        ByteBufferPool bufferPool = (_context == null) ? null : _context.getServer().getBean(ByteBufferPool.class);
+        _resourceService.setContentFactory(new ResourceContentFactory(this, _mimeTypes, _resourceService.getPrecompressedFormats(), bufferPool));
         _resourceService.setWelcomeFactory(this);
 
         super.doStart();

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/resource/ByteBufferRangeWriter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/resource/ByteBufferRangeWriter.java
@@ -30,17 +30,10 @@ import org.eclipse.jetty.util.BufferUtil;
 public class ByteBufferRangeWriter implements RangeWriter
 {
     private final ByteBuffer buffer;
-    private boolean closed = false;
 
     public ByteBufferRangeWriter(ByteBuffer buffer)
     {
-        this.buffer = buffer.asReadOnlyBuffer();
-    }
-
-    @Override
-    public void close() throws IOException
-    {
-        closed = true;
+        this.buffer = buffer;
     }
 
     @Override
@@ -60,5 +53,10 @@ public class ByteBufferRangeWriter implements RangeWriter
         src.position((int)skipTo);
         src.limit(Math.addExact((int)skipTo, (int)length));
         BufferUtil.writeTo(src, outputStream);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/resource/HttpContentRangeWriter.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/resource/HttpContentRangeWriter.java
@@ -45,12 +45,8 @@ public class HttpContentRangeWriter
     {
         Objects.requireNonNull(content, "HttpContent");
 
-        // Try direct buffer
-        ByteBuffer buffer = content.getDirectBuffer();
-        if (buffer == null)
-        {
-            buffer = content.getIndirectBuffer();
-        }
+        // Use an indirect buffer as we might be able to access array directly to prevent a copy.
+        ByteBuffer buffer = content.getIndirectBuffer();
         if (buffer != null)
         {
             return new ByteBufferRangeWriter(buffer);
@@ -78,6 +74,6 @@ public class HttpContentRangeWriter
                 LOG.debug("Skipping ReadableByteChannel option", e);
         }
 
-        return new InputStreamRangeWriter(() -> content.getInputStream());
+        return new InputStreamRangeWriter(content::getInputStream);
     }
 }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.CachedContentFactory;
 import org.eclipse.jetty.server.ResourceContentFactory;
 import org.eclipse.jetty.server.ResourceService;
@@ -253,11 +254,12 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             _cache = (CachedContentFactory)_servletContext.getAttribute(resourceCache);
         }
 
+        ByteBufferPool bufferPool = _contextHandler.getServer().getBean(ByteBufferPool.class);
         try
         {
             if (_cache == null && (maxCachedFiles != -2 || maxCacheSize != -2 || maxCachedFileSize != -2))
             {
-                _cache = new CachedContentFactory(null, this, _mimeTypes, _useFileMappedBuffer, _resourceService.isEtags(), _resourceService.getPrecompressedFormats());
+                _cache = new CachedContentFactory(null, this, _mimeTypes, _useFileMappedBuffer, _resourceService.isEtags(), _resourceService.getPrecompressedFormats(), bufferPool);
                 if (maxCacheSize >= 0)
                     _cache.setMaxCacheSize(maxCacheSize);
                 if (maxCachedFileSize >= -1)
@@ -276,7 +278,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
         HttpContent.ContentFactory contentFactory = _cache;
         if (contentFactory == null)
         {
-            contentFactory = new ResourceContentFactory(this, _mimeTypes, _resourceService.getPrecompressedFormats());
+            contentFactory = new ResourceContentFactory(this, _mimeTypes, _resourceService.getPrecompressedFormats(), bufferPool);
             if (resourceCache != null)
                 _servletContext.setAttribute(resourceCache, contentFactory);
         }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -193,6 +193,11 @@ public class StringUtil
         return String.valueOf(chars);
     }
 
+    public static boolean equalsIgnoreCase(String a, String b)
+    {
+        return (a == null) ? (b == null) : a.equalsIgnoreCase(b);
+    }
+
     public static boolean startsWithIgnoreCase(String s, String w)
     {
         if (w == null)


### PR DESCRIPTION
Implementations of `HttpContent` now use the servers `ByteBufferPool` to allocate temporary buffers for resources.
Any allocated buffers are released back to the `ByteBufferPool` when the `HttpContentrelease()` method is called.

Avoid using direct buffers before calling `BufferUtil.writeTo()`.