### PR TITLE
Issue #5150 - Infinite connection timeout support in ManagedSelector

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -690,7 +690,7 @@ public class HttpClient extends ContainerLifeCycle
     }
 
     /**
-     * @return the max time, in milliseconds, a connection can take to connect to destinations
+     * @return the max time, in milliseconds, a connection can take to connect to destinations. Zero value means infinite timeout.
      */
     @ManagedAttribute("The timeout, in milliseconds, for connect() operations")
     public long getConnectTimeout()
@@ -699,7 +699,7 @@ public class HttpClient extends ContainerLifeCycle
     }
 
     /**
-     * @param connectTimeout the max time, in milliseconds, a connection can take to connect to destinations
+     * @param connectTimeout the max time, in milliseconds, a connection can take to connect to destinations. Zero value means infinite timeout.
      * @see java.net.Socket#connect(SocketAddress, int)
      */
     public void setConnectTimeout(long connectTimeout)

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -888,7 +888,11 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
         {
             this.channel = channel;
             this.attachment = attachment;
-            this.timeout = ManagedSelector.this._selectorManager.getScheduler().schedule(this, ManagedSelector.this._selectorManager.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            final long timeout = ManagedSelector.this._selectorManager.getConnectTimeout();
+            if (timeout > 0)
+                this.timeout = ManagedSelector.this._selectorManager.getScheduler().schedule(this, timeout, TimeUnit.MILLISECONDS);
+            else
+                this.timeout = null;
         }
 
         @Override
@@ -919,7 +923,8 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
         {
             if (failed.compareAndSet(false, true))
             {
-                timeout.cancel();
+                if (timeout != null)
+                    timeout.cancel();
                 IO.close(channel);
                 ManagedSelector.this._selectorManager.connectionFailed(channel, failure, attachment);
             }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -888,7 +888,7 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
         {
             this.channel = channel;
             this.attachment = attachment;
-            final long timeout = ManagedSelector.this._selectorManager.getConnectTimeout();
+            long timeout = ManagedSelector.this._selectorManager.getConnectTimeout();
             if (timeout > 0)
                 this.timeout = ManagedSelector.this._selectorManager.getScheduler().schedule(this, timeout, TimeUnit.MILLISECONDS);
             else


### PR DESCRIPTION
Closes #5150 
`ManagedSelector` never timeouts connection in case connection timeout is set to zero.