### PR TITLE
Bump protostream from 4.2.2.Final to 4.3.4.Final

### DIFF
--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.infinispan.protostream</groupId>
       <artifactId>protostream</artifactId>
-      <version>4.2.2.Final</version>
+      <version>${infinispan.protostream.version}</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>org.infinispan.protostream</groupId>
       <artifactId>protostream</artifactId>
-      <version>4.2.2.Final</version>
+      <version>${infinispan.protostream.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <jsp.version>8.5.54</jsp.version>
     <infinispan.version>9.4.8.Final</infinispan.version>
+    <infinispan.protostream.version>4.3.4.Final</infinispan.protostream.version>
     <alpn.agent.version>2.0.10</alpn.agent.version>
     <conscrypt.version>2.5.1</conscrypt.version>
     <asm.version>9.0</asm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <jsp.version>8.5.54</jsp.version>
     <infinispan.version>9.4.8.Final</infinispan.version>
     <infinispan.protostream.version>4.3.4.Final</infinispan.protostream.version>
+    <gson.version>2.8.6</gson.version>
     <alpn.agent.version>2.0.10</alpn.agent.version>
     <conscrypt.version>2.5.1</conscrypt.version>
     <asm.version>9.0</asm.version>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>org.infinispan.protostream</groupId>
       <artifactId>protostream</artifactId>
-      <version>4.2.2.Final</version>
+      <version>${infinispan.protostream.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -130,6 +130,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Earlier branch (`jetty-9.4.x`) replacement for PRs #5504 and #5546
This is an infinispan dependency.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>