### PR TITLE
Issue #1337 Use either absolute or relative multipart file location

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -187,15 +187,14 @@ public class MultiPartFormInputStream
         public void write(String fileName) throws IOException
         {
             Path p = Path.of(fileName);
+            if (!p.isAbsolute())
+                p = _tmpDir.resolve(p);
             
             if (_file == null)
             {
                 _temporary = false;
 
                 // part data is only in the ByteArrayOutputStream and never been written to disk
-                if (!p.isAbsolute())
-                    p = _tmpDir.resolve(p);
-
                 _file = Files.createFile(p).toFile();
 
                 try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(_file)))
@@ -214,9 +213,8 @@ public class MultiPartFormInputStream
                 _temporary = false;
 
                 Path src = _file.toPath();
-                Path target = (p.isAbsolute() ? p : _tmpDir.resolve(p));
-                Files.move(src, target, StandardCopyOption.REPLACE_EXISTING);
-                _file = target.toFile();
+                Files.move(src, p, StandardCopyOption.REPLACE_EXISTING);
+                _file = p.toFile();
             }
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -186,17 +186,17 @@ public class MultiPartFormInputStream
         @Override
         public void write(String fileName) throws IOException
         {
-            Path p = FileSystems.getDefault().getPath(fileName);
+            Path p = Path.of(fileName);
             
             if (_file == null)
             {
                 _temporary = false;
 
                 // part data is only in the ByteArrayOutputStream and never been written to disk
-                if (p.isAbsolute())
-                    _file = Files.createFile(p).toFile();
-                else
-                    _file = Files.createFile(_tmpDir.resolve(p)).toFile();
+                if (!p.isAbsolute())
+                    p = _tmpDir.resolve(p);
+
+                _file = Files.createFile(p).toFile();
 
                 try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(_file)))
                 {
@@ -549,10 +549,7 @@ public class MultiPartFormInputStream
                 // If the MultiPartConfigElement.location is
                 // relative, make it relative to the context tmp dir
                 Path location = FileSystems.getDefault().getPath(_config.getLocation());
-                if (location.isAbsolute())
-                    _tmpDir = location;
-                else
-                    _tmpDir = _contextTmpDir.toPath().resolve(location);
+                _tmpDir = (location.isAbsolute() ? location : _contextTmpDir.toPath().resolve(location));
             }
 
             if (!Files.exists(_tmpDir))

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -539,13 +539,15 @@ public class MultiPartFormInputStream
         MultiPartParser parser = null;
         try
         {
-            // sort out the location to which to write the files
-            if (_config.getLocation() == null)
-                _tmpDir = _contextTmpDir.toPath();
-            else if ("".equals(_config.getLocation()))
+            // Sort out the location to which to write files:
+            // If there is a MultiPartConfigElement.location, use it
+            // otherwise default to the context tmp dir
+            if (StringUtil.isBlank(_config.getLocation()))
                 _tmpDir = _contextTmpDir.toPath();
             else
             {
+                // If the MultiPartConfigElement.location is
+                // relative, make it relative to the context tmp dir
                 Path location = FileSystems.getDefault().getPath(_config.getLocation());
                 if (location.isAbsolute())
                     _tmpDir = location;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -546,6 +546,7 @@ public class MultiPartFormInputStreamTest
         assertThat(tpfrfb.exists(), is(true));  //explicitly written file did not get removed after cleanup
         tpfrfb.deleteOnExit(); //clean up test 
     }
+
     @Test
     public void testPartTmpFileDeletion() throws Exception
     {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -453,7 +454,7 @@ public class MultiPartFormInputStreamTest
     }
 
     @Test
-    public void testPartFileNotDeleted() throws Exception
+    public void testPartFileRelative() throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 50);
         MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(createMultipartRequestString("tptfd").getBytes()),
@@ -465,7 +466,7 @@ public class MultiPartFormInputStreamTest
 
         MultiPart part = (MultiPart)mpis.getPart("stuff");
         File stuff = part.getFile();
-        assertThat(stuff, notNullValue()); // longer than 100 bytes, should already be a tmp file
+        assertThat(stuff, notNullValue()); // longer than 50 bytes, should already be a tmp file
         part.write("tptfd.txt");
         File tptfd = new File(_dirname + File.separator + "tptfd.txt");
         assertThat(tptfd.exists(), is(true));
@@ -474,7 +475,77 @@ public class MultiPartFormInputStreamTest
         assertThat(tptfd.exists(), is(true));  //explicitly written file did not get removed after cleanup
         tptfd.deleteOnExit(); //clean up test
     }
+    
+    @Test
+    public void testPartFileAbsolute() throws Exception
+    {
+        MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 50);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(createMultipartRequestString("tpfa").getBytes()),
+            _contentType,
+            config,
+            _tmpDir);
+        mpis.setDeleteOnExit(true);
+        mpis.getParts();
 
+        MultiPart part = (MultiPart)mpis.getPart("stuff");
+        File stuff = part.getFile();
+        assertThat(stuff, notNullValue()); // longer than 50 bytes, should already be a tmp file
+        Path path = MavenTestingUtils.getTargetTestingPath().resolve("tpfa.txt");
+        part.write(path.toFile().getAbsolutePath());
+        File tpfa = path.toFile();
+        assertThat(tpfa.exists(), is(true));
+        assertThat(stuff.exists(), is(false)); //got renamed
+        part.cleanUp();
+        assertThat(tpfa.exists(), is(true));  //explicitly written file did not get removed after cleanup
+        tpfa.deleteOnExit(); //clean up test 
+    }
+    
+    @Test
+    public void testPartFileAbsoluteFromBuffer() throws Exception
+    {
+        MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 5000);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(createMultipartRequestString("tpfafb").getBytes()),
+            _contentType,
+            config,
+            _tmpDir);
+        mpis.setDeleteOnExit(true);
+        mpis.getParts();
+
+        MultiPart part = (MultiPart)mpis.getPart("stuff");
+        //Content should still be in the buffer, because the length is < 5000, 
+        assertNull(part.getFile());
+        //test writing to an absolute filename
+        Path path = MavenTestingUtils.getTargetTestingPath().resolve("tpfafb.txt");
+        part.write(path.toFile().getAbsolutePath());
+        File tpfafb = path.toFile();
+        assertThat(tpfafb.exists(), is(true));
+        part.cleanUp();
+        assertThat(tpfafb.exists(), is(true));  //explicitly written file did not get removed after cleanup
+        tpfafb.deleteOnExit(); //clean up test 
+    }
+    
+    @Test
+    public void testPartFileRelativeFromBuffer() throws Exception
+    {
+        MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 5000);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(createMultipartRequestString("tpfrfb").getBytes()),
+            _contentType,
+            config,
+            _tmpDir);
+        mpis.setDeleteOnExit(true);
+        mpis.getParts();
+
+        MultiPart part = (MultiPart)mpis.getPart("stuff");
+        //Content should still be in the buffer, because the length is < 5000, 
+        assertNull(part.getFile());
+        //test writing to a relative filename
+        part.write("tpfrfb.txt");
+        File tpfrfb = new File(_tmpDir, "tpfrfb.txt");
+        assertThat(tpfrfb.exists(), is(true));
+        part.cleanUp();
+        assertThat(tpfrfb.exists(), is(true));  //explicitly written file did not get removed after cleanup
+        tpfrfb.deleteOnExit(); //clean up test 
+    }
     @Test
     public void testPartTmpFileDeletion() throws Exception
     {
@@ -488,7 +559,7 @@ public class MultiPartFormInputStreamTest
 
         MultiPart part = (MultiPart)mpis.getPart("stuff");
         File stuff = part.getFile();
-        assertThat(stuff, notNullValue()); // longer than 100 bytes, should already be a tmp file
+        assertThat(stuff, notNullValue()); // longer than 50 bytes, should already be a tmp file
         assertThat(stuff.exists(), is(true));
         part.cleanUp();
         assertThat(stuff.exists(), is(false));  //tmp file was removed after cleanup


### PR DESCRIPTION
Closes #1337 

Now https://github.com/eclipse-ee4j/servlet-api/pull/276 has been merged to the spec, the meaning of Part.write(String) is a bit clearer. This PR implements using either an absolute or relative location (relative to the MultiPartConfigElement.location).