### PR TITLE
Support Apache Commons Daemon methods in XmlConfiguration

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/startup/start-jar.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/startup/start-jar.adoc
@@ -65,7 +65,7 @@ When executed `start.jar` performs the following actions:
 3.  Uses default behavior of `java.io.File` (Relative to `System.getProperty` ("user.dir") and then as absolute file system path).
 * Loads any dependent modules (merges XXNK, library, and properties results with active command line).
 * Builds out server classpath.
-* Determines run mode:
+* Determines run mode as one of:
 ** Shows informational command line options and exit.
 ** Executes Jetty normally, waits for Jetty to stop.
 ** Executes a forked JVM to run Jetty in, waits for forked JVM to exit.
@@ -89,9 +89,36 @@ Lists the resolved configuration that will start Jetty.
 * Server classpath
 * Server XML configuration files
 --dry-run::
-Prints the resolved command line that `start.jar` should use to start a forked instance of Jetty.
+Print the command line that the start.jar generates, then exit. This may be used to generate command lines when the start.ini includes -X or -D arguments:
+....
+$ java -jar start.jar --dry-run > jetty.sh
+$ . jetty.sh
+....
+--dry-run=<parts>::
+Print specific parts of the command line. The parts are a comma separated list of:
+
+ * "java" - the JVM to run
+ * "opts" - the JVM options (eg -D and -X flags)
+ * "path" - the JVM class path or JPMS modules options
+ * "main" - the main class to run
+ * "args" - the arguments passed to the main class
+
+It is possible to decompose the start command:
+....
+$ OPTS=$(java -jar start.jar --dry-run=opts,path)
+$ MAIN=$(java -jar start.jar --dry-run=main)
+$ ARGS=$(java -jar start.jar --dry-run=args)
+$ java $OPTS -Dextra=opt $MAIN $ARGS extra=arg
+....
+Alternatively to create an args file for java:
+....
+$ java -jar start.jar --dry-run=opts,path,main,args > /tmp/args
+$ java @/tmp/args
+....
 --exec::
-Starts a forked instance of Jetty.
+Forces the start to use a forked instance of java to run Jetty.
+Some modules include `--exec` in order to set java command line options.
+Some start options, such as `--jpms` also imply `--exec`
 --exec-properties=<filename>::
 Assign a fixed name to the file used to transfer properties to the sub process.
 This allows the generated properties file to be saved and reused.
@@ -99,7 +126,7 @@ Without this option, a temporary file is used.
 --commands=<filename>::
 Instructs `start.jar` to use each line of the specified file as arguments on the command line.
 
-===== Debugg and Start Logging
+===== Debug and Start Logging
 
 --debug::
 Enables debugging output of the startup procedure.
@@ -274,4 +301,26 @@ If you have a need for a shaded version of `start.jar` (such as for Gradle), you
     <version>{VERSION}</version>
     <classifier>shaded</classifier>
 </dependency>
+....
+
+==== Start.jar without exec or forking.
+
+Some Jetty modules include the `--exec` option so that java command line options can be set.
+Also some `start.jar` options (eg. `--jpms`) include an implicit `--exec`.
+To start jetty without forking a new JVM instance from the start JVM, the `--dry-run` option can be used to generate a command line:
+....
+$ CMD=$(java -jar start.jar --dry-run)
+$ $CMD
+....
+It is possible to decompose the start command so that it can be modified:
+....
+$ OPTS=$(java -jar start.jar --dry-run=opts,path)
+$ MAIN=$(java -jar start.jar --dry-run=main)
+$ ARGS=$(java -jar start.jar --dry-run=args)
+$ java $OPTS -Dextra=opt $MAIN $ARGS extra=arg
+....
+Alternatively to create an args file for java:
+....
+$ java -jar start.jar --dry-run=opts,path,main,args > /tmp/args
+$ java @/tmp/args
 ....

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -206,7 +206,7 @@ public class Main
 
         StartLog.debug("%s - %s", invokedClass, invokedClass.getPackage().getImplementationVersion());
 
-        CommandLineBuilder cmd = args.getMainArgs(false);
+        CommandLineBuilder cmd = args.getMainArgs(StartArgs.ARG_PARTS);
         String[] argArray = cmd.getArgs().toArray(new String[0]);
         StartLog.debug("Command Line Args: %s", cmd.toString());
 
@@ -415,7 +415,7 @@ public class Main
         // Show Command Line to execute Jetty
         if (args.isDryRun())
         {
-            CommandLineBuilder cmd = args.getMainArgs(true);
+            CommandLineBuilder cmd = args.getMainArgs(args.getDryRunParts());
             System.out.println(cmd.toString(StartLog.isDebugEnabled() ? " \\\n" : " "));
         }
 
@@ -454,7 +454,7 @@ public class Main
         // execute Jetty in another JVM
         if (args.isExec())
         {
-            CommandLineBuilder cmd = args.getMainArgs(true);
+            CommandLineBuilder cmd = args.getMainArgs(StartArgs.ALL_PARTS);
             cmd.debug();
             ProcessBuilder pbuilder = new ProcessBuilder(cmd.getArgs());
             StartLog.endStartLog();

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -233,7 +233,7 @@ public class StartArgs
     private boolean updateIni = false;
     private String mavenBaseUri;
 
-    private Boolean exec = null; // Tri state as --no-exec overrules --exec
+    private boolean exec = false;
     private String execProperties;
     private boolean approveAllLicenses = false;
 
@@ -568,8 +568,7 @@ public class StartArgs
 
             for (String jvmArg : module.getJvmArgs())
             {
-                if (exec != Boolean.FALSE)
-                    exec = true; // TODO is this necessary as --jpms turns on exec anyway
+                exec = true;
                 jvmArgs.add(jvmArg);
             }
 
@@ -966,7 +965,7 @@ public class StartArgs
 
     public boolean isExec()
     {
-        return exec == Boolean.TRUE;
+        return exec;
     }
 
     public boolean isLicenseCheckRequired()
@@ -1170,8 +1169,7 @@ public class StartArgs
         {
             jpms = true;
             // Need to fork because we cannot use JDK 9 Module APIs.
-            if (exec != Boolean.FALSE)
-                exec = true;
+            exec = true;
             return;
         }
 
@@ -1200,15 +1198,7 @@ public class StartArgs
         // Enable forked execution of Jetty server
         if ("--exec".equals(arg))
         {
-            if (exec != Boolean.FALSE)
-                exec = true;
-            return;
-        }
-
-        // Enable forked execution of Jetty server
-        if ("--no-exec".equals(arg))
-        {
-            exec = false;
+            exec = true;
             return;
         }
 

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -28,7 +28,10 @@ Command Line Options:
 
   --dry-run        Print the command line that the start.jar generates,
                    then exit. This may be used to generate command lines
-                   when the start.ini includes -X or -D arguments.
+                   when the start.ini includes -X or -D arguments:
+
+                     java -jar start.jar --dry-run > jetty.sh
+                     . jetty.sh
 
   --dry-run=parts  Print specific parts of the command line. The parts
                    are a comma separated list of
@@ -37,20 +40,23 @@ Command Line Options:
                      o  "path" - the JVM class path or JPMS modules options
                      o  "main" - the main class to run
                      o  "args" - the arguments passed to the main class
-                   It is possible to manually run jetty without execution with:
 
-                     java $(java -jar start.jar --dry-run=opts) -jar start.jar --no-exec
+                   It is possible to decompose the start command:
+
+                     OPTS=$(java -jar start.jar --dry-run=opts,path)
+                     MAIN=$(java -jar start.jar --dry-run=main)
+                     ARGS=$(java -jar start.jar --dry-run=args)
+                     java $OPTS -Dextra=opt $MAIN $ARGS extra=arg
+
+                   Alternatively to create an args file for java:
+
+                     java -jar start.jar --dry-run=opts,path,main,args > /tmp/args
+                     java @/tmp/args
 
   --exec           Run the generated command line (see --dry-run) in
                    a sub process. This can be used when start.ini
                    contains -X or -D arguments, but creates an extra
                    JVM instance.
-
-  --no-exec        Overrule any --exec options to force no exec.  If
-                   any JVM options exist they need to be passed directly
-                   to the JVM (see --dry-run:opts) like:
-
-                     java $(java -jar start.jar --dry-run=opts) -jar start.jar --no-exec
                    
   --exec-properties=<filename>
                    Assign a fixed name to the file used to transfer 

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -30,10 +30,27 @@ Command Line Options:
                    then exit. This may be used to generate command lines
                    when the start.ini includes -X or -D arguments.
 
+  --dry-run=parts  Print specific parts of the command line. The parts
+                   are a comma separated list of
+                     o  "java" - the JVM to run
+                     o  "opts" - the JVM options (eg -D and -X flags)
+                     o  "path" - the JVM class path or JPMS modules options
+                     o  "main" - the main class to run
+                     o  "args" - the arguments passed to the main class
+                   It is possible to manually run jetty without execution with:
+
+                     java $(java -jar start.jar --dry-run=opts) -jar start.jar --no-exec
+
   --exec           Run the generated command line (see --dry-run) in
                    a sub process. This can be used when start.ini
                    contains -X or -D arguments, but creates an extra
                    JVM instance.
+
+  --no-exec        Overrule any --exec options to force no exec.  If
+                   any JVM options exist they need to be passed directly
+                   to the JVM (see --dry-run:opts) like:
+
+                     java $(java -jar start.jar --dry-run=opts) -jar start.jar --no-exec
                    
   --exec-properties=<filename>
                    Assign a fixed name to the file used to transfer 
@@ -58,7 +75,6 @@ Debug and Start Logging:
                    output will be sent.  This is useful for capturing startup
                    issues where the jetty specific logger has not yet kicked
                    in due to startup configuration errors.
-
 
 Module Management:
 ------------------

--- a/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -193,7 +193,7 @@ public class MainTest
         assertThat("jetty.home", baseHome.getHome(), is(homePath.toString()));
         assertThat("jetty.base", baseHome.getBase(), is(homePath.toString()));
 
-        CommandLineBuilder commandLineBuilder = args.getMainArgs(true);
+        CommandLineBuilder commandLineBuilder = args.getMainArgs(StartArgs.ALL_PARTS);
         String commandLine = commandLineBuilder.toString("\n");
         String expectedExpansion = String.format("-Xloggc:%s/logs/gc-%s.log",
             baseHome.getBase(), System.getProperty("java.version")

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -378,7 +378,7 @@ public class XmlConfiguration
     public Object configure(Object obj) throws Exception
     {
         if (_objects != null)
-            throw new IllegalStateException();
+            throw new IllegalStateException("XmlConfiguration constructed for start lifecycle");
         return _processor.configure(obj);
     }
 
@@ -394,7 +394,7 @@ public class XmlConfiguration
     public Object configure() throws Exception
     {
         if (_objects != null)
-            throw new IllegalStateException();
+            throw new IllegalStateException("XmlConfiguration constructed for start lifecycle");
         if (LOG.isDebugEnabled())
             LOG.debug("Configure {}", _location);
         return _processor.configure();
@@ -1856,6 +1856,9 @@ public class XmlConfiguration
     // implement Apache commons daemon (jsvc) lifecycle methods (init, start, stop, destroy)
     public void init(String[] args) throws Exception
     {
+        if (_objects == null)
+            throw new IllegalStateException("XmlConfiguration not constructed for start lifecycle");
+
         try
         {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>)() ->
@@ -1915,7 +1918,7 @@ public class XmlConfiguration
     public void start() throws Exception
     {
         if (_objects == null)
-            throw new IllegalStateException();
+            throw new IllegalStateException("XmlConfiguration not constructed for start lifecycle");
 
         // For all objects created by XmlConfigurations, start them if they are lifecycles.
         for (Object obj : _objects)
@@ -1934,9 +1937,9 @@ public class XmlConfiguration
     public void stop() throws Exception
     {
         if (_objects == null)
-            throw new IllegalStateException();
+            throw new IllegalStateException("XmlConfiguration not constructed for start lifecycle");
 
-        // For all objects created by XmlConfigurations, start them if they are lifecycles.
+        // For all objects created by XmlConfigurations, stop them if they are lifecycles.
         for (Object obj : _objects)
         {
             if (obj instanceof LifeCycle)
@@ -1952,7 +1955,7 @@ public class XmlConfiguration
     public void destroy()
     {
         if (_objects == null)
-            throw new IllegalStateException();
+            throw new IllegalStateException("XmlConfiguration not constructed for start lifecycle");
 
         // For all objects created by XmlConfigurations, start them if they are lifecycles.
         for (Object obj : _objects)

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -61,6 +61,7 @@ import org.eclipse.jetty.util.Pool;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.annotation.Name;
+import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -202,6 +203,7 @@ public class XmlConfiguration
     private final Resource _location;
     private final String _dtd;
     private ConfigurationProcessor _processor;
+    private final List<Object> _objects;
 
     ConfigurationParser getParser()
     {
@@ -209,6 +211,17 @@ public class XmlConfiguration
         if (entry == null)
             return new ConfigurationParser(null);
         return entry.getPooled();
+    }
+
+    /**
+     * Constructor for use with the Apache Commons Daemon lifecycle methods.
+     * A XmlConfiguration constructed in this way cannot be used for any other purpose.
+     */
+    public XmlConfiguration()
+    {
+        _objects = new ArrayList<>();
+        _location = null;
+        _dtd = null;
     }
 
     /**
@@ -225,6 +238,7 @@ public class XmlConfiguration
             _location = resource;
             setConfig(parser.parse(inputStream));
             _dtd = parser.getDTD();
+            _objects = null;
         }
     }
 
@@ -263,6 +277,7 @@ public class XmlConfiguration
             _location = null;
             setConfig(parser.parse(source));
             _dtd = parser.getDTD();
+            _objects = null;
         }
     }
 
@@ -283,6 +298,7 @@ public class XmlConfiguration
             _location = null;
             setConfig(parser.parse(source));
             _dtd = parser.getDTD();
+            _objects = null;
         }
     }
 
@@ -361,6 +377,8 @@ public class XmlConfiguration
      */
     public Object configure(Object obj) throws Exception
     {
+        if (_objects != null)
+            throw new IllegalStateException();
         return _processor.configure(obj);
     }
 
@@ -375,6 +393,8 @@ public class XmlConfiguration
      */
     public Object configure() throws Exception
     {
+        if (_objects != null)
+            throw new IllegalStateException();
         if (LOG.isDebugEnabled())
             LOG.debug("Configure {}", _location);
         return _processor.configure();
@@ -1833,24 +1853,8 @@ public class XmlConfiguration
         return values;
     }
 
-    /**
-     * Runs the XML configurations as a main application.
-     * The command line is used to obtain properties files (must be named '*.properties') and XmlConfiguration files.
-     * <p>
-     * Any property file on the command line is added to a combined Property instance that is passed to each configuration file via
-     * {@link XmlConfiguration#getProperties()}.
-     * <p>
-     * Each configuration file on the command line is used to create a new XmlConfiguration instance and the
-     * {@link XmlConfiguration#configure()} method is used to create the configured object.
-     * If the resulting object is an instance of {@link LifeCycle}, then it is started.
-     * <p>
-     * Any IDs created in a configuration are passed to the next configuration file on the command line using {@link #getIdMap()}.
-     * This allows objects with IDs created in one config file to be referenced in subsequent config files on the command line.
-     *
-     * @param args array of property and xml configuration filenames or {@link Resource}s.
-     * @throws Exception if the XML configurations cannot be run
-     */
-    public static void main(final String... args) throws Exception
+    // implement Apache commons daemon (jsvc) lifecycle methods (init, start, stop, destroy)
+    public void init(String[] args) throws Exception
     {
         try
         {
@@ -1873,7 +1877,6 @@ public class XmlConfiguration
 
                 // For all arguments, parse XMLs
                 XmlConfiguration last = null;
-                List<Object> objects = new ArrayList<>(args.length);
                 for (String arg : args)
                 {
                     if (!arg.toLowerCase(Locale.ENGLISH).endsWith(".properties") && (arg.indexOf('=') < 0))
@@ -1892,20 +1895,9 @@ public class XmlConfiguration
                         }
 
                         Object obj = configuration.configure();
-                        if (obj != null && !objects.contains(obj))
-                            objects.add(obj);
+                        if (obj != null && !_objects.contains(obj))
+                            _objects.add(obj);
                         last = configuration;
-                    }
-                }
-
-                // For all objects created by XmlConfigurations, start them if they are lifecycles.
-                for (Object obj : objects)
-                {
-                    if (obj instanceof LifeCycle)
-                    {
-                        LifeCycle lc = (LifeCycle)obj;
-                        if (!lc.isRunning())
-                            lc.start();
                     }
                 }
 
@@ -1917,6 +1909,82 @@ public class XmlConfiguration
             LOG.warn(e);
             throw e;
         }
+    }
+
+    // implement Apache commons daemon (jsvc) lifecycle methods (init, start, stop, destroy)
+    public void start() throws Exception
+    {
+        if (_objects == null)
+            throw new IllegalStateException();
+
+        // For all objects created by XmlConfigurations, start them if they are lifecycles.
+        for (Object obj : _objects)
+        {
+            if (obj instanceof LifeCycle)
+            {
+                LifeCycle lc = (LifeCycle)obj;
+                if (!lc.isRunning())
+                    lc.start();
+            }
+        }
+
+    }
+
+    // implement Apache commons daemon (jsvc) lifecycle methods (init, start, stop, destroy)
+    public void stop() throws Exception
+    {
+        if (_objects == null)
+            throw new IllegalStateException();
+
+        // For all objects created by XmlConfigurations, start them if they are lifecycles.
+        for (Object obj : _objects)
+        {
+            if (obj instanceof LifeCycle)
+            {
+                LifeCycle lc = (LifeCycle)obj;
+                if (lc.isRunning())
+                    lc.stop();
+            }
+        }
+    }
+
+    // implement Apache commons daemon (jsvc) lifecycle methods (init, start, stop, destroy)
+    public void destroy()
+    {
+        if (_objects == null)
+            throw new IllegalStateException();
+
+        // For all objects created by XmlConfigurations, start them if they are lifecycles.
+        for (Object obj : _objects)
+        {
+            if (obj instanceof Destroyable)
+                ((Destroyable)obj).destroy();
+        }
+        _objects.clear();
+    }
+
+    /**
+     * Runs the XML configurations as a main application.
+     * The command line is used to obtain properties files (must be named '*.properties') and XmlConfiguration files.
+     * <p>
+     * Any property file on the command line is added to a combined Property instance that is passed to each configuration file via
+     * {@link XmlConfiguration#getProperties()}.
+     * <p>
+     * Each configuration file on the command line is used to create a new XmlConfiguration instance and the
+     * {@link XmlConfiguration#configure()} method is used to create the configured object.
+     * If the resulting object is an instance of {@link LifeCycle}, then it is started.
+     * <p>
+     * Any IDs created in a configuration are passed to the next configuration file on the command line using {@link #getIdMap()}.
+     * This allows objects with IDs created in one config file to be referenced in subsequent config files on the command line.
+     *
+     * @param args array of property and xml configuration filenames or {@link Resource}s.
+     * @throws Exception if the XML configurations cannot be run
+     */
+    public static void main(final String... args) throws Exception
+    {
+        XmlConfiguration xmlConfig = new XmlConfiguration();
+        xmlConfig.init(args);
+        xmlConfig.start();
     }
 
     private static class ConfigurationParser extends XmlParser implements AutoCloseable


### PR DESCRIPTION
This is a minimal change to allow XmlConfiguration to be substituted for start.Main if using a --dry-run to avoid an exec.