### PR TITLE
Bump tycho from 1.4.0 to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <asm.version>9.0</asm.version>
     <jmh.version>1.26</jmh.version>
     <jmhjar.name>benchmarks</jmhjar.name>
-    <tycho-version>1.4.0</tycho-version>
+    <tycho-version>2.1.0</tycho-version>
     <junit.version>5.7.0</junit.version>
     <maven.version>3.6.3</maven.version>
     <maven.resolver.version>1.6.1</maven.resolver.version>


### PR DESCRIPTION
Replacement for PR #5582, but on an earlier branch.

This dependency is used by the `tycho-pack200a-plugin` as part of the p2 repository `eclipse-sign` profile.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>