### PR TITLE
ForwardedRequestCustomizer behavior should not be applied to requests without forwarding headers

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -819,20 +819,26 @@ public class ForwardedRequestCustomizer implements Customizer
             }
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Forwarded-Host</code>
+         */
         public void handleForwardedHost(HttpField field)
         {
             updateAuthority(getLeftMost(field.getValue()), Source.XFORWARDED_HOST);
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Forwarded-For</code>
+         */
         public void handleForwardedFor(HttpField field)
         {
             HostPort hostField = new HostPort(getLeftMost(field.getValue()));
             getFor().setHostPort(hostField, Source.XFORWARDED_FOR);
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Forwarded-Server</code>
+         */
         public void handleForwardedServer(HttpField field)
         {
             if (getProxyAsAuthority())
@@ -840,7 +846,9 @@ public class ForwardedRequestCustomizer implements Customizer
             updateAuthority(getLeftMost(field.getValue()), Source.XFORWARDED_SERVER);
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Forwarded-Port</code>
+         */
         public void handleForwardedPort(HttpField field)
         {
             int port = HostPort.parsePort(getLeftMost(field.getValue()));
@@ -848,13 +856,17 @@ public class ForwardedRequestCustomizer implements Customizer
             updatePort(port, Source.XFORWARDED_PORT);
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Forwarded-Proto</code>
+         */
         public void handleProto(HttpField field)
         {
             updateProto(getLeftMost(field.getValue()), Source.XFORWARDED_PROTO);
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>X-Proxied-Https</code>
+         */
         public void handleHttps(HttpField field)
         {
             if ("on".equalsIgnoreCase(field.getValue()) || "true".equalsIgnoreCase(field.getValue()))
@@ -863,9 +875,21 @@ public class ForwardedRequestCustomizer implements Customizer
                 updateProto(HttpScheme.HTTPS.asString(), Source.XPROXIED_HTTPS);
                 updatePort(getSecurePort(_config), Source.XPROXIED_HTTPS);
             }
+            else if ("off".equalsIgnoreCase(field.getValue()) || "false".equalsIgnoreCase(field.getValue()))
+            {
+                _secure = false;
+                updateProto(HttpScheme.HTTP.asString(), Source.XPROXIED_HTTPS);
+                updatePort(80, Source.XPROXIED_HTTPS);
+            }
+            else
+            {
+                throw new BadMessageException("Invalid value for " + field.getName());
+            }
         }
 
-        @SuppressWarnings("unused")
+        /**
+         * Called if header is <code>Forwarded</code>
+         */
         public void handleRFC7239(HttpField field)
         {
             addValue(field.getValue());

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -498,36 +498,37 @@ public class ForwardedRequestCustomizer implements Customizer
                 request.setScheme(config.getSecureScheme());
             }
 
-            // Set authority
-            String host = null;
-            int port = -1;
-
             // Use authority from headers, if configured.
             if (forwarded._authority != null)
             {
-                host = forwarded._authority._host;
-                port = forwarded._authority._port;
-            }
+                String host = forwarded._authority._host;
+                int port = forwarded._authority._port;
 
-            // Fall back to request metadata if needed.
-            HttpURI requestURI = request.getMetaData().getURI();
-            if (host == null)
-            {
-                host = requestURI.getHost();
-            }
-            if (port == MutableHostPort.UNSET) // is unset by headers
-            {
-                port = requestURI.getPort();
-            }
-            // Don't change port if port == IMPLIED.
+                HttpURI requestURI = request.getMetaData().getURI();
 
-            // Update authority if different from metadata
-            if (requestURI != null && host != null &&
-                (!host.equalsIgnoreCase(requestURI.getHost()) ||
-                    port != requestURI.getPort()))
-            {
-                httpFields.put(new HostPortHttpField(host, port));
-                request.setAuthority(host, port);
+                if (requestURI != null)
+                {
+                    // Fall back to request metadata if needed.
+                    if (host == null)
+                    {
+                        host = requestURI.getHost();
+                    }
+
+                    if (port == MutableHostPort.UNSET) // is unset by headers
+                    {
+                        port = requestURI.getPort();
+                    }
+
+                    // Don't change port if port == IMPLIED.
+
+                    // Update authority if different from metadata
+                    if (!host.equalsIgnoreCase(requestURI.getHost()) ||
+                        port != requestURI.getPort())
+                    {
+                        httpFields.put(new HostPortHttpField(host, port));
+                        request.setAuthority(host, port);
+                    }
+                }
             }
 
             // Set Remote Address

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -880,7 +880,7 @@ public class ForwardedRequestCustomizer implements Customizer
             {
                 _secure = false;
                 updateProto(HttpScheme.HTTP.asString(), Source.XPROXIED_HTTPS);
-                updatePort(80, Source.XPROXIED_HTTPS);
+                updatePort(MutableHostPort.IMPLIED, Source.XPROXIED_HTTPS);
             }
             else
             {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -522,8 +522,9 @@ public class ForwardedRequestCustomizer implements Customizer
             // Don't change port if port == IMPLIED.
 
             // Update authority if different from metadata
-            if (!host.equalsIgnoreCase(requestURI.getHost()) ||
-                port != requestURI.getPort())
+            if (requestURI != null && host != null &&
+                (!host.equalsIgnoreCase(requestURI.getHost()) ||
+                    port != requestURI.getPort()))
             {
                 httpFields.put(new HostPortHttpField(host, port));
                 request.setAuthority(host, port);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -481,13 +481,12 @@ public class ForwardedRequestCustomizer implements Customizer
 
         if (match)
         {
-            String proto = "http";
+            String proto;
 
             // Is secure status configured from headers?
             if (forwarded.isSecure())
             {
-                // set default to https
-                proto = config.getSecureScheme();
+                request.setSecure(true);
             }
 
             // Set Scheme from configured protocol
@@ -526,15 +525,6 @@ public class ForwardedRequestCustomizer implements Customizer
             {
                 httpFields.put(new HostPortHttpField(host, port));
                 request.setAuthority(host, port);
-            }
-
-            // Set secure status
-            if (forwarded.isSecure() ||
-                proto.equalsIgnoreCase(config.getSecureScheme()) ||
-                port == getSecurePort(config))
-            {
-                request.setSecure(true);
-                request.setScheme(proto);
             }
 
             // Set Remote Address
@@ -801,6 +791,7 @@ public class ForwardedRequestCustomizer implements Customizer
             if (isSslIsSecure())
             {
                 _secure = true;
+                _proto = "https";
             }
         }
 
@@ -811,6 +802,7 @@ public class ForwardedRequestCustomizer implements Customizer
             if (isSslIsSecure())
             {
                 _secure = true;
+                _proto = "https";
             }
         }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -143,6 +142,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("0.0.0.0").serverPort(80)
+                    .secure(false)
                     .requestURL("http://0.0.0.0/example")
             ),
             Arguments.of(
@@ -153,7 +153,31 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("0.0.0.0").serverPort(80)
+                    .secure(false)
                     .requestURL("http://0.0.0.0/example")
+            ),
+            Arguments.of(
+                new Request("HTTP/1.0 - No Host header, with X-Forwarded-Host")
+                    .headers(
+                        "GET /example HTTP/1.0",
+                        "X-Forwarded-Host: alt.example.net:7070"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .secure(false)
+                    .requestURL("http://alt.example.net:7070/example")
+            ),
+            Arguments.of(
+                new Request("HTTP/1.0 - Empty Host header, with X-Forwarded-Host")
+                    .headers(
+                        "GET /example HTTP/1.0",
+                        "Host:",
+                        "X-Forwarded-Host: alt.example.net:7070"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .secure(false)
+                    .requestURL("http://alt.example.net:7070/example")
             ),
             // Host IPv4
             Arguments.of(
@@ -164,6 +188,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("1.2.3.4").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://1.2.3.4:2222/")
             ),
             Arguments.of(new Request("IPv6 Host Only")
@@ -173,6 +198,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("[::1]").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://[::1]:2222/")
             ),
             Arguments.of(new Request("IPv4 in Request Line")
@@ -182,6 +208,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("1.2.3.4").serverPort(2222)
+                    .secure(true)
                     .requestURL("https://1.2.3.4:2222/")
             ),
             Arguments.of(new Request("IPv6 in Request Line")
@@ -191,6 +218,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("[::1]").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://[::1]:2222/")
             ),
 
@@ -207,6 +235,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("[2001:db8:cafe::17]").remotePort(4711)
             ),
@@ -220,6 +249,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -233,6 +263,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -247,6 +278,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -260,6 +292,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -271,6 +304,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -284,6 +318,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("example.com").serverPort(80)
+                    .secure(false)
                     .requestURL("http://example.com/")
                     .remoteAddr("192.0.2.43").remotePort(0)
             ),
@@ -297,6 +332,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("myhost").serverPort(443)
+                    .secure(true)
                     .requestURL("https://myhost/")
             ),
 
@@ -311,6 +347,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("example.com").serverPort(80)
+                    .secure(false)
                     .remoteAddr("10.20.30.40")
                     .requestURL("http://example.com/")
             ),
@@ -325,6 +362,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("example.com").serverPort(81)
+                    .secure(true)
                     .remoteAddr("10.20.30.40")
                     .requestURL("https://example.com:81/")
             ),
@@ -337,6 +375,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("example.com").serverPort(443)
+                    .secure(true)
                     .requestURL("https://example.com/")
             ),
             Arguments.of(new Request("ProxyPass (IPv6 from [::1]:80 to localhost:8080)")
@@ -348,6 +387,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("[::1]").serverPort(80)
+                    .secure(false)
                     .remoteAddr("10.20.30.40")
                     .requestURL("http://[::1]/")
             ),
@@ -360,6 +400,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("[::1]").serverPort(8888)
+                    .secure(false)
                     .remoteAddr("10.20.30.40")
                     .requestURL("http://[::1]:8888/")
             ),
@@ -374,6 +415,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("example.com").serverPort(443)
+                    .secure(true)
                     .remoteAddr("10.20.30.40")
                     .requestURL("https://example.com/")
             ),
@@ -387,6 +429,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("myhost").serverPort(443)
+                    .secure(true)
                     .requestURL("https://myhost/")
             ),
             Arguments.of(new Request("X-Forwarded-For (multiple headers)")
@@ -398,6 +441,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("10.9.8.7").remotePort(0)
             ),
@@ -409,6 +453,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("10.9.8.7").remotePort(1111)
             ),
@@ -420,6 +465,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("[2001:db8:cafe::17]").remotePort(1111)
             ),
@@ -432,6 +478,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://myhost:2222/")
                     .remoteAddr("[1:2:3:4:5:6:7:8]").remotePort(0)
             ),
@@ -446,6 +493,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://myhost:2222/")
                     .remoteAddr("[1:2:3:4:5:6:7:8]").remotePort(0)
             ),
@@ -458,6 +506,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(2222)
+                    .secure(false)
                     .requestURL("http://myhost:2222/")
                     .remoteAddr("[1:2:3:4:5:6:7:8]").remotePort(0)
             ),
@@ -470,6 +519,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(4444)
+                    .secure(false)
                     .requestURL("http://myhost:4444/")
                     .remoteAddr("192.168.1.200").remotePort(0)
             ),
@@ -483,6 +533,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("192.168.1.200").remotePort(4444)
             ),
@@ -495,6 +546,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(4444)
+                    .secure(false)
                     .requestURL("http://myhost:4444/")
                     .remoteAddr("192.168.1.200").remotePort(0)
             ),
@@ -509,6 +561,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .secure(true)
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -523,6 +576,7 @@ public class ForwardedRequestCustomizerTest
                         ),
                 new Expectations()
                     .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .secure(true)
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -538,6 +592,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .secure(true)
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -553,6 +608,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .secure(true)
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -568,6 +624,7 @@ public class ForwardedRequestCustomizerTest
                         ),
                 new Expectations()
                     .scheme("https").serverName("www.example.com").serverPort(4333)
+                    .secure(true)
                     .requestURL("https://www.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -581,6 +638,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("fw.example.com").serverPort(4333)
+                    .secure(false)
                     .requestURL("http://fw.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -594,6 +652,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("fw.example.com").serverPort(4333)
+                    .secure(false)
                     .requestURL("http://fw.example.com:4333/")
                     .remoteAddr("8.5.4.3").remotePort(2222)
             ),
@@ -609,6 +668,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("sub1.example.com").serverPort(10003)
+                    .secure(true)
                     .requestURL("https://sub1.example.com:10003/")
                     .remoteAddr("127.0.0.1").remotePort(8888)
             ),
@@ -624,6 +684,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("sub1.example.com").serverPort(10003)
+                    .secure(true)
                     .requestURL("https://sub1.example.com:10003/")
                     .remoteAddr("127.0.0.1").remotePort(8888)
             ),
@@ -640,6 +701,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("sub1.example.com").serverPort(10003)
+                    .secure(true)
                     .requestURL("https://sub1.example.com:10003/")
                     .remoteAddr("127.0.0.1").remotePort(8888)
             ),
@@ -655,6 +717,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("sub1.example.com").serverPort(10003)
+                    .secure(true)
                     .requestURL("https://sub1.example.com:10003/")
                     .remoteAddr("127.0.0.1").remotePort(8888)
             ),
@@ -671,8 +734,34 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("example.com").serverPort(80)
+                    .secure(false)
                     .requestURL("http://example.com/")
                     .remoteAddr("192.0.2.43").remotePort(0)
+            ),
+            Arguments.of(
+                new Request("RFC7239 - mixed with HTTP/1.0 - No Host header")
+                    .headers(
+                        "GET /example HTTP/1.0",
+                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.net:7070"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .secure(false)
+                    .requestURL("http://alt.example.net:7070/example")
+                    .remoteAddr("1.1.1.1").remotePort(6060)
+            ),
+            Arguments.of(
+                new Request("RFC7239 - mixed with HTTP/1.0 - Empty Host header")
+                    .headers(
+                        "GET /example HTTP/1.0",
+                        "Host:",
+                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.net:7070"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .secure(false)
+                    .requestURL("http://alt.example.net:7070/example")
+                    .remoteAddr("1.1.1.1").remotePort(6060)
             ),
             // =================================================================
             // Forced Behavior
@@ -686,6 +775,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("always.example.com").serverPort(80)
+                    .secure(false)
                     .requestURL("http://always.example.com/")
                     .remoteAddr("11.9.8.7").remotePort(1111)
             ),
@@ -699,6 +789,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("always.example.com").serverPort(9090)
+                    .secure(false)
                     .requestURL("http://always.example.com:9090/")
                     .remoteAddr("11.9.8.7").remotePort(1111)
             ),
@@ -712,6 +803,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("myhost").serverPort(443)
+                    .secure(true)
                     .requestURL("https://myhost/")
                     .remoteAddr("0.0.0.0").remotePort(0)
             ),
@@ -724,6 +816,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
@@ -737,6 +830,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("myhost").serverPort(443)
+                    .secure(true)
                     .requestURL("https://myhost/")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("0123456789abcdef")
@@ -750,6 +844,7 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
                     .requestURL("http://myhost/")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslCertificate("Wibble")
@@ -763,8 +858,120 @@ public class ForwardedRequestCustomizerTest
                     ),
                 new Expectations()
                     .scheme("https").serverName("myhost").serverPort(443)
+                    .secure(true)
                     .requestURL("https://myhost/")
                     .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslCertificate("0123456789abcdef")
+            ),
+            // =================================================================
+            // Complicated scenarios
+            Arguments.of(new Request("No initial authority, X-Forwarded-Proto on http, Proxy-Ssl-Id exists (setSslIsSecure==true)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
+                    .headers(
+                        "GET /foo HTTP/1.1",
+                        "Host: myhost",
+                        "X-Forwarded-Proto: http",
+                        "Proxy-Ssl-Id: Wibble"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(true)
+                    .requestURL("http://myhost/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+            ),
+            Arguments.of(new Request("https initial authority, X-Forwarded-Proto on http, Proxy-Ssl-Id exists (setSslIsSecure==false)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
+                    .headers(
+                        "GET https://alt.example.net/foo HTTP/1.1",
+                        "Host: myhost",
+                        "X-Forwarded-Proto: http",
+                        "Proxy-Ssl-Id: Wibble"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://alt.example.net/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+            ),
+            Arguments.of(new Request("No initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==true)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
+                    .headers(
+                        "GET /foo HTTP/1.1",
+                        "Host: myhost",
+                        "X-Proxied-Https: off", // this wins for scheme and secure
+                        "Proxy-Ssl-Id: Wibble"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://myhost/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+            ),
+            Arguments.of(new Request("Https initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==true)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
+                    .headers(
+                        "GET https://alt.example.net/foo HTTP/1.1",
+                        "Host: myhost",
+                        "X-Proxied-Https: off", // this wins for scheme and secure
+                        "Proxy-Ssl-Id: Wibble"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://alt.example.net/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+            ),
+            Arguments.of(new Request("Https initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==true) (alt order)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
+                    .headers(
+                        "GET https://alt.example.net/foo HTTP/1.1",
+                        "Host: myhost",
+                        "Proxy-Ssl-Id: Wibble",
+                        "X-Proxied-Https: off" // this wins for scheme and secure
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://alt.example.net/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+            ),
+            Arguments.of(new Request("Http initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==false)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
+                    .headers(
+                        "GET https://alt.example.net/foo HTTP/1.1",
+                        "Host: myhost",
+                        "X-Proxied-Https: off",
+                        "Proxy-Ssl-Id: Wibble",
+                        "Proxy-auth-cert: 0123456789abcdef"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://alt.example.net/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
+                    .sslCertificate("0123456789abcdef")
+            ),
+            Arguments.of(new Request("Http initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==false) (alt)")
+                    .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
+                    .headers(
+                        "GET https://alt.example.net/foo HTTP/1.1",
+                        "Host: myhost",
+                        "Proxy-Ssl-Id: Wibble",
+                        "Proxy-auth-cert: 0123456789abcdef",
+                        "X-Proxied-Https: off"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://alt.example.net/foo")
+                    .remoteAddr("0.0.0.0").remotePort(0)
+                    .sslSession("Wibble")
                     .sslCertificate("0123456789abcdef")
             )
         );
@@ -868,20 +1075,31 @@ public class ForwardedRequestCustomizerTest
         expectations.accept(actual);
     }
 
-    @Test
-    public void testBadInput() throws Exception
+    public static Stream<Request> badRequestCases()
     {
-        Request request = new Request("Bad port value")
-            .headers(
-                "GET / HTTP/1.1",
-                "Host: myhost",
-                "X-Forwarded-Port: "
-            );
+        return Stream.of(
+            new Request("Bad port value")
+                .headers(
+                    "GET / HTTP/1.1",
+                    "Host: myhost",
+                    "X-Forwarded-Port: "
+                ),
+            new Request("Invalid X-Proxied-Https value")
+                .headers(
+                    "GET / HTTP/1.1",
+                    "Host: myhost",
+                    "X-Proxied-Https: foo"
+                )
+        );
+    }
 
+    @ParameterizedTest
+    @MethodSource("badRequestCases")
+    public void testBadInput(Request request) throws Exception
+    {
         request.configure(customizer);
 
         String rawRequest = request.getRawRequest((header) -> header);
-        // System.out.println(rawRequest);
 
         HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
         assertThat("status", response.getStatus(), is(400));
@@ -946,12 +1164,13 @@ public class ForwardedRequestCustomizerTest
         int expectedRemotePort = 0;
         String expectedSslSession;
         String expectedSslCertificate;
+        Boolean secure;
 
         @Override
         public void accept(Actual actual)
         {
             assertThat("scheme", actual.scheme.get(), is(expectedScheme));
-            if (expectedScheme.equals("https"))
+            if (secure != null && secure)
             {
                 assertTrue(actual.wasSecure.get(), "wasSecure");
             }
@@ -971,6 +1190,12 @@ public class ForwardedRequestCustomizerTest
             {
                 assertThat("sslCertificate", actual.sslCertificate.get(), is(expectedSslCertificate));
             }
+        }
+
+        public Expectations secure(boolean flag)
+        {
+            this.secure = flag;
+            return this;
         }
 
         public Expectations scheme(String scheme)

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -135,6 +135,26 @@ public class ForwardedRequestCustomizerTest
     public static Stream<Arguments> cases()
     {
         return Stream.of(
+            // HTTP 1.0
+            Arguments.of(
+                new Request("HTTP/1.0 - no Host header")
+                    .headers(
+                        "GET /example HTTP/1.0"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("0.0.0.0").serverPort(80)
+                    .requestURL("http://0.0.0.0/example")
+            ),
+            Arguments.of(
+                new Request("HTTP/1.0 - Empty Host header")
+                    .headers(
+                        "GET /example HTTP/1.0",
+                        "Host:"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("0.0.0.0").serverPort(80)
+                    .requestURL("http://0.0.0.0/example")
+            ),
             // Host IPv4
             Arguments.of(
                 new Request("IPv4 Host Only")
@@ -157,12 +177,12 @@ public class ForwardedRequestCustomizerTest
             ),
             Arguments.of(new Request("IPv4 in Request Line")
                     .headers(
-                        "GET http://1.2.3.4:2222/ HTTP/1.1",
+                        "GET https://1.2.3.4:2222/ HTTP/1.1",
                         "Host: wrong"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("1.2.3.4").serverPort(2222)
-                    .requestURL("http://1.2.3.4:2222/")
+                    .scheme("https").serverName("1.2.3.4").serverPort(2222)
+                    .requestURL("https://1.2.3.4:2222/")
             ),
             Arguments.of(new Request("IPv6 in Request Line")
                     .headers(
@@ -931,7 +951,7 @@ public class ForwardedRequestCustomizerTest
         public void accept(Actual actual)
         {
             assertThat("scheme", actual.scheme.get(), is(expectedScheme));
-            if (actual.scheme.get().equals("https"))
+            if (expectedScheme.equals("https"))
             {
                 assertTrue(actual.wasSecure.get(), "wasSecure");
             }


### PR DESCRIPTION
If the request has no Forwarding headers, the customization that ForwardingRequestCustomizer typically does should be skipped.

Closes #5443 

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>