### PR TITLE
#5924 remove odd jetty-documentation dependency busting javadoc gener…

### DIFF
--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -114,11 +114,6 @@
             <artifactId>asciidoctorj-diagram</artifactId>
             <version>2.0.5</version>
           </dependency>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-documentation</artifactId>
-            <version>${project.version}</version>
-          </dependency>
         </dependencies>
         <configuration>
           <backend>html5</backend>


### PR DESCRIPTION
Using jetty-documentation dependency in the asciidoctor plugin (which is odd since this is a plugin execution depending on the artifact it is running in?) seems to mess up the javadoc generation in the subsequent module when it is activated by the ci profile (or eclipse-release).