### PR TITLE
Fixes #5079 - :authority header for IPv6 address not having square br…

### DIFF
--- a/examples/embedded/src/test/java/org/eclipse/jetty/embedded/OneWebAppTest.java
+++ b/examples/embedded/src/test/java/org/eclipse/jetty/embedded/OneWebAppTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,8 +55,10 @@ public class OneWebAppTest extends AbstractEmbeddedTest
     }
 
     @Test
+    @Tag("external")
     public void testGetAsyncRest() throws Exception
     {
+        // The async rest webapp forwards the call to ebay.com.
         URI uri = server.getURI().resolve("/testAsync?items=mouse,beer,gnome");
         ContentResponse response = client.newRequest(uri)
             .method(HttpMethod.GET)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -64,7 +64,6 @@ import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.io.ssl.SslClientConnectionFactory;
 import org.eclipse.jetty.util.Fields;
-import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.Promise;
@@ -1164,7 +1163,7 @@ public class HttpClient extends ContainerLifeCycle
     @Deprecated
     protected String normalizeHost(String host)
     {
-        return HostPort.normalizeHost(host);
+        return host;
     }
 
     public static int normalizePort(String scheme, int port)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -64,6 +64,7 @@ import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.io.ssl.SslClientConnectionFactory;
 import org.eclipse.jetty.util.Fields;
+import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.Promise;
@@ -1163,7 +1164,7 @@ public class HttpClient extends ContainerLifeCycle
     @Deprecated
     protected String normalizeHost(String host)
     {
-        return host;
+        return HostPort.normalizeHost(host);
     }
 
     public static int normalizePort(String scheme, int port)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1155,10 +1155,14 @@ public class HttpClient extends ContainerLifeCycle
         return encodingField;
     }
 
+    /**
+     * @param host the host to normalize
+     * @return the host itself
+     * @deprecated no replacement, do not use it
+     */
+    @Deprecated
     protected String normalizeHost(String host)
     {
-        if (host != null && host.startsWith("[") && host.endsWith("]"))
-            return host.substring(1, host.length() - 1);
         return host;
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -95,7 +95,7 @@ public class HttpRequest implements Request
         this.client = client;
         this.conversation = conversation;
         scheme = uri.getScheme();
-        host = client.normalizeHost(uri.getHost());
+        host = uri.getHost();
         port = HttpClient.normalizePort(scheme, uri.getPort());
         path = uri.getRawPath();
         query = uri.getRawQuery();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.client;
 
 import java.util.Objects;
 
+import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.URIUtil;
 
 public class Origin
@@ -107,7 +108,7 @@ public class Origin
 
         public Address(String host, int port)
         {
-            this.host = Objects.requireNonNull(host);
+            this.host = HostPort.normalizeHost(Objects.requireNonNull(host));
             this.port = port;
         }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
@@ -67,8 +67,10 @@ public class HttpClientURITest extends AbstractHttpClientServerTest
         Assumptions.assumeTrue(Net.isIpv6InterfaceAvailable());
         start(scenario, new EmptyServerHandler());
 
-        String host = "::1";
-        Request request = client.newRequest(host, connector.getLocalPort())
+        String hostAddress = "::1";
+        String host = "[" + hostAddress + "]";
+        // Explicitly use a non-bracketed IPv6 host.
+        Request request = client.newRequest(hostAddress, connector.getLocalPort())
             .scheme(scenario.getScheme())
             .timeout(5, TimeUnit.SECONDS);
 

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/EmptyServerHandler.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/EmptyServerHandler.java
@@ -1,0 +1,41 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.proxy;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class EmptyServerHandler extends AbstractHandler
+{
+    @Override
+    public final void handle(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+        jettyRequest.setHandled(true);
+        service(target, jettyRequest, request, response);
+    }
+
+    protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+    }
+}

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyServerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyServerTest.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Utf8StringBuilder;
@@ -53,6 +54,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -226,6 +228,8 @@ public class ForwardProxyServerTest
     @ValueSource(strings = {"::2", "[::3]"})
     public void testIPv6WithXForwardedForHeader(String ipv6) throws Exception
     {
+        Assumptions.assumeTrue(Net.isIpv6InterfaceAvailable());
+
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         ConnectionFactory http = new HttpConnectionFactory(httpConfig);
@@ -263,6 +267,8 @@ public class ForwardProxyServerTest
     @Test
     public void testIPv6WithForwardedHeader() throws Exception
     {
+        Assumptions.assumeTrue(Net.isIpv6InterfaceAvailable());
+
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         ConnectionFactory http = new HttpConnectionFactory(httpConfig);

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyServerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyServerTest.java
@@ -21,10 +21,14 @@ package org.eclipse.jetty.proxy;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.AbstractConnection;
@@ -33,9 +37,14 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.AbstractConnectionFactory;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
@@ -44,10 +53,13 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -73,7 +85,7 @@ public class ForwardProxyServerTest
     private Server proxy;
     private ServerConnector proxyConnector;
 
-    protected void startServer(SslContextFactory.Server serverTLS, ConnectionFactory connectionFactory) throws Exception
+    protected void startServer(SslContextFactory.Server serverTLS, ConnectionFactory connectionFactory, Handler handler) throws Exception
     {
         serverSslContextFactory = serverTLS;
         QueuedThreadPool serverThreads = new QueuedThreadPool();
@@ -81,10 +93,11 @@ public class ForwardProxyServerTest
         server = new Server(serverThreads);
         serverConnector = new ServerConnector(server, serverSslContextFactory, connectionFactory);
         server.addConnector(serverConnector);
+        server.setHandler(handler);
         server.start();
     }
 
-    protected void startProxy() throws Exception
+    protected void startProxy(ProxyServlet proxyServlet) throws Exception
     {
         QueuedThreadPool proxyThreads = new QueuedThreadPool();
         proxyThreads.setName("proxy");
@@ -98,7 +111,7 @@ public class ForwardProxyServerTest
         proxy.setHandler(connectHandler);
 
         ServletContextHandler proxyHandler = new ServletContextHandler(connectHandler, "/");
-        proxyHandler.addServlet(ProxyServlet.class, "/*");
+        proxyHandler.addServlet(new ServletHolder(proxyServlet), "/*");
 
         proxy.start();
     }
@@ -165,7 +178,7 @@ public class ForwardProxyServerTest
                             // the client, and convert it to a relative URI.
                             // The ConnectHandler won't modify what the client
                             // sent, which must be a relative URI.
-                            assertThat(request.length(), Matchers.greaterThan(0));
+                            assertThat(request.length(), greaterThan(0));
                             if (serverSslContextFactory == null)
                                 assertFalse(request.contains("http://"));
                             else
@@ -185,8 +198,8 @@ public class ForwardProxyServerTest
                     }
                 };
             }
-        });
-        startProxy();
+        }, new EmptyServerHandler());
+        startProxy(new ProxyServlet());
 
         SslContextFactory.Client clientTLS = new SslContextFactory.Client(true);
         HttpClient httpClient = new HttpClient(clientTLS);
@@ -207,5 +220,80 @@ public class ForwardProxyServerTest
         {
             httpClient.stop();
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"::2", "[::3]"})
+    public void testIPv6WithXForwardedForHeader(String ipv6) throws Exception
+    {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        ConnectionFactory http = new HttpConnectionFactory(httpConfig);
+        startServer(null, http, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, org.eclipse.jetty.server.Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                String remoteHost = jettyRequest.getRemoteHost();
+                assertThat(remoteHost, Matchers.matchesPattern("\\[.+\\]"));
+                String remoteAddr = jettyRequest.getRemoteAddr();
+                assertThat(remoteAddr, Matchers.matchesPattern("\\[.+\\]"));
+            }
+        });
+        startProxy(new ProxyServlet()
+        {
+            @Override
+            protected void addProxyHeaders(HttpServletRequest clientRequest, Request proxyRequest)
+            {
+                proxyRequest.header(HttpHeader.X_FORWARDED_FOR, ipv6);
+            }
+        });
+
+        HttpClient httpClient = new HttpClient();
+        httpClient.getProxyConfiguration().getProxies().add(newHttpProxy());
+        httpClient.start();
+
+        ContentResponse response = httpClient.newRequest("[::1]", serverConnector.getLocalPort())
+            .scheme("http")
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void testIPv6WithForwardedHeader() throws Exception
+    {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        ConnectionFactory http = new HttpConnectionFactory(httpConfig);
+        startServer(null, http, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, org.eclipse.jetty.server.Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                String remoteHost = jettyRequest.getRemoteHost();
+                assertThat(remoteHost, Matchers.matchesPattern("\\[.+\\]"));
+                String remoteAddr = jettyRequest.getRemoteAddr();
+                assertThat(remoteAddr, Matchers.matchesPattern("\\[.+\\]"));
+            }
+        });
+        startProxy(new ProxyServlet()
+        {
+            @Override
+            protected void addProxyHeaders(HttpServletRequest clientRequest, Request proxyRequest)
+            {
+                proxyRequest.header(HttpHeader.FORWARDED, "for=\"[::2]\"");
+            }
+        });
+
+        HttpClient httpClient = new HttpClient();
+        httpClient.getProxyConfiguration().getProxies().add(newHttpProxy());
+        httpClient.start();
+
+        ContentResponse response = httpClient.newRequest("[::1]", serverConnector.getLocalPort())
+            .scheme("http")
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
     }
 }

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
@@ -59,11 +59,13 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -467,6 +469,8 @@ public class ForwardProxyTLSServerTest
     @MethodSource("proxyTLS")
     public void testIPv6(SslContextFactory.Server proxyTLS) throws Exception
     {
+        Assumptions.assumeTrue(Net.isIpv6InterfaceAvailable());
+
         startTLSServer(new ServerHandler());
         startProxy(proxyTLS);
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -703,7 +703,7 @@ public class ForwardedRequestCustomizerTest
         public void accept(Actual actual)
         {
             assertThat("scheme", actual.scheme.get(), is(expectedScheme));
-            if (actual.scheme.equals("https"))
+            if (actual.scheme.get().equals("https"))
             {
                 assertTrue(actual.wasSecure.get(), "wasSecure");
             }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java
@@ -109,8 +109,8 @@ public class ProxyConnectionTest
 
         assertThat(response, Matchers.containsString("HTTP/1.1 200"));
         assertThat(response, Matchers.containsString("pathInfo=/path"));
-        assertThat(response, Matchers.containsString("remote=eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee:65535"));
-        assertThat(response, Matchers.containsString("local=ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535"));
+        assertThat(response, Matchers.containsString("remote=[eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee]:65535"));
+        assertThat(response, Matchers.containsString("local=[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535"));
     }
 
     @ParameterizedTest
@@ -147,8 +147,8 @@ public class ProxyConnectionTest
 
         assertThat(response, Matchers.containsString("HTTP/1.1 200"));
         assertThat(response, Matchers.containsString("pathInfo=/path"));
-        assertThat(response, Matchers.containsString("local=eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee:8080"));
-        assertThat(response, Matchers.containsString("remote=ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:12345"));
+        assertThat(response, Matchers.containsString("local=[eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee]:8080"));
+        assertThat(response, Matchers.containsString("remote=[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:12345"));
     }
 
     @ParameterizedTest

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -813,7 +813,7 @@ public class ResponseTest
             };
 
         int[] ports = new int[]{8080, 80};
-        String[] hosts = new String[]{null, "myhost", "192.168.0.1", "0::1"};
+        String[] hosts = new String[]{null, "myhost", "192.168.0.1", "[0::1]"};
         for (int port : ports)
         {
             for (String host : hosts)
@@ -850,7 +850,7 @@ public class ResponseTest
                     String location = response.getHeader("Location");
 
                     String expected = tests[i][1]
-                        .replace("@HOST@", host == null ? request.getLocalAddr() : (host.contains(":") ? ("[" + host + "]") : host))
+                        .replace("@HOST@", host == null ? request.getLocalAddr() : host)
                         .replace("@PORT@", host == null ? ":8888" : (port == 80 ? "" : (":" + port)));
                     assertEquals(expected, location, "test-" + i + " " + host + ":" + port);
                 }
@@ -887,7 +887,7 @@ public class ResponseTest
             };
 
         int[] ports = new int[]{8080, 80};
-        String[] hosts = new String[]{null, "myhost", "192.168.0.1", "0::1"};
+        String[] hosts = new String[]{null, "myhost", "192.168.0.1", "[0::1]"};
         for (int port : ports)
         {
             for (String host : hosts)
@@ -925,7 +925,7 @@ public class ResponseTest
                     String location = response.getHeader("Location");
 
                     String expected = tests[i][1]
-                        .replace("@HOST@", host == null ? request.getLocalAddr() : (host.contains(":") ? ("[" + host + "]") : host))
+                        .replace("@HOST@", host == null ? request.getLocalAddr() : host)
                         .replace("@PORT@", host == null ? ":8888" : (port == 80 ? "" : (":" + port)));
                     assertEquals(expected, location, "test-" + i + " " + host + ":" + port);
                 }

--- a/jetty-servlet/src/test/resources/jetty-logging.properties
+++ b/jetty-servlet/src/test/resources/jetty-logging.properties
@@ -1,5 +1,4 @@
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
-org.eclipse.jetty.LEVEL=INFO
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.servlet.LEVEL=DEBUG

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -1369,12 +1369,10 @@ public class DoSFilter implements Filter
         }
     }
 
-    private String createRemotePortId(final ServletRequest request)
+    private String createRemotePortId(ServletRequest request)
     {
-        final String addr = request.getRemoteAddr();
-        final int port = request.getRemotePort();
-        if (addr.contains(":"))
-            return "[" + addr + "]:" + port;
+        String addr = request.getRemoteAddr();
+        int port = request.getRemotePort();
         return addr + ":" + port;
     }
 }


### PR DESCRIPTION
…ackets.

On the client:
* Origin.Address.host is passed through HostPort.normalizeHost(),
so that if it is IPv6 is bracketed.
Now the ipv6 address passed to an `HttClient` request is bracketed.
* HttpRequest was de-bracketing the host, but now it does not anymore.

On the server:
* Request.getLocalAddr(), getLocalName(), getRemoteAddr(),
getRemoteHost(), getServerName(), when dealing with an IPv6 address,
return it bracketed.
The reason to return bracketed IPv6 also from *Addr() methods is that
if it is used with InetAddress/InetSocketAddress it still works, but
often it is interpreted as a URI host so brackets are necessary.
* DoSFilter was blindly bracketing - now it does not.

Added a number of test cases, and fixed those that expected
non-bracketed IPv6.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>