### PR TITLE
Fixes #5689 - Jetty ssl keystorePath doesn't work with absolute path.

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-ssl-context.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl-context.xml
@@ -11,12 +11,24 @@
 
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Set name="Provider"><Property name="jetty.sslContext.provider"/></Set>
-  <Set name="KeyStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.keyStorePath" deprecated="jetty.keystore" default="etc/keystore"/></Set>
+  <Set name="KeyStorePath">
+    <Property name="jetty.sslContext.keyStoreAbsolutePath">
+      <Default>
+        <Property name="jetty.base" default="." />/<Property name="jetty.sslContext.keyStorePath" deprecated="jetty.keystore" default="etc/keystore"/>
+      </Default>
+    </Property>
+  </Set>
   <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" deprecated="jetty.keystore.password" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>
   <Set name="KeyStoreType"><Property name="jetty.sslContext.keyStoreType" default="JKS"/></Set>
   <Set name="KeyStoreProvider"><Property name="jetty.sslContext.keyStoreProvider"/></Set>
   <Set name="KeyManagerPassword"><Property name="jetty.sslContext.keyManagerPassword" deprecated="jetty.keymanager.password" default="OBF:1u2u1wml1z7s1z7a1wnl1u2g"/></Set>
-  <Set name="TrustStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.trustStorePath" deprecated="jetty.truststore" default="etc/keystore"/></Set>
+  <Set name="TrustStorePath">
+    <Property name="jetty.sslContext.trustStoreAbsolutePath">
+      <Default>
+        <Property name="jetty.base" default="." />/<Property name="jetty.sslContext.trustStorePath" deprecated="jetty.truststore" default="etc/keystore"/>
+      </Default>
+    </Property>
+  </Set>
   <Set name="TrustStorePassword"><Property name="jetty.sslContext.trustStorePassword" deprecated="jetty.truststore.password"/></Set>
   <Set name="TrustStoreType"><Property name="jetty.sslContext.trustStoreType"/></Set>
   <Set name="TrustStoreProvider"><Property name="jetty.sslContext.trustStoreProvider"/></Set>

--- a/jetty-server/src/main/config/modules/ssl.mod
+++ b/jetty-server/src/main/config/modules/ssl.mod
@@ -87,26 +87,30 @@ basehome:modules/ssl/keystore|etc/keystore
 ## SSL JSSE Provider
 # jetty.sslContext.provider=
 
-## Keystore file path (relative to $jetty.base)
+## KeyStore file path (relative to $jetty.base)
 # jetty.sslContext.keyStorePath=etc/keystore
+## KeyStore absolute file path
+# jetty.sslContext.keyStoreAbsolutePath=${jetty.base}/etc/keystore
 
-## Truststore file path (relative to $jetty.base)
+## TrustStore file path (relative to $jetty.base)
 # jetty.sslContext.trustStorePath=etc/keystore
+## TrustStore absolute file path
+# jetty.sslContext.trustStoreAbsolutePath=${jetty.base}/etc/keystore
 
-## Keystore password
+## KeyStore password
 # jetty.sslContext.keyStorePassword=OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4
 
-## Keystore type and provider
+## KeyStore type and provider
 # jetty.sslContext.keyStoreType=JKS
 # jetty.sslContext.keyStoreProvider=
 
 ## KeyManager password
 # jetty.sslContext.keyManagerPassword=OBF:1u2u1wml1z7s1z7a1wnl1u2g
 
-## Truststore password
+## TrustStore password
 # jetty.sslContext.trustStorePassword=OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4
 
-## Truststore type and provider
+## TrustStore type and provider
 # jetty.sslContext.trustStoreType=JKS
 # jetty.sslContext.trustStoreProvider=
 


### PR DESCRIPTION
Introduced new properties jetty.sslContext.keyStoreAbsolutePath
and jetty.sslContext.trustStoreAbsolutePath to default to
${jetty.base}/etc/keystore.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>