### PR TITLE
Issue #5321 - add some missing module-info.java files

### DIFF
--- a/jetty-cdi/src/main/java/module-info.java
+++ b/jetty-cdi/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.cdi
+{
+    requires org.eclipse.jetty.annotations;
+    requires transitive org.eclipse.jetty.webapp;
+
+    exports org.eclipse.jetty.cdi;
+}

--- a/jetty-hazelcast/src/main/java/module-info.java
+++ b/jetty-hazelcast/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.hazelcast.session
+{
+    requires transitive com.hazelcast.core;
+    requires transitive org.eclipse.jetty.server;
+    requires transitive org.eclipse.jetty.util;
+
+    exports org.eclipse.jetty.hazelcast.session;
+}

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -24,12 +24,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.net.httpserver</groupId>
-      <artifactId>http</artifactId>
-      <version>20070405</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${project.version}</version>

--- a/jetty-http-spi/src/main/java/module-info.java
+++ b/jetty-http-spi/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.http.spi
+{
+    requires transitive jdk.httpserver;
+    requires transitive org.eclipse.jetty.server;
+    requires transitive org.eclipse.jetty.util;
+
+    exports org.eclipse.jetty.http.spi;
+}

--- a/jetty-memcached/jetty-memcached-sessions/src/main/java/module-info.java
+++ b/jetty-memcached/jetty-memcached-sessions/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.memcached.session
+{
+    requires transitive org.eclipse.jetty.server;
+    requires transitive org.eclipse.jetty.util;
+    requires transitive xmemcached;
+
+    exports org.eclipse.jetty.memcached.session;
+}

--- a/jetty-nosql/src/main/java/module-info.java
+++ b/jetty-nosql/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.nosql
+{
+    requires transitive mongo.java.driver;
+    requires transitive org.eclipse.jetty.server;
+
+    exports org.eclipse.jetty.nosql;
+    exports org.eclipse.jetty.nosql.mongodb;
+}

--- a/jetty-openid/src/main/java/module-info.java
+++ b/jetty-openid/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under
+// the terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0
+//
+// This Source Code may also be made available under the following
+// Secondary Licenses when the conditions for such availability set
+// forth in the Eclipse Public License, v. 2.0 are satisfied:
+// the Apache License v2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.security.openid
+{
+    requires transitive org.eclipse.jetty.client;
+    requires transitive org.eclipse.jetty.security;
+    requires org.eclipse.jetty.util.ajax;
+
+    exports org.eclipse.jetty.security.openid;
+}


### PR DESCRIPTION
Attempt to fix Issue #5321

I was unable to get a module-info for `jetty-gcloud-session-manager` to work without getting a bunch of errors, and wasn't sure how to fix them. So I have left this module-info file out of this PR for now.

The errors were slightly different each time I built it.

> Error:java: java.lang.module.ResolutionException: Modules protobuf.lite and protobuf.java export package com.google.protobuf to module google.http.client.appengine