### PR TITLE
Issue #5824 Durable ConstraintMappings.

### DIFF
--- a/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.http.PathMap;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.URIUtil;
@@ -64,6 +65,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     private static final String OMISSION_SUFFIX = ".omission";
     private static final String ALL_METHODS = "*";
     private final List<ConstraintMapping> _constraintMappings = new CopyOnWriteArrayList<>();
+    private final List<ConstraintMapping> _durableConstraintMappings = new CopyOnWriteArrayList<>();
     private final Set<String> _roles = new CopyOnWriteArraySet<>();
     private final PathMap<Map<String, RoleInfo>> _constraintMap = new PathMap<>();
     private boolean _denyUncoveredMethods = false;
@@ -308,8 +310,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void setConstraintMappings(List<ConstraintMapping> constraintMappings, Set<String> roles)
     {
+        _durableConstraintMappings.clear();
         _constraintMappings.clear();
-        _constraintMappings.addAll(constraintMappings);
+        
+        if (isInDurableState())
+            _durableConstraintMappings.addAll(constraintMappings);
 
         if (roles == null)
         {
@@ -331,6 +336,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
 
         if (isStarted())
         {
+            _constraintMappings.addAll(constraintMappings);    
             for (ConstraintMapping mapping : _constraintMappings)
             {
                 processConstraintMapping(mapping);
@@ -357,7 +363,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void addConstraintMapping(ConstraintMapping mapping)
     {
-        _constraintMappings.add(mapping);
+        if (isInDurableState())
+            _durableConstraintMappings.add(mapping);
+        
         if (mapping.getConstraint() != null && mapping.getConstraint().getRoles() != null)
         {
             //allow for lazy role naming: if a role is named in a security constraint, try and
@@ -372,6 +380,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
 
         if (isStarted())
         {
+            _constraintMappings.add(mapping);
             processConstraintMapping(mapping);
         }
     }
@@ -404,14 +413,8 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected void doStart() throws Exception
     {
-        _constraintMap.clear();
-        if (_constraintMappings != null)
-        {
-            for (ConstraintMapping mapping : _constraintMappings)
-            {
-                processConstraintMapping(mapping);
-            }
-        }
+        _constraintMappings.addAll(_durableConstraintMappings);
+        _constraintMappings.stream().forEach(m -> processConstraintMapping(m));
 
         //Servlet Spec 3.1 pg 147 sec 13.8.4.2 log paths for which there are uncovered http methods
         checkPathsWithUncoveredHttpMethods();
@@ -424,6 +427,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     {
         super.doStop();
         _constraintMap.clear();
+        _constraintMappings.clear();
     }
 
     /**
@@ -856,5 +860,24 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             methods.add(strings[i]);
         }
         return methods;
+    }
+    
+    /**
+     * Constraints can be added to the ConstraintSecurityHandler before the 
+     * associated context is started. These constraints should persist across
+     * a stop/start. Others can be added after the associated context is starting
+     * (eg by a web.xml/web-fragment.xml, annotation or javax.servlet api call) -
+     * these should not be persisted across a stop/start as they will be re-added on
+     * the restart.
+     * 
+     * @return true if the context with which this ConstraintSecurityHandler
+     * has not yet started, or if there is no context, the server has not yet started.
+     */
+    private boolean isInDurableState()
+    {
+        ContextHandler context = ContextHandler.getContextHandler(null);
+        Server server = getServer();
+        
+        return (context == null && server == null) || (context != null && !context.isRunning()) || (context == null && server != null && !server.isRunning());
     }
 }

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
@@ -262,12 +262,19 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * @return Returns the constraintMappings.
+     * @return only the durable mappings if we are not yet started, otherwise
+     * return both the durables and transients.
      */
     @Override
     public List<ConstraintMapping> getConstraintMappings()
     {
-        return _constraintMappings;
+        //if we've started, then we've processed both the durable and
+        //transient constraint mappings
+        if (isRunning())
+            return _constraintMappings;
+        else
+            //otherwise, we only have durables
+            return _durableConstraintMappings;
     }
 
     @Override

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
@@ -307,12 +307,15 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void setConstraintMappings(List<ConstraintMapping> constraintMappings, Set<String> roles)
     {
-        _durableConstraintMappings.clear();
+
         _constraintMappings.clear();
-        _constraintMappings.addAll(constraintMappings);    
+        _constraintMappings.addAll(constraintMappings);
         
+        _durableConstraintMappings.clear();
         if (isInDurableState())
+        {
             _durableConstraintMappings.addAll(constraintMappings);
+        }
 
         if (roles == null)
         {
@@ -357,10 +360,10 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void addConstraintMapping(ConstraintMapping mapping)
     {
+        _constraintMappings.add(mapping);
+        
         if (isInDurableState())
             _durableConstraintMappings.add(mapping);
-        
-        _constraintMappings.add(mapping);
         
         if (mapping.getConstraint() != null && mapping.getConstraint().getRoles() != null)
         {

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
@@ -214,6 +214,9 @@ public class ConstraintTest
     @Test
     public void testConstraints() throws Exception
     {
+        //constraint mappings are not available until the server is started.
+        _server.start();
+        
         List<ConstraintMapping> mappings = new ArrayList<>(_security.getConstraintMappings());
 
         assertTrue(mappings.get(0).getConstraint().isForbidden());
@@ -698,7 +701,7 @@ public class ConstraintTest
     @MethodSource("basicScenarios")
     public void testBasic(Scenario scenario) throws Exception
     {
-        List<ConstraintMapping> list = new ArrayList<>(_security.getConstraintMappings());
+        List<ConstraintMapping> list = new ArrayList<>(getConstraintMappings());
 
         Constraint constraint6 = new Constraint();
         constraint6.setAuthenticate(true);

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
@@ -214,9 +214,6 @@ public class ConstraintTest
     @Test
     public void testConstraints() throws Exception
     {
-        //constraint mappings are not available until the server is started.
-        _server.start();
-        
         List<ConstraintMapping> mappings = new ArrayList<>(_security.getConstraintMappings());
 
         assertTrue(mappings.get(0).getConstraint().isForbidden());
@@ -256,10 +253,13 @@ public class ConstraintTest
         
         _server.stop();
         
+        //After a stop, just the durable mappings are left
         mappings = _security.getConstraintMappings();
-        assertThat("after restart", 0, Matchers.equalTo(mappings.size()));
+        assertThat("after stop", getConstraintMappings().size(), Matchers.equalTo(mappings.size()));
         
         _server.start();
+        
+        //Verify the constraints are just the durables
         mappings = _security.getConstraintMappings();
         assertThat("after restart", getConstraintMappings().size(), Matchers.equalTo(mappings.size()));
         
@@ -278,6 +278,7 @@ public class ConstraintTest
         _server.stop();
         _server.start();
         
+        //After a stop, only the durable mappings remain
         mappings = _security.getConstraintMappings();
         assertThat("after addition", getConstraintMappings().size(), Matchers.equalTo(mappings.size()));
     }


### PR DESCRIPTION
closes #5824 

Ensure that ConstraintMappings that are added to the ConstraintSecurityHandler before the context starts are retained across restarts, but those that are added after the context is starting (eg via annotations, web.xml/web-fragment.xml, javax.security api) are not.