### PR TITLE
remove unnecessary transition to READY in ContentProducer.isReady

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
@@ -223,7 +223,6 @@ class AsyncContentProducer implements ContentProducer
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("isReady(), got transformed content {} {}", content, this);
-            _httpChannel.getState().onContentAdded();
             return true;
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
@@ -114,7 +114,6 @@ public interface ContentProducer
      * If there isn't any and the implementation does not block, this method will trigger a
      * {@link javax.servlet.ReadListener} callback once some content is available.
      * This call is always non-blocking.
-     * After this call, state can be either of UNREADY or READY.
      * @return true if some content is immediately available, false otherwise.
      */
     boolean isReady();


### PR DESCRIPTION
[closes #5704] It doesn't look necessary to transition to READY after a call to isReady.