### PR TITLE
Issue #5868 - allow request attributes to be set in websocket upgrade

### DIFF
--- a/jetty-websocket/websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
@@ -432,7 +433,8 @@ public abstract class CoreClientUpgradeRequest extends HttpRequest implements Re
         customizer.customize(coreSession);
 
         HttpClient httpClient = wsClient.getHttpClient();
-        WebSocketConnection wsConnection = new WebSocketConnection(endPoint, httpClient.getExecutor(), httpClient.getScheduler(), httpClient.getByteBufferPool(), coreSession);
+        ByteBufferPool bufferPool = wsClient.getWebSocketComponents().getBufferPool();
+        WebSocketConnection wsConnection = new WebSocketConnection(endPoint, httpClient.getExecutor(), httpClient.getScheduler(), bufferPool, coreSession);
         wsClient.getEventListeners().forEach(wsConnection::addEventListener);
         coreSession.setWebSocketConnection(wsConnection);
         notifyUpgradeListeners((listener) -> listener.onHandshakeResponse(this, response));

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeRequest.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeRequest.java
@@ -39,6 +39,10 @@ import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
 import org.eclipse.jetty.websocket.core.server.internal.UpgradeHttpServletRequest;
 
+/**
+ * Upgrade request used for websocket negotiation.
+ * Provides getters for things like the requested extensions and subprotocols so that the headers don't have to be parsed manually.
+ */
 public class ServerUpgradeRequest
 {
     private final URI requestURI;

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeResponse.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeResponse.java
@@ -26,6 +26,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 
+/**
+ * Upgrade response used for websocket negotiation.
+ * Allows setting of extensions and subprotocol without using headers directly.
+ */
 public class ServerUpgradeResponse
 {
     private final HttpServletResponse response;

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/UpgradeHttpServletRequest.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/UpgradeHttpServletRequest.java
@@ -14,6 +14,8 @@
 package org.eclipse.jetty.websocket.core.server.internal;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -30,6 +32,7 @@ import javax.servlet.AsyncContext;
 import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -84,6 +87,9 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     private final InetSocketAddress remoteAddress;
     private final String remoteName;
     private final InetSocketAddress serverAddress;
+
+    private boolean isAsyncStarted;
+    private boolean isAsyncSupported;
 
     public UpgradeHttpServletRequest(HttpServletRequest httpRequest)
     {
@@ -145,6 +151,8 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
             attributes.put(name, request.getAttribute(name));
         }
 
+        this.isAsyncStarted = request.isAsyncStarted();
+        this.isAsyncSupported = request.isAsyncSupported();
         request = null;
     }
 
@@ -197,13 +205,17 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     @Override
     public long getDateHeader(String name)
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getDateHeader(name);
     }
 
     @Override
     public int getIntHeader(String name)
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getIntHeader(name);
     }
 
     @Override
@@ -291,31 +303,41 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     @Override
     public String getRequestedSessionId()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getRequestedSessionId();
     }
 
     @Override
     public boolean isRequestedSessionIdValid()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.isRequestedSessionIdValid();
     }
 
     @Override
     public boolean isRequestedSessionIdFromCookie()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.isRequestedSessionIdFromCookie();
     }
 
     @Override
     public boolean isRequestedSessionIdFromURL()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.isRequestedSessionIdFromURL();
     }
 
     @Override
     public boolean isRequestedSessionIdFromUrl()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.isRequestedSessionIdFromUrl();
     }
 
     @Override
@@ -407,7 +429,7 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     public void setAttribute(String name, Object value)
     {
         if (request == null)
-            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+            attributes.put(name, value);
         request.setAttribute(name, value);
     }
 
@@ -415,7 +437,7 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     public void removeAttribute(String name)
     {
         if (request == null)
-            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+            attributes.remove(name);
         request.removeAttribute(name);
     }
 
@@ -476,122 +498,162 @@ public class UpgradeHttpServletRequest implements HttpServletRequest
     }
 
     @Override
-    public boolean authenticate(HttpServletResponse response)
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.authenticate(response);
     }
 
     @Override
     public String changeSessionId()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.changeSessionId();
     }
 
     @Override
     public AsyncContext getAsyncContext()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getAsyncContext();
     }
 
     @Override
     public String getCharacterEncoding()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getCharacterEncoding();
     }
 
     @Override
     public int getContentLength()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getContentLength();
     }
 
     @Override
     public long getContentLengthLong()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getContentLengthLong();
     }
 
     @Override
     public String getContentType()
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getContentType();
     }
 
     @Override
-    public ServletInputStream getInputStream()
+    public ServletInputStream getInputStream() throws IOException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getInputStream();
     }
 
     @Override
-    public Part getPart(String name)
+    public Part getPart(String name) throws IOException, ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getPart(name);
     }
 
     @Override
-    public Collection<Part> getParts()
+    public Collection<Part> getParts() throws IOException, ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getParts();
     }
 
     @Override
-    public BufferedReader getReader()
+    public BufferedReader getReader() throws IOException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getReader();
     }
 
     @Override
     public RequestDispatcher getRequestDispatcher(String path)
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.getRequestDispatcher(path);
     }
 
     @Override
     public boolean isAsyncStarted()
     {
-        return false;
+        if (request == null)
+            return isAsyncStarted;
+        return request.isAsyncStarted();
     }
 
     @Override
     public boolean isAsyncSupported()
     {
-        return false;
+        if (request == null)
+            return isAsyncSupported;
+        return request.isAsyncSupported();
     }
 
     @Override
-    public void login(String username, String password)
+    public void login(String username, String password) throws ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        request.login(username, password);
     }
 
     @Override
-    public void logout()
+    public void logout() throws ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        request.logout();
     }
 
     @Override
-    public void setCharacterEncoding(String enc)
+    public void setCharacterEncoding(String enc) throws UnsupportedEncodingException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        request.setCharacterEncoding(enc);
     }
 
     @Override
     public AsyncContext startAsync() throws IllegalStateException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.startAsync();
     }
 
     @Override
     public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.startAsync(servletRequest, servletResponse);
     }
 
     @Override
-    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass)
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException
     {
-        throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        if (request == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return request.upgrade(handlerClass);
     }
 }

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/UpgradeHttpServletResponse.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/UpgradeHttpServletResponse.java
@@ -1,0 +1,367 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.server.internal;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+public class UpgradeHttpServletResponse implements HttpServletResponse
+{
+    private static final String UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE = "Feature unsupported after Upgraded to WebSocket";
+
+    private HttpServletResponse _response;
+    private int _status;
+    private Map<String, Collection<String>> _headers;
+    private Locale _locale;
+    private String _characterEncoding;
+    private String _contentType;
+
+    public UpgradeHttpServletResponse(HttpServletResponse response)
+    {
+        _response = response;
+    }
+
+    public void upgrade()
+    {
+        _status = _response.getStatus();
+        _locale = _response.getLocale();
+        _characterEncoding = _response.getCharacterEncoding();
+        _contentType = _response.getContentType();
+        _headers = new HashMap<>();
+        for (String name : _response.getHeaderNames())
+        {
+            _headers.put(name, _response.getHeaders(name));
+        }
+
+        _response = null;
+    }
+
+    public HttpServletResponse getResponse()
+    {
+        return _response;
+    }
+
+    @Override
+    public int getStatus()
+    {
+        if (_response == null)
+            return _status;
+        return _response.getStatus();
+    }
+
+    @Override
+    public String getHeader(String s)
+    {
+        if (_response == null)
+        {
+            Collection<String> values = _headers.get(s);
+            if (values == null)
+                return null;
+            return values.stream().findFirst().orElse(null);
+        }
+
+        return _response.getHeader(s);
+    }
+
+    @Override
+    public Collection<String> getHeaders(String s)
+    {
+        if (_response == null)
+            return _headers.get(s);
+        return _response.getHeaders(s);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames()
+    {
+        if (_response == null)
+            return _headers.keySet();
+        return _response.getHeaderNames();
+    }
+
+    @Override
+    public Locale getLocale()
+    {
+        if (_response == null)
+            return _locale;
+        return _response.getLocale();
+    }
+
+    @Override
+    public boolean containsHeader(String s)
+    {
+        if (_response == null)
+        {
+            Collection<String> values = _headers.get(s);
+            return values != null && !values.isEmpty();
+        }
+
+        return _response.containsHeader(s);
+    }
+
+    @Override
+    public String getCharacterEncoding()
+    {
+        if (_response == null)
+            return _characterEncoding;
+        return _response.getCharacterEncoding();
+    }
+
+    @Override
+    public String getContentType()
+    {
+        if (_response == null)
+            return _contentType;
+        return _response.getContentType();
+    }
+
+    @Override
+    public void addCookie(Cookie cookie)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.addCookie(cookie);
+    }
+
+    @Override
+    public String encodeURL(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.encodeURL(s);
+    }
+
+    @Override
+    public String encodeRedirectURL(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.encodeRedirectURL(s);
+    }
+
+    @Override
+    public String encodeUrl(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.encodeUrl(s);
+    }
+
+    @Override
+    public String encodeRedirectUrl(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.encodeRedirectUrl(s);
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.getOutputStream();
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.getWriter();
+    }
+
+    @Override
+    public void setCharacterEncoding(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setCharacterEncoding(s);
+    }
+
+    @Override
+    public void setContentLength(int i)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setContentLength(i);
+    }
+
+    @Override
+    public void setContentLengthLong(long l)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setContentLengthLong(l);
+    }
+
+    @Override
+    public void setContentType(String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setContentType(s);
+    }
+
+    @Override
+    public void setBufferSize(int i)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setBufferSize(i);
+    }
+
+    @Override
+    public int getBufferSize()
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.getBufferSize();
+    }
+
+    @Override
+    public void flushBuffer() throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.flushBuffer();
+    }
+
+    @Override
+    public void resetBuffer()
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.resetBuffer();
+    }
+
+    @Override
+    public boolean isCommitted()
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        return _response.isCommitted();
+    }
+
+    @Override
+    public void reset()
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.reset();
+    }
+
+    @Override
+    public void setLocale(Locale locale)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setLocale(locale);
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.sendError(sc, msg);
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.sendError(sc);
+    }
+
+    @Override
+    public void setHeader(String name, String value)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setHeader(name, value);
+    }
+
+    @Override
+    public void sendRedirect(String s) throws IOException
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.sendRedirect(s);
+    }
+
+    @Override
+    public void setDateHeader(String s, long l)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setDateHeader(s, l);
+    }
+
+    @Override
+    public void addDateHeader(String s, long l)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.addDateHeader(s, l);
+    }
+
+    @Override
+    public void addHeader(String name, String value)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.addHeader(name, value);
+    }
+
+    @Override
+    public void setIntHeader(String s, int i)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setIntHeader(s, i);
+    }
+
+    @Override
+    public void addIntHeader(String s, int i)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.addIntHeader(s, i);
+    }
+
+    @Override
+    public void setStatus(int i)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setStatus(i);
+    }
+
+    @Override
+    public void setStatus(int i, String s)
+    {
+        if (_response == null)
+            throw new UnsupportedOperationException(UNSUPPORTED_AFTER_WEBSOCKET_UPGRADE);
+        _response.setStatus(i, s);
+    }
+}

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnTests.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/autobahn/AutobahnTests.java
@@ -37,6 +37,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,7 @@ import org.testcontainers.utility.MountableFile;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Disabled
 @Testcontainers
 public class AutobahnTests
 {

--- a/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-websocket/websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/JettyWebSocketServerContainer.java
@@ -124,9 +124,8 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             throw new WebSocketException("Duplicate WebSocket Mapping for PathSpec");
 
         WebSocketUpgradeFilter.ensureFilter(contextHandler.getServletContext());
-        webSocketMappings.addMapping(ps,
-            (req, resp) -> creator.createWebSocket(new DelegatedServerUpgradeRequest(req), new DelegatedServerUpgradeResponse(resp)),
-            frameHandlerFactory, customizer);
+        WebSocketCreator coreCreator = (req, resp) -> creator.createWebSocket(new DelegatedServerUpgradeRequest(req), new DelegatedServerUpgradeResponse(resp));
+        webSocketMappings.addMapping(ps, coreCreator, frameHandlerFactory, customizer);
     }
 
     public void addMapping(String pathSpec, final Class<?> endpointClass)

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketServletAttributeTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketServletAttributeTest.java
@@ -1,0 +1,90 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JettyWebSocketServletAttributeTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private WebSocketClient client;
+    private final EchoSocket serverEndpoint = new EchoSocket();
+
+    @BeforeEach
+    public void before()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        client = new WebSocketClient();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    public void start(JettyWebSocketServletContainerInitializer.Configurator configurator) throws Exception
+    {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, configurator);
+
+        server.start();
+        client.start();
+    }
+
+    @Test
+    public void testAttributeSetInNegotiation() throws Exception
+    {
+        start((context, container) -> container.addMapping("/", (req, resp) ->
+        {
+            req.setServletAttribute("myWebSocketCustomAttribute", "true");
+            return serverEndpoint;
+        }));
+
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/filterPath");
+        EventSocket clientEndpoint = new EventSocket();
+        client.connect(clientEndpoint, uri);
+        assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(serverEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+
+        // We should have our custom attribute on the upgraded request, which was set in the negotiation.
+        JettyServerUpgradeRequest upgradeRequest = (JettyServerUpgradeRequest)serverEndpoint.session.getUpgradeRequest();
+        assertThat(upgradeRequest.getServletAttribute("myWebSocketCustomAttribute"), is("true"));
+
+        clientEndpoint.session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
@@ -347,8 +347,8 @@ public class WebSocketOverHTTP2Test
             });
             factory.addMapping("/ws/connectionClose", (request, response) ->
             {
-                UpgradeHttpServletRequest servletRequest = (UpgradeHttpServletRequest)request.getHttpServletRequest();
-                Request baseRequest = servletRequest.getBaseRequest();
+                UpgradeHttpServletRequest upgradeRequest = (UpgradeHttpServletRequest)request.getHttpServletRequest();
+                Request baseRequest = (Request)upgradeRequest.getHttpServletRequest();
                 baseRequest.getHttpChannel().getEndPoint().close();
                 return new EchoSocket();
             });


### PR DESCRIPTION
**Issue #5868 & #5865**

We now remove references to the `HttpServletRequest` and `HttpServletResponse` after the websocket upgrade, and allow access to the request attribute setters during and after the websocket upgrade. 

After the upgrade all relevant information from the request & response are copied locally into `UpgradeHttpServletRequest` and `UpgradeHttpServletResponse` before they are recycled.