### PR TITLE
Fixes #5475 Scan for updated ASM version

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationParser.java
@@ -107,7 +107,10 @@ public class AnnotationParser
         int asmFieldId = asmVersion.get();
         try
         {
-            return (int)Opcodes.class.getField("ASM" + asmFieldId).get(null);
+            String fieldName = "ASM" + asmFieldId;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Using ASM API from {}.{}", Opcodes.class.getName(), fieldName);
+            return (int)Opcodes.class.getField(fieldName).get(null);
         }
         catch (Throwable e)
         {


### PR DESCRIPTION
Scan for the highest known ASM version so we can always run on latest JVM if the ASM jar is updated. #5475 