### PR TITLE
Issue #5368 - ensure onMessage exits before next frame is read

### DIFF
--- a/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrAnnotatedEventDriver.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrAnnotatedEventDriver.java
@@ -131,7 +131,7 @@ public class JsrAnnotatedEventDriver extends AbstractJsrEventDriver
                         session.close(e);
                     }
 
-                    stream.close();
+                    stream.handlerComplete();
                 });
             }
         }

--- a/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrAnnotatedEventDriver.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrAnnotatedEventDriver.java
@@ -118,10 +118,8 @@ public class JsrAnnotatedEventDriver extends AbstractJsrEventDriver
                 if (LOG.isDebugEnabled())
                     LOG.debug("Binary Message InputStream");
 
-                final MessageInputStream stream = new MessageInputStream(session);
+                MessageInputStream stream = new MessageInputStream(session);
                 activeMessage = stream;
-
-                // Always dispatch streaming read to another thread.
                 dispatch(() ->
                 {
                     try
@@ -329,11 +327,8 @@ public class JsrAnnotatedEventDriver extends AbstractJsrEventDriver
                 if (LOG.isDebugEnabled())
                     LOG.debug("Text Message Writer");
 
-                MessageInputStream inputStream = new MessageInputStream(session);
-                final MessageReader reader = new MessageReader(inputStream);
-                activeMessage = inputStream;
-
-                // Always dispatch streaming read to another thread.
+                MessageReader reader = new MessageReader(session);
+                activeMessage = reader;
                 dispatch(() ->
                 {
                     try
@@ -343,9 +338,10 @@ public class JsrAnnotatedEventDriver extends AbstractJsrEventDriver
                     catch (Throwable e)
                     {
                         session.close(e);
+                        return;
                     }
 
-                    inputStream.close();
+                    reader.handlerComplete();
                 });
             }
         }

--- a/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrEndpointEventDriver.java
+++ b/jetty-websocket/javax-websocket-client-impl/src/main/java/org/eclipse/jetty/websocket/jsr356/endpoints/JsrEndpointEventDriver.java
@@ -100,9 +100,10 @@ public class JsrEndpointEventDriver extends AbstractJsrEventDriver
                     catch (Throwable t)
                     {
                         session.close(t);
+                        return;
                     }
 
-                    inputStream.close();
+                    inputStream.handlerComplete();
                 });
             }
             else
@@ -197,8 +198,7 @@ public class JsrEndpointEventDriver extends AbstractJsrEventDriver
             {
                 @SuppressWarnings("unchecked")
                 MessageHandler.Whole<Reader> handler = (Whole<Reader>)wrapper.getHandler();
-                MessageInputStream inputStream = new MessageInputStream(session);
-                MessageReader reader = new MessageReader(inputStream);
+                MessageReader reader = new MessageReader(session);
                 activeMessage = reader;
                 dispatch(() ->
                 {
@@ -209,9 +209,10 @@ public class JsrEndpointEventDriver extends AbstractJsrEventDriver
                     catch (Throwable t)
                     {
                         session.close(t);
+                        return;
                     }
 
-                    inputStream.close();
+                    reader.handlerComplete();
                 });
             }
             else

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/io/AbstractWebSocketConnection.java
@@ -521,7 +521,7 @@ public abstract class AbstractWebSocketConnection extends AbstractConnection imp
     {
         ByteBuffer resume = readState.resume();
         if (resume != null)
-            onFillable(resume);
+            getExecutor().execute(() -> onFillable(resume));
     }
 
     @Override

--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageReader.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageReader.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
+import org.eclipse.jetty.websocket.api.Session;
+
 /**
  * Support class for reading a (single) WebSocket TEXT message via a Reader.
  * <p>
@@ -32,6 +34,11 @@ import java.nio.charset.StandardCharsets;
 public class MessageReader extends InputStreamReader implements MessageAppender
 {
     private final MessageInputStream stream;
+
+    public MessageReader(Session session)
+    {
+        this(new MessageInputStream(session));
+    }
 
     public MessageReader(MessageInputStream stream)
     {
@@ -49,5 +56,10 @@ public class MessageReader extends InputStreamReader implements MessageAppender
     public void messageComplete()
     {
         this.stream.messageComplete();
+    }
+
+    public void handlerComplete()
+    {
+        this.stream.handlerComplete();
     }
 }

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/MessageInputStreamTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/MessageInputStreamTest.java
@@ -172,9 +172,10 @@ public class MessageInputStreamTest
                 {
                     // wait for a little bit before sending input closed
                     TimeUnit.MILLISECONDS.sleep(1000);
+                    stream.appendFrame(null, true);
                     stream.messageComplete();
                 }
-                catch (InterruptedException e)
+                catch (InterruptedException | IOException e)
                 {
                     hadError.set(true);
                     e.printStackTrace(System.err);

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/MessageInputStreamTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/message/MessageInputStreamTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.jetty.websocket.common.message;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.api.SuspendToken;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -111,9 +113,10 @@ public class MessageInputStreamTest
             startLatch.await();
 
             // Read it from the stream.
-            byte[] buf = new byte[32];
-            int len = stream.read(buf);
-            String message = new String(buf, 0, len, StandardCharsets.UTF_8);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IO.copy(stream, out);
+            byte[] bytes = out.toByteArray();
+            String message = new String(bytes, 0, bytes.length, StandardCharsets.UTF_8);
 
             // Test it
             assertThat("Error when appending", hadError.get(), is(false));
@@ -206,9 +209,10 @@ public class MessageInputStreamTest
         session.provideContent();
 
         // Read entire message it from the stream.
-        byte[] buf = new byte[32];
-        int len = stream.read(buf);
-        String message = new String(buf, 0, len, StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IO.copy(stream, out);
+        byte[] bytes = out.toByteArray();
+        String message = new String(bytes, 0, bytes.length, StandardCharsets.UTF_8);
 
         // Test it
         assertThat("Message", message, is("Hello World!"));


### PR DESCRIPTION
**Issue #5368**
When reading a websocket message with a `Reader` or `InputStream` ensure that the `onMessage()` method has exited before resuming to read and parse websocket frames. Otherwise a call to the `MessageInputStream.read()` or` MessageInputStream.close()` could parse the next websocket frame which could trigger a second nested call to `onMessage()` in the same thread. 