### PR TITLE
Issue #5901 Update to javax.servlet.api 4.0.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j2.version>2.13.0</log4j2.version>
     <logback.version>1.3.0-alpha5</logback.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
-    <servlet.api.version>4.0.5</servlet.api.version>
+    <servlet.api.version>4.0.6</servlet.api.version>
     <websocket.api.version>1.1.2</websocket.api.version>
     <jsp.version>9.0.29</jsp.version>
     <infinispan.version>9.4.8.Final</infinispan.version>


### PR DESCRIPTION
Update to jetty toolchain servlet-api jar version 4.0.6, which contains a change to it's module-info to `open` the `javax.servlet.resources` package to all modules.

This change was necessary because the org.mortbay apache-jsp jar (which is an automatic module) uses ServletContext.class.getResource(String) in order to obtain the servlet dtds and xsds,  and that method needs the javax.servlet.resources package to be``open``ed in order for them to be visible. 