### PR TITLE
Bump build-helper-maven-plugin from 3.0.0 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,7 +735,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Replacement for PR #5430 (which updates `jetty-11.0.x`)
Performing upgrade of dependency in earlier branch: `jetty-9.4.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>