### PR TITLE
Change WebSocketRemoteEndpoint private method to protected that allow user directly send ByteBuffer as TextFrame to client

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.java
@@ -47,7 +47,7 @@ import org.eclipse.jetty.websocket.common.io.FutureWriteCallback;
  */
 public class WebSocketRemoteEndpoint implements RemoteEndpoint
 {
-    private enum MsgType
+    protected enum MsgType
     {
         BLOCKING,
         ASYNC,
@@ -56,7 +56,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         PARTIAL_BINARY
     }
 
-    private static final WriteCallback NOOP_CALLBACK = new WriteCallback()
+    protected static final WriteCallback NOOP_CALLBACK = new WriteCallback()
     {
         @Override
         public void writeSuccess()
@@ -69,7 +69,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         }
     };
 
-    private static final Logger LOG = Log.getLogger(WebSocketRemoteEndpoint.class);
+    protected static final Logger LOG = Log.getLogger(WebSocketRemoteEndpoint.class);
 
     private static final int ASYNC_MASK = 0x0000FFFF;
     private static final int BLOCK_MASK = 0x00010000;
@@ -99,7 +99,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         this.batchMode = batchMode;
     }
 
-    private void blockingWrite(WebSocketFrame frame) throws IOException
+    protected void blockingWrite(WebSocketFrame frame) throws IOException
     {
         try (WriteBlocker b = blocker.acquireWriteBlocker())
         {
@@ -108,7 +108,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         }
     }
 
-    private boolean lockMsg(MsgType type)
+    protected boolean lockMsg(MsgType type)
     {
         // Blocking -> BLOCKING  ; Async -> ASYNC     ; Partial -> PARTIAL_XXXX ; Stream -> STREAMING
         // Blocking -> Pending!! ; Async -> BLOCKING  ; Partial -> Pending!!    ; Stream -> STREAMING 
@@ -173,7 +173,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         }
     }
 
-    private void unlockMsg(MsgType type)
+    protected void unlockMsg(MsgType type)
     {
         while (true)
         {
@@ -234,7 +234,7 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
      * @param frame the frame to write
      * @return the future for the network write of the frame
      */
-    private Future<Void> sendAsyncFrame(WebSocketFrame frame)
+    protected Future<Void> sendAsyncFrame(WebSocketFrame frame)
     {
         FutureWriteCallback future = new FutureWriteCallback();
         uncheckedSendFrame(frame, future);


### PR DESCRIPTION
we want send bytebuffer as TextFrame directly. for example
```
public class XWebSocketRemoteEndpoint extends WebSocketRemoteEndpoint {
	
	public XWebSocketRemoteEndpoint(LogicalConnection connection, OutgoingFrames outgoing) {
		super(connection, outgoing);
	}
	
	public XWebSocketRemoteEndpoint(LogicalConnection connection, OutgoingFrames outgoing, BatchMode batchMode) {
		super(connection, outgoing, batchMode);
	}
	
	public void sendString(ByteBuffer text) throws IOException
	{
		lockMsg(MsgType.BLOCKING);
		try
		{
			WebSocketFrame frame = new TextFrame().setPayload(text);
			if (LOG.isDebugEnabled())
			{
				LOG.debug("sendString with {}", BufferUtil.toDetailString(frame.getPayload()));
			}
			blockingWrite(frame);
		}
		finally
		{
			unlockMsg(MsgType.BLOCKING);
		}
	}

	public void sendString(ByteBuffer text) throws IOException
	{
		lockMsg(MsgType.BLOCKING);
		try
		{
			WebSocketFrame frame = new TextFrame().setPayload(text);
			if (LOG.isDebugEnabled())
			{
				LOG.debug("sendString with {}", BufferUtil.toDetailString(frame.getPayload()));
			}
			blockingWrite(frame);
		}
		finally
		{
			unlockMsg(MsgType.BLOCKING);
		}
	}

	public Future<Void> sendStringByFuture(ByteBuffer text)
	{
		lockMsg(MsgType.ASYNC);
		try
		{
			TextFrame frame = new TextFrame().setPayload(text);
			if (LOG.isDebugEnabled())
			{
				LOG.debug("sendStringByFuture with {}", BufferUtil.toDetailString(frame.getPayload()));
			}
			return sendAsyncFrame(frame);
		}
		finally
		{
			unlockMsg(MsgType.ASYNC);
		}
	}

	public void sendString(ByteBuffer text, WriteCallback callback)
	{
		lockMsg(MsgType.ASYNC);
		try
		{
			TextFrame frame = new TextFrame().setPayload(text);
			if (LOG.isDebugEnabled())
			{
				LOG.debug("sendString({},{})", BufferUtil.toDetailString(frame.getPayload()), callback);
			}
			uncheckedSendFrame(frame, callback == null ? NOOP_CALLBACK : callback);
		}
		finally
		{
			unlockMsg(MsgType.ASYNC);
		}
	}
}
```
add an extra method `public void sendString(ByteBuffer text)` to avoid create new string and avoid byte array copy, 
and we know that `ByteBuffer` contains utf-8 byte array.
so could jetty change `private method` to `protected` that allow us to extension this class?