### PR TITLE
Issue #5475 Update to spifly 1.3.2

### DIFF
--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.apache.aries.spifly</groupId>
       <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Closes #5475 

Update jetty-osgi tests to use spifly 1.3.2