### PR TITLE
Issue #5794 ensuring serverChannel is closed in the event of a failed bind to ensure proper resources are cleaned

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -346,6 +346,14 @@ public class ServerConnector extends AbstractNetworkConnector
             }
             catch (BindException e)
             {
+                try
+                {
+                    serverChannel.close();
+                }
+                catch (IOException ioe)
+                {
+                    LOG.warn(ioe);
+                }
                 throw new IOException("Failed to bind to " + bindAddress, e);
             }
         }


### PR DESCRIPTION
Issue #5794 ensuring serverChannel is closed in the event of a failed bind to ensure proper resources are cleaned

Signed-off-by: Joe Witt <joewitt@apache.org>