### PR TITLE
Issue #5113 - allow sending of raw WebSocket Frames from Jetty WebSocket API

### DIFF
--- a/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/FrameRemoteEndpointTest.java
+++ b/jetty-websocket/jetty-websocket-tests/src/test/java/org/eclipse/jetty/websocket/tests/FrameRemoteEndpointTest.java
@@ -1,0 +1,199 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.websocket.api.FrameRemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.extensions.Frame;
+import org.eclipse.jetty.websocket.api.util.WSURI;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.common.io.FutureWriteCallback;
+import org.eclipse.jetty.websocket.server.NativeWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FrameRemoteEndpointTest
+{
+    private Server server;
+    private WebSocketClient client;
+
+    @BeforeEach
+    public void start() throws Exception
+    {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        NativeWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+            container.addMapping("/", EchoSocket.class));
+        WebSocketUpgradeFilter.configure(contextHandler);
+
+        server.setHandler(contextHandler);
+
+        client = new WebSocketClient();
+        server.start();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testFrameRemoteEndpoint() throws Exception
+    {
+        EventSocket clientSocket = new EventSocket();
+        Session session = client.connect(clientSocket, WSURI.toWebsocket(server.getURI())).get(5, TimeUnit.SECONDS);
+
+        FrameRemoteEndpoint frameRemote = session.getFrameRemote();
+        assertThrows(IllegalStateException.class, session::getRemote);
+
+        List<WSFrame> frames = Arrays.asList(
+            new WSFrame(Frame.Type.TEXT.getOpCode(), BufferUtil.toBuffer("hello"), false, true),
+            new WSFrame(Frame.Type.CONTINUATION.getOpCode(), BufferUtil.toBuffer(" wo"), false, true),
+            new WSFrame(Frame.Type.CONTINUATION.getOpCode(), BufferUtil.toBuffer("rld!"), true, true));
+
+        for (Frame frame : frames)
+        {
+            FutureWriteCallback callback = new FutureWriteCallback();
+            frameRemote.uncheckedSendFrame(frame, callback);
+            callback.block();
+        }
+
+        String message = clientSocket.textMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(message, is("hello world!"));
+    }
+
+    public static class WSFrame implements Frame
+    {
+        private final byte opcode;
+        private final ByteBuffer payload;
+        private final boolean fin;
+        private final byte[] mask;
+
+        public WSFrame(byte opcode, ByteBuffer payload, boolean fin, boolean masked)
+        {
+            this.opcode = opcode;
+            this.payload = payload;
+            this.fin = fin;
+            this.mask = masked ? newMask() : null;
+        }
+
+        @Override
+        public byte getOpCode()
+        {
+            return opcode;
+        }
+
+        @Override
+        public ByteBuffer getPayload()
+        {
+            return payload;
+        }
+
+        @Override
+        public int getPayloadLength()
+        {
+            return payload == null ? 0 : payload.remaining();
+        }
+
+        @Override
+        public boolean isFin()
+        {
+            return fin;
+        }
+
+        @Override
+        public byte[] getMask()
+        {
+            return mask;
+        }
+
+        private static byte[] newMask()
+        {
+            byte[] mask = new byte[4];
+            new SecureRandom().nextBytes(mask);
+            return mask;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return Type.from(getOpCode());
+        }
+
+        @Override
+        public boolean hasPayload()
+        {
+            return getPayloadLength() > 0;
+        }
+
+        @Override
+        public boolean isLast()
+        {
+            return isFin();
+        }
+
+        @Override
+        public boolean isMasked()
+        {
+            return getMask() != null;
+        }
+
+        @Override
+        public boolean isRsv1()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isRsv2()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isRsv3()
+        {
+            return false;
+        }
+    }
+}

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/FrameRemoteEndpoint.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/FrameRemoteEndpoint.java
@@ -1,0 +1,30 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.websocket.api;
+
+import org.eclipse.jetty.websocket.api.extensions.Frame;
+
+/**
+ * @deprecated Removed in Jetty-10 where the low level websocket-core API allows direct sending of WebSocket frames.
+ */
+@Deprecated
+public interface FrameRemoteEndpoint
+{
+    void uncheckedSendFrame(Frame frame, WriteCallback callback);
+}

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/FrameRemoteEndpoint.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/FrameRemoteEndpoint.java
@@ -26,5 +26,11 @@ import org.eclipse.jetty.websocket.api.extensions.Frame;
 @Deprecated
 public interface FrameRemoteEndpoint
 {
+    /**
+     * Initiates the asynchronous transmission of a WebSocket frame to the remote endpoint.
+     * This method returns before the frame is transmitted.
+     * @param frame the WebSocket frame to send.
+     * @param callback the callback to notify of success or failure of the write operation
+     */
     void uncheckedSendFrame(Frame frame, WriteCallback callback);
 }

--- a/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
+++ b/jetty-websocket/websocket-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
@@ -125,6 +125,18 @@ public interface Session extends Closeable
     RemoteEndpoint getRemote();
 
     /**
+     * Return a reference to the FrameRemoteEndpoint object representing the other end of this conversation.
+     * This allows sending raw unchecked WebSocket frames to the remote endpoint. Either this method or
+     * {@link #getRemote()} can be used to write to the remote endpoint, but these cannot be used in combination.
+     *
+     * @return the frame remote endpoint
+     * @throws IllegalStateException if getRemote() has already been called on this session.
+     * @deprecated Removed in Jetty-10 where the low level websocket-core API allows direct sending of WebSocket frames.
+     */
+    @Deprecated
+    FrameRemoteEndpoint getFrameRemote();
+
+    /**
      * Get the address of the remote side.
      *
      * @return the remote side address

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.java
@@ -29,8 +29,10 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.websocket.api.BatchMode;
+import org.eclipse.jetty.websocket.api.FrameRemoteEndpoint;
 import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.eclipse.jetty.websocket.api.WriteCallback;
+import org.eclipse.jetty.websocket.api.extensions.Frame;
 import org.eclipse.jetty.websocket.api.extensions.OutgoingFrames;
 import org.eclipse.jetty.websocket.common.BlockingWriteCallback.WriteBlocker;
 import org.eclipse.jetty.websocket.common.frames.BinaryFrame;
@@ -45,7 +47,7 @@ import org.eclipse.jetty.websocket.common.io.FutureWriteCallback;
 /**
  * Endpoint for Writing messages to the Remote websocket.
  */
-public class WebSocketRemoteEndpoint implements RemoteEndpoint
+public class WebSocketRemoteEndpoint implements RemoteEndpoint, FrameRemoteEndpoint
 {
     private enum MsgType
     {
@@ -298,10 +300,11 @@ public class WebSocketRemoteEndpoint implements RemoteEndpoint
         }
     }
 
-    public void uncheckedSendFrame(WebSocketFrame frame, WriteCallback callback)
+    @Override
+    public void uncheckedSendFrame(Frame frame, WriteCallback callback)
     {
         BatchMode batchMode = BatchMode.OFF;
-        if (frame.isDataFrame())
+        if (frame.getType().isData() || frame.getType().isContinuation())
             batchMode = getBatchMode();
         outgoing.outgoingFrame(frame, callback, batchMode);
     }

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/EmptySession.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/EmptySession.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.eclipse.jetty.websocket.api.CloseStatus;
+import org.eclipse.jetty.websocket.api.FrameRemoteEndpoint;
 import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.SuspendToken;
@@ -77,6 +78,12 @@ public class EmptySession implements Session, SuspendToken
 
     @Override
     public RemoteEndpoint getRemote()
+    {
+        return null;
+    }
+
+    @Override
+    public FrameRemoteEndpoint getFrameRemote()
     {
         return null;
     }


### PR DESCRIPTION
**Issue #5113**

This adds `FrameRemoteEndpoint` interface to the Jetty WebSocket API which allows the sending of unchecked websocket frames.

The user of this has to manage things like the frame masking as the implementation expects to receive the `WebSocketFrame` implementation class and not the API `Frame`.

The `FrameRemoteEndpoint` is already deprecated as this feature will be replaced in jetty-10 by the websocket-core API.