### PR TITLE
Access to cookie config with accessor method

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -639,22 +639,23 @@ public class SessionHandler extends ScopedHandler
     {
         if (isUsingCookies())
         {
-            String sessionPath = (_cookieConfig.getPath() == null) ? contextPath : _cookieConfig.getPath();
+            SessionCookieConfig cookieConfig = getSessionCookieConfig();
+            String sessionPath = (cookieConfig.getPath() == null) ? contextPath : cookieConfig.getPath();
             sessionPath = (StringUtil.isEmpty(sessionPath)) ? "/" : sessionPath;
             String id = getExtendedId(session);
             HttpCookie cookie = null;
 
             cookie = new HttpCookie(
-                _cookieConfig.getName(),
+                cookieConfig.getName(),
                 id,
-                _cookieConfig.getDomain(),
+                cookieConfig.getDomain(),
                 sessionPath,
-                _cookieConfig.getMaxAge(),
-                _cookieConfig.isHttpOnly(),
-                _cookieConfig.isSecure() || (isSecureRequestOnly() && requestIsSecure),
-                HttpCookie.getCommentWithoutAttributes(_cookieConfig.getComment()),
+                cookieConfig.getMaxAge(),
+                cookieConfig.isHttpOnly(),
+                cookieConfig.isSecure() || (isSecureRequestOnly() && requestIsSecure),
+                HttpCookie.getCommentWithoutAttributes(cookieConfig.getComment()),
                 0,
-                HttpCookie.getSameSiteFromComment(_cookieConfig.getComment()));
+                HttpCookie.getSameSiteFromComment(cookieConfig.getComment()));
 
             return cookie;
         }


### PR DESCRIPTION
With this change one can provide different cookie configs for the same SessionHandler
without coping the whole method into the inherited class.

Signed-off-by: dpecar <dejan.pecar@abacus.ch>