### PR TITLE
upgrade ant dependencies version to 1.10.8 to avoid security warning

### DIFF
--- a/jetty-ant/pom.xml
+++ b/jetty-ant/pom.xml
@@ -49,14 +49,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ant</groupId>
+      <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.6.5</version>
     </dependency>
     <dependency>
-      <groupId>ant</groupId>
+      <groupId>org.apache.ant</groupId>
       <artifactId>ant-launcher</artifactId>
-      <version>1.6.5</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -109,7 +109,6 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.8.4</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <weld.version>3.1.3.Final</weld.version>
     <jetty.perf-helper.version>1.0.5</jetty.perf-helper.version>
-    <ant.version>1.9.15</ant.version>
+    <ant.version>1.10.8</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <weld.version>3.1.3.Final</weld.version>
     <jetty.perf-helper.version>1.0.5</jetty.perf-helper.version>
+    <ant.version>1.9.15</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
@@ -1145,6 +1146,16 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>1.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>${ant.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant-launcher</artifactId>
+        <version>${ant.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Signed-off-by: olivier lamy <oliver.lamy@gmail.com>