### PR TITLE
Also manage graceful shutdown of already started async requests

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -189,7 +189,7 @@ public class StatisticsHandler extends HandlerWrapper implements Graceful
             _dispatchedStats.decrement();
             _dispatchedTimeStats.record(dispatched);
 
-            if (state.isSuspended())
+            if (state.isSuspended() || state.isAsyncStarted())
             {
                 if (state.isInitial())
                 {


### PR DESCRIPTION
This fixes #5105. The issue was that the async request could already be started, when reaching the finally-block, where the callback handler to facilitate the graceful shutdown is added. In that case, the callback handler is not added, and the stat handler will already count the request as finished.

Signed-off-by: Thomas Draebing <thomas.draebing@sap.com>