### PR TITLE
backport fix for ArithmeticException in Pool

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -301,6 +301,11 @@ public class Pool<T> implements AutoCloseable, Dumpable
             {
                 LOGGER.ignore(e);
                 size = entries.size();
+                // Size can be 0 when the pool is in the middle of
+                // acquiring a connection while another thread
+                // removes the last one from the pool.
+                if (size == 0)
+                    break;
             }
             index = (index + 1) % size;
         }


### PR DESCRIPTION
Fixes https://github.com/eclipse/jetty.project/issues/5819.

The original bug (https://github.com/eclipse/jetty.project/issues/5731) also affects 9.4.x despite the fact that it was reported against 10.0.x.

The fix should have been applied to 9.4.x too, which is what this PR is about.
