### PR TITLE
Issue #5830 Remove com.sun.nio.file import.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -31,11 +30,9 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EventListener;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -739,8 +736,6 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
     private static final WatchEvent.Kind<?>[] WATCH_DIR_KINDS = {ENTRY_CREATE, ENTRY_DELETE};
 
     private WatchService watchService;
-    private WatchEvent.Modifier[] watchModifiers;
-    private boolean nativeWatchService;
 
     private final List<Config> configs = new ArrayList<>();
     private final Map<WatchKey, Config> keys = new ConcurrentHashMap<>();
@@ -874,7 +869,7 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
     protected void doStart() throws Exception
     {
         //create a new watchservice
-        createWatchService();
+        this.watchService = FileSystems.getDefault().newWatchService();
 
         //ensure setting of quiet time is appropriate now we have a watcher
         setUpdateQuietTime(getUpdateQuietTimeMillis(), TimeUnit.MILLISECONDS);
@@ -925,45 +920,6 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
 
         configs.clear();
         listeners.clear();
-    }
-
-    /**
-     * Create a fresh WatchService and determine if it is a
-     * native implementation or not.
-     */
-    private void createWatchService() throws IOException
-    {
-        //create a watch service
-        this.watchService = FileSystems.getDefault().newWatchService();
-
-        WatchEvent.Modifier[] modifiers = null;
-        boolean nativeService = true;
-        // Try to determine native behavior
-        // See http://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else
-        try
-        {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Class<?> pollingWatchServiceClass = Class.forName("sun.nio.fs.PollingWatchService", false, cl);
-            if (pollingWatchServiceClass.isAssignableFrom(this.watchService.getClass()))
-            {
-                nativeService = false;
-                LOG.info("Using Non-Native Java {}", pollingWatchServiceClass.getName());
-                Class<?> c = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier", false, cl);
-                Field f = c.getField("HIGH");
-                modifiers = new WatchEvent.Modifier[]
-                    {
-                        (WatchEvent.Modifier)f.get(c)
-                    };
-            }
-        }
-        catch (Throwable t)
-        {
-            // Unknown JVM environment, assuming native.
-            LOG.ignore(t);
-        }
-
-        this.watchModifiers = modifiers;
-        this.nativeWatchService = nativeService;
     }
 
     /**
@@ -1068,25 +1024,16 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
     protected void register(Path path, Config config) throws IOException
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Registering watch on {} {}", path, watchModifiers == null ? null : Arrays.asList(watchModifiers));
+            LOG.debug("Registering watch on {}", path);
 
         register(path, config, WATCH_EVENT_KINDS);
     }
 
     private void register(Path path, Config config, WatchEvent.Kind<?>[] kinds) throws IOException
     {
-        if (watchModifiers != null)
-        {
-            // Java Watcher
-            WatchKey key = path.register(watchService, kinds, watchModifiers);
-            keys.put(key, config);
-        }
-        else
-        {
-            // Native Watcher
-            WatchKey key = path.register(watchService, kinds);
-            keys.put(key, config);
-        }
+        // Native Watcher
+        WatchKey key = path.register(watchService, kinds);
+        keys.put(key, config);
     }
 
     /**
@@ -1402,14 +1349,6 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
     public void setUpdateQuietTime(long duration, TimeUnit unit)
     {
         long desiredMillis = unit.toMillis(duration);
-
-        if (watchService != null && !this.nativeWatchService && (desiredMillis < 5000))
-        {
-            LOG.warn("Quiet Time is too low for non-native WatchService [{}]: {} < 5000 ms (defaulting to 5000 ms)", watchService.getClass().getName(), desiredMillis);
-            this.updateQuietTimeDuration = 5000;
-            this.updateQuietTimeUnit = TimeUnit.MILLISECONDS;
-            return;
-        }
 
         if (IS_WINDOWS && (desiredMillis < 1000))
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java
@@ -948,7 +948,7 @@ public class PathWatcher extends AbstractLifeCycle implements Runnable
             {
                 nativeService = false;
                 LOG.info("Using Non-Native Java {}", pollingWatchServiceClass.getName());
-                Class<?> c = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier");
+                Class<?> c = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier", false, cl);
                 Field f = c.getField("HIGH");
                 modifiers = new WatchEvent.Modifier[]
                     {


### PR DESCRIPTION
Closes #5830

The bnd tool which generates the osgi manifest for jetty-util is including an `Import-Package` for `com.sun.nio.file`, even though this class is only speculatively loaded (ie it is not mandatory for it to be present).

By using the 3-arg Class.forName(String name, boolean initialize, ClassLoader loader) method call, we can get bnd to ignore this package.

BTW: the speculative loading of the com.sun.nio.file.SensitivityWatchEventModifier will probably be removed in jetty-10 onwards, as will any references in jetty-util module-info.java.
