### PR TITLE
Fix ArithmeticException "/ by zero" in Pool.acquire()

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -249,6 +249,11 @@ public class Pool<T> implements AutoCloseable, Dumpable
             {
                 LOGGER.trace("IGNORED", e);
                 size = entries.size();
+                // Size can be 0 when the pool is in the middle of
+                // acquiring a connection while another thread
+                // removes the last one from the pool.
+                if (size == 0)
+                    break;
             }
             index = (index + 1) % size;
         }


### PR DESCRIPTION
[closes #5731]
Just add a `if (size == 0)` check when the size is re-calculated to avoid the ArithmeticException of the modulo operator.