### PR TITLE
JDK-8244090 MethodHandles bug fixed in JDK16

### DIFF
--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/DeploymentTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/server/DeploymentTest.java
@@ -93,8 +93,13 @@ public class DeploymentTest
         assertThat(error.getMessage(), Matchers.containsString("503 Service Unavailable"));
     }
 
+    /**
+     * This reproduces some classloading issue with MethodHandles in JDK14-15, this has been fixed in JDK16.
+     * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8244090">JDK-8244090</a>
+     * @throws Exception if there is an error during the test.
+     */
     @Test
-    @DisabledOnJre({JRE.JAVA_14, JRE.JAVA_15}) // TODO: Waiting for bug https://bugs.openjdk.java.net/browse/JDK-8244090.
+    @DisabledOnJre({JRE.JAVA_14, JRE.JAVA_15})
     public void testDifferentWebAppsWithSameClassInSignature() throws Exception
     {
         WSServer.WebApp app1 = server.createWebApp("test1");


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8244090

- Update javadoc as the bug is now fixed in JDK 16 but will still not work for 14 & 15.
- Move the websocket distribution tests with stacktraces to `BadAppTests`.