### PR TITLE
SessionCookieConfig name may be null

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -655,7 +655,7 @@ public class SessionHandler extends ScopedHandler
      */
     public HttpCookie getSessionCookie(HttpSession session, String contextPath, boolean requestIsSecure)
     {
-        if (isUsingCookies() && _cookieConfig.getName() != null)
+        if (isUsingCookies())
         {
             String sessionPath = (_cookieConfig.getPath() == null) ? contextPath : _cookieConfig.getPath();
             sessionPath = (StringUtil.isEmpty(sessionPath)) ? "/" : sessionPath;
@@ -663,7 +663,7 @@ public class SessionHandler extends ScopedHandler
             HttpCookie cookie = null;
 
             cookie = new HttpCookie(
-                _cookieConfig.getName(),
+                getSessionCookieName(_cookieConfig),
                 id,
                 _cookieConfig.getDomain(),
                 sessionPath,
@@ -1379,6 +1379,13 @@ public class SessionHandler extends ScopedHandler
         Session getSession();
     }
 
+    public static String getSessionCookieName(SessionCookieConfig config)
+    {
+        if (config == null || config.getName() == null)
+            return __DefaultSessionCookie;
+        return config.getName();
+    }
+
     /**
      * CookieConfig
      *
@@ -1471,7 +1478,7 @@ public class SessionHandler extends ScopedHandler
                 throw new IllegalArgumentException("Blank cookie name");
             if (name != null)
                 Syntax.requireValidRFC2616Token(name, "Bad Session cookie name");
-            _sessionCookie = StringUtil.isBlank(name) ? __DefaultSessionCookie : name;
+            _sessionCookie = name;
         }
 
         @Override
@@ -1645,12 +1652,12 @@ public class SessionHandler extends ScopedHandler
         HttpSession session = null;
 
         //first try getting id from a cookie
-        if (isUsingCookies() && getSessionCookieConfig().getName() != null)
+        if (isUsingCookies())
         {
             Cookie[] cookies = request.getCookies();
             if (cookies != null && cookies.length > 0)
             {
-                final String sessionCookie = getSessionCookieConfig().getName();
+                final String sessionCookie = getSessionCookieName(getSessionCookieConfig());
                 for (Cookie cookie : cookies)
                 {
                     if (sessionCookie.equalsIgnoreCase(cookie.getName()))

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -654,7 +654,7 @@ public class SessionHandler extends ScopedHandler
      */
     public HttpCookie getSessionCookie(HttpSession session, String contextPath, boolean requestIsSecure)
     {
-        if (isUsingCookies())
+        if (isUsingCookies() && _cookieConfig.getName() != null)
         {
             String sessionPath = (_cookieConfig.getPath() == null) ? contextPath : _cookieConfig.getPath();
             sessionPath = (StringUtil.isEmpty(sessionPath)) ? "/" : sessionPath;
@@ -1640,23 +1640,23 @@ public class SessionHandler extends ScopedHandler
         HttpSession session = null;
 
         //first try getting id from a cookie
-        if (isUsingCookies())
+        if (isUsingCookies() && getSessionCookieConfig().getName() != null)
         {
             Cookie[] cookies = request.getCookies();
             if (cookies != null && cookies.length > 0)
             {
                 final String sessionCookie = getSessionCookieConfig().getName();
-                for (int i = 0; i < cookies.length; i++)
+                for (Cookie cookie : cookies)
                 {
-                    if (sessionCookie.equalsIgnoreCase(cookies[i].getName()))
+                    if (sessionCookie.equalsIgnoreCase(cookie.getName()))
                     {
-                        String id = cookies[i].getValue();
+                        String id = cookie.getValue();
                         requestedSessionIdFromCookie = true;
                         if (LOG.isDebugEnabled())
                             LOG.debug("Got Session ID {} from cookie {}", id, sessionCookie);
 
                         HttpSession s = getHttpSession(id);
-                        
+
                         if (requestedSessionId == null)
                         {
                             //no previous id, always accept this one

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java
@@ -46,6 +46,7 @@ import javax.servlet.http.HttpSessionListener;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SessionIdManager;
@@ -1466,7 +1467,11 @@ public class SessionHandler extends ScopedHandler
         {
             if (_context != null && _context.getContextHandler().isAvailable())
                 throw new IllegalStateException("CookieConfig cannot be set after ServletContext is started");
-            _sessionCookie = name;
+            if ("".equals(name))
+                throw new IllegalArgumentException("Blank cookie name");
+            if (name != null)
+                Syntax.requireValidRFC2616Token(name, "Bad Session cookie name");
+            _sessionCookie = StringUtil.isBlank(name) ? __DefaultSessionCookie : name;
         }
 
         @Override

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.security.ConstraintAware;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.authentication.FormAuthenticator;
+import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.FilterMapping;
@@ -732,7 +733,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                     case WebFragment:
                     {
                         //a web-fragment set the value, all web-fragments must have the same value
-                        if (!name.equals(context.getSessionHandler().getSessionCookieConfig().getName()))
+                        if (!name.equals(SessionHandler.getSessionCookieName(context.getSessionHandler().getSessionCookieConfig())))
                             throw new IllegalStateException("Conflicting cookie-config name " + name + " in " + descriptor.getResource());
                         break;
                     }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
@@ -732,7 +732,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                     case WebFragment:
                     {
                         //a web-fragment set the value, all web-fragments must have the same value
-                        if (!context.getSessionHandler().getSessionCookieConfig().getName().equals(name))
+                        if (!name.equals(context.getSessionHandler().getSessionCookieConfig().getName()))
                             throw new IllegalStateException("Conflicting cookie-config name " + name + " in " + descriptor.getResource());
                         break;
                     }

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/StandardDescriptorProcessor.java
@@ -806,7 +806,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                     case WebFragment:
                     {
                         //a web-fragment set the value, all web-fragments must have the same value
-                        if (!context.getSessionHandler().getSessionCookieConfig().getPath().equals(path))
+                        if (!path.equals(context.getSessionHandler().getSessionCookieConfig().getPath()))
                             throw new IllegalStateException("Conflicting cookie-config path " + path + " in " + descriptor.getResource());
                         break;
                     }


### PR DESCRIPTION
Protect against NPE by make a null name in SessionCookieConfig deactive session cookies.
See discussion in https://github.com/eclipse-ee4j/jakartaee-tck/pull/567