### PR TITLE
Issue #5365 ISE not NPE if fail to create session.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1623,6 +1623,9 @@ public class Request implements HttpServletRequest
             throw new IllegalStateException("No SessionManager");
 
         _session = _sessionHandler.newHttpSession(this);
+        if (_session == null)
+            throw new IllegalStateException("Create session failed");
+        
         HttpCookie cookie = _sessionHandler.getSessionCookie(_session, getContextPath(), isSecure());
         if (cookie != null)
             _channel.getResponse().replaceCookie(cookie);


### PR DESCRIPTION
Closes #5365 

SessionHandler.newHttpSession(Request) is called by Request.getSession(true) when a new session needs to be created. If SessionHandler fails to create the session for whatever reason, it logs the exception and returns null. Request.getSession(true) isn't expecting a null and can cause a confusing NPE elsewhere deeper in the code.  As Request.getSession(boolean) is a servlet api method, it cannot throw a checked exception, nor according to the api can it return null. So we throw ISE if SessionHandler.newHttpSession(Request) returns null.  I think in jetty-10 it would be better to modify the signature of SessionHandler.newHttpSession(Request) to throw the exception rather than catching and returning null.