### PR TITLE
Fixes #5633 - Allow to configure HttpClient request authority.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -562,7 +562,13 @@ public class HttpClient extends ContainerLifeCycle
         return new Origin(scheme, host, port, tag);
     }
 
-    protected HttpDestination resolveDestination(Origin origin)
+    /**
+     * <p>Returns, creating it if absent, the destination with the given origin.</p>
+     *
+     * @param origin the origin that identifies the destination
+     * @return the destination for the given origin
+     */
+    public HttpDestination resolveDestination(Origin origin)
     {
         return destinations.computeIfAbsent(origin, o ->
         {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -120,7 +120,13 @@ public abstract class HttpConnection implements Connection, Attachable
         if (version.getVersion() <= 11)
         {
             if (!headers.containsKey(HttpHeader.HOST.asString()))
-                headers.put(getHttpDestination().getHostField());
+            {
+                URI uri = request.getURI();
+                if (uri != null)
+                    headers.put(HttpHeader.HOST, uri.getAuthority());
+                else
+                    headers.put(getHttpDestination().getHostField());
+            }
         }
 
         // Add content headers

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -253,15 +253,13 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         abort(x);
     }
 
+    public void send(Request request, Response.CompleteListener listener)
+    {
+        ((HttpRequest)request).sendAsync(this, listener);
+    }
+
     protected void send(HttpRequest request, List<Response.ResponseListener> listeners)
     {
-        if (!getScheme().equalsIgnoreCase(request.getScheme()))
-            throw new IllegalArgumentException("Invalid request scheme " + request.getScheme() + " for destination " + this);
-        if (!getHost().equalsIgnoreCase(request.getHost()))
-            throw new IllegalArgumentException("Invalid request host " + request.getHost() + " for destination " + this);
-        int port = request.getPort();
-        if (port >= 0 && getPort() != port)
-            throw new IllegalArgumentException("Invalid request port " + port + " for destination " + this);
         send(new HttpExchange(this, request, listeners));
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
@@ -722,7 +723,7 @@ public class HttpRequest implements Request
     public ContentResponse send() throws InterruptedException, TimeoutException, ExecutionException
     {
         FutureResponseListener listener = new FutureResponseListener(this);
-        send(this, listener);
+        send(listener);
 
         try
         {
@@ -761,15 +762,20 @@ public class HttpRequest implements Request
     @Override
     public void send(Response.CompleteListener listener)
     {
-        send(this, listener);
+        sendAsync(client::send, listener);
     }
 
-    private void send(HttpRequest request, Response.CompleteListener listener)
+    void sendAsync(HttpDestination destination, Response.CompleteListener listener)
+    {
+        sendAsync(destination::send, listener);
+    }
+
+    private void sendAsync(BiConsumer<HttpRequest, List<Response.ResponseListener>> sender, Response.CompleteListener listener)
     {
         if (listener != null)
             responseListeners.add(listener);
         sent();
-        client.send(request, responseListeners);
+        sender.accept(this, responseListeners);
     }
 
     void sent()


### PR DESCRIPTION
Introduced HttpDestination.send(Request, Response.CompleteListener) to send a request using the given destination.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>