### PR TITLE
Issue #5268 Change WARN to DEBUG for NullSessionCache eviction setter.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/NullSessionCache.java
@@ -87,7 +87,8 @@ public class NullSessionCache extends AbstractSessionCache
     @Override
     public void setEvictionPolicy(int evictionTimeout)
     {
-        LOG.warn("Ignoring eviction setting: {}", evictionTimeout);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Ignoring eviction setting: {}", evictionTimeout);
     }
 
     @Override


### PR DESCRIPTION
Closes #5268 

Change the WARN to a DEBUG log statement as the logging occurs during the normal course of events.