### PR TITLE
Issue #5493 - Fix and simplify graceful shutdown of StatisticsHandler

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/Graceful.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/Graceful.java
@@ -78,7 +78,8 @@ public interface Graceful
         public CompletableFuture<Void> shutdown()
         {
             if (_done.get() == null)
-                _done.compareAndSet(null, new CompletableFuture<Void>()
+            {
+                _done.compareAndSet(null, new CompletableFuture<>()
                 {
                     @Override
                     public String toString()
@@ -86,6 +87,7 @@ public interface Graceful
                         return String.format("Shutdown<%s>@%x", _component, hashCode());
                     }
                 });
+            }
             CompletableFuture<Void> done = _done.get();
             check();
             return done;
@@ -108,6 +110,15 @@ public interface Graceful
             CompletableFuture<Void> done = _done.get();
             if (done != null && isShutdownDone())
                 done.complete(null);
+        }
+
+        public void cancel()
+        {
+            CompletableFuture<Void> done = _done.get();
+            if (done != null && !done.isDone())
+                done.cancel(true);
+
+            _done.set(null);
         }
 
         /**


### PR DESCRIPTION
**Issue #5493**

- Make the `Shutdown` held by `StatisticsHandler` final and implement a cancel method to call in doStart and doStop.
- The shutdown check is now always done in `isShutdownDone()` and not externally.
- I have also removed the response buffer flushing after shutdown.