### PR TITLE
Bump xmemcached from 2.4.5 to 2.4.6

### DIFF
--- a/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.googlecode.xmemcached</groupId>
       <artifactId>xmemcached</artifactId>
-      <version>2.4.5</version>
+      <version>2.4.6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Replacement for PR #5581, but from an earlier branch point (`jetty-9.4.x`).

This dependency is used by `jetty-memcached-sessions`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>