### PR TITLE
Fix bug that messes up the max usage count when the entries' max usage counter on overflow

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -429,6 +429,12 @@ public class Pool<T> implements AutoCloseable, Dumpable
             this.state = new AtomicBiInteger(Integer.MIN_VALUE, 0);
         }
 
+        // for testing only
+        void setUsageCount(int usageCount)
+        {
+            this.state.getAndSetHi(usageCount);
+        }
+
         /** Enable a reserved entry {@link Entry}.
          * An entry returned from the {@link #reserve(int)} method must be enabled with this method,
          * once and only once, before it is usable by the pool.
@@ -507,7 +513,9 @@ public class Pool<T> implements AutoCloseable, Dumpable
                 if (closed || multiplexingCount >= maxMultiplex || (currentMaxUsageCount > 0 && usageCount >= currentMaxUsageCount))
                     return false;
 
-                if (state.compareAndSet(encoded, usageCount + 1, multiplexingCount + 1))
+                // Prevent overflowing the usage counter by capping it at Integer.MAX_VALUE.
+                int newUsageCount = usageCount == Integer.MAX_VALUE ? Integer.MAX_VALUE : usageCount + 1;
+                if (state.compareAndSet(encoded, newUsageCount, multiplexingCount + 1))
                     return true;
             }
         }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
@@ -538,6 +538,24 @@ public class PoolTest
         assertThat(e1.getUsageCount(), is(2));
     }
 
+    @ParameterizedTest
+    @MethodSource(value = "strategy")
+    public void testDynamicMaxUsageCountChangeOverflowMaxInt(Factory factory)
+    {
+        Pool<String> pool = factory.getPool(1);
+        Pool<String>.Entry entry = pool.reserve(-1);
+        entry.enable("aaa", false);
+        entry.setUsageCount(Integer.MAX_VALUE);
+
+        Pool<String>.Entry acquired1 = pool.acquire();
+        assertThat(acquired1, notNullValue());
+        assertThat(pool.release(acquired1), is(true));
+
+        pool.setMaxUsageCount(1);
+        Pool<String>.Entry acquired2 = pool.acquire();
+        assertThat(acquired2, nullValue());
+    }
+
     @Test
     public void testConfigLimits()
     {


### PR DESCRIPTION
Closes https://github.com/eclipse/jetty.project/issues/5741