### PR TITLE
Issue #5725 Review preventers.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/DOMLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/DOMLeakPreventer.java
@@ -30,7 +30,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
  *
  * Note that according to the bug report, a heap dump may not identify the GCRoot, making
  * it difficult to identify the cause of the leak.
+ * 
+ * @deprecated reported as fixed in jdk 7, see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6916498
  */
+@Deprecated
 public class DOMLeakPreventer extends AbstractLeakPreventer
 {
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/GCThreadLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/GCThreadLeakPreventer.java
@@ -34,7 +34,10 @@ import java.lang.reflect.Method;
  * RMI.
  *
  * Inspired by Tomcat JreMemoryLeakPrevention.
+ * 
+ * @deprecated fixed in jdvm 9b130, see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8157570
  */
+@Deprecated
 public class GCThreadLeakPreventer extends AbstractLeakPreventer
 {
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/Java2DLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/Java2DLeakPreventer.java
@@ -25,7 +25,11 @@ package org.eclipse.jetty.util.preventers;
  * before webapp classloaders are created.
  *
  * See https://issues.apache.org/bugzilla/show_bug.cgi?id=51687
+ * 
+ * @deprecated fixed in jdk 9, see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6489540
+ * 
  */
+@Deprecated
 public class Java2DLeakPreventer extends AbstractLeakPreventer
 {
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/LDAPLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/LDAPLeakPreventer.java
@@ -27,7 +27,10 @@ package org.eclipse.jetty.util.preventers;
  * load the LdapPoolManager.
  *
  * Inspired by Tomcat JreMemoryLeakPrevention
+ * 
+ * @deprecated fixed in jdk 8u192
  */
+@Deprecated 
 public class LDAPLeakPreventer extends AbstractLeakPreventer
 {
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/LoginConfigurationLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/LoginConfigurationLeakPreventer.java
@@ -26,7 +26,9 @@ package org.eclipse.jetty.util.preventers;
  * that by invoking the classloading here.
  *
  * Inspired by Tomcat JreMemoryLeakPrevention
+ * @deprecated classloader does not seem to be held any more
  */
+@Deprecated
 public class LoginConfigurationLeakPreventer extends AbstractLeakPreventer
 {
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/SecurityProviderLeakPreventer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/SecurityProviderLeakPreventer.java
@@ -28,7 +28,10 @@ import java.security.Security;
  * is not a webapp classloader.
  *
  * Inspired by Tomcat JreMemoryLeakPrevention
+ * 
+ * @deprecated sun.security.pkcs11.SunPKCS11 class explicitly sets thread classloader to null
  */
+@Deprecated
 public class SecurityProviderLeakPreventer extends AbstractLeakPreventer
 {
 


### PR DESCRIPTION
Closes #5725

Reviewed the Preventers and deprecated them where there is information that the cause has been fixed in the jvm.

Note that any Preventer that is documented as being fixed prior to jdk11 should be deleted from jetty-10/11 when this change is merged through.