### PR TITLE
Issue #5901 Update to jakarta.servlet.api 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j2.version>2.13.0</log4j2.version>
     <logback.version>1.3.0-alpha5</logback.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
-    <servlet.api.version>5.0.1</servlet.api.version>
+    <servlet.api.version>5.0.2</servlet.api.version>
     <!-- change version in jetty-websocket/websocket-jakarta-server/src/main/config/modules/websocket-jakarta.mod -->
     <websocket.api.version>2.0.0</websocket.api.version>
     <jsp.version>10.0.0-M10</jsp.version>


### PR DESCRIPTION
Update to jakarta.servlet.api 5.0.2 to pick up change to module-info to `open`  `jakarta.servlet.resources` package.