### PR TITLE
Issue #5684 Fix testSetBadBoolean and remove @Disabled

### DIFF
--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -1046,7 +1046,6 @@ public class XmlConfigurationTest
     }
 
     @Test
-    @Disabled
     public void testSetBadBoolean() throws Exception
     {
         XmlConfiguration xmlConfiguration = asXmlConfiguration(
@@ -1054,8 +1053,10 @@ public class XmlConfigurationTest
                 "  <Set name=\"boolean\">tru</Set>" +
                 "</Configure>");
 
+        //Any string other than "true" (case insensitive) will be false
+        //according to Boolean constructor.
         NativeHolder bh = (NativeHolder)xmlConfiguration.configure();
-        assertTrue(bh.getBoolean(), "boolean['tru']");
+        assertFalse(bh.getBoolean(), "boolean['tru']");
     }
 
     @Test


### PR DESCRIPTION
As part of the general review of all Disabled tests in #5684, reviewed the disabled test XmlConfigurationTest.testSetBadBoolean.  

Changed it to test for failure for setting the value "tru", as this computes to *false* by new Boolean(String).