### PR TITLE
Allow start.jar to list enabled modules

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -266,6 +266,10 @@ public class Main
         System.out.printf("%nModules %s:%n", t);
         System.out.printf("=========%s%n", "=".repeat(t.length()));
         args.getAllModules().listModules(tags);
+
+        // for default module listings, also show enabled modules
+        if ("[-internal]".equals(t) || "[*]".equals(t))
+            args.getAllModules().listEnabled();
     }
 
     public void showModules(StartArgs args)

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -167,6 +167,8 @@ public class Modules implements Iterable<Module>
         if (tags.contains("-*"))
             return;
 
+        tags = new ArrayList<>(tags);
+
         boolean wild = tags.contains("*");
         Set<String> included = new HashSet<>();
         if (wild)

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -347,8 +347,6 @@ public class StartArgs
             }
             System.out.println();
         }
-
-        System.out.println();
     }
 
     public void dumpJvmArgs()

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -19,12 +19,15 @@ Command Line Options:
   --list-config    List the resolved configuration that will be used to
                    start Jetty.
                    Output includes:
+                     o  Enabled jetty modules
                      o  Java Environment
                      o  Jetty Environment
+                     o  Config file search order
                      o  JVM Arguments
+                     o  System Properties
                      o  Properties
-                     o  Server Classpath
-                     o  Server XML Configuration
+                     o  Java Classpath
+                     o  XML Configuration files
 
   --dry-run        Print the command line that the start.jar generates,
                    then exit. This may be used to generate command lines


### PR DESCRIPTION
Fixes #5679 and #5680 listing modules
+ Updated usage to show that --list-config lists the enabled Modules
+ fixed unsupported operation in --list-all-modules
+ list enabled modules with default --list-module