### PR TITLE
NPE protection on WebInfConfiguration.deconfigure()

### DIFF
--- a/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.io;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -41,12 +42,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -447,6 +451,64 @@ public class IOTest
         {
             assertEquals(0, buffer.remaining());
         }
+    }
+
+    @Test
+    public void testDeleteNull()
+    {
+        assertFalse(IO.delete(null));
+    }
+
+    @Test
+    public void testDeleteNonExistentFile(TestInfo testInfo)
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        File noFile = new File(dir, "nada");
+        assertFalse(IO.delete(noFile));
+    }
+
+    @Test
+    public void testIsEmptyNull()
+    {
+        assertTrue(IO.isEmptyDir(null));
+    }
+
+    @Test
+    public void testIsEmptyDoesNotExist(TestInfo testInfo)
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        File noFile = new File(dir, "nada");
+        assertTrue(IO.isEmptyDir(noFile));
+    }
+
+    @Test
+    public void testIsEmptyExistButAsFile(TestInfo testInfo) throws IOException
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        File file = new File(dir, "nada");
+        FS.touch(file);
+        assertFalse(IO.isEmptyDir(file));
+    }
+
+    @Test
+    public void testIsEmptyExistAndIsEmpty(TestInfo testInfo)
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        assertTrue(IO.isEmptyDir(dir));
+    }
+
+    @Test
+    public void testIsEmptyExistAndHasContent(TestInfo testInfo) throws IOException
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        File file = new File(dir, "nada");
+        FS.touch(file);
+        assertFalse(IO.isEmptyDir(dir));
     }
 
     @Test

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractJettyMojo.java
@@ -49,7 +49,6 @@ import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.util.PathWatcher;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -559,7 +558,12 @@ public abstract class AbstractJettyMojo extends AbstractMojo
             File target = new File(project.getBuild().getDirectory());
             File tmp = new File(target, "tmp");
             if (!tmp.exists())
-                tmp.mkdirs();
+            {
+                if (!tmp.mkdirs())
+                {
+                    throw new MojoFailureException("Unable to create temp directory: " + tmp);
+                }
+            }
             webApp.setTempDirectory(tmp);
         }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -382,6 +382,27 @@ public class IO
     }
 
     /**
+     * Test if directory is empty.
+     *
+     * @param dir the directory
+     * @return true if directory is null, doesn't exist, or has no content.
+     * false if not a directory, or has contents
+     */
+    public static boolean isEmptyDir(File dir)
+    {
+        if (dir == null)
+            return true;
+        if (!dir.exists())
+            return true;
+        if (!dir.isDirectory())
+            return false;
+        String[] list = dir.list();
+        if (list == null)
+            return true;
+        return list.length <= 0;
+    }
+
+    /**
      * Closes an arbitrary closable, and logs exceptions at ignore level
      *
      * @param closeable the closeable to close

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -361,10 +361,13 @@ public class IO
      * This delete will recursively delete directories - BE CAREFUL
      *
      * @param file The file (or directory) to be deleted.
-     * @return true if anything was deleted. (note: this does not mean that all content in a directory was deleted)
+     * @return true if file was deleted, or directory referenced was deleted.
+     * false if file doesn't exist, or was null.
      */
     public static boolean delete(File file)
     {
+        if (file == null)
+            return false;
         if (!file.exists())
             return false;
         if (file.isDirectory())

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -357,9 +357,9 @@ public class WebInfConfiguration extends AbstractConfiguration
         File tempDirectory = context.getTempDirectory();
 
         // if we're not persisting the temp dir contents delete it
-        if (!context.isPersistTempDirectory() && tempDirectory != null && tempDirectory.exists())
+        if (!context.isPersistTempDirectory() && !IO.isEmptyDir(tempDirectory))
         {
-            IO.delete(context.getTempDirectory());
+            IO.delete(tempDirectory);
         }
 
         //if it wasn't explicitly configured by the user, then unset it

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -355,7 +355,7 @@ public class WebInfConfiguration extends AbstractConfiguration
     public void deconfigure(WebAppContext context) throws Exception
     {
         //if we're not persisting the temp dir contents delete it
-        if (!context.isPersistTempDirectory())
+        if (!context.isPersistTempDirectory() && context.getTempDirectory() != null && context.getTempDirectory().exists())
         {
             IO.delete(context.getTempDirectory());
         }
@@ -522,21 +522,16 @@ public class WebInfConfiguration extends AbstractConfiguration
         if (dir == null)
             throw new IllegalArgumentException("Null temp dir");
 
-        //if dir exists and we don't want it persisted, delete it
-        if (dir.exists() && !context.isPersistTempDirectory())
+        // if it doesn't exist make it
+        if (!dir.exists())
         {
-            if (!IO.delete(dir))
-                throw new IllegalStateException("Failed to delete temp dir " + dir);
+            if (!dir.mkdirs())
+            {
+                throw new IllegalStateException("Unable to create temp dir " + dir);
+            }
         }
 
-        //if it doesn't exist make it
-        if (!dir.exists())
-            dir.mkdirs();
-
-        if (!context.isPersistTempDirectory())
-            dir.deleteOnExit();
-
-        //is it useable
+        // is it useable
         if (!dir.canWrite() || !dir.isDirectory())
             throw new IllegalStateException("Temp dir " + dir + " not useable: writeable=" + dir.canWrite() + ", dir=" + dir.isDirectory());
     }


### PR DESCRIPTION
* NPE protection on IO.delete(File)
* Fail in jetty-maven-plugin if unable to create temp directory.
* NPE protection in WebInfConfiguration.deconfigure()
* Removing Temp dir forced deletion in WebInfConfiguration.configureTempDirectory()