### PR TITLE
Issue #5706 - fix potential NPE from websocket-core ServerUpgradeResponse

### DIFF
--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
@@ -37,14 +37,13 @@ import org.eclipse.jetty.websocket.client.JettyUpgradeListener;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JettyWebSocketNegotiationTest
@@ -117,7 +116,6 @@ public class JettyWebSocketNegotiationTest
         }
     }
 
-    @Disabled("Work in progress; ServerUpgradeResponse in websocket-core throws NPEs")
     @Test
     public void testManualNegotiationInCreator() throws Exception
     {
@@ -128,7 +126,7 @@ public class JettyWebSocketNegotiationTest
                 .filter(ec -> "permessage-deflate".equals(ec.getName()))
                 .filter(ec -> ec.getParameters().containsKey("client_no_context_takeover"))
                 .count();
-            assertThat(matchedExts, Matchers.is(1L));
+            assertThat(matchedExts, is(1L));
 
             // Manually drop the param so it is not negotiated in the extension stack.
             resp.setHeader("Sec-WebSocket-Extensions", "permessage-deflate");
@@ -151,6 +149,7 @@ public class JettyWebSocketNegotiationTest
 
         client.connect(socket, uri, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS);
         HttpResponse httpResponse = responseReference.get();
-        System.err.println(httpResponse.getHeaders());
+        String extensions = httpResponse.getHeaders().get("Sec-WebSocket-Extensions");
+        assertThat(extensions, is("permessage-deflate"));
     }
 }


### PR DESCRIPTION
**Issue #5706**

Bad implementation in `ServerUpgradeResponse` could cause NPEs if websocket extensions were set directly through the headers.