### PR TITLE
Jetty 9.4.x 5859 classloader leak queuedthreadpool

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
@@ -1,6 +1,6 @@
 //
 //  ========================================================================
-//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
 //  ------------------------------------------------------------------------
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the Eclipse Public License v1.0

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
@@ -23,10 +23,10 @@ import java.security.PrivilegedAction;
 import java.util.function.Supplier;
 
 /**
- * PrivilegedThreadFactory
- *
  * Convenience class to ensure that a new Thread is created
- * inside a privileged block. This prevents the Thread constructor
+ * inside a privileged block. 
+ * 
+ * This prevents the Thread constructor
  * from pinning the caller's context classloader. This happens
  * when the Thread constructor takes a snapshot of the current
  * calling context - which contains ProtectionDomains that may

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
@@ -20,9 +20,10 @@ package org.eclipse.jetty.util.thread;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.function.Supplier;
 
 /**
- * ThreadCreator
+ * PrivilegedThreadFactory
  *
  * Convenience class to ensure that a new Thread is created
  * inside a privileged block. This prevents the Thread constructor
@@ -32,21 +33,23 @@ import java.security.PrivilegedAction;
  * reference the context classloader - and remembers it for the
  * lifetime of the Thread.
  */
-class ThreadCreator
+class PrivilegedThreadFactory
 {
-    interface Factory<T extends Thread>
-    {
-        T newThread();
-    }
-    
-    static <T extends Thread> T create(Factory<T> maker)
+    /**
+     * Use a Supplier to make a new thread, calling it within
+     * a privileged block to prevent classloader pinning.
+     * 
+     * @param newThreadSupplier a Supplier to create a fresh thread
+     * @return a new thread, protected from classloader pinning.
+     */
+    static <T extends Thread> T newThread(Supplier<T> newThreadSupplier)
     {
         return AccessController.doPrivileged(new PrivilegedAction<T>()
         {
             @Override
             public T run()
             {
-                return maker.newThread();
+                return newThreadSupplier.get();
             }
         });
     }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -20,6 +20,8 @@ package org.eclipse.jetty.util.thread;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -685,12 +687,19 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     @Override
     public Thread newThread(Runnable runnable)
     {
-        Thread thread = new Thread(_threadGroup, runnable);
-        thread.setDaemon(isDaemon());
-        thread.setPriority(getThreadsPriority());
-        thread.setName(_name + "-" + thread.getId());
-        thread.setContextClassLoader(this.getClass().getClassLoader());
-        return thread;
+        return (AccessController.doPrivileged(new PrivilegedAction<Thread>()
+        {
+            @Override
+            public Thread run()
+            {
+                Thread thread = new Thread(_threadGroup, runnable);
+                thread.setDaemon(isDaemon());
+                thread.setPriority(getThreadsPriority());
+                thread.setName(_name + "-" + thread.getId());
+                thread.setContextClassLoader(this.getClass().getClassLoader());
+                return thread;
+            }
+        }));
     }
 
     protected void removeThread(Thread thread)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -693,7 +693,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
             thread.setDaemon(isDaemon());
             thread.setPriority(getThreadsPriority());
             thread.setName(_name + "-" + thread.getId());
-            thread.setContextClassLoader(this.getClass().getClassLoader());
+            thread.setContextClassLoader(getClass().getClassLoader());
             return thread;
         });
     }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -687,7 +687,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     @Override
     public Thread newThread(Runnable runnable)
     {
-        return ThreadCreator.create(() ->
+        return PrivilegedThreadFactory.newThread(() ->
         {
             Thread thread = new Thread(_threadGroup, runnable);
             thread.setDaemon(isDaemon());

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -689,7 +689,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
         thread.setDaemon(isDaemon());
         thread.setPriority(getThreadsPriority());
         thread.setName(_name + "-" + thread.getId());
-        thread.setContextClassLoader(QueuedThreadPool.class.getClassLoader());
+        thread.setContextClassLoader(this.getClass().getClassLoader());
         return thread;
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -689,6 +689,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
         thread.setDaemon(isDaemon());
         thread.setPriority(getThreadsPriority());
         thread.setName(_name + "-" + thread.getId());
+        thread.setContextClassLoader(QueuedThreadPool.class.getClassLoader());
         return thread;
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -687,19 +687,15 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     @Override
     public Thread newThread(Runnable runnable)
     {
-        return (AccessController.doPrivileged(new PrivilegedAction<Thread>()
+        return ThreadCreator.create(() ->
         {
-            @Override
-            public Thread run()
-            {
-                Thread thread = new Thread(_threadGroup, runnable);
-                thread.setDaemon(isDaemon());
-                thread.setPriority(getThreadsPriority());
-                thread.setName(_name + "-" + thread.getId());
-                thread.setContextClassLoader(this.getClass().getClassLoader());
-                return thread;
-            }
-        }));
+            Thread thread = new Thread(_threadGroup, runnable);
+            thread.setDaemon(isDaemon());
+            thread.setPriority(getThreadsPriority());
+            thread.setName(_name + "-" + thread.getId());
+            thread.setContextClassLoader(this.getClass().getClassLoader());
+            return thread;
+        });
     }
 
     protected void removeThread(Thread thread)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.util.thread;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -36,7 +38,15 @@ import org.eclipse.jetty.util.log.Logger;
 public class ShutdownThread extends Thread
 {
     private static final Logger LOG = Log.getLogger(ShutdownThread.class);
-    private static final ShutdownThread _thread = new ShutdownThread();
+    private static final ShutdownThread _thread = AccessController.doPrivileged(new PrivilegedAction<ShutdownThread>()
+        {
+            @Override
+            public ShutdownThread run()
+            {
+                return new ShutdownThread();
+            }
+        
+        });
 
     private boolean _hooked;
     private final List<LifeCycle> _lifeCycles = new CopyOnWriteArrayList<LifeCycle>();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
@@ -38,7 +38,7 @@ import org.eclipse.jetty.util.log.Logger;
 public class ShutdownThread extends Thread
 {
     private static final Logger LOG = Log.getLogger(ShutdownThread.class);
-    private static final ShutdownThread _thread = ThreadCreator.create(() ->
+    private static final ShutdownThread _thread = PrivilegedThreadFactory.newThread(() ->
     {
         return new ShutdownThread();
     });

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
@@ -38,15 +38,10 @@ import org.eclipse.jetty.util.log.Logger;
 public class ShutdownThread extends Thread
 {
     private static final Logger LOG = Log.getLogger(ShutdownThread.class);
-    private static final ShutdownThread _thread = AccessController.doPrivileged(new PrivilegedAction<ShutdownThread>()
-        {
-            @Override
-            public ShutdownThread run()
-            {
-                return new ShutdownThread();
-            }
-        
-        });
+    private static final ShutdownThread _thread = ThreadCreator.create(() ->
+    {
+        return new ShutdownThread();
+    });
 
     private boolean _hooked;
     private final List<LifeCycle> _lifeCycles = new CopyOnWriteArrayList<LifeCycle>();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadCreator.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadCreator.java
@@ -1,0 +1,53 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util.thread;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * ThreadCreator
+ *
+ * Convenience class to ensure that a new Thread is created
+ * inside a privileged block. This prevents the Thread constructor
+ * from pinning the caller's context classloader. This happens
+ * when the Thread constructor takes a snapshot of the current
+ * calling context - which contains ProtectionDomains that may
+ * reference the context classloader - and remembers it for the
+ * lifetime of the Thread.
+ */
+class ThreadCreator
+{
+    interface Factory<T extends Thread>
+    {
+        T newThread();
+    }
+    
+    static <T extends Thread> T create(Factory<T> maker)
+    {
+        return AccessController.doPrivileged(new PrivilegedAction<T>()
+        {
+            @Override
+            public T run()
+            {
+                return maker.newThread();
+            }
+        });
+    }
+}

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -840,10 +840,6 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
     public void testContextClassLoader() throws Exception
     {
         QueuedThreadPool tp = new QueuedThreadPool();
-        tp.setMinThreads(1);
-        tp.setMaxThreads(3);
-        tp.setIdleTimeout(1000);
-        tp.setThreadsPriority(Thread.NORM_PRIORITY - 1);
         try (StacklessLogging stackless = new StacklessLogging(QueuedThreadPool.class))
         {
             //change the current thread's classloader to something else
@@ -859,8 +855,6 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             
             //new thread should be set to the classloader of the QueuedThreadPool
             assertThat(t.getContextClassLoader(), Matchers.equalTo(QueuedThreadPool.class.getClassLoader()));
-            
-            t.start();
         }
     }
     

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.log.StacklessLogging;
 import org.eclipse.jetty.util.thread.ThreadPool.SizedThreadPool;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -833,6 +834,24 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         assertThat(count(dump, "QueuedThreadPoolTest.lambda$testDump$"), is(1));
     }
 
+    @Test
+    public void testContextClassLoader() throws Exception
+    {
+        QueuedThreadPool tp = new QueuedThreadPool();
+        tp.setMinThreads(1);
+        tp.setMaxThreads(2);
+        tp.setIdleTimeout(1000);
+        tp.setThreadsPriority(Thread.NORM_PRIORITY - 1);
+        try (StacklessLogging stackless = new StacklessLogging(QueuedThreadPool.class))
+        {
+            tp.start();
+            tp.execute(() ->
+            {
+                assertThat(Thread.currentThread().getContextClassLoader(), Matchers.equalTo(QueuedThreadPool.class.getClassLoader()));
+            });
+        }
+    }
+    
     private int count(String s, String p)
     {
         int c = 0;


### PR DESCRIPTION
See #5859

Ensure that QueuedThreadPool threads have their initial context classloader explicitly set, rather than defaulting to whatever the calling thread is using.