### PR TITLE
Bump checkstyle from 8.29 to 8.36.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <jetty.url>https://eclipse.org/jetty</jetty.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-support.version>1.4</build-support.version>
-    <checkstyle.version>8.29</checkstyle.version>
+    <checkstyle.version>8.36.2</checkstyle.version>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j2.version>2.11.2</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
@@ -421,7 +421,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <configuration>
           <configLocation>jetty-checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>


### PR DESCRIPTION
Replacement for PR #5424 (which updates `jetty-11.0.x`)
Performing upgrade of dependency in earlier branch: `jetty-9.4.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>