### PR TITLE
Issue #4954 - Expose header size/length from HttpParser

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -365,6 +365,11 @@ public class HttpParser
         return _contentPosition;
     }
 
+    public int getHeaderLength()
+    {
+        return _headerBytes;
+    }
+
     /**
      * Set if a HEAD response is expected
      *


### PR DESCRIPTION
- Minimal new API for exposing byte counts to HttpChannel.Listener users

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>