### PR TITLE
Fix archive assemblies (tar.gz and zip) to have fixed file/dir modes.

### DIFF
--- a/jetty-home/src/main/assembly/jetty-assembly.xml
+++ b/jetty-home/src/main/assembly/jetty-assembly.xml
@@ -15,6 +15,8 @@
         <exclude>**/META-INF/**</exclude>
         <exclude>*-config.jar</exclude>
       </excludes>
+      <fileMode>0444</fileMode>
+      <directoryMode>0755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-home/src/main/assembly/jetty-assembly.xml
+++ b/jetty-home/src/main/assembly/jetty-assembly.xml
@@ -14,9 +14,19 @@
       <excludes>
         <exclude>**/META-INF/**</exclude>
         <exclude>*-config.jar</exclude>
+        <!-- we'll build up shell scripts with execute in separate file-set -->
+        <exclude>bin/*.sh</exclude>
       </excludes>
-      <fileMode>0444</fileMode>
-      <directoryMode>0755</directoryMode>
+      <fileMode>0400</fileMode>
+      <directoryMode>0700</directoryMode>
+    </fileSet>
+    <fileSet>
+      <directory>${assembly-directory}</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>bin/*.sh</include>
+      </includes>
+      <fileMode>0500</fileMode>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
+ Not taking the modes from whatever defaults the filesystem
  that ran the build is currently on.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>