### PR TITLE
Issue #5170 - fix upgrade bug in HttpReceiverOverHTTP

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/TransformingFlusher.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/TransformingFlusher.java
@@ -137,7 +137,7 @@ public abstract class TransformingFlusher
         protected void onCompleteFailure(Throwable t)
         {
             if (log.isDebugEnabled())
-                log.debug("failed to flush", t);
+                log.debug("onCompleteFailure {}", t.toString());
 
             notifyCallbackFailure(current.callback, t);
             current = null;
@@ -157,14 +157,14 @@ public abstract class TransformingFlusher
         }
         catch (Throwable x)
         {
-            log.warn("Exception while notifying success of callback " + callback, x);
+            log.warn("Exception while notifying success of callback {}", callback, x);
         }
     }
 
     private void notifyCallbackFailure(Callback callback, Throwable failure)
     {
         if (log.isDebugEnabled())
-            log.debug("notifyCallbackFailure {} {}", callback, failure);
+            log.debug("notifyCallbackFailure {} {}", callback, failure.toString());
 
         try
         {
@@ -173,7 +173,7 @@ public abstract class TransformingFlusher
         }
         catch (Throwable x)
         {
-            log.warn("Exception while notifying failure of callback " + callback, x);
+            log.warn("Exception while notifying failure of callback {}", callback, x);
         }
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -470,7 +470,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         catch (Throwable t)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Error during fillAndParse()", t);
+                LOG.debug("Error during fillAndParse() {}", t.toString());
 
             if (networkBuffer != null)
             {

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -250,7 +250,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             public void failed(Throwable cause)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("failed onFrame(" + frame + ")", cause);
+                    LOG.debug("failed onFrame({}) {}", frame, cause.toString());
 
                 frame.close();
                 if (referenced != null)

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.WritePendingException;
 import java.time.Duration;
 import java.util.List;
@@ -390,7 +391,7 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
     public void processConnectionError(Throwable cause, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("processConnectionError {} {}", this, cause);
+            LOG.debug("processConnectionError {} {}", this, cause.toString());
 
         int code;
         if (cause instanceof CloseException)
@@ -424,11 +425,13 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
     public void processHandlerError(Throwable cause, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("processHandlerError {} {}", this, cause);
+            LOG.debug("processHandlerError {} {}", this, cause.toString());
 
         int code;
         if (cause instanceof CloseException)
             code = ((CloseException)cause).getStatusCode();
+        else if (cause instanceof ClosedChannelException)
+            code = CloseStatus.NO_CLOSE;
         else if (cause instanceof Utf8Appendable.NotUtf8Exception)
             code = CloseStatus.BAD_PAYLOAD;
         else if (cause instanceof WebSocketTimeoutException || cause instanceof TimeoutException || cause instanceof SocketTimeoutException)
@@ -438,7 +441,14 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
         else
             code = CloseStatus.SERVER_ERROR;
 
-        close(new CloseStatus(code, cause), callback);
+        CloseStatus closeStatus = new CloseStatus(code, cause);
+        if (CloseStatus.isTransmittableStatusCode(code))
+            close(closeStatus, callback);
+        else
+        {
+            if (sessionState.onClosed(closeStatus))
+                closeConnection(closeStatus, callback);
+        }
     }
 
     /**
@@ -458,10 +468,10 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
             () ->
             {
                 sessionState.onOpen();
-                if (!demanding)
-                    connection.demand(1);
                 if (LOG.isDebugEnabled())
                     LOG.debug("ConnectionState: Transition to OPEN");
+                if (!demanding)
+                    connection.demand(1);
             },
             x ->
             {
@@ -574,7 +584,7 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
         catch (Throwable t)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Failed sendFrame()", t);
+                LOG.debug("Failed sendFrame() {}", t.toString());
 
             if (frame.getOpCode() == OpCode.CLOSE)
             {

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
@@ -391,7 +391,7 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
     public void processConnectionError(Throwable cause, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("processConnectionError {} {}", this, cause.toString());
+            LOG.debug("processConnectionError {}", this, cause);
 
         int code;
         if (cause instanceof CloseException)
@@ -425,7 +425,7 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
     public void processHandlerError(Throwable cause, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("processHandlerError {} {}", this, cause.toString());
+            LOG.debug("processHandlerError {}", this, cause);
 
         int code;
         if (cause instanceof CloseException)
@@ -554,9 +554,7 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
         }
         catch (Throwable t)
         {
-            if (LOG.isDebugEnabled())
-                LOG.warn("Invalid outgoing frame: {}", frame, t);
-
+            LOG.warn("Invalid outgoing frame: {}", frame, t);
             callback.failed(t);
             return;
         }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
@@ -221,7 +221,7 @@ public class WebSocketSessionState
         return false;
     }
 
-    public boolean onIncomingFrame(Frame frame) throws ProtocolException
+    public boolean onIncomingFrame(Frame frame) throws ProtocolException, ClosedChannelException
     {
         byte opcode = frame.getOpCode();
         boolean fin = frame.isFin();
@@ -229,7 +229,7 @@ public class WebSocketSessionState
         try (AutoLock l = lock.lock())
         {
             if (!isInputOpen())
-                throw new IllegalStateException(_sessionState.toString());
+                throw new ClosedChannelException();
 
             if (opcode == OpCode.CLOSE)
             {

--- a/jetty-websocket/websocket-core-tests/fuzzingserver.json
+++ b/jetty-websocket/websocket-core-tests/fuzzingserver.json
@@ -4,7 +4,7 @@
   },
   "url": "ws://127.0.0.1:9001",
   "outdir": "./target/reports/clients",
-  "cases": ["1.1.6"],
+  "cases": ["*"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/jetty-websocket/websocket-core-tests/fuzzingserver.json
+++ b/jetty-websocket/websocket-core-tests/fuzzingserver.json
@@ -4,7 +4,7 @@
   },
   "url": "ws://127.0.0.1:9001",
   "outdir": "./target/reports/clients",
-  "cases": ["*"],
+  "cases": ["1.1.6"],
   "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/TestMessageHandler.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/TestMessageHandler.java
@@ -43,26 +43,14 @@ public class TestMessageHandler extends MessageHandler
     @Override
     public void onOpen(CoreSession coreSession, Callback callback)
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("onOpen {}", coreSession);
-        this.coreSession = coreSession;
         super.onOpen(coreSession, callback);
+        this.coreSession = coreSession;
         openLatch.countDown();
-    }
-
-    @Override
-    public void onFrame(Frame frame, Callback callback)
-    {
-        if (LOG.isDebugEnabled())
-            LOG.debug("onFrame {}", frame);
-        super.onFrame(frame, callback);
     }
 
     @Override
     public void onError(Throwable cause, Callback callback)
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("onError", cause);
         super.onError(cause, callback);
         error = cause;
         errorLatch.countDown();
@@ -71,8 +59,6 @@ public class TestMessageHandler extends MessageHandler
     @Override
     public void onClosed(CloseStatus closeStatus, Callback callback)
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("onClosed {}", closeStatus);
         super.onClosed(closeStatus, callback);
         this.closeStatus = closeStatus;
         closeLatch.countDown();

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/UpgradeWithLeftOverHttpBytesTest.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/UpgradeWithLeftOverHttpBytesTest.java
@@ -19,20 +19,22 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.websocket.core.client.CoreClientUpgradeRequest;
 import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
 import org.eclipse.jetty.websocket.core.internal.Generator;
 import org.eclipse.jetty.websocket.core.internal.WebSocketCore;
@@ -43,8 +45,8 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UpgradeWithLeftOverHttpBytesTest extends WebSocketTester
@@ -74,10 +76,21 @@ public class UpgradeWithLeftOverHttpBytesTest extends WebSocketTester
     @Test
     public void testUpgradeWithLeftOverHttpBytes() throws Exception
     {
-        TestMessageHandler clientEndpoint = new TestMessageHandler();
-        CompletableFuture<CoreSession> clientConnect = client.connect(clientEndpoint, serverUri);
+        CountDownLatch onOpenWait = new CountDownLatch(1);
+        TestMessageHandler clientEndpoint = new TestMessageHandler()
+        {
+            @Override
+            public void onOpen(CoreSession coreSession, Callback callback)
+            {
+                assertDoesNotThrow(() -> onOpenWait.await(5, TimeUnit.SECONDS));
+                super.onOpen(coreSession, callback);
+            }
+        };
+        CoreClientUpgradeRequest coreUpgrade = CoreClientUpgradeRequest.from(client, serverUri, clientEndpoint);
+        client.connect(coreUpgrade);
         Socket serverSocket = server.accept();
 
+        // Receive the upgrade request with the Socket.
         String upgradeRequest = getRequestHeaders(serverSocket.getInputStream());
         assertThat(upgradeRequest, containsString("HTTP/1.1"));
         assertThat(upgradeRequest, containsString("Upgrade: websocket"));
@@ -88,21 +101,34 @@ public class UpgradeWithLeftOverHttpBytesTest extends WebSocketTester
             "Connection: Upgrade\n" +
             "Sec-WebSocket-Accept: " + getAcceptKey(upgradeRequest) + "\n" +
             "\n";
+        Frame firstFrame = new Frame(OpCode.TEXT, BufferUtil.toBuffer("first message payload"));
+        byte[] bytes = combineToByteArray(BufferUtil.toBuffer(upgradeResponse), generateFrame(firstFrame));
+        serverSocket.getOutputStream().write(bytes);
 
-        Frame dataFrame = new Frame(OpCode.TEXT, BufferUtil.toBuffer("first message payload"));
+        // Now we send the rest of the data.
+        int numFrames = 1000;
+        for (int i = 0; i < numFrames; i++)
+        {
+            Frame frame = new Frame(OpCode.TEXT, BufferUtil.toBuffer(Integer.toString(i)));
+            serverSocket.getOutputStream().write(toByteArray(frame));
+        }
         Frame closeFrame = new CloseStatus(CloseStatus.NORMAL, "closed by test").toFrame();
+        serverSocket.getOutputStream().write(toByteArray(closeFrame));
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        baos.write(upgradeResponse.getBytes(StandardCharsets.ISO_8859_1));
-        BufferUtil.writeTo(generateFrame(dataFrame), baos);
-        BufferUtil.writeTo(generateFrame(closeFrame), baos);
-        serverSocket.getOutputStream().write(baos.toByteArray());
-
-        // Check the client receives upgrade response and then the two websocket frames.
-        CoreSession coreSession = clientConnect.get(5, TimeUnit.SECONDS);
-        assertNotNull(coreSession);
+        // First payload sent with upgrade request, delay to ensure HttpConnection is not still reading from network.
+        Thread.sleep(4000);
+        onOpenWait.countDown();
         assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
         assertThat(clientEndpoint.textMessages.poll(5, TimeUnit.SECONDS), is("first message payload"));
+
+        // We receive the rest of the frames all sent as separate writes.
+        for (int i = 0; i < numFrames; i++)
+        {
+            String msg = clientEndpoint.textMessages.poll(5, TimeUnit.SECONDS);
+            assertThat(msg, is(Integer.toString(i)));
+        }
+
+        // Closed successfully with correct status.
         assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
         assertThat(clientEndpoint.closeStatus.getCode(), is(CloseStatus.NORMAL));
         assertThat(clientEndpoint.closeStatus.getReason(), is("closed by test"));
@@ -130,5 +156,21 @@ public class UpgradeWithLeftOverHttpBytesTest extends WebSocketTester
     {
         Scanner s = new Scanner(is).useDelimiter("\r\n\r\n");
         return s.hasNext() ? s.next() : "";
+    }
+
+    byte[] combineToByteArray(ByteBuffer... buffers) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (ByteBuffer bb : buffers)
+        {
+            BufferUtil.writeTo(bb, baos);
+        }
+
+        return baos.toByteArray();
+    }
+
+    byte[] toByteArray(Frame frame)
+    {
+        return BufferUtil.toArray(generateFrame(frame));
     }
 }

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/UpgradeWithLeftOverHttpBytesTest.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/UpgradeWithLeftOverHttpBytesTest.java
@@ -116,7 +116,7 @@ public class UpgradeWithLeftOverHttpBytesTest extends WebSocketTester
         serverSocket.getOutputStream().write(toByteArray(closeFrame));
 
         // First payload sent with upgrade request, delay to ensure HttpConnection is not still reading from network.
-        Thread.sleep(4000);
+        Thread.sleep(1000);
         onOpenWait.countDown();
         assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
         assertThat(clientEndpoint.textMessages.poll(5, TimeUnit.SECONDS), is("first message payload"));

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnFrameHandler.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnFrameHandler.java
@@ -24,9 +24,13 @@ import java.time.Duration;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.TestMessageHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AutobahnFrameHandler extends TestMessageHandler
 {
+    protected static final Logger LOG = LoggerFactory.getLogger(AutobahnFrameHandler.class);
+
     @Override
     public void onOpen(CoreSession coreSession, Callback callback)
     {
@@ -46,5 +50,12 @@ public class AutobahnFrameHandler extends TestMessageHandler
     public void onText(String wholeMessage, Callback callback)
     {
         sendText(wholeMessage, callback, false);
+    }
+
+    @Override
+    public void onError(Throwable cause, Callback callback)
+    {
+        LOG.warn("Error from AutobahnFrameHandler: {}", cause.toString());
+        super.onError(cause, callback);
     }
 }


### PR DESCRIPTION
Fixes a bug introduced when fixing issue #5170.

The `HttpExchange` could be null when the response completes in `HttpReceiverOverHTTP`, in this case we end incorrectly continue reading and parsing in the `HttpReceiverOverHttp`, and this can result in `ReadPendingException` and other issues including losing the websocket data.

I have also cleaned up the debug logging in websocket to prevent the same stacktrace being logged at every level. They should only be logged in `processConnectionError()` and `processHandlerError()`.