### PR TITLE
Cleanup setPathQuery from #5954

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -705,6 +705,7 @@ public interface HttpURI
             _path = null;
             _decodedPath = null;
             _param = null;
+            _query = null;
             if (pathQuery != null)
                 parse(State.PATH, pathQuery);
             return this;

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -236,6 +236,13 @@ public class HttpURITest
         assertEquals("p2", uri.getParam());
         assertEquals("name=value", uri.getQuery());
 
+        uri = builder.pathQuery("/f%30%30;p0/bar;p1;p2").asImmutable();
+        assertEquals("http://host:8888/f%30%30;p0/bar;p1;p2", uri.toString());
+        assertEquals("/f%30%30;p0/bar;p1;p2", uri.getPath());
+        assertEquals("/f00/bar", uri.getDecodedPath());
+        assertEquals("p2", uri.getParam());
+        assertEquals(null, uri.getQuery());
+
         uri = builder.query("other=123456").asImmutable();
         assertEquals("http://host:8888/f%30%30;p0/bar;p1;p2?other=123456", uri.toString());
         assertEquals("/f%30%30;p0/bar;p1;p2", uri.getPath());


### PR DESCRIPTION
Cleanup setPathQuery from #5954 so that it does not retain an old query if the passed string does not contain a query