### PR TITLE
Issue #5105 - StatisticsHandler Graceful Shutdown of Async Requests

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -6,7 +6,7 @@
   <Call name="insertHandler">
     <Arg>
       <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler">
-        <Set name="asyncGraceful"><Property name="jetty.statistics.asyncGraceful" default="true"/></Set>
+        <Set name="gracefulShutdownWaitsForRequests"><Property name="jetty.statistics.gracefulShutdownWaitsForRequests" default="true"/></Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -5,7 +5,11 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="insertHandler">
     <Arg>
-      <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler"></New>
+      <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler">
+        <Set name="waitForSuspendedRequestsOnShutdown">
+          <Property name="jetty.statistics.waitForSuspendedRequestsOnShutdown" default="true"/>
+        </Set>
+      </New>
     </Arg>
   </Call>
   <Call class="org.eclipse.jetty.server.ServerConnectionStatistics" name="addToAllConnectors">

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -6,8 +6,8 @@
   <Call name="insertHandler">
     <Arg>
       <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler">
-        <Set name="waitForSuspendedRequestsOnShutdown">
-          <Property name="jetty.statistics.waitForSuspendedRequestsOnShutdown" default="true"/>
+        <Set name="asyncGraceful">
+          <Property name="jetty.statistics.asyncGraceful" default="true"/>
         </Set>
       </New>
     </Arg>

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -6,9 +6,7 @@
   <Call name="insertHandler">
     <Arg>
       <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler">
-        <Set name="asyncGraceful">
-          <Property name="jetty.statistics.asyncGraceful" default="true"/>
-        </Set>
+        <Set name="asyncGraceful"><Property name="jetty.statistics.asyncGraceful" default="true"/></Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -19,4 +19,4 @@ jetty.webapp.addServerClasses+=,-org.eclipse.jetty.servlet.StatisticsServlet
 [ini-template]
 
 ## If the Graceful shutdown should wait for async requests as well as the currently dispatched ones.
-# jetty.statistics.asyncGraceful=true
+# jetty.statistics.gracefulShutdownWaitsForRequests=true

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -15,3 +15,8 @@ etc/jetty-stats.xml
 
 [ini]
 jetty.webapp.addServerClasses+=,-org.eclipse.jetty.servlet.StatisticsServlet
+
+[ini-template]
+
+## If the Graceful shutdown should wait for suspended requests as well as dispatched ones.
+# jetty.statistics.waitForSuspendedRequestsOnShutdown=true

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -18,5 +18,5 @@ jetty.webapp.addServerClasses+=,-org.eclipse.jetty.servlet.StatisticsServlet
 
 [ini-template]
 
-## If the Graceful shutdown should wait for suspended requests as well as dispatched ones.
-# jetty.statistics.waitForSuspendedRequestsOnShutdown=true
+## If the Graceful shutdown should wait for async requests as well as the currently dispatched ones.
+# jetty.statistics.asyncGraceful=true

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
@@ -61,7 +61,6 @@ public class DebugHandler extends HandlerWrapper implements Connection.Listener
         final Thread thread = Thread.currentThread();
         final String old_name = thread.getName();
 
-        boolean suspend = false;
         boolean retry = false;
         String name = (String)request.getAttribute("org.eclipse.jetty.thread.name");
         if (name == null)
@@ -103,11 +102,10 @@ public class DebugHandler extends HandlerWrapper implements Connection.Listener
         finally
         {
             thread.setName(old_name);
-            suspend = baseRequest.getHttpChannelState().isSuspended();
-            if (suspend)
+            if (baseRequest.getHttpChannelState().isAsyncStarted())
             {
                 request.setAttribute("org.eclipse.jetty.thread.name", name);
-                print(name, "SUSPEND");
+                print(name, "ASYNC");
             }
             else
                 print(name, "RESPONSE " + base_response.getStatus() + (ex == null ? "" : ("/" + ex)) + " " + base_response.getContentType());

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -189,7 +189,7 @@ public class StatisticsHandler extends HandlerWrapper implements Graceful
             _dispatchedStats.decrement();
             _dispatchedTimeStats.record(dispatched);
 
-            if (state.isSuspended())
+            if (state.isSuspended() || state.isAsyncStarted())
             {
                 if (state.isInitial())
                 {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -28,6 +28,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.AsyncContextEvent;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpChannelState;
@@ -151,7 +152,11 @@ public class StatisticsHandler extends HandlerWrapper implements Graceful
     {
         Handler handler = getHandler();
         if (handler == null || !isStarted() || isShutdown())
+        {
+            if (!baseRequest.getResponse().isCommitted())
+                response.sendError(HttpStatus.SERVICE_UNAVAILABLE_503);
             return;
+        }
 
         _dispatchedStats.increment();
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
@@ -305,7 +305,7 @@ public class GracefulStopTest
                         ).getBytes());
                         client2.getOutputStream().flush();
                         String response2 = IO.toString(client2.getInputStream());
-                        assertThat(response2, containsString(" 503 "));
+                        assertThat(response2, containsString(" 404 "));
 
                         now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
                         Thread.sleep(Math.max(1, end - now));
@@ -330,8 +330,9 @@ public class GracefulStopTest
             assertThat(response, containsString(" 200 OK"));
             assertThat(response, containsString("read 10/10"));
 
-            assertThat(stats.getRequests(), is(2));
-            assertThat(stats.getResponses5xx(), is(1));
+            // The StatisticsHandler was shutdown when it received the second request so does not contribute to the stats.
+            assertThat(stats.getRequests(), is(1));
+            assertThat(stats.getResponses4xx(), is(0));
         }
     }
 
@@ -631,7 +632,7 @@ public class GracefulStopTest
 
         // Check new connections rejected!
         String unavailable = connector.getResponse("GET / HTTP/1.1\r\nHost:localhost\r\n\r\n");
-        assertThat(unavailable, containsString(" 503 Service Unavailable"));
+        assertThat(unavailable, containsString(" 404 Not Found"));
         assertThat(unavailable, Matchers.containsString("Connection: close"));
 
         // Check completed 200 has close

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
@@ -558,6 +558,7 @@ public class GracefulStopTest
     public void testCommittedResponsesAreClosed() throws Exception
     {
         Server server = new Server();
+        server.setDumpAfterStart(true);
 
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java
@@ -305,7 +305,7 @@ public class GracefulStopTest
                         ).getBytes());
                         client2.getOutputStream().flush();
                         String response2 = IO.toString(client2.getInputStream());
-                        assertThat(response2, containsString(" 404 "));
+                        assertThat(response2, containsString(" 503 "));
 
                         now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
                         Thread.sleep(Math.max(1, end - now));
@@ -558,7 +558,6 @@ public class GracefulStopTest
     public void testCommittedResponsesAreClosed() throws Exception
     {
         Server server = new Server();
-        server.setDumpAfterStart(true);
 
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);
@@ -633,7 +632,7 @@ public class GracefulStopTest
 
         // Check new connections rejected!
         String unavailable = connector.getResponse("GET / HTTP/1.1\r\nHost:localhost\r\n\r\n");
-        assertThat(unavailable, containsString(" 404 Not Found"));
+        assertThat(unavailable, containsString(" 503 Service Unavailable"));
         assertThat(unavailable, Matchers.containsString("Connection: close"));
 
         // Check completed 200 has close

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -431,7 +431,7 @@ public class StatisticsHandlerTest
         CyclicBarrier barrier = new CyclicBarrier(3);
         final AtomicReference<AsyncContext> asyncHolder = new AtomicReference<>();
         final CountDownLatch dispatched = new CountDownLatch(1);
-        _statsHandler.waitForSuspendedRequestsOnShutdown(true);
+        _statsHandler.setAsyncGraceful(true);
         _statsHandler.setHandler(new AbstractHandler()
         {
             @Override
@@ -487,7 +487,7 @@ public class StatisticsHandlerTest
         CyclicBarrier barrier = new CyclicBarrier(3);
         final AtomicReference<AsyncContext> asyncHolder = new AtomicReference<>();
         final CountDownLatch dispatched = new CountDownLatch(1);
-        _statsHandler.waitForSuspendedRequestsOnShutdown(false);
+        _statsHandler.setAsyncGraceful(false);
         _statsHandler.setHandler(new AbstractHandler()
         {
             @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -431,7 +431,7 @@ public class StatisticsHandlerTest
         CyclicBarrier barrier = new CyclicBarrier(3);
         final AtomicReference<AsyncContext> asyncHolder = new AtomicReference<>();
         final CountDownLatch dispatched = new CountDownLatch(1);
-        _statsHandler.setAsyncGraceful(true);
+        _statsHandler.setGracefulShutdownWaitsForRequests(true);
         _statsHandler.setHandler(new AbstractHandler()
         {
             @Override
@@ -487,7 +487,7 @@ public class StatisticsHandlerTest
         CyclicBarrier barrier = new CyclicBarrier(3);
         final AtomicReference<AsyncContext> asyncHolder = new AtomicReference<>();
         final CountDownLatch dispatched = new CountDownLatch(1);
-        _statsHandler.setAsyncGraceful(false);
+        _statsHandler.setGracefulShutdownWaitsForRequests(false);
         _statsHandler.setHandler(new AbstractHandler()
         {
             @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -364,6 +364,65 @@ public class StatisticsHandlerTest
     }
 
     @Test
+    public void asyncDispatchTest() throws Exception
+    {
+        final AtomicReference<AsyncContext> asyncHolder = new AtomicReference<>();
+        final CyclicBarrier[] barrier = {new CyclicBarrier(2), new CyclicBarrier(2), new CyclicBarrier(2), new CyclicBarrier(2)};
+        _statsHandler.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String path, Request request, HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws ServletException
+            {
+                request.setHandled(true);
+                try
+                {
+                    if (asyncHolder.get() == null)
+                    {
+                        barrier[0].await();
+                        barrier[1].await();
+                        AsyncContext asyncContext = request.startAsync();
+                        asyncHolder.set(asyncContext);
+                        asyncContext.dispatch();
+                    }
+                    else
+                    {
+                        barrier[2].await();
+                        barrier[3].await();
+                    }
+                }
+                catch (Exception x)
+                {
+                    throw new ServletException(x);
+                }
+            }
+        });
+        _server.start();
+
+        String request = "GET / HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "\r\n";
+        _connector.executeRequest(request);
+
+        // Before we have started async we have one active request.
+        barrier[0].await();
+        assertEquals(1, _statistics.getConnections());
+        assertEquals(1, _statsHandler.getRequests());
+        assertEquals(1, _statsHandler.getRequestsActive());
+        assertEquals(1, _statsHandler.getDispatched());
+        assertEquals(1, _statsHandler.getDispatchedActive());
+        barrier[1].await();
+
+        // After we are async the same request should still be active even though we have async dispatched.
+        barrier[2].await();
+        assertEquals(1, _statistics.getConnections());
+        assertEquals(1, _statsHandler.getRequests());
+        assertEquals(1, _statsHandler.getRequestsActive());
+        assertEquals(2, _statsHandler.getDispatched());
+        assertEquals(1, _statsHandler.getDispatchedActive());
+        barrier[3].await();
+    }
+
+    @Test
     public void testSuspendExpire() throws Exception
     {
         final long dispatchTime = 10;


### PR DESCRIPTION
**Issue #5105**

I have rebased this PR onto the branch from PR #5173 from @thomasdraebing.

If an async request has already started we do not properly add the `AsyncListener` to the `HttpChannelState` and instead treat it as a completed blocking request even though it has not completed. This is because we used the check `state.isSuspended()` instead of `state.isAsyncStarted()`.

This PR also adds an optional configuration to not wait for the suspended requests when doing a graceful shutdown, but instead shutdown when there are no actively dispatched requests. This can be used as a setter on `StatisticsHandler` or by an ini property on `stats.mod`.