### PR TITLE
Issue #5088 Review ContextHandler locking

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1805,7 +1805,7 @@ public class Request implements HttpServletRequest
         }
         else if (encoded.startsWith("/"))
         {
-            path = (encoded.length() == 1) ? "/" : URIUtil.canonicalPath(URIUtil.decodePath(encoded));
+            path = (encoded.length() == 1) ? "/" : URIUtil.canonicalPath(uri.getDecodedPath());
         }
         else if ("*".equals(encoded) || HttpMethod.CONNECT.is(getMethod()))
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -824,8 +824,22 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         //   AVAILABLE ----false--> UNAVAILABLE
         if (available)
         {
-            if (_availability.compareAndSet(Availability.UNAVAILABLE, Availability.AVAILABLE))
-                throw new IllegalStateException(_availability.get().toString());
+            while (true)
+            {
+                Availability availability = _availability.get();
+                switch (availability)
+                {
+                    case AVAILABLE:
+                        break;
+                    case UNAVAILABLE:
+                        if (!_availability.compareAndSet(availability, Availability.AVAILABLE))
+                            continue;
+                        break;
+                    default:
+                        throw new IllegalStateException(availability.toString());
+                }
+                break;
+            }
         }
         else
         {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -417,6 +417,18 @@ public class ContextHandlerTest
         assertThat(connector.getResponse("GET /foo/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo'"));
         assertThat(connector.getResponse("GET /foo/bar/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo/bar'"));
 
+        // If we make foobar unavailable, then requests will be handled by 503
+        foobar.setAvailable(false);
+        assertThat(connector.getResponse("GET / HTTP/1.0\n\n"), Matchers.containsString("ctx=''"));
+        assertThat(connector.getResponse("GET /foo/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo'"));
+        assertThat(connector.getResponse("GET /foo/bar/xxx HTTP/1.0\n\n"), Matchers.containsString(" 503 "));
+
+        // If we make foobar available, then requests will be handled normally
+        foobar.setAvailable(true);
+        assertThat(connector.getResponse("GET / HTTP/1.0\n\n"), Matchers.containsString("ctx=''"));
+        assertThat(connector.getResponse("GET /foo/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo'"));
+        assertThat(connector.getResponse("GET /foo/bar/xxx HTTP/1.0\n\n"), Matchers.containsString("ctx='/foo/bar'"));
+
         // If we stop foobar, then requests will be handled by foo
         foobar.stop();
         assertThat(connector.getResponse("GET / HTTP/1.0\n\n"), Matchers.containsString("ctx=''"));

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
@@ -114,6 +114,13 @@ public class URIUtilCanonicalPathTest
                 // paths with encoded segments should remain encoded
                 // canonicalPath() is not responsible for decoding characters
                 {"%2e%2e/", "%2e%2e/"},
+                {"/%2e%2e/", "/%2e%2e/"},
+
+                // paths with parameters are not elided
+                // canonicalPath() is not responsible for decoding characters
+                {"/foo/.;/bar", "/foo/.;/bar"},
+                {"/foo/..;/bar", "/foo/..;/bar"},
+                {"/foo/..;/..;/bar", "/foo/..;/..;/bar"},
             };
 
         ArrayList<Arguments> ret = new ArrayList<>();

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -1434,7 +1434,6 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 setClassLoader(null);
             }
 
-            setAvailable(false);
             _unavailableException = null;
         }
     }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -1434,7 +1434,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 setClassLoader(null);
             }
 
-            setAvailable(true);
+            setAvailable(false);
             _unavailableException = null;
         }
     }


### PR DESCRIPTION
The locking was primarily as a memory guard for the availability status, which was already volatile.
Have instead using an AtomicReference with a simple state machine layered on top of start/stop lifecycle.
There was also protection for AttributesMap, which is no longer needed as AttributesMap is now concurrent.