### PR TITLE
Bump org.eclipse.osgi.services from 3.7.100 to 3.9.0

### DIFF
--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi.services</artifactId>
-      <version>3.7.100</version>
+      <version>3.9.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>