### PR TITLE
Fixes #5152 - HttpClient should handle unsolicited responses.

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1839,6 +1839,61 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         assertArrayEquals(bytes, baos.toByteArray());
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testUnsolicitedResponseBytesFromServer(Scenario scenario) throws Exception
+    {
+        String response = "" +
+            "HTTP/1.1 408 Request Timeout\r\n" +
+            "Content-Length: 0\r\n" +
+            "Connection: close\r\n" +
+            "\r\n";
+        testUnsolicitedBytesFromServer(scenario, response);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testUnsolicitedInvalidBytesFromServer(Scenario scenario) throws Exception
+    {
+        String response = "ABCDEF";
+        testUnsolicitedBytesFromServer(scenario, response);
+    }
+
+    private void testUnsolicitedBytesFromServer(Scenario scenario, String bytesFromServer) throws Exception
+    {
+        try (ServerSocket server = new ServerSocket(0))
+        {
+            HttpClientTransport transport = new HttpClientTransportOverHTTP(1);
+            transport.setConnectionPoolFactory(destination ->
+            {
+                ConnectionPool connectionPool = new DuplexConnectionPool(destination, 1, destination);
+                connectionPool.preCreateConnections(1);
+                return connectionPool;
+            });
+            startClient(scenario, transport, null);
+
+            String host = "localhost";
+            int port = server.getLocalPort();
+
+            // Resolve the destination which will pre-create a connection.
+            HttpDestination destination = client.resolveDestination(new Origin("http", host, port));
+
+            // Accept the connection and send an unsolicited 408.
+            try (Socket socket = server.accept())
+            {
+                OutputStream output = socket.getOutputStream();
+                output.write(bytesFromServer.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+            }
+
+            // Give some time to the client to process the response.
+            Thread.sleep(1000);
+
+            AbstractConnectionPool pool = (AbstractConnectionPool)destination.getConnectionPool();
+            assertEquals(0, pool.getConnectionCount());
+        }
+    }
+
     private void assertCopyRequest(Request original)
     {
         Request copy = client.copyRequest((HttpRequest)original, original.getURI());


### PR DESCRIPTION
Now closing the connection if an unsolicited response is detected,
no matter what response status code, or whether it has a
Connection: close header, or whether it's just random bytes from
the server, and also no matter whether the client read -1.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>