### PR TITLE
Issue #5394 Fix injection for quickstart

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/PreconfigureQuickStartWar.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/PreconfigureQuickStartWar.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.JarResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.slf4j.Logger;
@@ -109,7 +110,7 @@ public class PreconfigureQuickStartWar
                                 new AnnotationConfiguration());
         webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
         webapp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "");
-
+        webapp.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\.jar$|.*/org.apache.taglibs.taglibs-standard-impl-.*\\.jar$");
         if (xml != null)
         {
             if (xml.isDirectory() || !xml.toString().toLowerCase(Locale.ENGLISH).endsWith(".xml"))

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
@@ -157,7 +157,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("xmlns", "http://xmlns.jcp.org/xml/ns/javaee");
         webappAttr.put("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
         webappAttr.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_" + (major + "_" + minor) + ".xsd");
-        webappAttr.put("metadata-complete", "false");
+        webappAttr.put("metadata-complete", Boolean.toString(context.getMetaData().isMetaDataComplete()));
         webappAttr.put("version", major + "." + minor);
 
         XmlAppendable out = new XmlAppendable(stream, "UTF-8");

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartGeneratorConfiguration.java
@@ -157,7 +157,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("xmlns", "http://xmlns.jcp.org/xml/ns/javaee");
         webappAttr.put("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
         webappAttr.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_" + (major + "_" + minor) + ".xsd");
-        webappAttr.put("metadata-complete", "true");
+        webappAttr.put("metadata-complete", "false");
         webappAttr.put("version", major + "." + minor);
 
         XmlAppendable out = new XmlAppendable(stream, "UTF-8");

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
@@ -139,14 +139,16 @@ public class QuickStartTest
         }
 
         server.setHandler(webapp);
-
         server.start();
 
-        URL url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/");
+        URL url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/test/");
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setRequestMethod("POST");
+        
         assertEquals(200, connection.getResponseCode());
-        assertThat(IO.toString((InputStream)connection.getContent()), Matchers.containsString("Test Specification WebApp"));
-
+        String content = IO.toString((InputStream)connection.getContent());
+        assertThat(content, Matchers.containsString("Results"));
+        assertThat(content, Matchers.not(Matchers.containsString("FAIL")));
         server.stop();
     }
 


### PR DESCRIPTION
Closes #5394 

Resource injection was broken with jetty-10 and quickstart. We made changes to accord with the servlet tck tests and servlet 4.0 clarifications that if a web descriptor was metadata-complete, we would not do resource injections. The descriptor that quickstart generated was marked as metadata-complete, thus we did not do resource injections.  I think it is incorrect to mark the quickstart-web.xml as metadata-complete: according to the clarified wording of the spec section 8.1, it would only be metadata-complete iff it contained the declarative equivalents of all resource injection annotations (and others like post-construct, pre-destroy etc etc). As jetty "introspects" to find these kind of annotations at the point at which an object is going into service, rather than during the blanket annotation code-scan,  the quickstart-web.xml will never contain them and thus cannot be considered metadata-complete.

So, the solution is to simply mark the generated quickstart-web.xml as metadata-complete=false.

I've also changed one of the quickstart tests to really check properly for injection/post-construct etc happening correctly - previously the test was just testing if the webapp got deployed by retrieving static content, which is not sufficient.
