### PR TITLE
Issue #5451 - Removing file/dir permission management from codebase

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormInputStream.java
@@ -42,7 +42,6 @@ import javax.servlet.http.Part;
 
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.ByteArrayOutputStream2;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.LazyList;
 import org.eclipse.jetty.util.MultiException;
 import org.eclipse.jetty.util.MultiMap;
@@ -153,7 +152,7 @@ public class MultiPartFormInputStream
         protected void createFile() throws IOException
         {
             Path parent = MultiPartFormInputStream.this._tmpDir.toPath();
-            Path tempFile = Files.createTempFile(parent, "MultiPart", "", IO.getUserOnlyFileAttribute(parent));
+            Path tempFile = Files.createTempFile(parent, "MultiPart", "");
             _file = tempFile.toFile();
 
             OutputStream fos = Files.newOutputStream(tempFile, StandardOpenOption.WRITE);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartInputStreamParser.java
@@ -191,7 +191,7 @@ public class MultiPartInputStreamParser
             throws IOException
         {
             Path parent = MultiPartInputStreamParser.this._tmpDir.toPath();
-            Path tempFile = Files.createTempFile(parent, "MultiPart", "", IO.getUserOnlyFileAttribute(parent));
+            Path tempFile = Files.createTempFile(parent, "MultiPart", "");
             _file = tempFile.toFile();
 
             OutputStream fos = Files.newOutputStream(tempFile, StandardOpenOption.WRITE);


### PR DESCRIPTION
Replacement for PR #5457, but removes the permission management from the codebase.

These methods and constants were recently added, and do not exist in any published release.
Since we don't want to manage permissions in the codebase, this PR removes the partial efforts from the codebase entirely.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>