### PR TITLE
Fix DefaultServletTest cases which deal with filesystem path name normalization

### DIFF
--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -2056,7 +2056,7 @@ public class DefaultServletTest
         response = HttpTester.parseResponse(rawResponse);
         assertThat(response.toString(), response.getStatus(), is(HttpStatus.PRECONDITION_FAILED_412));
     }
-    
+
     @Test
     public void testGetUtf8NfcFile() throws Exception
     {
@@ -2065,10 +2065,15 @@ public class DefaultServletTest
         context.addServlet(DefaultServlet.class, "/");
         context.addAliasCheck(new SameFileAliasChecker());
 
-        // UTF-8 NFC format
+        // Create file with UTF-8 NFC format
         String filename = "swedish-" + new String(TypeUtil.fromHexString("C3A5"), UTF_8) + ".txt";
         createFile(docRoot.resolve(filename), "hi a-with-circle");
 
+        // Using filesystem, attempt to access via NFD format
+        Path nfdPath = docRoot.resolve("swedish-a" + new String(TypeUtil.fromHexString("CC8A"), UTF_8) + ".txt");
+        boolean filesystemSupportsNFDAccess = Files.exists(nfdPath);
+
+        // Make requests
         String rawResponse;
         HttpTester.Response response;
 
@@ -2081,7 +2086,7 @@ public class DefaultServletTest
         // Request as UTF-8 NFD
         rawResponse = connector.getResponse("GET /context/swedish-a%CC%8A.txt HTTP/1.1\r\nHost:test\r\nConnection:close\r\n\r\n");
         response = HttpTester.parseResponse(rawResponse);
-        if (OS.MAC.isCurrentOs())
+        if (filesystemSupportsNFDAccess)
         {
             assertThat(response.getStatus(), is(HttpStatus.OK_200));
             assertThat(response.getContent(), is("hi a-with-circle"));
@@ -2100,9 +2105,13 @@ public class DefaultServletTest
         context.addServlet(DefaultServlet.class, "/");
         context.addAliasCheck(new SameFileAliasChecker());
 
-        // UTF-8 NFD format
-        String filename = "swedish-" + new String(TypeUtil.fromHexString("61CC8A"), UTF_8) + ".txt";
+        // Create file with UTF-8 NFD format
+        String filename = "swedish-a" + new String(TypeUtil.fromHexString("CC8A"), UTF_8) + ".txt";
         createFile(docRoot.resolve(filename), "hi a-with-circle");
+
+        // Using filesystem, attempt to access via NFC format
+        Path nfcPath = docRoot.resolve("swedish-" + new String(TypeUtil.fromHexString("C3A5"), UTF_8) + ".txt");
+        boolean filesystemSupportsNFCAccess = Files.exists(nfcPath);
 
         String rawResponse;
         HttpTester.Response response;
@@ -2116,7 +2125,7 @@ public class DefaultServletTest
         // Request as UTF-8 NFC
         rawResponse = connector.getResponse("GET /context/swedish-%C3%A5.txt HTTP/1.1\r\nHost:test\r\nConnection:close\r\n\r\n");
         response = HttpTester.parseResponse(rawResponse);
-        if (OS.MAC.isCurrentOs())
+        if (filesystemSupportsNFCAccess)
         {
             assertThat(response.getStatus(), is(HttpStatus.OK_200));
             assertThat(response.getContent(), is("hi a-with-circle"));


### PR DESCRIPTION
Attempt to satisfy Filesystem behaviors in testcase.
+ Not relying on OS type