### PR TITLE
Issue #5539 - Proper StatisticsServlet output format via content negotiation

### DIFF
--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestOSGiUtil.java
@@ -133,6 +133,7 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("javax.annotation").artifactId("javax.annotation-api").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.apache.geronimo.specs").artifactId("geronimo-jta_1.1_spec").version("1.1.1").start());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util-ajax").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-deploy").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-server").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-servlet").versionAsInProject().start());

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -9,6 +9,10 @@ handler
 
 [depend]
 server
+servlet
+
+[lib]
+lib/jetty-util-ajax-${jetty.version}.jar
 
 [xml]
 etc/jetty-stats.xml

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -43,6 +43,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util-ajax</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -59,13 +59,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * You can use normal HTTP content negotiation to ask for the statistics.
  * Specify a request <code>Accept</code> header for one of the following formats:
- *     <ul>
- *         <li><code>application/json</code></li>
- *         <li><code>text/xml</code></li>
- *         <li><code>text/html</code></li>
- *         <li><code>text/plain</code> - default if no <code>Accept</code> header specified</li>
- *     </ul>
  * </p>
+ * <ul>
+ *     <li><code>application/json</code></li>
+ *     <li><code>text/xml</code></li>
+ *     <li><code>text/html</code></li>
+ *     <li><code>text/plain</code> - default if no <code>Accept</code> header specified</li>
+ * </ul>
  */
 public class StatisticsServlet extends HttpServlet
 {

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -235,7 +235,16 @@ public class StatisticsServlet extends HttpServlet
             return values.getValues();
         }
 
-        // No accept specified, return that we allow ALL mime types
+        // No accept header specified, try 'accept' parameter (for those clients that are
+        // so ancient that they cannot set the standard HTTP `Accept` header)
+        String acceptParameter = request.getParameter("accept");
+        if (acceptParameter != null)
+        {
+            // return that we support the one type specified in the 'accept' parameter
+            return Collections.singletonList(acceptParameter);
+        }
+
+        // return that we allow ALL mime types
         return Collections.singletonList("*/*");
     }
 

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -54,6 +54,19 @@ import org.eclipse.jetty.util.log.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * Collect and report statistics about requests / responses / connections and more.
+ * <p>
+ * You can use normal HTTP content negotiation to ask for the statistics.
+ * Specify a request <code>Accept</code> header for one of the following formats:
+ *     <ul>
+ *         <li><code>application/json</code></li>
+ *         <li><code>text/xml</code></li>
+ *         <li><code>text/html</code></li>
+ *         <li><code>text/plain</code> - default if no <code>Accept</code> header specified</li>
+ *     </ul>
+ * </p>
+ */
 public class StatisticsServlet extends HttpServlet
 {
     private static final Logger LOG = Log.getLogger(StatisticsServlet.class);

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -19,28 +19,40 @@
 package org.eclipse.jetty.servlet;
 
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.QuotedQualityCSV;
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ConnectorStatistics;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
-import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.ajax.JSON;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class StatisticsServlet extends HttpServlet
 {
@@ -49,7 +61,7 @@ public class StatisticsServlet extends HttpServlet
     boolean _restrictToLocalhost = true; // defaults to true
     private StatisticsHandler _statsHandler;
     private MemoryMXBean _memoryBean;
-    private Connector[] _connectors;
+    private List<Connector> _connectors;
 
     @Override
     public void init() throws ServletException
@@ -58,20 +70,16 @@ public class StatisticsServlet extends HttpServlet
         ContextHandler.Context scontext = (ContextHandler.Context)context;
         Server server = scontext.getContextHandler().getServer();
 
-        Handler handler = server.getChildHandlerByClass(StatisticsHandler.class);
+        _statsHandler = server.getChildHandlerByClass(StatisticsHandler.class);
 
-        if (handler != null)
-        {
-            _statsHandler = (StatisticsHandler)handler;
-        }
-        else
+        if (_statsHandler == null)
         {
             LOG.warn("Statistics Handler not installed!");
             return;
         }
 
         _memoryBean = ManagementFactory.getMemoryMXBean();
-        _connectors = server.getConnectors();
+        _connectors = Arrays.asList(server.getConnectors());
 
         if (getInitParameter("restrictToLocalhost") != null)
         {
@@ -80,47 +88,150 @@ public class StatisticsServlet extends HttpServlet
     }
 
     @Override
-    public void doPost(HttpServletRequest sreq, HttpServletResponse sres) throws ServletException, IOException
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
-        doGet(sreq, sres);
+        doGet(request, response);
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
         if (_statsHandler == null)
         {
             LOG.warn("Statistics Handler not installed!");
-            resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return;
         }
         if (_restrictToLocalhost)
         {
-            if (!isLoopbackAddress(req.getRemoteAddr()))
+            if (!isLoopbackAddress(request.getRemoteAddr()))
             {
-                resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }
         }
 
-        if (Boolean.parseBoolean(req.getParameter("statsReset")))
+        if (Boolean.parseBoolean(request.getParameter("statsReset")))
         {
+            response.setStatus(HttpServletResponse.SC_OK);
             _statsHandler.statsReset();
             return;
         }
 
-        String wantXml = req.getParameter("xml");
-        if (wantXml == null)
-            wantXml = req.getParameter("XML");
+        List<String> acceptable = getOrderedAcceptableMimeTypes(request);
 
-        if (Boolean.parseBoolean(wantXml))
+        for (String mimeType : acceptable)
         {
-            sendXmlResponse(resp);
+            switch (mimeType)
+            {
+                case "application/json":
+                    writeJsonResponse(response);
+                    return;
+                case "text/xml":
+                    writeXmlResponse(response);
+                    return;
+                case "text/html":
+                    writeHtmlResponse(response);
+                    return;
+                case "text/plain":
+                    writeTextResponse(response);
+                    return;
+                case "*/*":
+                    String wantXml = request.getParameter("xml");
+                    if (wantXml == null)
+                        wantXml = request.getParameter("XML");
+
+                    if (Boolean.parseBoolean(wantXml))
+                    {
+                        writeXmlResponse(response);
+                    }
+                    else
+                    {
+                        writeTextResponse(response);
+                    }
+                    return;
+                default:
+                    if (LOG.isDebugEnabled())
+                    {
+                        LOG.debug("Ignoring unrecognized mime-type {}", mimeType);
+                    }
+                    break;
+            }
         }
-        else
+        // None of the listed `Accept` mime-types were found.
+        response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+    }
+
+    private void writeTextResponse(HttpServletResponse response) throws IOException
+    {
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("text/plain");
+        CharSequence text = generateResponse(new TextProducer());
+        response.getWriter().print(text.toString());
+    }
+
+    private void writeHtmlResponse(HttpServletResponse response) throws IOException
+    {
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("text/html");
+        Writer htmlWriter = new OutputStreamWriter(response.getOutputStream(), UTF_8);
+        htmlWriter.append("<html><head><title>");
+        htmlWriter.append(this.getClass().getSimpleName());
+        htmlWriter.append("</title></head><body>\n");
+        CharSequence html = generateResponse(new HtmlProducer());
+        htmlWriter.append(html.toString());
+        htmlWriter.append("\n</body></html>\n");
+        htmlWriter.flush();
+    }
+
+    private void writeXmlResponse(HttpServletResponse response) throws IOException
+    {
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("text/xml");
+        CharSequence xml = generateResponse(new XmlProducer());
+        response.getWriter().print(xml.toString());
+    }
+
+    private void writeJsonResponse(HttpServletResponse response) throws IOException
+    {
+        // We intentionally don't put "UTF-8" into the response headers
+        // as the rules for application/json state that it should never be
+        // present on the HTTP Content-Type header.
+        // It is also true that the application/json mime-type is always UTF-8.
+        response.setContentType("application/json");
+        CharSequence json = generateResponse(new JsonProducer());
+        Writer jsonWriter = new OutputStreamWriter(response.getOutputStream(), UTF_8);
+        jsonWriter.append(json);
+        jsonWriter.flush();
+    }
+
+    private List<String> getOrderedAcceptableMimeTypes(HttpServletRequest request)
+    {
+        QuotedQualityCSV values = null;
+        Enumeration<String> enumAccept = request.getHeaders("Accept");
+        if (enumAccept != null)
         {
-            sendTextResponse(resp);
+            while (enumAccept.hasMoreElements())
+            {
+                String value = enumAccept.nextElement();
+                if (StringUtil.isNotBlank(value))
+                {
+                    if (values == null)
+                    {
+                        values = new QuotedQualityCSV(QuotedQualityCSV.MOST_SPECIFIC_MIME_ORDERING);
+                    }
+                    values.addValue(value);
+                }
+            }
         }
+
+        if (values != null)
+        {
+            return values.getValues();
+        }
+
+        // No accept specified, return that we allow ALL mime types
+        return Collections.singletonList("*/*");
     }
 
     private boolean isLoopbackAddress(String address)
@@ -137,177 +248,362 @@ public class StatisticsServlet extends HttpServlet
         }
     }
 
-    private void sendXmlResponse(HttpServletResponse response) throws IOException
+    private CharSequence generateResponse(OutputProducer outputProducer)
     {
-        StringBuilder sb = new StringBuilder();
+        Map<String, Object> top = new HashMap<>();
 
-        sb.append("<statistics>\n");
+        // requests
+        Map<String, Number> requests = new HashMap<>();
+        requests.put("statsOnMs", _statsHandler.getStatsOnMs());
 
-        sb.append("  <requests>\n");
-        sb.append("    <statsOnMs>").append(_statsHandler.getStatsOnMs()).append("</statsOnMs>\n");
+        requests.put("requests", _statsHandler.getRequests());
 
-        sb.append("    <requests>").append(_statsHandler.getRequests()).append("</requests>\n");
-        sb.append("    <requestsActive>").append(_statsHandler.getRequestsActive()).append("</requestsActive>\n");
-        sb.append("    <requestsActiveMax>").append(_statsHandler.getRequestsActiveMax()).append("</requestsActiveMax>\n");
-        sb.append("    <requestsTimeTotal>").append(_statsHandler.getRequestTimeTotal()).append("</requestsTimeTotal>\n");
-        sb.append("    <requestsTimeMean>").append(_statsHandler.getRequestTimeMean()).append("</requestsTimeMean>\n");
-        sb.append("    <requestsTimeMax>").append(_statsHandler.getRequestTimeMax()).append("</requestsTimeMax>\n");
-        sb.append("    <requestsTimeStdDev>").append(_statsHandler.getRequestTimeStdDev()).append("</requestsTimeStdDev>\n");
+        requests.put("requestsActive", _statsHandler.getRequestsActive());
+        requests.put("requestsActiveMax", _statsHandler.getRequestsActiveMax());
+        requests.put("requestsTimeTotal", _statsHandler.getRequestTimeTotal());
+        requests.put("requestsTimeMean", _statsHandler.getRequestTimeMean());
+        requests.put("requestsTimeMax", _statsHandler.getRequestTimeMax());
+        requests.put("requestsTimeStdDev", _statsHandler.getRequestTimeStdDev());
 
-        sb.append("    <dispatched>").append(_statsHandler.getDispatched()).append("</dispatched>\n");
-        sb.append("    <dispatchedActive>").append(_statsHandler.getDispatchedActive()).append("</dispatchedActive>\n");
-        sb.append("    <dispatchedActiveMax>").append(_statsHandler.getDispatchedActiveMax()).append("</dispatchedActiveMax>\n");
-        sb.append("    <dispatchedTimeTotalMs>").append(_statsHandler.getDispatchedTimeTotal()).append("</dispatchedTimeTotalMs>\n");
-        sb.append("    <dispatchedTimeMeanMs>").append(_statsHandler.getDispatchedTimeMean()).append("</dispatchedTimeMeanMs>\n");
-        sb.append("    <dispatchedTimeMaxMs>").append(_statsHandler.getDispatchedTimeMax()).append("</dispatchedTimeMaxMs>\n");
-        sb.append("    <dispatchedTimeStdDevMs>").append(_statsHandler.getDispatchedTimeStdDev()).append("</dispatchedTimeStdDevMs>\n");
+        requests.put("dispatched", _statsHandler.getDispatched());
+        requests.put("dispatchedActive", _statsHandler.getDispatchedActive());
+        requests.put("dispatchedActiveMax", _statsHandler.getDispatchedActiveMax());
+        requests.put("dispatchedTimeTotal", _statsHandler.getDispatchedTimeTotal());
+        requests.put("dispatchedTimeMean", _statsHandler.getDispatchedTimeMean());
+        requests.put("dispatchedTimeMax", _statsHandler.getDispatchedTimeMax());
+        requests.put("dispatchedTimeStdDev", _statsHandler.getDispatchedTimeStdDev());
 
-        sb.append("    <asyncRequests>").append(_statsHandler.getAsyncRequests()).append("</asyncRequests>\n");
-        sb.append("    <requestsSuspended>").append(_statsHandler.getAsyncRequestsWaiting()).append("</requestsSuspended>\n");
-        sb.append("    <requestsSuspendedMax>").append(_statsHandler.getAsyncRequestsWaitingMax()).append("</requestsSuspendedMax>\n");
-        sb.append("    <requestsResumed>").append(_statsHandler.getAsyncDispatches()).append("</requestsResumed>\n");
-        sb.append("    <requestsExpired>").append(_statsHandler.getExpires()).append("</requestsExpired>\n");
-        sb.append("  </requests>\n");
+        requests.put("asyncRequests", _statsHandler.getAsyncRequests());
+        requests.put("requestsSuspended", _statsHandler.getAsyncDispatches());
+        requests.put("requestsSuspendedMax", _statsHandler.getAsyncRequestsWaiting());
+        requests.put("requestsResumed", _statsHandler.getAsyncRequestsWaitingMax());
+        requests.put("requestsExpired", _statsHandler.getExpires());
 
-        sb.append("  <responses>\n");
-        sb.append("    <responses1xx>").append(_statsHandler.getResponses1xx()).append("</responses1xx>\n");
-        sb.append("    <responses2xx>").append(_statsHandler.getResponses2xx()).append("</responses2xx>\n");
-        sb.append("    <responses3xx>").append(_statsHandler.getResponses3xx()).append("</responses3xx>\n");
-        sb.append("    <responses4xx>").append(_statsHandler.getResponses4xx()).append("</responses4xx>\n");
-        sb.append("    <responses5xx>").append(_statsHandler.getResponses5xx()).append("</responses5xx>\n");
-        sb.append("    <responsesBytesTotal>").append(_statsHandler.getResponsesBytesTotal()).append("</responsesBytesTotal>\n");
-        sb.append("  </responses>\n");
+        requests.put("errors", _statsHandler.getErrors());
 
-        sb.append("  <connections>\n");
-        for (Connector connector : _connectors)
+        top.put("requests", requests);
+
+        // responses
+        Map<String, Number> responses = new HashMap<>();
+        responses.put("responses1xx", _statsHandler.getResponses1xx());
+        responses.put("responses2xx", _statsHandler.getResponses2xx());
+        responses.put("responses3xx", _statsHandler.getResponses3xx());
+        responses.put("responses4xx", _statsHandler.getResponses4xx());
+        responses.put("responses5xx", _statsHandler.getResponses5xx());
+        responses.put("responsesBytesTotal", _statsHandler.getResponsesBytesTotal());
+        top.put("responses", responses);
+
+        // connections
+        List<Object> connections = new ArrayList<>();
+        _connectors.forEach((connector) ->
         {
-            sb.append("    <connector>\n");
-            sb.append("      <name>").append(connector.getClass().getName()).append("@").append(connector.hashCode()).append("</name>\n");
-            sb.append("      <protocols>\n");
-            for (String protocol : connector.getProtocols())
-            {
-                sb.append("      <protocol>").append(protocol).append("</protocol>\n");
-            }
-            sb.append("      </protocols>\n");
+            Map<String, Object> connectorDetail = new HashMap<>();
+            connectorDetail.put("name", String.format("%s@%X", connector.getClass().getName(), connector.hashCode()));
+            connectorDetail.put("protocols", connector.getProtocols());
 
             ConnectionStatistics connectionStats = null;
             if (connector instanceof AbstractConnector)
                 connectionStats = connector.getBean(ConnectionStatistics.class);
             if (connectionStats != null)
             {
-                sb.append("      <statsOn>true</statsOn>\n");
-                sb.append("      <connections>").append(connectionStats.getConnectionsTotal()).append("</connections>\n");
-                sb.append("      <connectionsOpen>").append(connectionStats.getConnections()).append("</connectionsOpen>\n");
-                sb.append("      <connectionsOpenMax>").append(connectionStats.getConnectionsMax()).append("</connectionsOpenMax>\n");
-                sb.append("      <connectionsDurationMean>").append(connectionStats.getConnectionDurationMean()).append("</connectionsDurationMean>\n");
-                sb.append("      <connectionsDurationMax>").append(connectionStats.getConnectionDurationMax()).append("</connectionsDurationMax>\n");
-                sb.append("      <connectionsDurationStdDev>").append(connectionStats.getConnectionDurationStdDev()).append("</connectionsDurationStdDev>\n");
-                sb.append("      <bytesIn>").append(connectionStats.getReceivedBytes()).append("</bytesIn>\n");
-                sb.append("      <bytesOut>").append(connectionStats.getSentBytes()).append("</bytesOut>\n");
-                sb.append("      <messagesIn>").append(connectionStats.getReceivedMessages()).append("</messagesIn>\n");
-                sb.append("      <messagesOut>").append(connectionStats.getSentMessages()).append("</messagesOut>\n");
+                connectorDetail.put("statsOn", true);
+                connectorDetail.put("connections", connectionStats.getConnectionsTotal());
+                connectorDetail.put("connectionsOpen>", connectionStats.getConnections());
+                connectorDetail.put("connectionsOpenMax", connectionStats.getConnectionsMax());
+                connectorDetail.put("connectionsDurationMean", connectionStats.getConnectionDurationMean());
+                connectorDetail.put("connectionsDurationMax", connectionStats.getConnectionDurationMax());
+                connectorDetail.put("connectionsDurationStdDev", connectionStats.getConnectionDurationStdDev());
+                connectorDetail.put("bytesIn", connectionStats.getReceivedBytes());
+                connectorDetail.put("bytesOut", connectionStats.getSentBytes());
+                connectorDetail.put("messagesIn", connectionStats.getReceivedMessages());
+                connectorDetail.put("messagesOut", connectionStats.getSentMessages());
             }
             else
             {
+                // Support for deprecated ConnectorStatistics (will be dropped in Jetty 10+)
                 ConnectorStatistics connectorStats = null;
                 if (connector instanceof AbstractConnector)
                     connectorStats = connector.getBean(ConnectorStatistics.class);
                 if (connectorStats != null)
                 {
-                    sb.append("      <statsOn>true</statsOn>\n");
-                    sb.append("      <connections>").append(connectorStats.getConnections()).append("</connections>\n");
-                    sb.append("      <connectionsOpen>").append(connectorStats.getConnectionsOpen()).append("</connectionsOpen>\n");
-                    sb.append("      <connectionsOpenMax>").append(connectorStats.getConnectionsOpenMax()).append("</connectionsOpenMax>\n");
-                    sb.append("      <connectionsDurationMean>").append(connectorStats.getConnectionDurationMean()).append("</connectionsDurationMean>\n");
-                    sb.append("      <connectionsDurationMax>").append(connectorStats.getConnectionDurationMax()).append("</connectionsDurationMax>\n");
-                    sb.append("      <connectionsDurationStdDev>").append(connectorStats.getConnectionDurationStdDev()).append("</connectionsDurationStdDev>\n");
-                    sb.append("      <messagesIn>").append(connectorStats.getMessagesIn()).append("</messagesIn>\n");
-                    sb.append("      <messagesOut>").append(connectorStats.getMessagesIn()).append("</messagesOut>\n");
-                    sb.append("      <elapsedMs>").append(connectorStats.getStartedMillis()).append("</elapsedMs>\n");
+                    connectorDetail.put("statsOn", true);
+                    connectorDetail.put("connections", connectorStats.getConnections());
+                    connectorDetail.put("connectionsOpen", connectorStats.getConnectionsOpen());
+                    connectorDetail.put("connectionsOpenMax", connectorStats.getConnectionsOpenMax());
+                    connectorDetail.put("connectionsDurationMean", connectorStats.getConnectionDurationMean());
+                    connectorDetail.put("connectionsDurationMax", connectorStats.getConnectionDurationMax());
+                    connectorDetail.put("connectionsDurationStdDev", connectorStats.getConnectionDurationStdDev());
+                    connectorDetail.put("messagesIn", connectorStats.getMessagesIn());
+                    connectorDetail.put("messagesOut", connectorStats.getMessagesIn());
+                    connectorDetail.put("elapsedMs", connectorStats.getStartedMillis());
                 }
                 else
                 {
-                    sb.append("      <statsOn>false</statsOn>\n");
+                    connectorDetail.put("statsOn", false);
                 }
             }
-            sb.append("    </connector>\n");
-        }
-        sb.append("  </connections>\n");
+            connections.add(connectorDetail);
+        });
+        top.put("connections", connections);
 
-        sb.append("  <memory>\n");
-        sb.append("    <heapMemoryUsage>").append(_memoryBean.getHeapMemoryUsage().getUsed()).append("</heapMemoryUsage>\n");
-        sb.append("    <nonHeapMemoryUsage>").append(_memoryBean.getNonHeapMemoryUsage().getUsed()).append("</nonHeapMemoryUsage>\n");
-        sb.append("  </memory>\n");
+        // memory
+        Map<String, Number> memoryMap = new HashMap<>();
+        memoryMap.put("heapMemoryUsage", _memoryBean.getHeapMemoryUsage().getUsed());
+        memoryMap.put("nonHeapMemoryUsage", _memoryBean.getNonHeapMemoryUsage().getUsed());
+        top.put("memory", memoryMap);
 
-        sb.append("</statistics>\n");
-
-        response.setContentType("text/xml");
-        PrintWriter pout = response.getWriter();
-        pout.write(sb.toString());
+        // the top level object
+        return outputProducer.generate("statistics", top);
     }
 
-    private void sendTextResponse(HttpServletResponse response) throws IOException
+    private interface OutputProducer
     {
-        StringBuilder sb = new StringBuilder();
-        sb.append(_statsHandler.toStatsHTML());
+        CharSequence generate(String id, Map<String, Object> map);
+    }
 
-        sb.append("<h2>Connections:</h2>\n");
-        for (Connector connector : _connectors)
+    private static class JsonProducer implements OutputProducer
+    {
+        @Override
+        public CharSequence generate(String id, Map<String, Object> map)
         {
-            sb.append("<h3>").append(connector.getClass().getName()).append("@").append(connector.hashCode()).append("</h3>");
-            sb.append("Protocols:");
-            for (String protocol : connector.getProtocols())
-            {
-                sb.append(protocol).append("&nbsp;");
-            }
-            sb.append("    <br />\n");
+            return JSON.toString(map);
+        }
+    }
 
-            ConnectionStatistics connectionStats = null;
-            if (connector instanceof Container)
-                connectionStats = connector.getBean(ConnectionStatistics.class);
-            if (connectionStats != null)
+    private static class XmlProducer implements OutputProducer
+    {
+        private final StringBuilder sb;
+        private int indent = 0;
+
+        public XmlProducer()
+        {
+            this.sb = new StringBuilder();
+        }
+
+        @Override
+        public CharSequence generate(String id, Map<String, Object> map)
+        {
+            add(id, map);
+            return sb;
+        }
+
+        private void indent()
+        {
+            sb.append("\n");
+            for (int i = 0; i < indent; i++)
             {
-                sb.append("Total connections: ").append(connectionStats.getConnectionsTotal()).append("<br />\n");
-                sb.append("Current connections open: ").append(connectionStats.getConnections()).append("<br />\n");
-                sb.append("Max concurrent connections open: ").append(connectionStats.getConnectionsMax()).append("<br />\n");
-                sb.append("Mean connection duration: ").append(connectionStats.getConnectionDurationMean()).append("<br />\n");
-                sb.append("Max connection duration: ").append(connectionStats.getConnectionDurationMax()).append("<br />\n");
-                sb.append("Connection duration standard deviation: ").append(connectionStats.getConnectionDurationStdDev()).append("<br />\n");
-                sb.append("Total bytes received: ").append(connectionStats.getReceivedBytes()).append("<br />\n");
-                sb.append("Total bytes sent: ").append(connectionStats.getSentBytes()).append("<br />\n");
-                sb.append("Total messages received: ").append(connectionStats.getReceivedMessages()).append("<br />\n");
-                sb.append("Total messages sent: ").append(connectionStats.getSentMessages()).append("<br />\n");
-            }
-            else
-            {
-                ConnectorStatistics connectorStats = null;
-                if (connector instanceof AbstractConnector)
-                    connectorStats = connector.getBean(ConnectorStatistics.class);
-                if (connectorStats != null)
-                {
-                    sb.append("Statistics gathering started ").append(connectorStats.getStartedMillis()).append("ms ago").append("<br />\n");
-                    sb.append("Total connections: ").append(connectorStats.getConnections()).append("<br />\n");
-                    sb.append("Current connections open: ").append(connectorStats.getConnectionsOpen()).append("<br />\n");
-                    sb.append("Max concurrent connections open: ").append(connectorStats.getConnectionsOpenMax()).append("<br />\n");
-                    sb.append("Mean connection duration: ").append(connectorStats.getConnectionDurationMean()).append("<br />\n");
-                    sb.append("Max connection duration: ").append(connectorStats.getConnectionDurationMax()).append("<br />\n");
-                    sb.append("Connection duration standard deviation: ").append(connectorStats.getConnectionDurationStdDev()).append("<br />\n");
-                    sb.append("Total messages in: ").append(connectorStats.getMessagesIn()).append("<br />\n");
-                    sb.append("Total messages out: ").append(connectorStats.getMessagesOut()).append("<br />\n");
-                }
-                else
-                {
-                    sb.append("Statistics gathering off.\n");
-                }
+                sb.append(' ').append(' ');
             }
         }
 
-        sb.append("<h2>Memory:</h2>\n");
-        sb.append("Heap memory usage: ").append(_memoryBean.getHeapMemoryUsage().getUsed()).append(" bytes").append("<br />\n");
-        sb.append("Non-heap memory usage: ").append(_memoryBean.getNonHeapMemoryUsage().getUsed()).append(" bytes").append("<br />\n");
+        private void add(String id, Object obj)
+        {
+            sb.append('<').append(StringUtil.sanitizeXmlString(id)).append('>');
+            indent++;
 
-        response.setContentType("text/html");
-        PrintWriter pout = response.getWriter();
-        pout.write(sb.toString());
+            boolean wasIndented = false;
+
+            if (obj instanceof Map)
+            {
+                //noinspection unchecked
+                addMap((Map<String, ?>)obj);
+                wasIndented = true;
+            }
+            else if (obj instanceof List)
+            {
+                addList(id, (List<?>)obj);
+                wasIndented = true;
+            }
+            else
+            {
+                addObject(obj);
+            }
+
+            indent--;
+            if (wasIndented)
+                indent();
+            sb.append("</").append(id).append('>');
+        }
+
+        private void addMap(Map<String, ?> map)
+        {
+            map.keySet().stream().sorted()
+                .forEach((key) ->
+                {
+                    indent();
+                    add(key, map.get(key));
+                });
+        }
+
+        private void addList(String parentId, List<?> list)
+        {
+            // drop the 's' at the end.
+            String childName = parentId.replaceFirst("s$", "");
+            list.forEach((entry) ->
+            {
+                indent();
+                add(childName, entry);
+            });
+        }
+
+        private void addObject(Object obj)
+        {
+            sb.append(StringUtil.sanitizeXmlString(Objects.toString(obj)));
+        }
+    }
+
+    private static class TextProducer implements OutputProducer
+    {
+        private final StringBuilder sb;
+        private int indent = 0;
+
+        public TextProducer()
+        {
+            this.sb = new StringBuilder();
+        }
+
+        @Override
+        public CharSequence generate(String id, Map<String, Object> map)
+        {
+            add(id, map);
+            return sb;
+        }
+
+        private void indent()
+        {
+            for (int i = 0; i < indent; i++)
+            {
+                sb.append(' ').append(' ');
+            }
+        }
+
+        private void add(String id, Object obj)
+        {
+            indent();
+            sb.append(id).append(": ");
+            indent++;
+
+            if (obj instanceof Map)
+            {
+                sb.append('\n');
+                //noinspection unchecked
+                addMap((Map<String, ?>)obj);
+            }
+            else if (obj instanceof List)
+            {
+                sb.append('\n');
+                addList(id, (List<?>)obj);
+            }
+            else
+            {
+                addObject(obj);
+                sb.append('\n');
+            }
+
+            indent--;
+        }
+
+        private void addMap(Map<String, ?> map)
+        {
+            map.keySet().stream().sorted()
+                .forEach((key) -> add(key, map.get(key)));
+        }
+
+        private void addList(String parentId, List<?> list)
+        {
+            // drop the 's' at the end.
+            String childName = parentId.replaceFirst("s$", "");
+            list.forEach((entry) -> add(childName, entry));
+        }
+
+        private void addObject(Object obj)
+        {
+            sb.append(obj);
+        }
+    }
+
+    private static class HtmlProducer implements OutputProducer
+    {
+        private final StringBuilder sb;
+        private int indent = 0;
+
+        public HtmlProducer()
+        {
+            this.sb = new StringBuilder();
+        }
+
+        @Override
+        public CharSequence generate(String id, Map<String, Object> map)
+        {
+            sb.append("<ul>\n");
+            add(id, map);
+            sb.append("</ul>\n");
+            return sb;
+        }
+
+        private void indent()
+        {
+            for (int i = 0; i < indent; i++)
+            {
+                sb.append(' ').append(' ');
+            }
+        }
+
+        private void add(String id, Object obj)
+        {
+            indent();
+            indent++;
+            sb.append("<li><em>").append(StringUtil.sanitizeXmlString(id)).append("</em>: ");
+            if (obj instanceof Map)
+            {
+                //noinspection unchecked
+                addMap((Map<String, ?>)obj);
+                indent();
+            }
+            else if (obj instanceof List)
+            {
+                addList(id, (List<?>)obj);
+                indent();
+            }
+            else
+            {
+                addObject(obj);
+            }
+            sb.append("</li>\n");
+
+            indent--;
+        }
+
+        private void addMap(Map<String, ?> map)
+        {
+            sb.append("\n");
+            indent();
+            sb.append("<ul>\n");
+            indent++;
+            map.keySet().stream().sorted(String::compareToIgnoreCase)
+                .forEach((key) -> add(key, map.get(key)));
+            indent--;
+            indent();
+            sb.append("</ul>\n");
+        }
+
+        private void addList(String parentId, List<?> list)
+        {
+            sb.append("\n");
+            indent();
+            sb.append("<ul>\n");
+            indent++;
+            // drop the 's' at the end.
+            String childName = parentId.replaceFirst("s$", "");
+            list.forEach((entry) -> add(childName, entry));
+            indent--;
+            indent();
+            sb.append("</ul>\n");
+        }
+
+        private void addObject(Object obj)
+        {
+            sb.append(StringUtil.sanitizeXmlString(Objects.toString(obj)));
+        }
     }
 }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -118,6 +118,11 @@ public class StatisticsServlet extends HttpServlet
             return;
         }
 
+        if (request.getParameter("xml") != null)
+        {
+            LOG.warn("'xml' parameter is deprecated, use 'Accept' request header instead");
+        }
+
         List<String> acceptable = getOrderedAcceptableMimeTypes(request);
 
         for (String mimeType : acceptable)
@@ -134,21 +139,8 @@ public class StatisticsServlet extends HttpServlet
                     writeHtmlResponse(response);
                     return;
                 case "text/plain":
-                    writeTextResponse(response);
-                    return;
                 case "*/*":
-                    String wantXml = request.getParameter("xml");
-                    if (wantXml == null)
-                        wantXml = request.getParameter("XML");
-
-                    if (Boolean.parseBoolean(wantXml))
-                    {
-                        writeXmlResponse(response);
-                    }
-                    else
-                    {
-                        writeTextResponse(response);
-                    }
+                    writeTextResponse(response);
                     return;
                 default:
                     if (LOG.isDebugEnabled())

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/StatisticsServlet.java
@@ -319,7 +319,7 @@ public class StatisticsServlet extends HttpServlet
             {
                 connectorDetail.put("statsOn", true);
                 connectorDetail.put("connections", connectionStats.getConnectionsTotal());
-                connectorDetail.put("connectionsOpen>", connectionStats.getConnections());
+                connectorDetail.put("connectionsOpen", connectionStats.getConnections());
                 connectorDetail.put("connectionsOpenMax", connectionStats.getConnectionsMax());
                 connectorDetail.put("connectionsDurationMean", connectionStats.getConnectionDurationMean());
                 connectorDetail.put("connectionsDurationMax", connectionStats.getConnectionDurationMax());

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/StatisticsServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/StatisticsServletTest.java
@@ -90,7 +90,7 @@ public class StatisticsServletTest
     }
 
     @Test
-    public void getStats()
+    public void testGetStats()
         throws Exception
     {
         addStatisticsHandler();
@@ -103,7 +103,7 @@ public class StatisticsServletTest
         assertEquals(response.getStatus(), 200);
 
         // Look for 200 response that was tracked
-        response = getResponse("/stats?xml=true");
+        response = getResponse("/stats");
         assertEquals(response.getStatus(), 200);
         Stats stats = parseStats(response.getContent());
 
@@ -114,7 +114,7 @@ public class StatisticsServletTest
         assertEquals(response.getStatus(), 200);
 
         // Request stats again
-        response = getResponse("/stats?xml=true");
+        response = getResponse("/stats");
         assertEquals(response.getStatus(), 200);
         stats = parseStats(response.getContent());
 
@@ -128,7 +128,7 @@ public class StatisticsServletTest
         assertEquals(response.getStatus(), 404);
 
         // Request stats again
-        response = getResponse("/stats?xml=true");
+        response = getResponse("/stats");
         assertEquals(response.getStatus(), 200);
         stats = parseStats(response.getContent());
 
@@ -142,7 +142,7 @@ public class StatisticsServletTest
     }
 
     @Test
-    public void getXmlResponse()
+    public void testGetXmlResponse()
         throws Exception
     {
         addStatisticsHandler();
@@ -166,6 +166,7 @@ public class StatisticsServletTest
 
         // Parse it, make sure it's well formed.
         DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+        docBuilderFactory.setValidating(false);
         DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
         try (ByteArrayInputStream input = new ByteArrayInputStream(response.getContentBytes()))
         {
@@ -176,7 +177,7 @@ public class StatisticsServletTest
     }
 
     @Test
-    public void getJsonResponse()
+    public void testGetJsonResponse()
         throws Exception
     {
         addStatisticsHandler();
@@ -213,7 +214,7 @@ public class StatisticsServletTest
     }
 
     @Test
-    public void getTextResponse()
+    public void testGetTextResponse()
         throws Exception
     {
         addStatisticsHandler();
@@ -243,7 +244,7 @@ public class StatisticsServletTest
     }
 
     @Test
-    public void getHtmlResponse()
+    public void testGetHtmlResponse()
         throws Exception
     {
         addStatisticsHandler();
@@ -263,7 +264,7 @@ public class StatisticsServletTest
 
         assertThat("Response.contentType", response.get(HttpHeader.CONTENT_TYPE), containsString("text/html"));
 
-        System.out.println(response.getContent());
+        // System.out.println(response.getContent());
 
         // Look for things that indicate it's a well formed HTML output
         assertThat(response.getContent(), containsString("<html>"));
@@ -281,6 +282,7 @@ public class StatisticsServletTest
     {
         HttpTester.Request request = new HttpTester.Request();
         request.setMethod("GET");
+        request.setHeader("Accept", "text/xml");
         request.setURI(path);
         request.setVersion(HttpVersion.HTTP_1_1);
         request.setHeader("Host", "test");

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/StatisticsServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/StatisticsServletTest.java
@@ -18,31 +18,42 @@
 
 package org.eclipse.jetty.servlet;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.ajax.JSON;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class StatisticsServletTest
 {
@@ -66,9 +77,7 @@ public class StatisticsServletTest
         _server.join();
     }
 
-    @Test
-    public void getStats()
-        throws Exception
+    private void addStatisticsHandler()
     {
         StatisticsHandler statsHandler = new StatisticsHandler();
         _server.setHandler(statsHandler);
@@ -78,30 +87,196 @@ public class StatisticsServletTest
         servletHolder.setInitParameter("restrictToLocalhost", "false");
         statsContext.addServlet(servletHolder, "/stats");
         statsContext.setSessionHandler(new SessionHandler());
+    }
+
+    @Test
+    public void getStats()
+        throws Exception
+    {
+        addStatisticsHandler();
         _server.start();
 
-        getResponse("/test1");
-        String response = getResponse("/stats?xml=true");
-        Stats stats = parseStats(response);
+        HttpTester.Response response;
+
+        // Trigger 2xx response
+        response = getResponse("/test1");
+        assertEquals(response.getStatus(), 200);
+
+        // Look for 200 response that was tracked
+        response = getResponse("/stats?xml=true");
+        assertEquals(response.getStatus(), 200);
+        Stats stats = parseStats(response.getContent());
 
         assertEquals(1, stats.responses2xx);
 
-        getResponse("/stats?statsReset=true");
+        // Reset stats
+        response = getResponse("/stats?statsReset=true");
+        assertEquals(response.getStatus(), 200);
+
+        // Request stats again
         response = getResponse("/stats?xml=true");
-        stats = parseStats(response);
+        assertEquals(response.getStatus(), 200);
+        stats = parseStats(response.getContent());
 
         assertEquals(1, stats.responses2xx);
 
-        getResponse("/test1");
-        getResponse("/nothing");
-        response = getResponse("/stats?xml=true");
-        stats = parseStats(response);
+        // Trigger 2xx response
+        response = getResponse("/test1");
+        assertEquals(response.getStatus(), 200);
+        // Trigger 4xx response
+        response = getResponse("/nothing");
+        assertEquals(response.getStatus(), 404);
 
+        // Request stats again
+        response = getResponse("/stats?xml=true");
+        assertEquals(response.getStatus(), 200);
+        stats = parseStats(response.getContent());
+
+        // Verify we see (from last reset)
+        // 1) request for /stats?statsReset=true [2xx]
+        // 2) request for /stats?xml=true [2xx]
+        // 3) request for /test1 [2xx]
+        // 4) request for /nothing [4xx]
         assertThat("2XX Response Count" + response, stats.responses2xx, is(3));
         assertThat("4XX Response Count" + response, stats.responses4xx, is(1));
     }
 
-    public String getResponse(String path)
+    @Test
+    public void getXmlResponse()
+        throws Exception
+    {
+        addStatisticsHandler();
+        _server.start();
+
+        HttpTester.Response response;
+        HttpTester.Request request = new HttpTester.Request();
+
+        request.setMethod("GET");
+        request.setURI("/stats");
+        request.setHeader("Accept", "text/xml");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+
+        ByteBuffer responseBuffer = _connector.getResponse(request.generate());
+        response = HttpTester.parseResponse(responseBuffer);
+
+        assertThat("Response.contentType", response.get(HttpHeader.CONTENT_TYPE), containsString("text/xml"));
+
+        // System.out.println(response.getContent());
+
+        // Parse it, make sure it's well formed.
+        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+        try (ByteArrayInputStream input = new ByteArrayInputStream(response.getContentBytes()))
+        {
+            Document doc = docBuilder.parse(input);
+            assertNotNull(doc);
+            assertEquals("statistics", doc.getDocumentElement().getNodeName());
+        }
+    }
+
+    @Test
+    public void getJsonResponse()
+        throws Exception
+    {
+        addStatisticsHandler();
+        _server.start();
+
+        HttpTester.Response response;
+        HttpTester.Request request = new HttpTester.Request();
+
+        request.setMethod("GET");
+        request.setURI("/stats");
+        request.setHeader("Accept", "application/json");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+
+        ByteBuffer responseBuffer = _connector.getResponse(request.generate());
+        response = HttpTester.parseResponse(responseBuffer);
+
+        assertThat("Response.contentType", response.get(HttpHeader.CONTENT_TYPE), is("application/json"));
+        assertThat("Response.contentType for json should never contain a charset",
+            response.get(HttpHeader.CONTENT_TYPE), not(containsString("charset")));
+
+        // System.out.println(response.getContent());
+
+        // Parse it, make sure it's well formed.
+        Object doc = JSON.parse(response.getContent());
+        assertNotNull(doc);
+        assertThat(doc, instanceOf(Map.class));
+        Map<?, ?> docMap = (Map<?, ?>)doc;
+        assertEquals(4, docMap.size());
+        assertNotNull(docMap.get("requests"));
+        assertNotNull(docMap.get("responses"));
+        assertNotNull(docMap.get("connections"));
+        assertNotNull(docMap.get("memory"));
+    }
+
+    @Test
+    public void getTextResponse()
+        throws Exception
+    {
+        addStatisticsHandler();
+        _server.start();
+
+        HttpTester.Response response;
+        HttpTester.Request request = new HttpTester.Request();
+
+        request.setMethod("GET");
+        request.setURI("/stats");
+        request.setHeader("Accept", "text/plain");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+
+        ByteBuffer responseBuffer = _connector.getResponse(request.generate());
+        response = HttpTester.parseResponse(responseBuffer);
+
+        assertThat("Response.contentType", response.get(HttpHeader.CONTENT_TYPE), containsString("text/plain"));
+
+        // System.out.println(response.getContent());
+
+        // Look for expected content
+        assertThat(response.getContent(), containsString("requests: "));
+        assertThat(response.getContent(), containsString("responses: "));
+        assertThat(response.getContent(), containsString("connections: "));
+        assertThat(response.getContent(), containsString("memory: "));
+    }
+
+    @Test
+    public void getHtmlResponse()
+        throws Exception
+    {
+        addStatisticsHandler();
+        _server.start();
+
+        HttpTester.Response response;
+        HttpTester.Request request = new HttpTester.Request();
+
+        request.setMethod("GET");
+        request.setURI("/stats");
+        request.setHeader("Accept", "text/html");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+
+        ByteBuffer responseBuffer = _connector.getResponse(request.generate());
+        response = HttpTester.parseResponse(responseBuffer);
+
+        assertThat("Response.contentType", response.get(HttpHeader.CONTENT_TYPE), containsString("text/html"));
+
+        System.out.println(response.getContent());
+
+        // Look for things that indicate it's a well formed HTML output
+        assertThat(response.getContent(), containsString("<html>"));
+        assertThat(response.getContent(), containsString("<body>"));
+        assertThat(response.getContent(), containsString("<em>requests</em>: "));
+        assertThat(response.getContent(), containsString("<em>responses</em>: "));
+        assertThat(response.getContent(), containsString("<em>connections</em>: "));
+        assertThat(response.getContent(), containsString("<em>memory</em>: "));
+        assertThat(response.getContent(), containsString("</body>"));
+        assertThat(response.getContent(), containsString("</html>"));
+    }
+
+    public HttpTester.Response getResponse(String path)
         throws Exception
     {
         HttpTester.Request request = new HttpTester.Request();
@@ -111,7 +286,7 @@ public class StatisticsServletTest
         request.setHeader("Host", "test");
 
         ByteBuffer responseBuffer = _connector.getResponse(request.generate());
-        return HttpTester.parseResponse(responseBuffer).getContent();
+        return HttpTester.parseResponse(responseBuffer);
     }
 
     public Stats parseStats(String xml)
@@ -120,7 +295,6 @@ public class StatisticsServletTest
         XPath xPath = XPathFactory.newInstance().newXPath();
 
         String responses4xx = xPath.evaluate("//responses4xx", new InputSource(new StringReader(xml)));
-
         String responses2xx = xPath.evaluate("//responses2xx", new InputSource(new StringReader(xml)));
 
         return new Stats(Integer.parseInt(responses2xx), Integer.parseInt(responses4xx));

--- a/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebInfConfigurationTest.java
+++ b/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebInfConfigurationTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.webapp;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.toolchain.test.FS;
@@ -72,7 +73,7 @@ public class WebInfConfigurationTest
         context.setClassLoader(loader);
         config.findAndFilterContainerPaths(context);
         List<Resource> containerResources = context.getMetaData().getContainerResources();
-        assertEquals(1, containerResources.size());
+        assertEquals(1, containerResources.size(), () -> containerResources.stream().map(Resource::toString).collect(Collectors.joining(",", "[", "]")));
         assertThat(containerResources.get(0).toString(), containsString("jetty-util"));
     }
 
@@ -93,7 +94,7 @@ public class WebInfConfigurationTest
         context.setClassLoader(loader);
         config.findAndFilterContainerPaths(context);
         List<Resource> containerResources = context.getMetaData().getContainerResources();
-        assertEquals(2, containerResources.size());
+        assertEquals(2, containerResources.size(), () -> containerResources.stream().map(Resource::toString).collect(Collectors.joining(",", "[", "]")));
         for (Resource r : containerResources)
         {
             String s = r.toString();
@@ -121,7 +122,7 @@ public class WebInfConfigurationTest
         context.setClassLoader(loader);
         config.findAndFilterContainerPaths(context);
         List<Resource> containerResources = context.getMetaData().getContainerResources();
-        assertEquals(1, containerResources.size());
+        assertEquals(1, containerResources.size(), () -> containerResources.stream().map(Resource::toString).collect(Collectors.joining(",", "[", "]")));
         assertThat(containerResources.get(0).toString(), containsString("jetty-util"));
     }
 

--- a/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebInfConfigurationTest.java
+++ b/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/WebInfConfigurationTest.java
@@ -67,7 +67,7 @@ public class WebInfConfigurationTest
     {
         WebInfConfiguration config = new WebInfConfiguration();
         WebAppContext context = new WebAppContext();
-        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[^/]*\\.jar$|.*/jetty-util/target/classes/");
+        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[0-9][^/]*\\.jar$|.*/jetty-util/target/classes/");
 
         WebAppClassLoader loader = new WebAppClassLoader(context);
         context.setClassLoader(loader);
@@ -89,7 +89,7 @@ public class WebInfConfigurationTest
     {
         WebInfConfiguration config = new WebInfConfiguration();
         WebAppContext context = new WebAppContext();
-        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[^/]*\\.jar$|.*/jetty-util/target/classes/$|.*/foo-bar-janb.jar");
+        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[0-9][^/]*\\.jar$|.*/jetty-util/target/classes/$|.*/foo-bar-janb.jar");
         WebAppClassLoader loader = new WebAppClassLoader(context);
         context.setClassLoader(loader);
         config.findAndFilterContainerPaths(context);
@@ -117,7 +117,7 @@ public class WebInfConfigurationTest
         WebInfConfiguration config = new WebInfConfiguration();
         WebAppContext context = new WebAppContext();
         context.setAttribute(JavaVersion.JAVA_TARGET_PLATFORM, "8");
-        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[^/]*\\.jar$|.*/jetty-util/target/classes/$|.*/foo-bar-janb.jar");
+        context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN, ".*/jetty-util-[0-9][^/]*\\.jar$|.*/jetty-util/target/classes/$|.*/foo-bar-janb.jar");
         WebAppClassLoader loader = new WebAppClassLoader(context);
         context.setClassLoader(loader);
         config.findAndFilterContainerPaths(context);

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -124,6 +124,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util-ajax</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>
       <version>${project.version}</version>

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/StatsTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/StatsTests.java
@@ -1,0 +1,170 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.tests.distribution;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StatsTests extends AbstractDistributionTest
+{
+    @Test
+    public void testStatsServlet() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        DistributionTester distribution = DistributionTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        String[] args1 = {
+            "--create-startd",
+            "--approve-all-licenses",
+            "--add-to-start=resources,server,http,webapp,deploy,stats"
+        };
+        try (DistributionTester.Run run1 = distribution.start(args1))
+        {
+            assertTrue(run1.awaitFor(5, TimeUnit.SECONDS));
+            assertEquals(0, run1.getExitValue());
+
+            Path webappsDir = distribution.getJettyBase().resolve("webapps");
+            FS.ensureDirExists(webappsDir.resolve("demo"));
+            FS.ensureDirExists(webappsDir.resolve("demo/WEB-INF"));
+
+            distribution.installBaseResource("stats-webapp/index.html", "webapps/demo/index.html");
+            distribution.installBaseResource("stats-webapp/WEB-INF/web.xml", "webapps/demo/WEB-INF/web.xml");
+
+            int port = distribution.freePort();
+            String[] args2 = {
+                "jetty.http.port=" + port
+            };
+            try (DistributionTester.Run run2 = distribution.start(args2))
+            {
+                assertTrue(run2.awaitConsoleLogsFor("Started @", 10, TimeUnit.SECONDS));
+
+                startHttpClient();
+
+                ContentResponse response;
+                URI serverBaseURI = URI.create("http://localhost:" + port);
+
+                response = client.GET(serverBaseURI.resolve("/demo/index.html"));
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertThat(response.getContentAsString(), containsString("<h1>Stats Demo</h1>"));
+
+                // ---------------
+                // Test XML accept
+                response = client.newRequest(serverBaseURI.resolve("/demo/stats"))
+                    .method(HttpMethod.GET)
+                    .header(HttpHeader.ACCEPT, "text/xml")
+                    .send();
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+
+                assertThat("Response.contentType", response.getHeaders().get(HttpHeader.CONTENT_TYPE), containsString("text/xml"));
+
+                // Parse it, make sure it's well formed.
+                DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+                docBuilderFactory.setValidating(false);
+                DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+                try (ByteArrayInputStream input = new ByteArrayInputStream(response.getContent()))
+                {
+                    Document doc = docBuilder.parse(input);
+                    assertNotNull(doc);
+                    assertEquals("statistics", doc.getDocumentElement().getNodeName());
+                }
+
+                // ---------------
+                // Test JSON accept
+                response = client.newRequest(serverBaseURI.resolve("/demo/stats"))
+                    .method(HttpMethod.GET)
+                    .header(HttpHeader.ACCEPT, "application/json")
+                    .send();
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+
+                assertThat("Response.contentType", response.getHeaders().get(HttpHeader.CONTENT_TYPE), containsString("application/json"));
+
+                Object doc = JSON.parse(response.getContentAsString());
+                assertNotNull(doc);
+                assertThat(doc, instanceOf(Map.class));
+                Map<?, ?> docMap = (Map<?, ?>)doc;
+                assertEquals(4, docMap.size());
+                assertNotNull(docMap.get("requests"));
+                assertNotNull(docMap.get("responses"));
+                assertNotNull(docMap.get("connections"));
+                assertNotNull(docMap.get("memory"));
+
+                // ---------------
+                // Test TEXT accept
+                response = client.newRequest(serverBaseURI.resolve("/demo/stats"))
+                    .method(HttpMethod.GET)
+                    .header(HttpHeader.ACCEPT, "text/plain")
+                    .send();
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+
+                assertThat("Response.contentType", response.getHeaders().get(HttpHeader.CONTENT_TYPE), containsString("text/plain"));
+
+                String textContent = response.getContentAsString();
+                assertThat(textContent, containsString("requests: "));
+                assertThat(textContent, containsString("responses: "));
+                assertThat(textContent, containsString("connections: "));
+                assertThat(textContent, containsString("memory: "));
+
+                // ---------------
+                // Test HTML accept
+                response = client.newRequest(serverBaseURI.resolve("/demo/stats"))
+                    .method(HttpMethod.GET)
+                    .header(HttpHeader.ACCEPT, "text/html")
+                    .send();
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+
+                assertThat("Response.contentType", response.getHeaders().get(HttpHeader.CONTENT_TYPE), containsString("text/html"));
+
+                String htmlContent = response.getContentAsString();
+                // Look for things that indicate it's a well formed HTML output
+                assertThat(htmlContent, containsString("<html>"));
+                assertThat(htmlContent, containsString("<body>"));
+                assertThat(htmlContent, containsString("<em>requests</em>: "));
+                assertThat(htmlContent, containsString("<em>responses</em>: "));
+                assertThat(htmlContent, containsString("<em>connections</em>: "));
+                assertThat(htmlContent, containsString("<em>memory</em>: "));
+                assertThat(htmlContent, containsString("</body>"));
+                assertThat(htmlContent, containsString("</html>"));
+            }
+        }
+    }
+}

--- a/tests/test-distribution/src/test/resources/stats-webapp/WEB-INF/web.xml
+++ b/tests/test-distribution/src/test/resources/stats-webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+  version="3.1">
+  <display-name>stats-demo</display-name>
+  <servlet>
+    <servlet-name>Stats</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlet.StatisticsServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>Stats</servlet-name>
+    <url-pattern>/stats</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/tests/test-distribution/src/test/resources/stats-webapp/index.html
+++ b/tests/test-distribution/src/test/resources/stats-webapp/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>stats-demo</title>
+</head>
+<body>
+<h1>Stats Demo</h1>
+</body>
+</html>


### PR DESCRIPTION
StatisticsServer can now present it's information in (text, html, json, and xml).

Selected via normal HTTP content negotiation.

Example output (expand to see details)

<details>
<summary>$ curl -H "Accept: text/xml" http://localhost:9090/stats</summary>

``` xml
<statistics>
  <connections>
    <connection>
      <name>org.eclipse.jetty.server.ServerConnector@4A87761D</name>
      <protocols>
        <protocol>http/1.1</protocol>
      </protocols>
      <statsOn>false</statsOn>
    </connection>
  </connections>
  <memory>
    <heapMemoryUsage>359372240</heapMemoryUsage>
    <nonHeapMemoryUsage>22923928</nonHeapMemoryUsage>
  </memory>
  <requests>
    <asyncRequests>0</asyncRequests>
    <dispatched>8</dispatched>
    <dispatchedActive>1</dispatchedActive>
    <dispatchedActiveMax>1</dispatchedActiveMax>
    <dispatchedTimeMax>12</dispatchedTimeMax>
    <dispatchedTimeMean>3.857142857142857</dispatchedTimeMean>
    <dispatchedTimeStdDev>3.0613177990314346</dispatchedTimeStdDev>
    <dispatchedTimeTotal>27</dispatchedTimeTotal>
    <errors>0</errors>
    <requests>8</requests>
    <requestsActive>1</requestsActive>
    <requestsActiveMax>1</requestsActiveMax>
    <requestsExpired>0</requestsExpired>
    <requestsResumed>0</requestsResumed>
    <requestsSuspended>0</requestsSuspended>
    <requestsSuspendedMax>0</requestsSuspendedMax>
    <requestsTimeMax>12</requestsTimeMax>
    <requestsTimeMean>3.857142857142857</requestsTimeMean>
    <requestsTimeStdDev>3.0613177990314346</requestsTimeStdDev>
    <requestsTimeTotal>27</requestsTimeTotal>
    <statsOnMs>132823</statsOnMs>
  </requests>
  <responses>
    <responses1xx>0</responses1xx>
    <responses2xx>6</responses2xx>
    <responses3xx>0</responses3xx>
    <responses4xx>1</responses4xx>
    <responses5xx>0</responses5xx>
    <responsesBytesTotal>6996</responsesBytesTotal>
  </responses>
</statistics>
```

</details>

<details>
<summary>$ curl -H "Accept: application/json" http://localhost:9090/stats | json_pp </summary>

``` json
{
   "requests" : {
      "dispatchedActive" : 1,
      "requestsActiveMax" : 1,
      "requestsTimeStdDev" : 3.11094840844396,
      "statsOnMs" : 97118,
      "errors" : 0,
      "requestsActive" : 1,
      "requestsExpired" : 0,
      "dispatchedTimeTotal" : 26,
      "asyncRequests" : 0,
      "dispatchedTimeMax" : 12,
      "requestsSuspendedMax" : 0,
      "requestsTimeTotal" : 26,
      "requestsTimeMax" : 12,
      "requestsSuspended" : 0,
      "requestsTimeMean" : 4.33333333333333,
      "dispatchedTimeStdDev" : 3.11094840844396,
      "dispatchedTimeMean" : 4.33333333333333,
      "dispatched" : 7,
      "requests" : 7,
      "dispatchedActiveMax" : 1,
      "requestsResumed" : 0
   },
   "memory" : {
      "heapMemoryUsage" : 359372240,
      "nonHeapMemoryUsage" : 22911656
   },
   "responses" : {
      "responses3xx" : 0,
      "responses4xx" : 1,
      "responses2xx" : 5,
      "responses1xx" : 0,
      "responsesBytesTotal" : 6171,
      "responses5xx" : 0
   },
   "connections" : [
      {
         "protocols" : [
            "http/1.1"
         ],
         "statsOn" : false,
         "name" : "org.eclipse.jetty.server.ServerConnector@4A87761D"
      }
   ]
}
```

</details>

<details>
<summary>$ curl -H "Accept: text/plain" http://localhost:9090/stats</summary>

``` none
statistics: 
  connections: 
    connection: 
      name: org.eclipse.jetty.server.ServerConnector@4A87761D
      protocols: 
        protocol: http/1.1
      statsOn: false
  memory: 
    heapMemoryUsage: 369941880
    nonHeapMemoryUsage: 22951424
  requests: 
    asyncRequests: 0
    dispatched: 9
    dispatchedActive: 1
    dispatchedActiveMax: 1
    dispatchedTimeMax: 12
    dispatchedTimeMean: 3.625
    dispatchedTimeStdDev: 2.8980288867731163
    dispatchedTimeTotal: 29
    errors: 0
    requests: 9
    requestsActive: 1
    requestsActiveMax: 1
    requestsExpired: 0
    requestsResumed: 0
    requestsSuspended: 0
    requestsSuspendedMax: 0
    requestsTimeMax: 12
    requestsTimeMean: 3.625
    requestsTimeStdDev: 2.8980288867731163
    requestsTimeTotal: 29
    statsOnMs: 147503
  responses: 
    responses1xx: 0
    responses2xx: 7
    responses3xx: 0
    responses4xx: 1
    responses5xx: 0
    responsesBytesTotal: 8618
```

</details>

<details>
<summary>$ curl -H "Accept: text/html" http://localhost:9090/stats</summary>

``` html
<html><head><title>StatisticsServlet</title></head><body>
<ul>
<li><em>statistics</em>: 
  <ul>
    <li><em>connections</em>: 
      <ul>
        <li><em>connection</em>: 
          <ul>
            <li><em>name</em>: org.eclipse.jetty.server.ServerConnector@4A87761D</li>
            <li><em>protocols</em>: 
              <ul>
                <li><em>protocol</em>: http/1.1</li>
              </ul>
              </li>
            <li><em>statsOn</em>: false</li>
          </ul>
          </li>
      </ul>
      </li>
    <li><em>memory</em>: 
      <ul>
        <li><em>heapMemoryUsage</em>: 369941880</li>
        <li><em>nonHeapMemoryUsage</em>: 22965800</li>
      </ul>
      </li>
    <li><em>requests</em>: 
      <ul>
        <li><em>asyncRequests</em>: 0</li>
        <li><em>dispatched</em>: 10</li>
        <li><em>dispatchedActive</em>: 1</li>
        <li><em>dispatchedActiveMax</em>: 1</li>
        <li><em>dispatchedTimeMax</em>: 12</li>
        <li><em>dispatchedTimeMean</em>: 3.4444444444444446</li>
        <li><em>dispatchedTimeStdDev</em>: 2.7556759606310752</li>
        <li><em>dispatchedTimeTotal</em>: 31</li>
        <li><em>errors</em>: 0</li>
        <li><em>requests</em>: 10</li>
        <li><em>requestsActive</em>: 1</li>
        <li><em>requestsActiveMax</em>: 1</li>
        <li><em>requestsExpired</em>: 0</li>
        <li><em>requestsResumed</em>: 0</li>
        <li><em>requestsSuspended</em>: 0</li>
        <li><em>requestsSuspendedMax</em>: 0</li>
        <li><em>requestsTimeMax</em>: 12</li>
        <li><em>requestsTimeMean</em>: 3.4444444444444446</li>
        <li><em>requestsTimeStdDev</em>: 2.7556759606310752</li>
        <li><em>requestsTimeTotal</em>: 31</li>
        <li><em>statsOnMs</em>: 163911</li>
      </ul>
      </li>
    <li><em>responses</em>: 
      <ul>
        <li><em>responses1xx</em>: 0</li>
        <li><em>responses2xx</em>: 8</li>
        <li><em>responses3xx</em>: 0</li>
        <li><em>responses4xx</em>: 1</li>
        <li><em>responses5xx</em>: 0</li>
        <li><em>responsesBytesTotal</em>: 9562</li>
      </ul>
      </li>
  </ul>
  </li>
</ul>

</body></html>
```

</details>

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>