### PR TITLE
throw ISE if the WebSocketSCI configure() is called on a started ServletContextHandler

### DIFF
--- a/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketServletContainerInitializer.java
+++ b/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketServletContainerInitializer.java
@@ -99,6 +99,9 @@ public class JavaxWebSocketServletContainerInitializer implements ServletContain
      */
     public static void configure(ServletContextHandler context, Configurator configurator)
     {
+        if (context.isStarted())
+            throw new IllegalStateException("configure should be called before starting");
+
         // In this embedded-jetty usage, allow ServletContext.addListener() to
         // add other ServletContextListeners (such as the ContextDestroyListener) after
         // the initialization phase is over. (important for this SCI to function)

--- a/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketServletContainerInitializer.java
+++ b/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/config/JavaxWebSocketServletContainerInitializer.java
@@ -99,7 +99,7 @@ public class JavaxWebSocketServletContainerInitializer implements ServletContain
      */
     public static void configure(ServletContextHandler context, Configurator configurator)
     {
-        if (context.isStarted())
+        if (!context.isStopped())
             throw new IllegalStateException("configure should be called before starting");
 
         // In this embedded-jetty usage, allow ServletContext.addListener() to

--- a/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/config/JettyWebSocketServletContainerInitializer.java
+++ b/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/config/JettyWebSocketServletContainerInitializer.java
@@ -53,6 +53,9 @@ public class JettyWebSocketServletContainerInitializer implements ServletContain
      */
     public static void configure(ServletContextHandler context, Configurator configurator)
     {
+        if (context.isStarted())
+            throw new IllegalStateException("configure should be called before starting");
+
         context.addEventListener(
             ContainerInitializer
                 .asContextListener(new JettyWebSocketServletContainerInitializer())

--- a/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/config/JettyWebSocketServletContainerInitializer.java
+++ b/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/config/JettyWebSocketServletContainerInitializer.java
@@ -53,7 +53,7 @@ public class JettyWebSocketServletContainerInitializer implements ServletContain
      */
     public static void configure(ServletContextHandler context, Configurator configurator)
     {
-        if (context.isStarted())
+        if (!context.isStopped())
             throw new IllegalStateException("configure should be called before starting");
 
         context.addEventListener(


### PR DESCRIPTION
The context listener added by the WebSocketServletContainerInitializers will never be called if the `ServletContextHandler` has already started. So we should throw `IllegalStateException` if the `ServletContextHandler` has been started.