### PR TITLE
Set source encoding of build-resources module to UTF-8

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -6,6 +6,10 @@
   <packaging>jar</packaging>
   <name>Jetty :: Build Resources</name>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Fixes https://github.com/eclipse/jetty.project/issues/5891