### PR TITLE
Issue #4430 Quickstart duplicate servlets,filters,listeners from context

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler.JspConfig;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletMapping;
+import org.eclipse.jetty.servlet.Source;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -212,6 +213,9 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         if (context.getServletHandler().getListeners() != null)
             for (ListenerHolder e : context.getServletHandler().getListeners())
             {
+                if (e.getSource() == Source.EMBEDDED)
+                    continue;
+                
                 out.openTag("listener", origin(md, e.getClassName() + ".listener"))
                     .tag("listener-class", e.getClassName())
                     .closeTag();
@@ -223,14 +227,20 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         {
             for (FilterHolder holder : servlets.getFilters())
             {
+                if (holder.getSource() == Source.EMBEDDED)
+                    continue;
                 outholder(out, md, holder);
             }
         }
 
         if (servlets.getFilterMappings() != null)
         {
-            for (FilterMapping mapping : servlets.getFilterMappings())
+            for (FilterMapping mapping :servlets.getFilterMappings())
             {
+                FilterHolder f = servlets.getFilter(mapping.getFilterName());
+                if (f != null && f.getSource() == Source.EMBEDDED)
+                    continue;
+                
                 out.openTag("filter-mapping");
                 out.tag("filter-name", mapping.getFilterName());
                 if (mapping.getPathSpecs() != null)
@@ -265,6 +275,8 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         {
             for (ServletHolder holder : servlets.getServlets())
             {
+                if (holder.getSource() == Source.EMBEDDED)
+                    continue;
                 outholder(out, md, holder);
             }
         }
@@ -273,6 +285,10 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         {
             for (ServletMapping mapping : servlets.getServletMappings())
             {
+                ServletHolder sh = servlets.getServlet(mapping.getServletName());
+                if (sh != null && sh.getSource() == Source.EMBEDDED)
+                    continue;
+                
                 out.openTag("servlet-mapping", origin(md, mapping.getServletName() + ".servlet.mappings"));
                 out.tag("servlet-name", mapping.getServletName());
                 if (mapping.getPathSpecs() != null)

--- a/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/FooFilter.java
+++ b/jetty-quickstart/src/test/java/org/eclipse/jetty/quickstart/FooFilter.java
@@ -1,0 +1,47 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.quickstart;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+public class FooFilter implements Filter
+{
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException
+    {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException
+    {
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+}

--- a/jetty-quickstart/src/test/resources/context.xml
+++ b/jetty-quickstart/src/test/resources/context.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<!-- ==================================================================
+Configure and deploy the test web application in $(jetty.home)/webapps/test
+
+Note. If this file did not exist or used a context path other that /test
+then the default configuration of jetty.xml would discover the test
+webapplication with a WebAppDeployer.  By specifying a context in this
+directory, additional configuration may be specified and hot deployments
+detected.
+===================================================================== -->
+
+<Configure id="testWebapp" class="org.eclipse.jetty.webapp.WebAppContext">
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!-- Required minimal context configuration :                        -->
+  <!--  + contextPath                                                  -->
+  <!--  + war OR resourceBase                                          -->
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Set name="contextPath">/test</Set>
+  
+  <Get name="servletHandler">
+    <Call name="addServletWithMapping">
+      <Arg>
+        <New class="org.eclipse.jetty.servlet.ServletHolder">
+          <Set name="name">FooServlet</Set>
+          <Set name="className">org.eclipse.jetty.quickstart.FooServlet</Set>
+        </New>
+      </Arg>
+      <Arg>/outer/*</Arg>
+    </Call>
+
+    <Call name="addFilterWithMapping">
+      <Arg>
+        <New class="org.eclipse.jetty.servlet.FilterHolder">
+            <Set name="className">org.eclipse.jetty.quickstart.FooFilter</Set>
+            <Set name="name">OuterFilter</Set>
+        </New>
+      </Arg>
+      <Arg>/outer/*</Arg>
+      <Arg type="java.lang.Integer">0</Arg>
+    </Call>
+    
+    <Call name="addListener">
+       <Arg>
+          <New class="org.eclipse.jetty.servlet.ListenerHolder">
+            <Set name="listener">
+              <New class="org.eclipse.jetty.quickstart.FooContextListener"></New>
+            </Set>
+          </New>
+       </Arg>
+    </Call>
+    
+  </Get>
+
+</Configure>


### PR DESCRIPTION
Closes #4430

If a context xml file configures servlets, filters or listeners, these get put into the quickstart-web.xml file leading to duplicates because the context xml file is re-applied when the context restarts.
This fix checks the Source of the servlet, servlet-mapping, filter, filter-mapping and listener before generating into quickstart-web.xml: any that were added via embedding (ie jetty api/xml) are ignored.

I've marked this for 10.0.0, but happy if it is delayed until 10.0.1.
It will probably also need to be backported (with modifications) for jetty-9.4.x as well.