### PR TITLE
Bump org.eclipse.osgi (platform) from 3.13.100 to 3.16.0

### DIFF
--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.13.100</version>
+      <version>3.16.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is a `jetty-9.4.x` version of PR #5500

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>