### PR TITLE
Change the way ConnectorStatistics is added to the Servers Connectors

### DIFF
--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/LikeJettyXml.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/LikeJettyXml.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.deploy.PropertiesConfigurationManager;
 import org.eclipse.jetty.deploy.bindings.DebugListenerBinding;
 import org.eclipse.jetty.deploy.providers.WebAppProvider;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.rewrite.handler.MsieSslRule;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
@@ -43,7 +44,6 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnectionStatistics;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -180,7 +180,7 @@ public class LikeJettyXml
         StatisticsHandler stats = new StatisticsHandler();
         stats.setHandler(server.getHandler());
         server.setHandler(stats);
-        ServerConnectionStatistics.addToAllConnectors(server);
+        server.addToAllConnectors(new ConnectionStatistics());
 
         // === Rewrite Handler
         RewriteHandler rewrite = new RewriteHandler();

--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/LikeJettyXml.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/LikeJettyXml.java
@@ -180,7 +180,7 @@ public class LikeJettyXml
         StatisticsHandler stats = new StatisticsHandler();
         stats.setHandler(server.getHandler());
         server.setHandler(stats);
-        server.addToAllConnectors(new ConnectionStatistics());
+        server.addBeanToAllConnectors(new ConnectionStatistics());
 
         // === Rewrite Handler
         RewriteHandler rewrite = new RewriteHandler();

--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/OneServletContextJmxStats.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/OneServletContextJmxStats.java
@@ -20,9 +20,9 @@ package org.eclipse.jetty.embedded;
 
 import java.lang.management.ManagementFactory;
 
+import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnectionStatistics;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
@@ -45,7 +45,7 @@ public class OneServletContextJmxStats
         context.addServlet(DefaultServlet.class, "/");
 
         // Add Connector Statistics tracking to all connectors
-        ServerConnectionStatistics.addToAllConnectors(server);
+        server.addToAllConnectors(new ConnectionStatistics());
         return server;
     }
 

--- a/examples/embedded/src/main/java/org/eclipse/jetty/embedded/OneServletContextJmxStats.java
+++ b/examples/embedded/src/main/java/org/eclipse/jetty/embedded/OneServletContextJmxStats.java
@@ -45,7 +45,7 @@ public class OneServletContextJmxStats
         context.addServlet(DefaultServlet.class, "/");
 
         // Add Connector Statistics tracking to all connectors
-        server.addToAllConnectors(new ConnectionStatistics());
+        server.addBeanToAllConnectors(new ConnectionStatistics());
         return server;
     }
 

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -8,7 +8,9 @@
       <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler"></New>
     </Arg>
   </Call>
-  <Call class="org.eclipse.jetty.server.ServerConnectionStatistics" name="addToAllConnectors">
-    <Arg><Ref refid="Server"/></Arg>
+  <Call name="addToAllConnectors">
+    <Arg>
+      <New class="org.eclipse.jetty.io.ConnectionStatistics"/>
+    </Arg>
   </Call>
 </Configure>

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -8,7 +8,7 @@
       <New id="StatsHandler" class="org.eclipse.jetty.server.handler.StatisticsHandler"></New>
     </Arg>
   </Call>
-  <Call name="addToAllConnectors">
+  <Call name="addBeanToAllConnectors">
     <Arg>
       <New class="org.eclipse.jetty.io.ConnectionStatistics"/>
     </Arg>

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectorStatistics.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectorStatistics.java
@@ -41,7 +41,7 @@ import org.eclipse.jetty.util.statistic.SampleStatistic;
  * Adding an instance of this class as with {@link AbstractConnector#addBean(Object)}
  * will register the listener with all connections accepted by that connector.
  *
- * @deprecated use {@link ServerConnectionStatistics} instead.
+ * @deprecated use {@link org.eclipse.jetty.io.ConnectionStatistics} instead.
  */
 @Deprecated
 @ManagedObject("Connector Statistics")

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.PreEncodedHttpField;
+import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
@@ -224,8 +225,8 @@ public class Server extends HandlerWrapper implements Attributes
         if (connector.getServer() != this)
             throw new IllegalArgumentException("Connector " + connector +
                 " cannot be shared among server " + connector.getServer() + " and server " + this);
-        if (_connectors.add(connector))
-            addBean(connector);
+        _connectors.add(connector);
+        addBean(connector);
     }
 
     /**
@@ -263,6 +264,19 @@ public class Server extends HandlerWrapper implements Attributes
         _connectors.removeAll(Arrays.asList(oldConnectors));
         if (connectors != null)
             _connectors.addAll(Arrays.asList(connectors));
+    }
+
+    /**
+     * Add a {@link Connection.Listener} as a bean to all connectors on the server, this
+     * will register the listener with all connections accepted by the connectors.
+     * @param listener the listener to be added.
+     */
+    public void addToAllConnectors(Connection.Listener listener)
+    {
+        for (Connector connector : getConnectors())
+        {
+            connector.addBean(listener);
+        }
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -267,15 +267,16 @@ public class Server extends HandlerWrapper implements Attributes
     }
 
     /**
-     * Add a {@link Connection.Listener} as a bean to all connectors on the server, this
-     * will register the listener with all connections accepted by the connectors.
-     * @param listener the listener to be added.
+     * Add a bean to all connectors on the server.
+     * If the bean is an instance of {@link Connection.Listener} it will also be
+     * registered as a listener on all connections accepted by the connectors.
+     * @param bean the bean to be added.
      */
-    public void addToAllConnectors(Connection.Listener listener)
+    public void addBeanToAllConnectors(Object bean)
     {
         for (Connector connector : getConnectors())
         {
-            connector.addBean(listener);
+            connector.addBean(bean);
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnectionStatistics.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnectionStatistics.java
@@ -18,17 +18,21 @@
 
 package org.eclipse.jetty.server;
 
+import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.ConnectionStatistics;
-import org.eclipse.jetty.util.component.Container;
 
+@Deprecated
 public class ServerConnectionStatistics extends ConnectionStatistics
 {
+    /**
+     * @param server the server to use to add {@link ConnectionStatistics} to all Connectors.
+     * @deprecated use {@link Server#addToAllConnectors(Connection.Listener)} instead.
+     */
     public static void addToAllConnectors(Server server)
     {
         for (Connector connector : server.getConnectors())
         {
-            if (connector instanceof Container)
-                connector.addBean(new ConnectionStatistics());
+            connector.addBean(new ConnectionStatistics());
         }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnectionStatistics.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnectionStatistics.java
@@ -18,7 +18,6 @@
 
 package org.eclipse.jetty.server;
 
-import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.ConnectionStatistics;
 
 @Deprecated
@@ -26,7 +25,7 @@ public class ServerConnectionStatistics extends ConnectionStatistics
 {
     /**
      * @param server the server to use to add {@link ConnectionStatistics} to all Connectors.
-     * @deprecated use {@link Server#addToAllConnectors(Connection.Listener)} instead.
+     * @deprecated use {@link Server#addBeanToAllConnectors(Object)} instead.
      */
     public static void addToAllConnectors(Server server)
     {


### PR DESCRIPTION
We currently have `ServerConnectionStatistics` which extends `ConnectionStatistics` but is never even constructed and only ever used for its static method to add a new `ConnectionStatistics` to every connector on the server.

I have moved the `addToAllConnectors()` method to be on `Server` and deprecated the `ServerConnectionStatistics` class. 

This will make it easier to do things like add a `IncludeExcludeConnectionStatistics` with xml like:
```xml
<Configure id="Server" class="org.eclipse.jetty.server.Server">
  <Call name="addToAllConnectors">
    <Arg>
      <New class="org.eclipse.jetty.io.IncludeExcludeConnectionStatistics">
        <Call name="include" arg="org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection"/>
      </New>
    </Arg>
  </Call>
</Configure>
```