### PR TITLE
Correct META-INF/LICENSE handling

### DIFF
--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -42,6 +42,8 @@
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>true</overWriteSnapshots>
+              <excludeScope>test</excludeScope>
+              <includeScope>runtime</includeScope>
             </configuration>
           </execution>
         </executions>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -27,7 +27,18 @@
             </goals>
             <configuration>
               <includes>**</includes>
-              <excludes>**/MANIFEST.MF,META-INF/LICENSE,META-INF/*.RSA,META-INF/*.DSA,META-INF/*.SF,module-info.class</excludes>
+              <excludes>
+                **/MANIFEST.MF,
+                META-INF/LICENSE,
+                META-INF/*.RSA,
+                META-INF/*.DSA,
+                META-INF/*.SF,
+                module-info.class,
+                readme.txt,
+                MANIFEST.MF,
+                about.html,
+                ecj.1
+              </excludes>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>true</overWriteSnapshots>
@@ -84,10 +95,12 @@
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <archive>
-              <manifestFile>src/main/resources/MANIFEST.MF</manifestFile>
               <manifest>
                 <mainClass>org.eclipse.jetty.runner.Runner</mainClass>
               </manifest>
+              <manifestEntries>
+                <Comment>Jetty Runner</Comment>
+              </manifestEntries>
             </archive>
           </configuration>
         </plugin>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -27,7 +27,7 @@
             </goals>
             <configuration>
               <includes>**</includes>
-              <excludes>**/MANIFEST.MF,META-INF/*.RSA,META-INF/*.DSA,META-INF/*.SF,module-info.class</excludes>
+              <excludes>**/MANIFEST.MF,META-INF/LICENSE,META-INF/*.RSA,META-INF/*.DSA,META-INF/*.SF,module-info.class</excludes>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>true</overWriteSnapshots>

--- a/jetty-runner/src/main/resources/MANIFEST.MF
+++ b/jetty-runner/src/main/resources/MANIFEST.MF
@@ -1,1 +1,0 @@
-Comment: Jetty Runner


### PR DESCRIPTION
Fixes #5168 

The `jetty-runner` uber-jar now uses `META-INF/LICENSE` from the maven build, not the dependencies it unpacks.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>