### PR TITLE
Backdown default version of asm to 7.

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -71,8 +71,8 @@ import org.objectweb.asm.Opcodes;
 public class AnnotationParser
 {
     private static final Logger LOG = Log.getLogger(AnnotationParser.class);
-    private static final int ASM_OPCODE_VERSION = Opcodes.ASM9; //compatibility of api
-    private static final String ASM_OPCODE_VERSION_STR = "ASM9";
+    private static final int ASM_OPCODE_VERSION = Opcodes.ASM7; //compatibility of api
+    private static final String ASM_OPCODE_VERSION_STR = "ASM7";
 
     /**
      * Map of classnames scanned and the first location from which scan occurred


### PR DESCRIPTION
Backing down the default version of asm from 9 to 7. This default version value is only used in the case where we cannot determine the actual version of the asm jars at runtime.