### PR TITLE
Issue #5360 Ensure @WebListeners have origin attr in quickstart-web.xml

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/WebListenerAnnotation.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/WebListenerAnnotation.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletContextAttributeListener;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletRequestAttributeListener;
 import javax.servlet.ServletRequestListener;
+import javax.servlet.annotation.WebListener;
 import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionIdListener;
 import javax.servlet.http.HttpSessionListener;
@@ -84,6 +85,7 @@ public class WebListenerAnnotation extends DiscoveredAnnotation
                     ListenerHolder h = _context.getServletHandler().newListenerHolder(new Source(Source.Origin.ANNOTATION, clazz.getName()));
                     h.setHeldClass(clazz);
                     _context.getServletHandler().addListener(h);
+                    metaData.setOrigin(clazz.getName() + ".listener", clazz.getAnnotation(WebListener.class), clazz);
                 }
             }
             else


### PR DESCRIPTION
Simple change to add `origin` in generated quickstart-web.xml for listeners added by `@WebListener` annotation.