### PR TITLE
Issue #5171 Simplify GzipHandler user-agent handling

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -739,13 +739,14 @@ public interface HttpFields extends Iterable<HttpField>
         }
 
         /** Ensure that specific HttpField exists when the field may not exist or may
-         * exist and be multi valued.
+         * exist and be multi valued.  Multiple existing fields are merged into a
+         * single field.
          * @param field The header to ensure is contained.  The field is used
          *              directly if possible so {@link PreEncodedHttpField}s can be
          *              passed.  If the value needs to be merged with existing values,
          *              then a new field is created.
          */
-        public void ensure(HttpField field)
+        public void ensureField(HttpField field)
         {
             // Is the field value multi valued?
             if (field.getValue().indexOf(',') < 0)

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -738,6 +738,38 @@ public interface HttpFields extends Iterable<HttpField>
             return this;
         }
 
+        /** Ensure that a multivalue CSV field contains the value
+         * @param header The header to check
+         * @param value The value that it must contain.
+         */
+        public void ensure(HttpHeader header, String value)
+        {
+            computeField(header, (h,l) ->
+            {
+                if (l == null || l.isEmpty())
+                    return new HttpField(h, value);
+
+                if (l.size() == 1)
+                {
+                    HttpField f = l.get(0);
+                    return f.contains(value) ? f : new HttpField(h, f.getValue() + ", " + value);
+                }
+                StringBuilder v = new StringBuilder();
+                boolean hasIt = false;
+                for (HttpField f : l)
+                {
+                    if (v.length() > 0)
+                        v.append(", ");
+                    v.append(f.getValue());
+                    if (f.contains(value))
+                        hasIt = true;
+                }
+                if (!hasIt)
+                    v.append(", ").append(value);
+                return new HttpField(h, v.toString());
+            });
+        }
+
         @Override
         public boolean equals(Object o)
         {

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -922,4 +922,25 @@ public class HttpFieldsTest
         fields.computeField("TEST", (n, f) -> null);
         assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("Before: value", "After: value"));
     }
+
+    @Test
+    public void testEnsureValue()
+    {
+        HttpFields.Mutable fields = HttpFields.build();
+        assertThat(fields.size(), is(0));
+
+        fields.ensure(HttpHeader.ETAG, "one");
+        assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("ETag: one"));
+
+        fields.ensure(HttpHeader.ETAG, "one");
+        assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("ETag: one"));
+
+        fields.add(new HttpField(HttpHeader.ETAG, "two"));
+        fields.ensure(HttpHeader.ETAG, "one");
+        assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("ETag: one, two"));
+
+        fields.add(new HttpField(HttpHeader.ETAG, "three"));
+        fields.ensure(HttpHeader.ETAG, "four");
+        assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("ETag: one, two, three, four"));
+    }
 }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -946,7 +946,6 @@ public class HttpFieldsTest
         assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("Vary: one, two, three, four"));
     }
 
-
     @Test
     public void testEnsureMultiValue()
     {

--- a/jetty-rewrite/src/main/config/modules/msie.mod
+++ b/jetty-rewrite/src/main/config/modules/msie.mod
@@ -1,0 +1,13 @@
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Enables the MSIE rewrite rule for MSIE 5 and 6 known bugs.
+
+[depend]
+rewrite
+
+[files]
+basehome:modules/rewrite/rewrite-msie.xml|etc/rewrite-msie.xml
+
+[xml]
+etc/rewrite-msie.xml

--- a/jetty-rewrite/src/main/config/modules/rewrite/rewrite-msie.xml
+++ b/jetty-rewrite/src/main/config/modules/rewrite/rewrite-msie.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
+  <Call name="addRule">
+    <Arg>
+      <New class="org.eclipse.jetty.rewrite.handler.MsieRule"/>
+    </Arg>
+  </Call>
+</Configure>
+

--- a/jetty-rewrite/src/main/config/modules/rewrite/rewrite-rules.xml
+++ b/jetty-rewrite/src/main/config/modules/rewrite/rewrite-rules.xml
@@ -2,14 +2,6 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
 <Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
 
-  <!-- Add rule to protect against IE ssl bug 
-  <Call name="addRule">
-    <Arg>
-      <New class="org.eclipse.jetty.rewrite.handler.MsieSslRule"/>
-    </Arg>
-  </Call>
-  -->
-
   <!-- protect favicon handling
   <Call name="addRule">
     <Arg>
@@ -98,6 +90,14 @@
          <Set name="code">400</Set>
          <Set name="message">ResponsePatternRule Demo</Set>
       </New>
+    </Arg>
+  </Call>
+  -->
+
+  <!-- Add rule to protect against IE ssl bug (see msie module and rewrite-msie.xml)
+  <Call name="addRule">
+    <Arg>
+      <New class="org.eclipse.jetty.rewrite.handler.MsieRule"/>
     </Arg>
   </Call>
   -->

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/MsieRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/MsieRule.java
@@ -44,7 +44,7 @@ public class MsieRule extends Rule
     private static final int IEv6 = '6';
     private static final Trie<Boolean> __IE6_BadOS = new ArrayTernaryTrie<>();
     private static final HttpField CONNECTION_CLOSE = new HttpField(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE);
-    public static final HttpField VARY_USER_AGENT = new PreEncodedHttpField(HttpHeader.VARY, HttpHeader.USER_AGENT.asString());
+    private static final HttpField VARY_USER_AGENT = new PreEncodedHttpField(HttpHeader.VARY, HttpHeader.USER_AGENT.asString());
 
     static
     {
@@ -75,7 +75,7 @@ public class MsieRule extends Rule
         String userAgent = reqFields.get(HttpHeader.USER_AGENT);
         boolean acceptEncodings = reqFields.contains(HttpHeader.ACCEPT_ENCODING);
         if (acceptEncodings)
-            resFields.ensure(VARY_USER_AGENT);
+            resFields.ensureField(VARY_USER_AGENT);
 
         int msie = userAgent.indexOf("MSIE");
         if (msie >= 0)
@@ -105,8 +105,8 @@ public class MsieRule extends Rule
                     if (version <= IEv5 || badOs)
                     {
                         reqFields.remove(HttpHeader.KEEP_ALIVE);
-                        reqFields.ensure(CONNECTION_CLOSE);
-                        resFields.ensure(CONNECTION_CLOSE);
+                        reqFields.ensureField(CONNECTION_CLOSE);
+                        resFields.ensureField(CONNECTION_CLOSE);
                         response.setHeader(HttpHeader.CONNECTION.asString(), HttpHeaderValue.CLOSE.asString());
                     }
                 }
@@ -116,5 +116,4 @@ public class MsieRule extends Rule
         }
         return null;
     }
-
 }

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/MsieRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/MsieRule.java
@@ -35,7 +35,7 @@ import org.eclipse.jetty.util.Trie;
  * Special handling for MSIE (Microsoft Internet Explorer).
  * <ul>
  *     <li>Disable keep alive for SSL from IE5 or IE6 on Windows 2000</li>
- *     <li>Disable encodings for IE<=6</li>
+ *     <li>Disable encodings for IE&lt;=6</li>
  * </ul>
  */
 public class MsieRule extends Rule

--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MsieRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MsieRuleTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -225,11 +226,14 @@ public class MsieRuleTest extends AbstractRuleTestCase
             .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)")
             .add(HttpHeader.ACCEPT_ENCODING, "gzip"));
 
+        _response.addHeader("Vary", "Something");
+
         String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
 
         assertEquals(_request.getRequestURI(), result);
         assertThat(_request.getHttpFields().stream().map(HttpField::toString).collect(Collectors.toList()),
             contains("Cookie: set=already", "User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"));
+        assertThat(_response.getHeader("Vary"), is("Something, User-Agent"));
     }
 
     @Test
@@ -238,6 +242,7 @@ public class MsieRuleTest extends AbstractRuleTestCase
         _request.setHttpFields(HttpFields.build(_request.getHttpFields())
             .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)")
             .add(HttpHeader.ACCEPT_ENCODING, "gzip"));
+        _response.addHeader("Vary", "Something");
 
         String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
 
@@ -247,6 +252,8 @@ public class MsieRuleTest extends AbstractRuleTestCase
                 "Cookie: set=already",
                 "User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)",
                 "Accept-Encoding: gzip"));
+
+        assertThat(_response.getHeader("Vary"), is("Something, User-Agent"));
     }
 
     @Test

--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MsieRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MsieRuleTest.java
@@ -1,0 +1,270 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.rewrite.handler;
+
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpHeaderValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MsieRuleTest extends AbstractRuleTestCase
+{
+    private MsieRule _rule;
+
+    @BeforeEach
+    public void init() throws Exception
+    {
+        // enable SSL
+        start(true);
+        _rule = new MsieRule();
+    }
+
+    @Test
+    public void testWin2kSP1WithIE5() throws Exception
+    {
+        HttpFields.Mutable fields = HttpFields.build(_request.getHttpFields());
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 5.01)");
+        _request.setHttpFields(fields);
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.01)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.01)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWin2kSP1WithIE6() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.01)"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWin2kSP1WithIE7() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.01)"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertNull(result);
+        assertNull(_response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWin2kWithIE5() throws Exception
+    {
+        HttpFields.Mutable fields = HttpFields.build(_request.getHttpFields());
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 5.0)");
+        _request.setHttpFields(fields);
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.0)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWin2kWithIE6() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)")
+            .asImmutable());
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWin2kWithIE7() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0)"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertNull(result);
+        assertNull(_response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWinVistaWithIE5() throws Exception
+    {
+        HttpFields.Mutable fields = HttpFields.build(_request.getHttpFields());
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 6.0)");
+        _request.setHttpFields(fields);
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 6.0)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 6.0)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWinVistaWithIE6() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 6.0)"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertThat(_request.getHttpFields().stream().map(HttpField::toString).collect(Collectors.toList()),
+            contains("Cookie: set=already", "User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 6.0)"));
+    }
+
+    @Test
+    public void testWinVistaWithIE7() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertNull(result);
+        assertNull(_response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWinXpWithIE5() throws Exception
+    {
+        HttpFields.Mutable fields = HttpFields.build(_request.getHttpFields());
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 5.1)");
+        _request.setHttpFields(fields);
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.1)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+
+        fields.add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)");
+        _request.setHttpFields(fields);
+        result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+        assertEquals(_request.getRequestURI(), result);
+        assertEquals(HttpHeaderValue.CLOSE.asString(), _response.getHeader(HttpHeader.CONNECTION.asString()));
+    }
+
+    @Test
+    public void testWinXpWithIE6() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)")
+            .add(HttpHeader.ACCEPT_ENCODING, "gzip"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertThat(_request.getHttpFields().stream().map(HttpField::toString).collect(Collectors.toList()),
+            contains("Cookie: set=already", "User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"));
+    }
+
+    @Test
+    public void testWinXpWithIE7() throws Exception
+    {
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)")
+            .add(HttpHeader.ACCEPT_ENCODING, "gzip"));
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertNull(result);
+        assertThat(_request.getHttpFields().stream().map(HttpField::toString).collect(Collectors.toList()),
+            contains(
+                "Cookie: set=already",
+                "User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)",
+                "Accept-Encoding: gzip"));
+    }
+
+    @Test
+    public void testWithoutSsl() throws Exception
+    {
+        // disable SSL
+        super.stop();
+        super.start(false);
+
+        _request.setHttpFields(HttpFields.build(_request.getHttpFields())
+            .add("User-Agent", "Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 5.0)")
+            .add(HttpHeader.ACCEPT_ENCODING, "deflate")
+        );
+
+        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
+
+        assertEquals(_request.getRequestURI(), result);
+        assertThat(_request.getHttpFields().stream().map(HttpField::toString).collect(Collectors.toList()),
+            contains("Cookie: set=already", "User-Agent: Mozilla/4.0 (compatible; MSIE 5.0; Windows NT 5.0)"));
+    }
+}

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -18,13 +18,6 @@
         <Set name="inflateBufferSize" property="jetty.gzip.inflateBufferSize"/>
         <Set name="deflaterPoolCapacity" property="jetty.gzip.deflaterPoolCapacity"/>
         <Set name="syncFlush" property="jetty.gzip.syncFlush"/>
-
-        <Set name="excludedAgentPatterns">
-          <Array type="String">
-            <Item><Property name="jetty.gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
-          </Array>
-        </Set>
-
         <Set name="includedMethodList" property="jetty.gzip.includedMethodList"/>
         <Set name="excludedMethodList" property="jetty.gzip.excludedMethodList"/>
 

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -1,8 +1,8 @@
 # DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
 
 [description]
-Enable GzipHandler for dynamic gzip compression
-for the entire server.
+Enable GzipHandler for dynamic gzip compression for the entire server.
+If MSIE prior to version 7 are to be handled, also enable the msie module.
 
 [tags]
 handler
@@ -23,9 +23,6 @@ etc/jetty-gzip.xml
 ## Gzip compression level (-1 for default)
 # jetty.gzip.compressionLevel=-1
 
-## User agents for which gzip is disabled
-# jetty.gzip.excludedUserAgent=.*MSIE.6\.0.*
-
 ## Inflate request buffer size, or 0 for no request inflation
 # jetty.gzip.inflateBufferSize=0
 
@@ -33,7 +30,7 @@ etc/jetty-gzip.xml
 # jetty.gzip.deflaterPoolCapacity=-1
 
 ## Comma separated list of included methods
-# jetty.gzip.includedMethodList=GET
+# jetty.gzip.includedMethodList=GET,POST
 
 ## Comma separated list of excluded methods
 # jetty.gzip.excludedMethodList=

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -43,7 +43,6 @@ import org.eclipse.jetty.server.HttpOutput;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.util.IncludeExclude;
-import org.eclipse.jetty.util.RegexSet;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.compression.DeflaterPool;
 import org.slf4j.Logger;
@@ -167,11 +166,10 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     private int _inflateBufferSize = -1;
     private EnumSet<DispatcherType> _dispatchers = EnumSet.of(DispatcherType.REQUEST);
     // non-static, as other GzipHandler instances may have different configurations
-    private final IncludeExclude<String> _agentPatterns = new IncludeExclude<>(RegexSet.class);
     private final IncludeExclude<String> _methods = new IncludeExclude<>();
     private final IncludeExclude<String> _paths = new IncludeExclude<>(PathSpecSet.class);
     private final IncludeExclude<String> _mimeTypes = new IncludeExclude<>();
-    private HttpField _vary;
+    private HttpField _vary = GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING;
 
     /**
      * Instantiates a new GzipHandler.
@@ -179,6 +177,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public GzipHandler()
     {
         _methods.include(HttpMethod.GET.asString());
+        _methods.include(HttpMethod.POST.asString());
         for (String type : MimeTypes.getKnownMimeTypes())
         {
             if ("image/svg+xml".equals(type))
@@ -198,19 +197,29 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
 
         if (LOG.isDebugEnabled())
             LOG.debug("{} mime types {}", this, _mimeTypes);
-
-        _agentPatterns.exclude(".*MSIE 6.0.*");
     }
 
     /**
-     * Add excluded to the User-Agent filtering.
-     *
-     * @param patterns Regular expressions matching user agents to exclude
-     * @see #addIncludedAgentPatterns(String...)
+     * @return The VARY field to use .
      */
-    public void addExcludedAgentPatterns(String... patterns)
+    public HttpField getVary()
     {
-        _agentPatterns.exclude(patterns);
+        return _vary;
+    }
+
+    /**
+     * @param vary The VARY field to use. It if is not an instance of {@link PreEncodedHttpField},
+     *             then it will be converted to one.
+     */
+    public void setVary(HttpField vary)
+    {
+        if (isRunning())
+            throw new IllegalStateException(getState());
+
+        if (vary == null || (vary instanceof PreEncodedHttpField))
+            _vary = vary;
+        else
+            _vary = new PreEncodedHttpField(vary.getHeader(), vary.getName(), vary.getValue());
     }
 
     /**
@@ -313,17 +322,6 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
-     * Adds included User-Agents for filtering.
-     *
-     * @param patterns Regular expressions matching user agents to include
-     * @see #addExcludedAgentPatterns(String...)
-     */
-    public void addIncludedAgentPatterns(String... patterns)
-    {
-        _agentPatterns.include(patterns);
-    }
-
-    /**
      * Adds included HTTP Methods (eg: POST, PATCH, DELETE) for filtering.
      *
      * @param methods The HTTP methods to include in compression.
@@ -413,20 +411,12 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     protected void doStart() throws Exception
     {
         _deflaterPool = newDeflaterPool(poolCapacity);
-        _vary = (_agentPatterns.size() > 0) ? GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING_USER_AGENT : GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING;
         super.doStart();
     }
 
     @Override
     public Deflater getDeflater(Request request, long contentLength)
     {
-        String ua = request.getHttpFields().get(HttpHeader.USER_AGENT);
-        if (ua != null && !isAgentGzipable(ua))
-        {
-            LOG.debug("{} excluded user agent {}", this, request);
-            return null;
-        }
-
         if (contentLength >= 0 && contentLength < _minGzipSize)
         {
             LOG.debug("{} excluded minGzipSize {}", this, request);
@@ -444,18 +434,6 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
-     * Get the current filter list of excluded User-Agent patterns
-     *
-     * @return the filter list of excluded User-Agent patterns
-     * @see #getIncludedAgentPatterns()
-     */
-    public String[] getExcludedAgentPatterns()
-    {
-        Set<String> excluded = _agentPatterns.getExcluded();
-        return excluded.toArray(new String[excluded.size()]);
-    }
-
-    /**
      * Get the current filter list of excluded HTTP methods
      *
      * @return the filter list of excluded HTTP methods
@@ -464,7 +442,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getExcludedMethods()
     {
         Set<String> excluded = _methods.getExcluded();
-        return excluded.toArray(new String[excluded.size()]);
+        return excluded.toArray(new String[0]);
     }
 
     /**
@@ -476,7 +454,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getExcludedMimeTypes()
     {
         Set<String> excluded = _mimeTypes.getExcluded();
-        return excluded.toArray(new String[excluded.size()]);
+        return excluded.toArray(new String[0]);
     }
 
     /**
@@ -488,19 +466,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getExcludedPaths()
     {
         Set<String> excluded = _paths.getExcluded();
-        return excluded.toArray(new String[excluded.size()]);
-    }
-
-    /**
-     * Get the current filter list of included User-Agent patterns
-     *
-     * @return the filter list of included User-Agent patterns
-     * @see #getExcludedAgentPatterns()
-     */
-    public String[] getIncludedAgentPatterns()
-    {
-        Set<String> includes = _agentPatterns.getIncluded();
-        return includes.toArray(new String[includes.size()]);
+        return excluded.toArray(new String[0]);
     }
 
     /**
@@ -512,7 +478,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getIncludedMethods()
     {
         Set<String> includes = _methods.getIncluded();
-        return includes.toArray(new String[includes.size()]);
+        return includes.toArray(new String[0]);
     }
 
     /**
@@ -524,7 +490,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getIncludedMimeTypes()
     {
         Set<String> includes = _mimeTypes.getIncluded();
-        return includes.toArray(new String[includes.size()]);
+        return includes.toArray(new String[0]);
     }
 
     /**
@@ -536,7 +502,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String[] getIncludedPaths()
     {
         Set<String> includes = _paths.getIncluded();
-        return includes.toArray(new String[includes.size()]);
+        return includes.toArray(new String[0]);
     }
 
     /**
@@ -736,20 +702,6 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
-     * Test if the provided User-Agent is allowed based on the User-Agent filters.
-     *
-     * @param ua the user agent
-     * @return whether compressing is allowed for the given user agent
-     */
-    protected boolean isAgentGzipable(String ua)
-    {
-        if (ua == null)
-            return false;
-
-        return _agentPatterns.test(ua);
-    }
-
-    /**
      * Test if the provided MIME type is allowed based on the MIME type filters.
      *
      * @param mimetype the MIME type to test
@@ -779,21 +731,6 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public void recycle(Deflater deflater)
     {
         _deflaterPool.release(deflater);
-    }
-
-    /**
-     * if(isStarted())
-     * throw new IllegalStateException(getState());
-     *
-     * Set the excluded filter list of User-Agent patterns (replacing any previously set)
-     *
-     * @param patterns Regular expressions list matching user agents to exclude
-     * @see #setIncludedAgentPatterns(String...)
-     */
-    public void setExcludedAgentPatterns(String... patterns)
-    {
-        _agentPatterns.getExcluded().clear();
-        addExcludedAgentPatterns(patterns);
     }
 
     /**
@@ -832,18 +769,6 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     {
         _paths.getExcluded().clear();
         _paths.exclude(pathspecs);
-    }
-
-    /**
-     * Set the included filter list of User-Agent patterns (replacing any previously set)
-     *
-     * @param patterns Regular expressions matching user agents to include
-     * @see #setExcludedAgentPatterns(String...)
-     */
-    public void setIncludedAgentPatterns(String... patterns)
-    {
-        _agentPatterns.getIncluded().clear();
-        addIncludedAgentPatterns(patterns);
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -200,7 +200,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
-     * @return The VARY field to use .
+     * @return The VARY field to use.
      */
     public HttpField getVary()
     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -189,7 +189,7 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
         {
             // We are varying the response due to accept encoding header.
             if (_vary != null)
-                fields.ensure(_vary);
+                fields.ensureField(_vary);
 
             long contentLength = response.getContentLength();
             if (contentLength < 0 && complete)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -46,7 +46,6 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
     public static Logger LOG = LoggerFactory.getLogger(GzipHttpOutputInterceptor.class);
     private static final byte[] GZIP_HEADER = new byte[]{(byte)0x1f, (byte)0x8b, Deflater.DEFLATED, 0, 0, 0, 0, 0, 0, 0};
 
-    public static final HttpField VARY_ACCEPT_ENCODING_USER_AGENT = new PreEncodedHttpField(HttpHeader.VARY, HttpHeader.ACCEPT_ENCODING + ", " + HttpHeader.USER_AGENT);
     public static final HttpField VARY_ACCEPT_ENCODING = new PreEncodedHttpField(HttpHeader.VARY, HttpHeader.ACCEPT_ENCODING.asString());
 
     private enum GZState
@@ -69,7 +68,7 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
 
     public GzipHttpOutputInterceptor(GzipFactory factory, HttpChannel channel, HttpOutput.Interceptor next, boolean syncFlush)
     {
-        this(factory, VARY_ACCEPT_ENCODING_USER_AGENT, channel.getHttpConfiguration().getOutputBufferSize(), channel, next, syncFlush);
+        this(factory, VARY_ACCEPT_ENCODING, channel.getHttpConfiguration().getOutputBufferSize(), channel, next, syncFlush);
     }
 
     public GzipHttpOutputInterceptor(GzipFactory factory, HttpField vary, HttpChannel channel, HttpOutput.Interceptor next, boolean syncFlush)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -189,12 +189,7 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
         {
             // We are varying the response due to accept encoding header.
             if (_vary != null)
-            {
-                if (fields.contains(HttpHeader.VARY))
-                    fields.addCSV(HttpHeader.VARY, _vary.getValues());
-                else
-                    fields.add(_vary);
-            }
+                fields.ensure(_vary);
 
             long contentLength = response.getContentLength();
             if (contentLength < 0 && complete)
@@ -248,27 +243,6 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
         {
             switch (_state.get())
             {
-                case NOT_COMPRESSING:
-                    return;
-
-                case MIGHT_COMPRESS:
-                    if (_state.compareAndSet(GZState.MIGHT_COMPRESS, GZState.NOT_COMPRESSING))
-                        return;
-                    break;
-
-                default:
-                    throw new IllegalStateException(_state.get().toString());
-            }
-        }
-    }
-
-    public void noCompressionIfPossible()
-    {
-        while (true)
-        {
-            switch (_state.get())
-            {
-                case COMPRESSING:
                 case NOT_COMPRESSING:
                     return;
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerBreakEvenSizeTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerBreakEvenSizeTest.java
@@ -59,7 +59,6 @@ public class GzipHandlerBreakEvenSizeTest
         server.addConnector(connector);
 
         GzipHandler gzipHandler = new GzipHandler();
-        gzipHandler.setExcludedAgentPatterns();
         gzipHandler.setMinGzipSize(0);
 
         ServletContextHandler context = new ServletContextHandler(gzipHandler, "/");

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
@@ -311,7 +311,7 @@ public class GzipHandlerTest
         assertThat(response.getStatus(), is(200));
         assertThat(response.get("Content-Encoding"), not(equalToIgnoringCase("gzip")));
         assertThat(response.get("ETag"), is(__contentETag));
-        assertThat(response.getValuesList("Vary"), Matchers.contains("Other", "Accept-Encoding"));
+        assertThat(response.getCSV("Vary", false), Matchers.contains("Other", "Accept-Encoding"));
 
         InputStream testIn = new ByteArrayInputStream(response.getContentBytes());
         ByteArrayOutputStream testOut = new ByteArrayOutputStream();

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/GzipHandlerTest.java
@@ -101,7 +101,6 @@ public class GzipHandlerTest
         _server.addConnector(_connector);
 
         GzipHandler gzipHandler = new GzipHandler();
-        gzipHandler.setExcludedAgentPatterns();
         gzipHandler.setMinGzipSize(16);
         gzipHandler.setInflateBufferSize(4096);
 
@@ -174,7 +173,7 @@ public class GzipHandlerTest
         }
 
         @Override
-        protected void doDelete(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+        protected void doDelete(HttpServletRequest req, HttpServletResponse response) throws IOException
         {
             String ifm = req.getHeader("If-Match");
             if (ifm != null && ifm.equals(__contentETag))

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipHandlerTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipHandlerTest.java
@@ -59,7 +59,6 @@ public class GzipHandlerTest extends AbstractGzipTest
         GzipHandler gzipHandler = new GzipHandler();
         gzipHandler.setMinGzipSize(32);
         gzipHandler.addIncludedMimeTypes("text/plain");
-        gzipHandler.setExcludedAgentPatterns();
 
         server = new Server();
         LocalConnector localConnector = new LocalConnector(server);


### PR DESCRIPTION
Issue #5171 Simplify GzipHandler user-agent handling:

+ Remove User-Agent handling from GzipHandler
+ Allow Vary header to be set
+ Create rewrite MsieRule to remove Accept-Encoding from IE<=6

Signed-off-by: Greg Wilkins <gregw@webtide.com>