### PR TITLE
remove warning log message on CompressExtension failure

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/extensions/compress/CompressExtension.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/extensions/compress/CompressExtension.java
@@ -441,7 +441,6 @@ public abstract class CompressExtension extends AbstractExtension
             notifyCallbackFailure(current.callback, x);
             // If something went wrong, very likely the compression context
             // will be invalid, so we need to fail this IteratingCallback.
-            LOG.warn(x);
             super.failed(x);
         }
 


### PR DESCRIPTION
**closes #5785**

I think logging this failure here is redundant because we already forward the failure onto all the `WriteCallback`s queued up in the `Flusher` anyway.