### PR TITLE
Bump jboss-logging from 3.3.2.Final to 3.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <maven.resolver.version>1.3.1</maven.resolver.version>
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <weld.version>3.1.3.Final</weld.version>
+    <jboss.logging.version>3.4.1.Final</jboss.logging.version>
     <jetty.perf-helper.version>1.0.6</jetty.perf-helper.version>
     <ant.version>1.10.8</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
@@ -1132,7 +1133,7 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
-        <version>3.3.2.Final</version>
+        <version>${jboss.logging.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
Replacement for PR #5434  (which updates `jetty-10.0.x`)
Performing upgrade of dependency in earlier branch: `jetty-9.4.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>