### PR TITLE
Jetty 9.4.x optimize parser warning from logs and add spotbug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,7 @@ pipeline {
           steps {
             container('jetty-build') {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk8", "clean install", "maven3",
-                            [[parserName: 'Maven'], [parserName: 'Java']])
+                mavenBuild( "jdk8", "-T2 clean install", "maven3")
                 // Collect up the jacoco execution results (only on main build)
                 jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
@@ -32,6 +31,7 @@ pipeline {
                        execPattern: '**/target/jacoco.exec',
                        classPattern: '**/target/classes',
                        sourcePattern: '**/src/main/java'
+                recordIssues id: "jdk8", name: "Static Analysis jdk8", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
               }
             }
           }
@@ -42,8 +42,8 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk11", "clean install -Djacoco.skip=true", "maven3",
-                            [[parserName: 'Maven'], [parserName: 'Java']])
+                mavenBuild( "jdk11", "-T2 clean install -Djacoco.skip=true -Perrorprone", "maven3")
+                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]
               }
             }
           }
@@ -54,8 +54,8 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk15", "clean install -Djacoco.skip=true", "maven3",
-                            [[parserName: 'Maven'], [parserName: 'Java']])
+                mavenBuild( "jdk15", "-T2 clean install -Djacoco.skip=true", "maven3")
+                recordIssues id: "jdk15", name: "Static Analysis jdk15", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
               }
             }
           }
@@ -65,10 +65,11 @@ pipeline {
           agent { node { label 'linux' } }
           steps {
             container( 'jetty-build' ) {
-              timeout( time: 60, unit: 'MINUTES' ) {
+              timeout( time: 120, unit: 'MINUTES' ) {
                 mavenBuild( "jdk11",
                             "install javadoc:javadoc javadoc:aggregate-jar -DskipTests -Dpmd.skip=true -Dcheckstyle.skip=true",
-                            "maven3", [[parserName: 'Maven'], [parserName: 'JavaDoc'], [parserName: 'Java']])
+                            "maven3")
+                recordIssues id: "javadoc", enabledForFailure: true, tools: [javaDoc()]
               }
             }
           }
@@ -78,9 +79,8 @@ pipeline {
           agent { node { label 'linux' } }
           steps {
             container( 'jetty-build' ) {
-              timeout( time: 60, unit: 'MINUTES' ) {
-                mavenBuild( "jdk8", "-Pcompact3 clean install -DskipTests", "maven3",
-                            [[parserName: 'Maven'], [parserName: 'Java']])
+              timeout( time: 120, unit: 'MINUTES' ) {
+                mavenBuild( "jdk8", "-T3 -Pcompact3 clean install -DskipTests", "maven3")
               }
             }
           }
@@ -130,7 +130,7 @@ def slackNotif() {
  * @param cmdline the command line in "<profiles> <goals> <properties>"`format.
  * @param consoleParsers array of console parsers to run
  */
-def mavenBuild(jdk, cmdline, mvnName, consoleParsers) {
+def mavenBuild(jdk, cmdline, mvnName) {
   script {
     try {
       withEnv(["JAVA_HOME=${ tool "$jdk" }",
@@ -138,16 +138,13 @@ def mavenBuild(jdk, cmdline, mvnName, consoleParsers) {
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
         configFileProvider(
                 [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS')]) {
-          sh "mvn -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -V -B -e -Djetty.testtracker.log=true $cmdline -Dunix.socket.tmp=/tmp/unixsocket"
+          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -V -B -e -Djetty.testtracker.log=true $cmdline -Dunix.socket.tmp=/tmp/unixsocket"
         }
       }
     }
     finally
     {
       junit testResults: '**/target/surefire-reports/*.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
-      if(consoleParsers!=null){
-        warnings consoleParsers: consoleParsers
-      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
           steps {
             container('jetty-build') {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk8", "-T2 clean install", "maven3")
+                mavenBuild( "jdk8", "clean install", "maven3")
                 // Collect up the jacoco execution results (only on main build)
                 jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
@@ -42,7 +42,7 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk11", "-T2 clean install -Djacoco.skip=true -Perrorprone", "maven3")
+                mavenBuild( "jdk11", "clean install -Djacoco.skip=true -Perrorprone", "maven3")
                 recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]
               }
             }
@@ -54,7 +54,7 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 240, unit: 'MINUTES' ) {
-                mavenBuild( "jdk15", "-T2 clean install -Djacoco.skip=true", "maven3")
+                mavenBuild( "jdk15", "clean install -Djacoco.skip=true", "maven3")
                 recordIssues id: "jdk15", name: "Static Analysis jdk15", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
               }
             }
@@ -80,7 +80,7 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 120, unit: 'MINUTES' ) {
-                mavenBuild( "jdk8", "-T3 -Pcompact3 clean install -DskipTests", "maven3")
+                mavenBuild( "jdk8", "-Pcompact3 clean install -DskipTests", "maven3")
               }
             }
           }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <sonar.skip>true</sonar.skip>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>
@@ -23,14 +24,6 @@
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
           <!-- No point deploying example projects -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <!-- No Point running Findbugs on example projects -->
           <skip>true</skip>
         </configuration>
       </plugin>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -9,6 +9,7 @@
   <name>Jetty :: ALPN :: Client</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.alpn.client</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.alpn.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -35,13 +36,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.alpn.*</onlyAnalyze>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-server/pom.xml
@@ -9,6 +9,7 @@
   <name>Jetty :: ALPN :: Server</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.alpn.server</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.alpn.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -17,13 +18,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.alpn.*</onlyAnalyze>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -10,6 +10,7 @@
   <description>Annotation support for deploying servlets in jetty.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.annotations</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.annotations.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -22,13 +23,6 @@
             <Import-Package>org.objectweb.asm;version="5",*</Import-Package>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=javax.servlet.ServletContainerInitializer)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional</Require-Capability>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.annotations.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -11,16 +11,10 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.client</bundle-symbolic-name>
     <jetty.test.policy.loc>target/test-policy</jetty.test.policy.loc>
+    <spotbugs.onlyAnalyze>org.eclipse.client.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.client.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/jetty-continuation/pom.xml
+++ b/jetty-continuation/pom.xml
@@ -10,16 +10,10 @@
   <description>Asynchronous API</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.continuation</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.continuation.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.continuation.*</onlyAnalyze>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -10,18 +10,8 @@
   <description>Jetty deployers</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.deploy</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.deploy.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.deploy.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-distribution/pom.xml
+++ b/jetty-distribution/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <assembly-directory>${basedir}/target/distribution</assembly-directory>
     <home-directory>${basedir}/target/home</home-directory>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>
@@ -380,14 +381,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <!-- No point performing Findbugs in assembly project -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -14,6 +14,7 @@
     <assembly-directory>${basedir}/target/jetty-home</assembly-directory>
     <source-assembly-directory>${basedir}/target/jetty-home-sources</source-assembly-directory>
     <jetty-setuid-version>1.0.4</jetty-setuid-version>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>
@@ -534,14 +535,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <!-- No point performing Findbugs in assembly project -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -9,6 +9,7 @@
   <name>Jetty :: Http Service Provider Interface</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.http.spi</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.http.spi.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -37,13 +38,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.http.spi.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -10,6 +10,7 @@
   <name>Jetty :: Http Utility</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.http</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.http.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -57,13 +58,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.http.*</onlyAnalyze>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jetty-io/pom.xml
+++ b/jetty-io/pom.xml
@@ -10,6 +10,7 @@
   <name>Jetty :: IO Utility</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.io</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.io.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -23,15 +24,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.io.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -12,6 +12,7 @@
     <bundle-symbolic-name>${project.groupId}.jaas</bundle-symbolic-name>
     <!-- 2.0.0.AM25 is breaking surefire -->
     <apacheds.version>2.0.0-M24</apacheds.version>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.jaas.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -20,13 +21,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.jaas.*</onlyAnalyze>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -12,17 +12,11 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.security.jaspi</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.jaspi.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.jaspi.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/jetty-jmh/pom.xml
+++ b/jetty-jmh/pom.xml
@@ -12,17 +12,11 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.jmh</bundle-symbolic-name>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -10,18 +10,8 @@
   <description>JMX management artifact for jetty.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.jmx</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.jmx.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.jmx.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -10,6 +10,7 @@
   <description>JNDI spi impl for java namespace.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.jndi</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.jndi.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -39,13 +40,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.jndi.*</onlyAnalyze>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -12,17 +12,11 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.openid</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.openid.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.security.openid.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty OSGi Boot JSP bundle</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.boot.jsp</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.osgi.boot.jasper.*,org.eclipse.jetty.osgi.boot.jsp.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -123,13 +124,6 @@
                 org.apache.jasper.*;version="[$(version;===;${jsp.version}),$(version;+;${jsp.version}))",
                 org.apache.el.*;version="[$(version;===;${jsp.version}),$(version;+;${jsp.version}))"</DynamicImport-Package>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.osgi.boot.jasper.*,org.eclipse.jetty.osgi.boot.jsp.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
@@ -11,6 +11,7 @@
   <description>Jetty OSGi Boot-Warurl bundle</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.boot.warurl</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.osgi.boot.warurl.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -34,13 +35,6 @@
             <Bundle-Name>RFC66 War URL</Bundle-Name>
             <Bundle-Activator>org.eclipse.jetty.osgi.boot.warurl.WarUrlActivator</Bundle-Activator>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.osgi.boot.warurl.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty OSGi Boot bundle</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.boot</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.osgi.boot.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -97,13 +98,6 @@
             </Import-Package>
             <_nouses>true</_nouses>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.osgi.boot.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-osgi/jetty-osgi-httpservice/pom.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty OSGi HttpService bundle</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.httpservice</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.osgi.httpservice.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -68,13 +69,6 @@
             </Import-Package>
             <_nouses>true</_nouses>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.osgi.httpservice.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty JavaEE style services</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.plus</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.plus.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -44,13 +45,6 @@
           <instructions>
             <Import-Package>javax.transaction.*;version="1.1",*</Import-Package>
           </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.plus.*</onlyAnalyze>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-proxy/pom.xml
+++ b/jetty-proxy/pom.xml
@@ -10,18 +10,8 @@
   <description>Jetty Proxy</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.proxy</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.proxy.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.proxy.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/jetty-rewrite/pom.xml
+++ b/jetty-rewrite/pom.xml
@@ -10,18 +10,8 @@
   <description>Jetty Rewrite Handler</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.rewrite</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.rewrite.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.rewrite.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -11,6 +11,8 @@
   <properties>
     <assembly-directory>target/distribution</assembly-directory>
     <bundle-symbolic-name>${project.groupId}.runner</bundle-symbolic-name>
+    <!-- too many external dependencies to fix... :) -->
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -10,16 +10,10 @@
   <description>Jetty security infrastructure</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.security</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.security.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/jetty-server/pom.xml
+++ b/jetty-server/pom.xml
@@ -10,6 +10,7 @@
   <description>The core jetty server artifact.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.server</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.server.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -24,13 +25,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.server.*</onlyAnalyze>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -11,6 +11,7 @@
   <description>Jetty Servlet Container</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.servlet</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -25,13 +26,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.servlet.*</onlyAnalyze>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -11,18 +11,8 @@
   <description>Utility Servlets from Jetty</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.servlets</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.servlets.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.servlets.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-start/pom.xml
+++ b/jetty-start/pom.xml
@@ -10,6 +10,7 @@
   <description>The start utility</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.start</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.start.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
@@ -21,13 +22,6 @@
               <mainClass>org.eclipse.jetty.start.Main</mainClass>
             </manifest>
           </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.start.*</onlyAnalyze>
         </configuration>
       </plugin>
       <plugin>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty UnixSocket</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.unixsocket</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.unixsocket.*</spotbugs.onlyAnalyze>
   </properties>
   <dependencies>
     <dependency>
@@ -41,13 +42,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.unixsocket.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/jetty-util-ajax/pom.xml
+++ b/jetty-util-ajax/pom.xml
@@ -10,18 +10,8 @@
   <description>JSON/Ajax Utility classes for Jetty</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.util.ajax</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.util.ajax.*</spotbugs.onlyAnalyze>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.util.ajax.*</onlyAnalyze>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -10,6 +10,7 @@
   <description>Utility classes for Jetty</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.util</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.util.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <resources>
@@ -19,13 +20,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.util.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -10,6 +10,7 @@
   <description>Jetty web application support</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.webapp</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.webapp.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <resources>
@@ -26,13 +27,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.webapp.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/jetty-websocket/pom.xml
+++ b/jetty-websocket/pom.xml
@@ -21,15 +21,11 @@
     <module>javax-websocket-client-impl</module>
     <module>javax-websocket-server-impl</module>
   </modules>
+  <properties>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.websocket.*</spotbugs.onlyAnalyze>
+  </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.websocket.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -10,16 +10,10 @@
   <description>The jetty xml utilities.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.xml</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.xml.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <onlyAnalyze>org.eclipse.jetty.xml.*</onlyAnalyze>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
     <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
 
+    <pmd.verbose>true</pmd.verbose>
+
     <!-- testing -->
     <it.debug>false</it.debug>
     <jetty.test.version>5.5</jetty.test.version>
@@ -262,7 +264,8 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <verbose>true</verbose>
+              <verbose>${pmd.verbose}</verbose>
+              <printFailingErrors>${pmd.verbose}</printFailingErrors>
             </configuration>
           </execution>
         </executions>
@@ -791,17 +794,6 @@
           <version>3.0.0</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.5</version>
-          <configuration>
-            <findbugsXmlOutput>true</findbugsXmlOutput>
-            <xmlOutput>true</xmlOutput>
-            <effort>Max</effort>
-            <onlyAnalyze>org.eclipse.jetty.*</onlyAnalyze>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
           <version>1.0.0</version>
@@ -1208,27 +1200,18 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <configuration>
                 <showWarnings>true</showWarnings>
-                <compilerId>javac-with-errorprone</compilerId>
-                <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                <compilerArgs>
-                  <arg>-XepAllErrorsAsWarnings</arg>
-                  <arg>-Xep:OperatorPrecedence:OFF</arg>
+                <compilerArgs combine.children="append">
+                  <arg>-XDcompilePolicy=simple</arg>
+                  <arg>-Xplugin:ErrorProne -XepAllErrorsAsWarnings</arg>
                 </compilerArgs>
+                <annotationProcessorPaths>
+                  <path>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>2.4.0</version>
+                  </path>
+                </annotationProcessorPaths>
               </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>org.codehaus.plexus</groupId>
-                  <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                  <version>2.8.8</version>
-                </dependency>
-                <!-- override plexus-compiler-javac-errorprone's dependency on
-                     Error Prone with the latest version -->
-                <dependency>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>2.4.0</version>
-                </dependency>
-              </dependencies>
             </plugin>
           </plugins>
         </pluginManagement>
@@ -1393,6 +1376,14 @@
       <properties>
         <settingsPath>${env.GLOBAL_MVN_SETTINGS}</settingsPath>
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
+        <spotbugs.failOnError>false</spotbugs.failOnError>
+        <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs -->
+        <spotbugs.threshold>Medium</spotbugs.threshold>
+        <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->
+        <spotbugs.effort>Default</spotbugs.effort>
+        <spotbugs.skip>false</spotbugs.skip>
+        <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
+        <pmd.verbose>false</pmd.verbose>
       </properties>
       <modules>
         <module>aggregates/jetty-all</module>
@@ -1400,6 +1391,11 @@
       <build>
         <pluginManagement>
           <plugins>
+            <plugin>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs-maven-plugin</artifactId>
+              <version>4.1.4</version>
+            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
@@ -1410,6 +1406,29 @@
             </plugin>
           </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotbugs</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>verify</phase>
+                <configuration>
+                  <skip>${spotbugs.skip}</skip>
+                  <failOnError>${spotbugs.failOnError}</failOnError>
+                  <xmlOutput>true</xmlOutput>
+                  <spotbugsXmlOutput>false</spotbugsXmlOutput>
+                  <effort>${spotbugs.effort}</effort>
+                  <threshold>${spotbugs.threshold}</threshold>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
     <profile>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>tests-parent</artifactId>
   <name>Jetty Tests :: Parent</name>
   <packaging>pom</packaging>
+  <properties>
+    <spotbugs.skip>true</spotbugs.skip>
+  </properties>
   <build>
     <pluginManagement>
       <plugins>
@@ -35,14 +38,6 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <!-- No point building javadoc on testing projects -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <configuration>
-            <!-- No Point running Findbugs on testing projects -->
             <skip>true</skip>
           </configuration>
         </plugin>


### PR DESCRIPTION
current logs parser are reading multiple time log files so this generate extra load on jenkins server.
this generate aggregated report per jdk as well (more readable)
<img width="1674" alt="Screen Shot 2020-11-27 at 6 57 47 pm" src="https://user-images.githubusercontent.com/19728/100431529-06d17880-30e4-11eb-99b2-4e40c9066dbe.png">
