### PR TITLE
Bump spifly from 1.2.4 to 1.3.2

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -71,8 +71,8 @@ import org.objectweb.asm.Opcodes;
 public class AnnotationParser
 {
     private static final Logger LOG = Log.getLogger(AnnotationParser.class);
-    private static final int ASM_OPCODE_VERSION = Opcodes.ASM7; //compatibility of api
-    private static final String ASM_OPCODE_VERSION_STR = "ASM7";
+    private static final int ASM_OPCODE_VERSION = Opcodes.ASM9; //compatibility of api
+    private static final String ASM_OPCODE_VERSION_STR = "ASM9";
 
     /**
      * Map of classnames scanned and the first location from which scan occurred
@@ -121,6 +121,16 @@ public class AnnotationParser
                     case 7:
                     {
                         asmVersion = Opcodes.ASM7;
+                        break;
+                    }
+                    case 8:
+                    {
+                        asmVersion = Opcodes.ASM8;
+                        break;
+                    }
+                    case 9:
+                    {
+                        asmVersion = Opcodes.ASM9;
                         break;
                     }
                     default:

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.apache.aries.spifly</groupId>
       <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-      <version>1.2.4</version>
+      <version>1.3.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
@@ -126,6 +126,8 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm-commons").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm-tree").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm-analysis").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm-util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.apache.aries.spifly").artifactId("org.apache.aries.spifly.dynamic.bundle").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty.toolchain").artifactId("jetty-osgi-servlet-api").versionAsInProject().noStart());
         res.add(mavenBundle().groupId("javax.annotation").artifactId("javax.annotation-api").versionAsInProject().start());


### PR DESCRIPTION
Closes #5475 

Update to spifly 1.3.2, and also fix the version of asm, which should always be updated in AnnotationParser.java whenever the version of asm is updated.