### PR TITLE
Bump maven-antrun-plugin from 1.8 to 3.0.0

### DIFF
--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -264,11 +264,11 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy todir="${assembly-directory}">
                   <fileset dir="${home-directory}/jetty-home-${project.version}/" />
                 </copy>
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -278,9 +278,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <chmod dir="${assembly-directory}/bin" perm="755" includes="**/*.sh" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -290,9 +290,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <delete file="${assembly-directory}/etc/keystore" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -113,10 +113,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):.*$" replace="maven://\1/\2/\3|lib/gcloud/\2-\3.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match="The following files have been resolved:" replace="[files]" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -126,12 +126,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/gcloud-datastore.mod">
                   <fileset file="src/main/config-template/modules/gcloud-datastore.mod" />
                   <fileset file="${project.build.directory}/deps.txt" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -488,9 +488,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <chmod dir="${assembly-directory}/bin" perm="755" includes="**/*.sh" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-infinispan/infinispan-embedded-query/pom.xml
+++ b/jetty-infinispan/infinispan-embedded-query/pom.xml
@@ -45,10 +45,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):.*$" replace="maven://\1/\2/\3|lib/infinispan/\2-\3.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match="The following files have been resolved:" replace="[files]" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -58,12 +58,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/infinispan-embedded-query-libs.mod">
                   <fileset file="src/main/config-template/modules/sessions/infinispan/embedded/infinispan-embedded-query-libs.mod" />
                   <fileset file="${project.build.directory}/deps.txt" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-infinispan/infinispan-embedded/pom.xml
+++ b/jetty-infinispan/infinispan-embedded/pom.xml
@@ -46,10 +46,10 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):.*$" replace="maven://\1/\2/\3|lib/infinispan/\2-\3.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match="The following files have been resolved:" replace="[files]" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -59,12 +59,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/infinispan-embedded-libs.mod">
                   <fileset file="src/main/config-templates/modules/sessions/infinispan/embedded/infinispan-embedded-libs.mod" />
                   <fileset file="${project.build.directory}/deps.txt" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -45,11 +45,11 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):(.*):.*$" replace="maven://\1/\2/\4/jar/\3|lib/infinispan/\2-\3-\4.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):.*$" replace="maven://\1/\2/\3|lib/infinispan/\2-\3.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match="The following files have been resolved:" replace="[files]" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -59,12 +59,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/infinispan-remote-query-libs.mod">
                   <fileset file="src/main/config-template/modules/sessions/infinispan/remote/infinispan-remote-query-libs.mod" />
                   <fileset file="${project.build.directory}/deps.txt" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -46,11 +46,11 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):(.*):.*$" replace="maven://\1/\2/\4/jar/\3|lib/infinispan/\2-\3-\4.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):.*$" replace="maven://\1/\2/\3|lib/infinispan/\2-\3.jar" byline="true" />
                 <replaceregexp file="${project.build.directory}/deps.txt" match="The following files have been resolved:" replace="[files]" />
-              </tasks>
+              </target>
             </configuration>
           </execution>
           <execution>
@@ -60,12 +60,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/infinispan-remote-libs.mod">
                   <fileset file="src/main/config-template/modules/sessions/infinispan/remote/infinispan-remote-libs.mod" />
                   <fileset file="${project.build.directory}/deps.txt" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -46,14 +46,14 @@
           <execution>
             <phase>process-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <!--delete file="target/classes/META-INF/MANIFEST.MF" /-->
                 <copy todir="target/classes/jettyhome">
                   <fileset dir="jettyhome">
                     <exclude name="**/*.log" />
                   </fileset>
                 </copy>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/jetty-osgi/jetty-osgi-httpservice/pom.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/pom.xml
@@ -43,11 +43,11 @@
           <execution>
             <phase>process-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <copy todir="target/classes/contexts">
                   <fileset dir="contexts" />
                 </copy>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -80,7 +80,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="${project.build.directory}/deps.txt" tofile="${project.build.directory}/deps-orig.txt" />
                 <!-- regex the deps with classifiers first -->
                 <replaceregexp file="${project.build.directory}/deps.txt" match=" *(.*):(.*):jar:(.*):(.*):.*$" replace="maven://\1/\2/\4/jar/\3|lib/jnr/\2-\4-\3.jar" byline="true" />
@@ -92,7 +92,7 @@
                   <fileset file="${project.build.directory}/deps.txt" />
                   <fileset file="src/main/config-template/modules/unixsocket-suffix.mod" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.8</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tests/test-webapps/test-jndi-webapp/pom.xml
+++ b/tests/test-webapps/test-jndi-webapp/pom.xml
@@ -29,14 +29,14 @@
             <id>generate-xml-files</id>
             <phase>process-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/plugin-context.xml">
                   <filelist dir="src/main/templates/" files="plugin-context-header.xml,env-definitions.xml" />
                 </concat>
                 <concat destfile="${project.build.directory}/test-jndi.xml">
                   <filelist dir="src/main/templates/" files="jetty-test-jndi-header.xml,env-definitions.xml" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -92,14 +92,14 @@
             <id>generate-xml-files</id>
             <phase>process-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <concat destfile="${project.build.directory}/plugin-context.xml">
                   <filelist dir="src/main/templates/" files="plugin-context-header.xml,env-definitions.xml" />
                 </concat>
                 <concat destfile="${project.build.directory}/test-spec.xml">
                   <filelist dir="src/main/templates/" files="annotations-context-header.xml,env-definitions.xml" />
                 </concat>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
This is a replacement for PR #5545 but from an earlier branch (`jetty-9.4.x`), and it has the required update of configuration/task to configuration/target.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>