### PR TITLE
Jetty 9.4.x improving handler documentation

### DIFF
--- a/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
@@ -174,7 +174,7 @@ This is typically used to pass a request to a link:{JDURL}/org/eclipse/jetty/ser
 ==== Injecting Handlers
 
 A custom handler can be injected using an injection based XML:
-[source, xml, subs="{sub-order}"]
+[source, xml]
 ----
 <?xml version="1.0"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">

--- a/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
@@ -170,6 +170,11 @@ This is typically used to pass a request to a link:{JDURL}/org/eclipse/jetty/ser
 * link:{JDURL}/org/eclipse/jetty/server/handler/HandlerList.html[`HandlerList`] - A list of handlers that are called in turn until the request state is set as handled.
 * link:{JDURL}/org/eclipse/jetty/server/handler/ContextHandlerCollection.html[`ContextHandlerCollection`] - A collection of Handlers, of which one is selected by best match for the context path.
 
+[[injecting-handlers]]
+==== Injecting Handlers
+
+A Handler may handle a request by:
+
 [[more-about-handlers]]
 ==== More About Handlers
 

--- a/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
@@ -173,7 +173,25 @@ This is typically used to pass a request to a link:{JDURL}/org/eclipse/jetty/ser
 [[injecting-handlers]]
 ==== Injecting Handlers
 
-A Handler may handle a request by:
+A custom handler can be injected using an injection based XML:
+[source, xml, subs="{sub-order}"]
+----
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="setHandler">
+        <Arg>
+            <New id="myCustomJettyHandler" class="com.my.handler.CustomJettyHandler" />
+        </Arg>
+    </Call>
+</Configure>
+----
+
+* The custom handler JAR should be available at /path/to/myjettybase/lib/ext/
+# The custom handler XML should be available at /path/to/myjettybase/etc/
+# The custom handler XML should be loaded into the jetty instance at the right point in the XML load order by declaring it to be used in a custom INI
+
 
 [[more-about-handlers]]
 ==== More About Handlers

--- a/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/handlers/writing-custom-handlers.adoc
@@ -188,9 +188,9 @@ A custom handler can be injected using an injection based XML:
 </Configure>
 ----
 
-* The custom handler JAR should be available at /path/to/myjettybase/lib/ext/
-# The custom handler XML should be available at /path/to/myjettybase/etc/
-# The custom handler XML should be loaded into the jetty instance at the right point in the XML load order by declaring it to be used in a custom INI
+* The custom handler JAR should be available at `/path/to/myjettybase/lib/ext/`
+* The custom handler XML should be available at `/path/to/myjettybase/etc/`
+* The custom handler XML should be loaded into the jetty instance at the right point in the XML load order by declaring it to be used in a custom INI
 
 
 [[more-about-handlers]]


### PR DESCRIPTION
Adding as discussed here: https://github.com/eclipse/jetty.project/issues/5172#issuecomment-678111710

* Adding Injecting Handlers section to writing-custom-handler.adoc
* Explaining XML based handler injection