### PR TITLE
Issue #5870 Windows URI case comparison fails

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
@@ -704,13 +704,12 @@ public class AnnotationConfiguration extends AbstractConfiguration
         }
 
         //Check if it is excluded by an ordering
-        URI loadingJarURI = sciResource.getURI();
         boolean found = false;
         Iterator<Resource> itor = orderedJars.iterator();
         while (!found && itor.hasNext())
         {
             Resource r = itor.next();
-            found = r.getURI().equals(loadingJarURI);
+            found = r.equals(sciResource);
         }
 
         if (LOG.isDebugEnabled())

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -34,6 +34,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -43,6 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceTest
 {
@@ -296,5 +298,18 @@ public class ResourceTest
         String globReference = testDir.toAbsolutePath().toString() + File.separator + '*';
         Resource globResource = Resource.newResource(globReference);
         assertNotNull(globResource, "Should have produced a Resource");
+    }
+    
+    @Test
+    @EnabledOnOs({OS.MAC, OS.WINDOWS}) 
+    public void testEquals() throws Exception
+    {
+        URI a = new URI("file:///c:/foo/bar");
+        URI b = new URI("file:///C:/foo/bar");
+        
+        Resource ra = Resource.newResource(a);
+        Resource rb = Resource.newResource(b);
+        
+        assertTrue(ra.equals(rb));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -43,8 +43,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceTest
 {
@@ -299,17 +299,30 @@ public class ResourceTest
         Resource globResource = Resource.newResource(globReference);
         assertNotNull(globResource, "Should have produced a Resource");
     }
-    
+
     @Test
-    @EnabledOnOs({OS.MAC, OS.WINDOWS}) 
-    public void testEquals() throws Exception
+    @EnabledOnOs(OS.WINDOWS)
+    public void testEqualsWindowsAltUriSyntax() throws Exception
+    {
+        URI a = new URI("file:/C:/foo/bar");
+        URI b = new URI("file:///C:/foo/bar");
+
+        Resource ra = Resource.newResource(a);
+        Resource rb = Resource.newResource(b);
+
+        assertEquals(rb, ra);
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void testEqualsWindowsCaseInsensitiveDrive() throws Exception
     {
         URI a = new URI("file:///c:/foo/bar");
         URI b = new URI("file:///C:/foo/bar");
         
         Resource ra = Resource.newResource(a);
         Resource rb = Resource.newResource(b);
-        
-        assertTrue(ra.equals(rb));
+
+        assertEquals(rb, ra);
     }
 }


### PR DESCRIPTION
Closes #5870.

On windows the URIs "file:/C:/foo/bar.jar"  and "file:/c:/foo/bar.jar" are not regarded as equal.  Change the AnnotationConfiguration to do comparison via Resource instead of URI.