### PR TITLE
Issue#5782 - Defensively handle null current context

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ListenerHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ListenerHolder.java
@@ -22,6 +22,7 @@ import java.util.EventListener;
 import javax.servlet.ServletException;
 
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
 
 /**
  * ListenerHolder
@@ -111,9 +112,12 @@ public class ListenerHolder extends BaseHolder<EventListener>
         {
             try
             {
-                ContextHandler contextHandler = ContextHandler.getCurrentContext().getContextHandler();
-                if (contextHandler != null)
-                    contextHandler.removeEventListener(_listener);
+                Context context = ContextHandler.getCurrentContext();
+                if( context != null ) {
+                    ContextHandler contextHandler = context.getContextHandler();
+                    if (contextHandler != null)
+                        contextHandler.removeEventListener(_listener);
+                }
                 getServletHandler().destroyListener(unwrap(_listener));
             }
             finally


### PR DESCRIPTION
fix a regression since 9.4.21.v20190926
see https://github.com/eclipse/jetty.project/issues/5782