### PR TITLE
Issue #5198 - update gzip handler

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -216,8 +216,7 @@ public class GZIPContentDecoder implements Destroyable
 
                             try
                             {
-                                int length = _inflater.inflate(buffer.array(), buffer.arrayOffset(), buffer.capacity());
-                                buffer.limit(length);
+                                _inflater.inflate(buffer);
                             }
                             catch (DataFormatException x)
                             {
@@ -235,23 +234,10 @@ public class GZIPContentDecoder implements Destroyable
                             {
                                 if (!compressed.hasRemaining())
                                     return;
-                                if (compressed.hasArray())
-                                {
-                                    _inflater.setInput(compressed.array(), compressed.arrayOffset() + compressed.position(), compressed.remaining());
-                                    compressed.position(compressed.limit());
-                                }
-                                else
-                                {
-                                    // TODO use the pool
-                                    byte[] input = new byte[compressed.remaining()];
-                                    compressed.get(input);
-                                    _inflater.setInput(input);
-                                }
+                                _inflater.setInput(compressed);
                             }
                             else if (_inflater.finished())
                             {
-                                int remaining = _inflater.getRemaining();
-                                compressed.position(compressed.limit() - remaining);
                                 _state = State.CRC;
                                 _size = 0;
                                 _value = 0;
@@ -395,7 +381,6 @@ public class GZIPContentDecoder implements Destroyable
                             if (_value != (_inflater.getBytesWritten() & UINT_MAX))
                                 throw new ZipException("Invalid input size");
 
-                            // TODO ByteBuffer result = output == null ? BufferUtil.EMPTY_BUFFER : ByteBuffer.wrap(output);
                             reset();
                             return;
                         }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -216,7 +216,9 @@ public class GZIPContentDecoder implements Destroyable
 
                             try
                             {
+                                int pos = BufferUtil.flipToFill(buffer);
                                 _inflater.inflate(buffer);
+                                BufferUtil.flipToFlush(buffer, pos);
                             }
                             catch (DataFormatException x)
                             {

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -18,8 +18,13 @@
         <Set name="inflateBufferSize" property="jetty.gzip.inflateBufferSize"/>
         <Set name="deflaterPoolCapacity" property="jetty.gzip.deflaterPoolCapacity"/>
         <Set name="syncFlush" property="jetty.gzip.syncFlush"/>
+        <Set name="dispatcherTypes" property="jetty.gzip.dispatcherTypes"/>
         <Set name="includedMethodList" property="jetty.gzip.includedMethodList"/>
         <Set name="excludedMethodList" property="jetty.gzip.excludedMethodList"/>
+        <Set name="includedMimeTypes" property="jetty.gzip.includedMimeTypeList"/>
+        <Set name="excludedMimeTypes" property="jetty.gzip.excludedMimeTypeList"/>
+        <Set name="includedPaths" property="jetty.gzip.includedPathList"/>
+        <Set name="excludedPaths" property="jetty.gzip.excludedPathList"/>
 
 <!--
         <Set name="includedMethods">

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -16,6 +16,7 @@
         <Set name="checkGzExists" property="jetty.gzip.checkGzExists"/>
         <Set name="compressionLevel" property="jetty.gzip.compressionLevel"/>
         <Set name="inflateBufferSize" property="jetty.gzip.inflateBufferSize"/>
+        <Set name="inflaterPoolCapacity" property="jetty.gzip.inflaterPoolCapacity"/>
         <Set name="deflaterPoolCapacity" property="jetty.gzip.deflaterPoolCapacity"/>
         <Set name="syncFlush" property="jetty.gzip.syncFlush"/>
         <Set name="dispatcherTypes" property="jetty.gzip.dispatcherTypes"/>

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -29,8 +29,26 @@ etc/jetty-gzip.xml
 ## Deflater pool max size (-1 for unlimited, 0 for no pool)
 # jetty.gzip.deflaterPoolCapacity=-1
 
-## Comma separated list of included methods
+## Set the {@link Deflater} flush mode to use.
+# jetty.gzip.syncFlush=false
+
+## The set of DispatcherType that this filter will operate on
+# jetty.gzip.dispatcherTypes=REQUEST
+
+## Comma separated list of included HTTP methods
 # jetty.gzip.includedMethodList=GET,POST
 
-## Comma separated list of excluded methods
+## Comma separated list of excluded HTTP methods
 # jetty.gzip.excludedMethodList=
+
+## Comma separated list of included MIME types
+# jetty.gzip.includedMimeTypeList=
+
+## Comma separated list of excluded MIME types
+# jetty.gzip.excludedMimeTypeList=
+
+## Comma separated list of included Path specs
+# jetty.gzip.includedPathList=
+
+## Comma separated list of excluded Path specs
+# jetty.gzip.excludedPathList=

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -26,8 +26,11 @@ etc/jetty-gzip.xml
 ## Inflate request buffer size, or 0 for no request inflation
 # jetty.gzip.inflateBufferSize=0
 
-## Deflater pool max size (-1 for unlimited, 0 for no pool)
+## Deflater pool max size (-1 for unlimited, 0 for no pooling)
 # jetty.gzip.deflaterPoolCapacity=-1
+
+## Inflater pool max size (-1 for unlimited, 0 for no pooling)
+# jetty.gzip.inflaterPoolCapacity=-1
 
 ## Set the {@link Deflater} flush mode to use.
 # jetty.gzip.syncFlush=false

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import java.util.zip.Deflater;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletContext;
@@ -773,6 +774,19 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     }
 
     /**
+     * Set of supported {@link DispatcherType} that this filter will operate on.
+     *
+     * @param dispatchers the set of {@link DispatcherType} that this filter will operate on
+     */
+    public void setDispatcherTypes(String... dispatchers)
+    {
+        setDispatcherTypes(Stream.of(dispatchers)
+            .flatMap(s -> Stream.of(StringUtil.csvSplit(s)))
+            .map(DispatcherType::valueOf)
+            .toArray(DispatcherType[]::new));
+    }
+
+    /**
      * Set the included filter list of HTTP methods (replacing any previously set)
      *
      * @param methods The methods to include in compression
@@ -902,7 +916,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
         return String.format("%s@%x{%s,min=%s,inflate=%s}", getClass().getSimpleName(), hashCode(), getState(), _minGzipSize, _inflateBufferSize);
     }
 
-    private static class CaseInsensitiveSet extends HashSet<String>
+    public static class CaseInsensitiveSet extends HashSet<String>
     {
         @Override
         public boolean add(String s)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.server.handler.gzip;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.Deflater;
@@ -168,7 +169,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     // non-static, as other GzipHandler instances may have different configurations
     private final IncludeExclude<String> _methods = new IncludeExclude<>();
     private final IncludeExclude<String> _paths = new IncludeExclude<>(PathSpecSet.class);
-    private final IncludeExclude<String> _mimeTypes = new IncludeExclude<>();
+    private final IncludeExclude<String> _mimeTypes = new IncludeExclude<>(CaseInsensitiveSet.class);
     private HttpField _vary = GzipHttpOutputInterceptor.VARY_ACCEPT_ENCODING;
 
     /**
@@ -899,5 +900,22 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     public String toString()
     {
         return String.format("%s@%x{%s,min=%s,inflate=%s}", getClass().getSimpleName(), hashCode(), getState(), _minGzipSize, _inflateBufferSize);
+    }
+
+    private static class CaseInsensitiveSet extends HashSet<String>
+    {
+        @Override
+        public boolean add(String s)
+        {
+            return super.add(s == null ? null : s.toLowerCase());
+        }
+
+        @Override
+        public boolean contains(Object o)
+        {
+            if (o instanceof String)
+                return super.contains(((String)o).toLowerCase());
+            return super.contains(o);
+        }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpInputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpInputInterceptor.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.HttpInput;
 import org.eclipse.jetty.server.HttpInput.Content;
 import org.eclipse.jetty.util.component.Destroyable;
+import org.eclipse.jetty.util.compression.InflaterPool;
 
 /**
  * An HttpInput Interceptor that inflates GZIP encoded request content.
@@ -34,9 +35,9 @@ public class GzipHttpInputInterceptor implements HttpInput.Interceptor, Destroya
     private final Decoder _decoder;
     private ByteBuffer _chunk;
 
-    public GzipHttpInputInterceptor(ByteBufferPool pool, int bufferSize)
+    public GzipHttpInputInterceptor(InflaterPool inflaterPool, ByteBufferPool pool, int bufferSize)
     {
-        _decoder = new Decoder(pool, bufferSize);
+        _decoder = new Decoder(inflaterPool, pool, bufferSize);
     }
 
     @Override
@@ -66,9 +67,9 @@ public class GzipHttpInputInterceptor implements HttpInput.Interceptor, Destroya
 
     private class Decoder extends GZIPContentDecoder
     {
-        private Decoder(ByteBufferPool pool, int bufferSize)
+        private Decoder(InflaterPool inflaterPool, ByteBufferPool bufferPool, int bufferSize)
         {
-            super(pool, bufferSize);
+            super(inflaterPool, bufferPool, bufferSize);
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -263,7 +263,6 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
 
     private class GzipBufferCB extends IteratingNestedCallback
     {
-        private ByteBuffer _copy;
         private final ByteBuffer _content;
         private final boolean _last;
 
@@ -272,6 +271,10 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
             super(callback);
             _content = content;
             _last = complete;
+            _crc.update(_content.slice());
+            _deflater.setInput(_content);
+            if (_last)
+                _deflater.finish();
         }
 
         @Override
@@ -296,11 +299,6 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
                     _channel.getByteBufferPool().release(_buffer);
                     _buffer = null;
                 }
-                if (_copy != null)
-                {
-                    _channel.getByteBufferPool().release(_copy);
-                    _copy = null;
-                }
                 return Action.SUCCEEDED;
             }
 
@@ -320,29 +318,13 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
             // If the deflator is not finished, then compress more data
             if (!_deflater.finished())
             {
-                if (_deflater.needsInput())
-                {
-                    // if there is no more content available to compress
-                    // then we are either finished all content or just the current write.
-                    if (BufferUtil.isEmpty(_content))
-                    {
-                        if (_last)
-                            _deflater.finish();
-                        else
-                            return Action.SUCCEEDED;
-                    }
-                    else
-                    {
-                        // TODO: this might be a bad place to use ByteBuffer API, the CRC can copy the buffer anyway.
-                        _crc.update(_content.slice());
-                        _deflater.setInput(_content.slice());
-                        if (_last)
-                            _deflater.finish();
-                    }
-                }
+                if (_deflater.needsInput() && !_last)
+                    return Action.SUCCEEDED;
 
                 // deflate the content into the available space in the buffer
+                int pos = BufferUtil.flipToFill(_buffer);
                 _deflater.deflate(_buffer, _syncFlush ? Deflater.SYNC_FLUSH : Deflater.NO_FLUSH);
+                BufferUtil.flipToFlush(_buffer, pos);
             }
 
             // If we have finished deflation and there is room for the trailer.
@@ -363,11 +345,10 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
         @Override
         public String toString()
         {
-            return String.format("%s[content=%s last=%b copy=%s buffer=%s deflate=%s %s]",
+            return String.format("%s[content=%s last=%b buffer=%s deflate=%s %s]",
                 super.toString(),
                 BufferUtil.toDetailString(_content),
                 _last,
-                BufferUtil.toDetailString(_copy),
                 BufferUtil.toDetailString(_buffer),
                 _deflater,
                 _deflater != null && _deflater.finished() ? "(finished)" : "");

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -354,6 +354,8 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
                         int off = slice.arrayOffset() + slice.position();
                         int len = slice.remaining();
                         _crc.update(array, off, len);
+                        // Ideally we would want to use the ByteBuffer API for Deflaters. However due the the ByteBuffer implementation
+                        // of the CRC32.update() it is less efficient for us to use this rather than to convert to array ourselves.
                         _deflater.setInput(array, off, len);
                         slice.position(slice.position() + len);
                         if (_last && BufferUtil.isEmpty(_content))

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipDefaultServletTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipDefaultServletTest.java
@@ -945,4 +945,62 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         UncompressedMetadata metadata = parseResponseContent(response);
         assertThat("Response Content Length", metadata.contentLength, is(fileSize));
     }
+
+    @Test
+    public void testUpperCaseMimeType() throws Exception
+    {
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.addExcludedMimeTypes("text/PLAIN");
+
+        server = new Server();
+        LocalConnector localConnector = new LocalConnector(server);
+        server.addConnector(localConnector);
+
+        Path contextDir = workDir.resolve("context");
+        FS.ensureDirExists(contextDir);
+
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        servletContextHandler.setContextPath("/context");
+        servletContextHandler.setBaseResource(new PathResource(contextDir));
+        ServletHolder holder = new ServletHolder("default", DefaultServlet.class);
+        holder.setInitParameter("etags", "true");
+        servletContextHandler.addServlet(holder, "/");
+        servletContextHandler.insertHandler(gzipHandler);
+
+        server.setHandler(servletContextHandler);
+
+        // Prepare Server File
+        int fileSize = DEFAULT_OUTPUT_BUFFER_SIZE * 4;
+        Path file = createFile(contextDir, "file.txt", fileSize);
+        String expectedSha1Sum = Sha1Sum.calculate(file);
+
+        server.start();
+
+        // Setup request
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "tester");
+        request.setHeader("Connection", "close");
+        request.setHeader("Accept-Encoding", "gzip");
+        request.setURI("/context/file.txt");
+
+        // Issue request
+        ByteBuffer rawResponse = localConnector.getResponse(request.generate(), 5, TimeUnit.SECONDS);
+
+        // Parse response
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+
+        assertThat("Response status", response.getStatus(), is(HttpStatus.OK_200));
+
+        // Response Content-Encoding check
+        assertThat("Response[Content-Encoding]", response.get("Content-Encoding"), not(containsString("gzip")));
+        assertThat("Response[Vary]", response.get("Vary"), is(nullValue()));
+
+        // Response Content checks
+        UncompressedMetadata metadata = parseResponseContent(response);
+        assertThat("Response Content Length", metadata.contentLength, is(fileSize));
+        assertThat("(Uncompressed) Content Length", metadata.uncompressedSize, is(fileSize));
+        assertThat("(Uncompressed) Content Hash", metadata.uncompressedSha1Sum, is(expectedSha1Sum));
+    }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/AsciiLowerCaseSet.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/AsciiLowerCaseSet.java
@@ -1,0 +1,38 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import java.util.HashSet;
+
+public class AsciiLowerCaseSet extends HashSet<String>
+{
+    @Override
+    public boolean add(String s)
+    {
+        return super.add(s == null ? null : StringUtil.asciiToLowerCase(s));
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        if (o instanceof String)
+            return super.contains(StringUtil.asciiToLowerCase((String)o));
+        return super.contains(o);
+    }
+}

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
@@ -30,7 +30,7 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
 
     private final Queue<T> _pool;
     private final AtomicInteger _numObjects = new AtomicInteger(0);
-    private final int _capacity;
+    private int _capacity;
 
     /**
      * Create a Pool of {@link T} instances.
@@ -44,7 +44,17 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
     public CompressionPool(int capacity)
     {
         _capacity = capacity;
-        _pool = (_capacity == 0) ? null : new ConcurrentLinkedQueue<>();
+        _pool = new ConcurrentLinkedQueue<>();
+    }
+
+    public int getCapacity()
+    {
+        return _capacity;
+    }
+
+    public void setCapacity(int capacity)
+    {
+        _capacity = capacity;
     }
 
     protected abstract T newObject();
@@ -85,7 +95,6 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
         if (_capacity == 0 || !isRunning())
         {
             end(object);
-            return;
         }
         else if (_capacity < 0)
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
@@ -134,4 +134,15 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
         }
         _numObjects.set(0);
     }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x{%s,size=%d,capacity=%s}",
+            getClass().getSimpleName(),
+            hashCode(),
+            getState(),
+            _pool.size(),
+            _capacity < 0 ? "UNLIMITED" : _capacity);
+    }
 }


### PR DESCRIPTION
Fixes #5198 - We now use the ByteBuffer API for inflaters/deflaters for `GzipHandler`.
Fixes #4988 - The GzipHandlers `IncludeExclude` for the MIME types now uses case insensitive set.
Fixes #1761 - Added extra configuration in the .ini file for `gzip.mod`.
Fixes #5246 - add deflater/inflater pools to server dump.