### PR TITLE
Issue #5713 Remove dependency on derby

### DIFF
--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -57,11 +57,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <settingsPath>src/it/settings.xml</settingsPath>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <testcontainers.version>1.15.0</testcontainers.version>
-    <derby.version>10.14.2.0</derby.version>
+    <maria.version>2.7.0</maria.version>
   </properties>
 
   <licenses>
@@ -1182,16 +1182,6 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-unixsocket</artifactId>
         <version>0.38.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derby</artifactId>
-        <version>${derby.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derbytools</artifactId>
-        <version>${derby.version}</version>
       </dependency>
       <!-- avoid depending on a range dependency from a transitive dependency -->
       <dependency>

--- a/tests/test-loginservice/pom.xml
+++ b/tests/test-loginservice/pom.xml
@@ -43,13 +43,30 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derbytools</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>${maria.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tests/test-loginservice/src/test/java/org/eclipse/jetty/DataSourceLoginServiceTest.java
+++ b/tests/test-loginservice/src/test/java/org/eclipse/jetty/DataSourceLoginServiceTest.java
@@ -27,7 +27,6 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.AuthenticationStore;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -36,71 +35,53 @@ import org.eclipse.jetty.plus.security.DataSourceLoginService;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.Loader;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * DataSourceLoginServiceTest
  */
+@Testcontainers(disabledWithoutDocker = true)
 public class DataSourceLoginServiceTest
 {
-
-    public static final String _content = "This is some protected content";
-    private static File _docRoot;
-    private static HttpClient _client;
-    private static String __realm = "DSRealm";
-    private static URI _baseUri;
-    private static DatabaseLoginServiceTestServer _testServer;
-
+    private static final String _content = "This is some protected content";
+    private static String REALM_NAME = "DSRealm";
+    private static File __docRoot;
+    private static URI __baseUri;
+    private static DatabaseLoginServiceTestServer __testServer;
+    private AuthenticationStore _authStore;
+    private HttpClient _client;
+    
     @BeforeAll
     public static void setUp() throws Exception
     {
+        __docRoot = MavenTestingUtils.getTargetTestingDir("dsloginservice-test");
+        FS.ensureDirExists(__docRoot);
 
-        _docRoot = MavenTestingUtils.getTargetTestingDir("loginservice-test");
-        FS.ensureDirExists(_docRoot);
-
-        File content = new File(_docRoot, "input.txt");
-        FileOutputStream out = new FileOutputStream(content);
-        out.write(_content.getBytes("utf-8"));
-        out.close();
-
-        //clear previous runs
-        File scriptFile = MavenTestingUtils.getTestResourceFile("droptables.sql");
-        int result = DatabaseLoginServiceTestServer.runscript(scriptFile);
-        //ignore result as derby spits errors for dropping tables that dont exist
-
-        //create afresh
-        scriptFile = MavenTestingUtils.getTestResourceFile("createdb.sql");
-        result = DatabaseLoginServiceTestServer.runscript(scriptFile);
-        assertThat("runScript result", result, is(0));
-
-        _testServer = new DatabaseLoginServiceTestServer();
-        _testServer.setResourceBase(_docRoot.getAbsolutePath());
-        _testServer.setLoginService(configureLoginService());
-        _testServer.start();
-        _baseUri = _testServer.getBaseUri();
-    }
-
-    @AfterAll
-    public static void tearDown()
-        throws Exception
-    {
-        if (_testServer != null)
+        File content = new File(__docRoot, "input.txt");
+        try (FileOutputStream out = new FileOutputStream(content))
         {
-            _testServer.stop();
-            _testServer = null;
+            out.write(_content.getBytes("utf-8"));
         }
-    }
 
-    public static DataSourceLoginService configureLoginService() throws Exception
-    {
+        //create a datasource and bind to jndi
+        MariaDbDataSource ds = new MariaDbDataSource();
+        ds.setDatabaseName(DatabaseLoginServiceTestServer.MARIA_DB_NAME);
+        ds.setUser(DatabaseLoginServiceTestServer.MARIA_DB_USER);
+        ds.setPassword(DatabaseLoginServiceTestServer.MARIA_DB_PASSWORD);
+        ds.setUrl(DatabaseLoginServiceTestServer.MARIA_DB_FULL_URL);
+        org.eclipse.jetty.plus.jndi.Resource binding = 
+            new org.eclipse.jetty.plus.jndi.Resource(null, "dstest", ds);
+        
+        __testServer = new DatabaseLoginServiceTestServer();
+        
         DataSourceLoginService loginService = new DataSourceLoginService();
         loginService.setUserTableName("users");
         loginService.setUserTableKey("id");
@@ -113,18 +94,41 @@ public class DataSourceLoginServiceTest
         loginService.setUserRoleTableRoleKey("role_id");
         loginService.setUserRoleTableUserKey("user_id");
         loginService.setJndiName("dstest");
-        loginService.setName(__realm);
-        if (_testServer != null)
-            loginService.setServer(_testServer.getServer());
+        loginService.setName(REALM_NAME);
+        loginService.setServer(__testServer.getServer());
+        
+        __testServer.setResourceBase(__docRoot.getAbsolutePath()); 
+        __testServer.setLoginService(loginService);
+        __testServer.start();
+        __baseUri = __testServer.getBaseUri();
+    }
 
-        //create a datasource
-        EmbeddedDataSource ds = new EmbeddedDataSource();
-        File db = new File(DatabaseLoginServiceTestServer.getDbRoot(), "loginservice");
-        ds.setDatabaseName(db.getAbsolutePath());
-        org.eclipse.jetty.plus.jndi.Resource binding = new org.eclipse.jetty.plus.jndi.Resource(null, "dstest",
-            ds);
-        assertThat("Created binding for dstest", binding, notNullValue());
-        return loginService;
+    @AfterAll
+    public static void tearDown()
+        throws Exception
+    {
+        if (__testServer != null)
+        {
+            __testServer.stop();
+            __testServer = null;
+        }
+    }
+
+    @BeforeEach
+    public void setupClient() throws Exception
+    {
+        _client = new HttpClient();
+        _authStore = _client.getAuthenticationStore();
+    }
+    
+    @AfterEach
+    public void stopClient() throws Exception
+    {
+        if (_client != null)
+        {
+            _client.stop();
+            _client = null;
+        }
     }
 
     @Test
@@ -132,9 +136,9 @@ public class DataSourceLoginServiceTest
     {
         try
         {
-            startClient("jetty", "jetty");
-
-            ContentResponse response = _client.GET(_baseUri.resolve("input.txt"));
+            _authStore.addAuthentication(new BasicAuthentication(__baseUri, REALM_NAME, "dstest", "dstest"));
+            _client.start();
+            ContentResponse response = _client.GET(__baseUri.resolve("input.txt"));
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals(_content, response.getContentAsString());
 
@@ -142,48 +146,30 @@ public class DataSourceLoginServiceTest
 
             String newpwd = String.valueOf(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
 
-            changePassword("jetty", newpwd);
+            changePassword("dstest", newpwd);
 
-            startClient("jetty", newpwd);
+            setupClient();
+            _authStore.addAuthentication(new BasicAuthentication(__baseUri, REALM_NAME, "dstest", newpwd));
+            _client.start();
 
-            response = _client.GET(_baseUri.resolve("input.txt"));
+            response = _client.GET(__baseUri.resolve("input.txt"));
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals(_content, response.getContentAsString());
         }
         finally
         {
-            stopClient();
+            changePassword("dstest", "dstest");
         }
     }
 
     protected void changePassword(String user, String newpwd) throws Exception
     {
-        Loader.loadClass("org.apache.derby.jdbc.EmbeddedDriver").getDeclaredConstructor().newInstance();
-        try (Connection connection = DriverManager.getConnection(DatabaseLoginServiceTestServer.__dbURL, "", "");
+        Loader.loadClass(DatabaseLoginServiceTestServer.MARIA_DB_DRIVER_CLASS);
+        try (Connection connection = DriverManager.getConnection(DatabaseLoginServiceTestServer.MARIA_DB_FULL_URL);
              Statement stmt = connection.createStatement())
         {
             connection.setAutoCommit(true);
             stmt.executeUpdate("update users set pwd='" + newpwd + "' where username='" + user + "'");
-        }
-    }
-
-    protected void startClient(String user, String pwd) throws Exception
-    {
-        _client = new HttpClient();
-        QueuedThreadPool executor = new QueuedThreadPool();
-        executor.setName(executor.getName() + "-client");
-        _client.setExecutor(executor);
-        AuthenticationStore authStore = _client.getAuthenticationStore();
-        authStore.addAuthentication(new BasicAuthentication(_baseUri, __realm, user, pwd));
-        _client.start();
-    }
-
-    protected void stopClient() throws Exception
-    {
-        if (_client != null)
-        {
-            _client.stop();
-            _client = null;
         }
     }
 }

--- a/tests/test-loginservice/src/test/java/org/eclipse/jetty/DatabaseLoginServiceTestServer.java
+++ b/tests/test-loginservice/src/test/java/org/eclipse/jetty/DatabaseLoginServiceTestServer.java
@@ -20,14 +20,11 @@ package org.eclipse.jetty;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,7 +33,6 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.derby.tools.ij;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.LoginService;
@@ -49,49 +45,61 @@ import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.security.Constraint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 /**
  * DatabaseLoginServiceTestServer
  */
 public class DatabaseLoginServiceTestServer
 {
-    protected static String __dbURL = "jdbc:derby:loginservice;create=true";
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseLoginServiceTestServer.class);
+    private static final Logger MARIADB_LOG = LoggerFactory.getLogger("org.eclipse.jetty.security.MariaDbLogs");
+    
+    static MariaDBContainer MARIA_DB;
+
+    protected static final String MARIA_DB_NAME = "lstest";
+    protected static final String MARIA_DB_USER = "beer";
+    protected static final String MARIA_DB_PASSWORD = "pacific_ale";
+    public static String MARIA_DB_DRIVER_CLASS;
+    public static String MARIA_DB_URL;
+    public static String MARIA_DB_FULL_URL;
+    
     protected Server _server;
     protected static String _protocol;
     protected static URI _baseUri;
     protected LoginService _loginService;
     protected String _resourceBase;
     protected TestHandler _handler;
-    private static File commonDerbySystemHome;
     protected static String _requestContent;
 
     protected static File _dbRoot;
 
     static
     {
-        _dbRoot = new File(MavenTestingUtils.getTargetTestingDir("loginservice-test"), "derby");
-        FS.ensureDirExists(_dbRoot);
-        System.setProperty("derby.system.home", _dbRoot.getAbsolutePath());
-    }
-
-    public static File getDbRoot()
-    {
-        return _dbRoot;
-    }
-
-    public static int runscript(File scriptFile) throws Exception
-    {
-        //System.err.println("Running script:"+scriptFile.getAbsolutePath());
-        try (FileInputStream fileStream = new FileInputStream(scriptFile))
+        try
         {
-            Loader.loadClass("org.apache.derby.jdbc.EmbeddedDriver").getDeclaredConstructor().newInstance();
-            Connection connection = DriverManager.getConnection(__dbURL, "", "");
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            return ij.runScript(connection, fileStream, "UTF-8", out, "UTF-8");
+            MARIA_DB =
+                new MariaDBContainer("mariadb:" + System.getProperty("mariadb.docker.version", "10.3.6"))
+                .withUsername(MARIA_DB_USER)
+                .withPassword(MARIA_DB_PASSWORD)
+                .withDatabaseName(MARIA_DB_NAME);
+            MARIA_DB = (MariaDBContainer)MARIA_DB.withInitScript("createdb.sql");
+            MARIA_DB = (MariaDBContainer)MARIA_DB.withLogConsumer(new Slf4jLogConsumer(MARIADB_LOG));
+            MARIA_DB.start();
+            String containerIpAddress =  MARIA_DB.getContainerIpAddress();
+            int mariadbPort = MARIA_DB.getMappedPort(3306);
+            MARIA_DB_URL = MARIA_DB.getJdbcUrl();
+            MARIA_DB_FULL_URL = MARIA_DB_URL + "?user=" + MARIA_DB_USER + "&password=" + MARIA_DB_PASSWORD;
+            MARIA_DB_DRIVER_CLASS = MARIA_DB.getDriverClassName();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/tests/test-loginservice/src/test/java/org/eclipse/jetty/JdbcLoginServiceTest.java
+++ b/tests/test-loginservice/src/test/java/org/eclipse/jetty/JdbcLoginServiceTest.java
@@ -21,6 +21,8 @@ package org.eclipse.jetty;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.PrintWriter;
 import java.net.URI;
 import javax.servlet.http.HttpServletResponse;
 
@@ -37,198 +39,86 @@ import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Testcontainers(disabledWithoutDocker = true)
 public class JdbcLoginServiceTest
 {
-
     private static String _content =
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis felis nunc. " +
-            "Quisque suscipit mauris et ante auctor ornare rhoncus lacus aliquet. Pellentesque " +
-            "habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. " +
-            "Vestibulum sit amet felis augue, vel convallis dolor. Cras accumsan vehicula diam " +
-            "at faucibus. Etiam in urna turpis, sed congue mi. Morbi et lorem eros. Donec vulputate " +
-            "velit in risus suscipit lobortis. Aliquam id urna orci, nec sollicitudin ipsum. " +
-            "Cras a orci turpis. Donec suscipit vulputate cursus. Mauris nunc tellus, fermentum " +
-            "eu auctor ut, mollis at diam. Quisque porttitor ultrices metus, vitae tincidunt massa " +
-            "sollicitudin a. Vivamus porttitor libero eget purus hendrerit cursus. Integer aliquam " +
-            "consequat mauris quis luctus. Cras enim nibh, dignissim eu faucibus ac, mollis nec neque. " +
-            "Aliquam purus mauris, consectetur nec convallis lacinia, porta sed ante. Suspendisse " +
-            "et cursus magna. Donec orci enim, molestie a lobortis eu, imperdiet vitae neque.";
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
-    private static File _docRoot;
-    private static HttpClient _client;
+    private static File __docRoot;
     private static String __realm = "JdbcRealm";
-    private static URI _baseUri;
-    private static DatabaseLoginServiceTestServer _testServer;
+    private static URI __baseUri;
+    private static DatabaseLoginServiceTestServer __testServer;
+    private HttpClient _client;
+    private AuthenticationStore _authStore;
 
     @BeforeAll
     public static void setUp() throws Exception
     {
-        _docRoot = MavenTestingUtils.getTargetTestingDir("loginservice-test");
-        FS.ensureDirExists(_docRoot);
-        File content = new File(_docRoot, "input.txt");
+        File dir = MavenTestingUtils.getTargetTestingDir("jdbcloginservice-test");
+        FS.ensureDirExists(dir);
 
+        //create the realm properties file based on dynamic + static info
+        File skeletonFile = MavenTestingUtils.getTestResourceFile("jdbcrealm.properties");
+        File realmFile = new File(dir, "realm.properties");
+        try (PrintWriter writer = new PrintWriter(new FileOutputStream(realmFile)))
+        {
+            writer.println("jdbcdriver = " + DatabaseLoginServiceTestServer.MARIA_DB_DRIVER_CLASS);
+            writer.println("url = " + DatabaseLoginServiceTestServer.MARIA_DB_URL);
+            writer.println("username = " + DatabaseLoginServiceTestServer.MARIA_DB_USER);
+            writer.println("password = " + DatabaseLoginServiceTestServer.MARIA_DB_PASSWORD);
+            IO.copy(new FileReader(skeletonFile), writer);
+        }
+
+        //make some static content
+        __docRoot = new File(dir, "docroot");
+        FS.ensureDirExists(__docRoot);
+        File content = new File(__docRoot, "input.txt");
         try (FileOutputStream out = new FileOutputStream(content))
         {
             out.write(_content.getBytes("utf-8"));
         }
 
-        //drop any tables that might have existed
-        File scriptFile = MavenTestingUtils.getTestResourceFile("droptables.sql");
-        int result = DatabaseLoginServiceTestServer.runscript(scriptFile);
-        //ignore result, if the tables dont already exist, derby spits out an error
-
-        //create the tables afresh
-        scriptFile = MavenTestingUtils.getTestResourceFile("createdb.sql");
-        result = DatabaseLoginServiceTestServer.runscript(scriptFile);
-        assertThat("runScript result", result, is(0));
-
-        File jdbcRealmFile = MavenTestingUtils.getTestResourceFile("jdbcrealm.properties");
-
-        LoginService loginService = new JDBCLoginService(__realm, jdbcRealmFile.getAbsolutePath());
-        _testServer = new DatabaseLoginServiceTestServer();
-        _testServer.setResourceBase(_docRoot.getAbsolutePath());
-        _testServer.setLoginService(loginService);
-        _testServer.start();
-        _baseUri = _testServer.getBaseUri();
+        LoginService loginService = new JDBCLoginService(__realm, realmFile.getAbsolutePath());
+        
+        __testServer = new DatabaseLoginServiceTestServer();
+        __testServer.setResourceBase(__docRoot.getAbsolutePath());
+        __testServer.setLoginService(loginService);
+        __testServer.start();
+        
+        __baseUri = __testServer.getBaseUri();
     }
 
     @AfterAll
     public static void tearDown()
         throws Exception
     {
-        if (_testServer != null)
+        if (__testServer != null)
         {
-            _testServer.stop();
-            _testServer = null;
+            __testServer.stop();
+            __testServer = null;
         }
     }
 
-    @Test
-    public void testPut() throws Exception
-    {
-        try
-        {
-            startClient();
-
-            Request request = _client.newRequest(_baseUri.resolve("output.txt"));
-            request.method(HttpMethod.PUT);
-            request.content(new BytesContentProvider(_content.getBytes()));
-            ContentResponse response = request.send();
-            int responseStatus = response.getStatus();
-            boolean statusOk = (responseStatus == 200 || responseStatus == 201);
-            assertTrue(statusOk);
-            String content = IO.toString(new FileInputStream(new File(_docRoot, "output.txt")));
-            assertEquals(_content, content);
-        }
-        finally
-        {
-            stopClient();
-        }
-    }
-
-    @Test
-    public void testGet() throws Exception
-    {
-        try
-        {
-            startClient();
-
-            ContentResponse response = _client.GET(_baseUri.resolve("input.txt"));
-            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
-            assertEquals(_content, response.getContentAsString());
-        }
-        finally
-        {
-            stopClient();
-        }
-    }
-
-    @Test
-    public void testGetNonExistantUser() throws Exception
-    {
-        try
-        {
-            startClient("foo", "bar");
-            ContentResponse response = _client.GET(_baseUri.resolve("input.txt"));
-            assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
-        }
-        finally
-        {
-            stopClient();
-        }
-    }
-
-    //Head requests to jetty-client are not working: see https://bugs.eclipse.org/bugs/show_bug.cgi?id=394552
-    @Disabled
-    public void testHead() throws Exception
-    {
-        try
-        {
-            startClient();
-
-            Request request = _client.newRequest(_baseUri.resolve("input.txt"));
-            request.method(HttpMethod.HEAD);
-            ContentResponse response = request.send();
-            int responseStatus = response.getStatus();
-            assertEquals(HttpStatus.OK_200, responseStatus);
-        }
-        finally
-        {
-            stopClient();
-        }
-    }
-
-    @Test
-    public void testPost() throws Exception
-    {
-        try
-        {
-            startClient();
-
-            Request request = _client.newRequest(_baseUri.resolve("test"));
-            request.method(HttpMethod.POST);
-            request.content(new BytesContentProvider(_content.getBytes()));
-            ContentResponse response = request.send();
-            assertEquals(HttpStatus.OK_200, response.getStatus());
-            assertEquals(_content, _testServer.getTestHandler().getRequestContent());
-        }
-        finally
-        {
-            stopClient();
-        }
-    }
-
-    protected void startClient(String user, String pwd)
-        throws Exception
+    @BeforeEach
+    public void setupClient() throws Exception
     {
         _client = new HttpClient();
-        QueuedThreadPool executor = new QueuedThreadPool();
-        executor.setName(executor.getName() + "-client");
-        _client.setExecutor(executor);
-        AuthenticationStore authStore = _client.getAuthenticationStore();
-        authStore.addAuthentication(new BasicAuthentication(_baseUri, __realm, user, pwd));
-        _client.start();
+        _authStore = _client.getAuthenticationStore();
     }
 
-    protected void startClient()
-        throws Exception
-    {
-        startClient("jetty", "jetty");
-    }
-
-    protected void stopClient()
-        throws Exception
+    @AfterEach
+    public void stopClient() throws Exception
     {
         if (_client != null)
         {
@@ -237,13 +127,70 @@ public class JdbcLoginServiceTest
         }
     }
 
-    protected HttpClient getClient()
+    @Test
+    public void testPut() throws Exception
     {
-        return _client;
+        _authStore.addAuthentication(new BasicAuthentication(__baseUri, __realm, "jetty", "jetty"));
+        _client.start();
+
+        Request request = _client.newRequest(__baseUri.resolve("output.txt"));
+        request.method(HttpMethod.PUT);
+        request.content(new BytesContentProvider(_content.getBytes()));
+        ContentResponse response = request.send();
+        int responseStatus = response.getStatus();
+        boolean statusOk = (responseStatus == 200 || responseStatus == 201);
+        assertTrue(statusOk);
+        String content = IO.toString(new FileInputStream(new File(__docRoot, "output.txt")));
+        assertEquals(_content, content);
     }
 
-    protected String getContent()
+    @Test
+    public void testGet() throws Exception
     {
-        return _content;
+        _authStore.addAuthentication(new BasicAuthentication(__baseUri, __realm, "jetty", "jetty"));
+        _client.start();
+        
+        ContentResponse response = _client.GET(__baseUri.resolve("input.txt"));
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(_content, response.getContentAsString());
+    }
+
+    @Test
+    public void testGetNonExistantUser() throws Exception
+    {
+        _authStore.addAuthentication(new BasicAuthentication(__baseUri, __realm, "foo", "bar"));
+        _client.start();
+
+        ContentResponse response = _client.GET(__baseUri.resolve("input.txt"));
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+    }
+
+    //Head requests to jetty-client are not working: see https://bugs.eclipse.org/bugs/show_bug.cgi?id=394552
+    @Test
+    public void testHead() throws Exception
+    {
+        _authStore.addAuthentication(new BasicAuthentication(__baseUri, __realm, "jetty", "jetty"));
+        _client.start();
+
+        Request request = _client.newRequest(__baseUri.resolve("input.txt"));
+        request.method(HttpMethod.HEAD);
+        ContentResponse response = request.send();
+        int responseStatus = response.getStatus();
+        assertEquals(HttpStatus.OK_200, responseStatus);
+    }
+
+    @Test
+    public void testPost() throws Exception
+    {
+        _authStore.addAuthentication(new BasicAuthentication(__baseUri, __realm, "jetty", "jetty"));
+        _client.start();
+
+        Request request = _client.newRequest(__baseUri.resolve("test"));
+        request.method(HttpMethod.POST);
+        request.content(new BytesContentProvider(_content.getBytes()));
+        ContentResponse response = request.send();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertEquals(_content, __testServer.getTestHandler().getRequestContent());
+
     }
 }

--- a/tests/test-loginservice/src/test/resources/createdb.sql
+++ b/tests/test-loginservice/src/test/resources/createdb.sql
@@ -28,7 +28,8 @@ INSERT INTO users VALUES
 (3,'other','OBF:1xmk1w261u9r1w1c1xmq'),
 (4,'plain','plain'),
 (5,'user','password'),
-(6,'digest','MD5:6e120743ad67abfbc385bc2bb754e297');
+(6,'digest','MD5:6e120743ad67abfbc385bc2bb754e297'),
+(7,'dstest','dstest');
 
 INSERT INTO user_roles VALUES
 (1,1),
@@ -37,4 +38,5 @@ INSERT INTO user_roles VALUES
 (3,1),
 (4,1),
 (5,1),
-(6,1);
+(6,1),
+(7,1);

--- a/tests/test-loginservice/src/test/resources/jdbcrealm.properties
+++ b/tests/test-loginservice/src/test/resources/jdbcrealm.properties
@@ -1,7 +1,3 @@
-jdbcdriver = org.apache.derby.jdbc.EmbeddedDriver
-url = jdbc:derby:loginservice
-username =
-password =
 usertable = users
 usertablekey = id
 usertableuserfield = username

--- a/tests/test-sessions/test-jdbc-sessions/pom.xml
+++ b/tests/test-sessions/test-jdbc-sessions/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>2.7.0</version>
+      <version>${maria.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
closes #5713 

jetty-plus does not need the dependency on derby so I removed it. That left the test/test-loginservice with a dependency on derby, so I've changed that to use the same docker-style test that the tests/test-sessions/test-jdbc-sessions use, so at least we have a single set of common dependencies (uses maria db for the database). Also cleaned up the test code.