### PR TITLE
Bump jna from 5.5.0 to 5.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,6 +1086,7 @@
         <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
       </dependency>
+      <!-- Test Container Deps -->
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
@@ -1099,7 +1100,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.5.0</version>
+        <version>5.6.0</version>
       </dependency>
       <!-- Old Deps -->
       <dependency>


### PR DESCRIPTION
Replacement for PR #5593, but from an earlier branch.

`jna` is a dependency for testcontainers.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>