### PR TITLE
Fixes #5882 - Simplify ALPN modules.

### DIFF
--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-11.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-11.mod
@@ -1,7 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[description]
-Provides support for ALPN based on JDK 9+ APIs.
-
-[lib]
-lib/jetty-alpn-java-server-${jetty.version}.jar

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-12.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-12.mod
@@ -1,4 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[depend]
-alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-13.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-13.mod
@@ -1,4 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[depend]
-alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-14.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-14.mod
@@ -1,4 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[depend]
-alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-15.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-15.mod
@@ -1,4 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[depend]
-alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-16.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-16.mod
@@ -1,4 +1,0 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
-[depend]
-alpn-impl/alpn-11

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-java.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-java.mod
@@ -1,0 +1,8 @@
+[description]
+Provides the ALPN implementation based on the Java APIs.
+
+[provides]
+alpn-impl|default
+
+[lib]
+lib/jetty-alpn-java-server-${jetty.version}.jar

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
@@ -8,10 +8,9 @@ internal
 
 [depend]
 ssl
-alpn-impl/alpn-${java.version.platform}
+alpn-impl
 
 [lib]
-lib/jetty-alpn-client-${jetty.version}.jar
 lib/jetty-alpn-server-${jetty.version}.jar
 
 [xml]

--- a/jetty-home/src/main/resources/modules/conscrypt.mod
+++ b/jetty-home/src/main/resources/modules/conscrypt.mod
@@ -1,5 +1,3 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
-
 [description]
 Installs the Conscrypt JSSE provider.
 
@@ -29,6 +27,5 @@ Conscrypt is distributed under the Apache Licence 2.0
 https://github.com/google/conscrypt/blob/master/LICENSE
 
 [ini]
-conscrypt.version?=2.0.0
+conscrypt.version?=2.5.1
 jetty.sslContext.provider?=Conscrypt
-


### PR DESCRIPTION
Deleted alpn-<version>.mod files, replaced by a single alpn-java.mod.
This new module _provides_ "alpn-impl" by default, and so does conscrypt.mod.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>