### PR TITLE
Bump maven.resolver.version from 1.3.1 to 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <tycho-version>1.4.0</tycho-version>
     <junit.version>5.7.0</junit.version>
     <maven.version>3.6.3</maven.version>
-    <maven.resolver.version>1.3.1</maven.resolver.version>
+    <maven.resolver.version>1.6.1</maven.resolver.version>
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <weld.version>3.1.5.Final</weld.version>
     <jboss.logging.version>3.4.1.Final</jboss.logging.version>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -34,6 +34,21 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${maven.resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven.resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+      <version>${maven.resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${maven.resolver.version}</version>
     </dependency>


### PR DESCRIPTION
Replacement for PR #5502 and #5505 but starting from branch `jetty-9.4.x` instead.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>