### PR TITLE
Fixes #5845 - Use UTF-8 encoding for client basic auth if requested.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/util/BasicAuthentication.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/util/BasicAuthentication.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.client.util;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
@@ -63,7 +64,9 @@ public class BasicAuthentication extends AbstractAuthentication
     @Override
     public Result authenticate(Request request, ContentResponse response, HeaderInfo headerInfo, Attributes context)
     {
-        return new BasicResult(getURI(), headerInfo.getHeader(), user, password);
+        String charsetParam = headerInfo.getParameter("charset");
+        Charset charset = charsetParam == null ? null : Charset.forName(charsetParam);
+        return new BasicResult(getURI(), headerInfo.getHeader(), user, password, charset);
     }
 
     /**
@@ -89,9 +92,16 @@ public class BasicAuthentication extends AbstractAuthentication
 
         public BasicResult(URI uri, HttpHeader header, String user, String password)
         {
+            this(uri, header, user, password, StandardCharsets.ISO_8859_1);
+        }
+
+        public BasicResult(URI uri, HttpHeader header, String user, String password, Charset charset)
+        {
             this.uri = uri;
             this.header = header;
-            byte[] authBytes = (user + ":" + password).getBytes(StandardCharsets.ISO_8859_1);
+            if (charset == null)
+                charset = StandardCharsets.ISO_8859_1;
+            byte[] authBytes = (user + ":" + password).getBytes(charset);
             this.value = "Basic " + Base64.getEncoder().encodeToString(authBytes);
         }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -157,7 +157,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     {
         startBasic(scenario, new EmptyServerHandler(), StandardCharsets.UTF_8);
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
-        testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "\u20AC"));
+        testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "€"));
     }
 
     @ParameterizedTest

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -79,17 +81,25 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 {
     private String realm = "TestRealm";
 
-    public void startBasic(final Scenario scenario, Handler handler) throws Exception
+    public void startBasic(Scenario scenario, Handler handler) throws Exception
     {
-        start(scenario, new BasicAuthenticator(), handler);
+        startBasic(scenario, handler, null);
     }
 
-    public void startDigest(final Scenario scenario, Handler handler) throws Exception
+    public void startBasic(Scenario scenario, Handler handler, Charset charset) throws Exception
+    {
+        BasicAuthenticator authenticator = new BasicAuthenticator();
+        if (charset != null)
+            authenticator.setCharset(charset);
+        start(scenario, authenticator, handler);
+    }
+
+    public void startDigest(Scenario scenario, Handler handler) throws Exception
     {
         start(scenario, new DigestAuthenticator(), handler);
     }
 
-    private void start(final Scenario scenario, Authenticator authenticator, Handler handler) throws Exception
+    private void start(Scenario scenario, Authenticator authenticator, Handler handler) throws Exception
     {
         server = new Server();
         File realmFile = MavenTestingUtils.getTestResourceFile("realm.properties");
@@ -143,6 +153,15 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
+    public void testBasicWithUTF8Password(Scenario scenario) throws Exception
+    {
+        startBasic(scenario, new EmptyServerHandler(), StandardCharsets.UTF_8);
+        URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
+        testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "\u20AC"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
     public void testDigestAuthentication(Scenario scenario) throws Exception
     {
         startDigest(scenario, new EmptyServerHandler());
@@ -159,11 +178,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         testAuthentication(scenario, new DigestAuthentication(uri, ANY_REALM, "digest", "digest"));
     }
 
-    private void testAuthentication(final Scenario scenario, Authentication authentication) throws Exception
+    private void testAuthentication(Scenario scenario, Authentication authentication) throws Exception
     {
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
 
-        final AtomicReference<CountDownLatch> requests = new AtomicReference<>(new CountDownLatch(1));
+        AtomicReference<CountDownLatch> requests = new AtomicReference<>(new CountDownLatch(1));
         Request.Listener.Adapter requestListener = new Request.Listener.Adapter()
         {
             @Override
@@ -247,7 +266,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         client.getAuthenticationStore().addAuthentication(new BasicAuthentication(uri, realm, "basic", "basic"));
 
-        final CountDownLatch requests = new CountDownLatch(3);
+        CountDownLatch requests = new CountDownLatch(3);
         Request.Listener.Adapter requestListener = new Request.Listener.Adapter()
         {
             @Override
@@ -286,7 +305,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         client.getAuthenticationStore().addAuthentication(new BasicAuthentication(uri, realm, "basic", "basic"));
 
-        final CountDownLatch requests = new CountDownLatch(3);
+        CountDownLatch requests = new CountDownLatch(3);
         Request.Listener.Adapter requestListener = new Request.Listener.Adapter()
         {
             @Override
@@ -314,7 +333,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     {
         startBasic(scenario, new EmptyServerHandler());
 
-        final AtomicReference<CountDownLatch> requests = new AtomicReference<>(new CountDownLatch(2));
+        AtomicReference<CountDownLatch> requests = new AtomicReference<>(new CountDownLatch(2));
         Request.Listener.Adapter requestListener = new Request.Listener.Adapter()
         {
             @Override
@@ -386,7 +405,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         // Request without Authentication would cause a 401,
         // but the client will throw an exception trying to
         // send the credentials to the server.
-        final String cause = "thrown_explicitly_by_test";
+        String cause = "thrown_explicitly_by_test";
         client.getAuthenticationStore().addAuthentication(new Authentication()
         {
             @Override
@@ -402,7 +421,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             }
         });
 
-        final CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(1);
         client.newRequest("localhost", connector.getLocalPort())
             .scheme(scenario.getScheme())
             .path("/secure")

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -157,7 +157,8 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     {
         startBasic(scenario, new EmptyServerHandler(), StandardCharsets.UTF_8);
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
-        testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "€"));
+        // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
+        testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "\u20AC"));
     }
 
     @ParameterizedTest

--- a/jetty-client/src/test/resources/realm.properties
+++ b/jetty-client/src/test/resources/realm.properties
@@ -1,4 +1,5 @@
 # Format is <user>:<password>,<roles>
 basic:basic
+basic_utf8:\u20AC
 digest:digest
 spnego_client:,admin

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.security.authentication;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import javax.servlet.ServletRequest;
@@ -34,28 +35,26 @@ import org.eclipse.jetty.server.Authentication.User;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.security.Constraint;
 
-/**
- * @version $Rev: 4793 $ $Date: 2009-03-19 00:00:01 +0100 (Thu, 19 Mar 2009) $
- */
 public class BasicAuthenticator extends LoginAuthenticator
 {
+    private Charset _charset;
 
-    public BasicAuthenticator()
+    public Charset getCharset()
     {
+        return _charset;
     }
 
-    /**
-     * @see org.eclipse.jetty.security.Authenticator#getAuthMethod()
-     */
+    public void setCharset(Charset charset)
+    {
+        this._charset = charset;
+    }
+
     @Override
     public String getAuthMethod()
     {
         return Constraint.__BASIC_AUTH;
     }
 
-    /**
-     * @see org.eclipse.jetty.security.Authenticator#validateRequest(javax.servlet.ServletRequest, javax.servlet.ServletResponse, boolean)
-     */
     @Override
     public Authentication validateRequest(ServletRequest req, ServletResponse res, boolean mandatory) throws ServerAuthException
     {
@@ -77,7 +76,10 @@ public class BasicAuthenticator extends LoginAuthenticator
                     if ("basic".equalsIgnoreCase(method))
                     {
                         credentials = credentials.substring(space + 1);
-                        credentials = new String(Base64.getDecoder().decode(credentials), StandardCharsets.ISO_8859_1);
+                        Charset charset = getCharset();
+                        if (charset == null)
+                            charset = StandardCharsets.ISO_8859_1;
+                        credentials = new String(Base64.getDecoder().decode(credentials), charset);
                         int i = credentials.indexOf(':');
                         if (i > 0)
                         {
@@ -86,9 +88,7 @@ public class BasicAuthenticator extends LoginAuthenticator
 
                             UserIdentity user = login(username, password, request);
                             if (user != null)
-                            {
                                 return new UserAuthentication(getAuthMethod(), user);
-                            }
                         }
                     }
                 }
@@ -97,7 +97,11 @@ public class BasicAuthenticator extends LoginAuthenticator
             if (DeferredAuthentication.isDeferred(response))
                 return Authentication.UNAUTHENTICATED;
 
-            response.setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), "basic realm=\"" + _loginService.getName() + '"');
+            String value = "basic realm=\"" + _loginService.getName() + "\"";
+            Charset charset = getCharset();
+            if (charset != null)
+                value += ", charset=\"" + charset.name() + "\"";
+            response.setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), value);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return Authentication.SEND_CONTINUE;
         }


### PR DESCRIPTION
* Introduced get/setCharset in BasicAuthenticator on server-side.
* Looking for the "charset" parameter on the client-side, and if there, use it.
* Added test case.
* Code cleanups.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>