### PR TITLE
Bump Bump openwebbeans from 2.0.19 to 2.0.20

### DIFF
--- a/tests/test-webapps/test-owb-cdi-webapp/pom.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.cdi.owb</bundle-symbolic-name>
-    <openwebbeans.version>2.0.19</openwebbeans.version>
+    <openwebbeans.version>2.0.20</openwebbeans.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Replacement for PRs #5663, #5658, and #5659 
But from branch `jetty-9.4.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>