### PR TITLE
Fix move from DISTRO to HOME for jetty-maven-plugin mode

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/maven/jetty-maven-plugin.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/maven/jetty-maven-plugin.adoc
@@ -204,9 +204,9 @@ See link:#container-classpath[Container Classpath vs WebApp Classpath].
 
 ===== In a jetty distribution
 
-`deployMode` of `DISTRO`.
+`deployMode` of `EXTERNAL`.
 This is similar to the old "jetty:run-distro" goal - your webapp is deployed into a dynamically downloaded, unpacked and configured jetty distribution.
-A separate process is forked to run the distro.
+A separate process is forked to run it.
 These extra configuration parameters are available:
 
 jettyBase::
@@ -234,7 +234,7 @@ These modules are enabled by default: `server,http,webapp,deploy`.
 The following configuration parameters are common to all of the `"run-"` and `"start-"` goals:
 
 deployMode::
-One of `EMBED`, `FORK` or `DISTRO`.
+One of `EMBED`, `FORK` or `EXTERNAL`.
 Default `EMBED`.
 Can also be configured by setting the Maven property `jetty.deployMode`.
 This parameter determines whether the webapp will run in jetty in-process with Maven, forked into a new process, or deployed into a jetty distribution.
@@ -281,7 +281,7 @@ It will make a classpath for the webapp to be deployed comprised of &lt;dependen
 
 If your production environment places specific jars onto the container's classpath, the equivalent way to do this with maven is to define these as &lt;dependencies&gt; for the _plugin_ itself, not the _project_. See http://maven.apache.org/pom.html#Plugins[configuring maven plugins].
 This is suitable if you are using either `EMBED` or `FORK` mode.
-If you are using `DISTRO` mode, then you should configure the `modules` parameter with the names of the jetty modules that place these jars onto the container classpath.
+If you are using `EXTERNAL` mode, then you should configure the `modules` parameter with the names of the jetty modules that place these jars onto the container classpath.
 
 Note that in `EMBED` or `FORK` mode, you could also influence the container classpath by setting the `useProvidedScope` parameter to `true`: this will place any dependencies with &lt;scope&gt;provided&lt;scope&gt; onto the plugin's classpath.
 Use this very cautiously: as the plugin already automatically places most jetty jars onto the classpath, you could wind up with duplicate jars. 
@@ -405,7 +405,7 @@ Include and exclude patterns that can be applied to the testClassesDirectory for
 If a file or directory is excluded by the patterns then a change in that file (or subtree in the case of a directory) is ignored and will not cause the webapp to redeploy.
 Patterns are specified as a relative path using a glob-like syntax as described in the http://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-[javadoc] for http://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-[FileSystem.getPathMatcher].
 
-See link:#deployment-modes[Deployment Modes] for other configuration parameters available when using the `run` goal in EMBED, FORK or DISTRO modes.
+See link:#deployment-modes[Deployment Modes] for other configuration parameters available when using the `run` goal in EMBED, FORK or EXTERNAL modes.
 
 Here's an example of a pom configuration for the plugin with the `run` goal:
 
@@ -507,7 +507,7 @@ scanTargetPatterns::
 Optional.
 List of directories with ant-style include/excludes patterns to specify other files to periodically scan for changes.
 
-See link:#deployment-modes[Deployment Modes] for other configuration parameters available when using the `run-war` goal in EMBED, FORK or DISTRO modes.
+See link:#deployment-modes[Deployment Modes] for other configuration parameters available when using the `run-war` goal in EMBED, FORK or EXTERNAL modes.
 
 [[jetty-start-goal]]
 ==== jetty:start
@@ -625,7 +625,7 @@ Optional.
 Used in conjunction with stopPort for stopping jetty.
 Useful to use in conjunction with the link:#jetty-stop-goal[stop] and link:#jetty-start-goal[start] goals.
 
-These additional configuration parameters are available when running in `FORK` or `DISTRO` mode:
+These additional configuration parameters are available when running in `FORK` or `EXTERNAL` mode:
 
 maxChildStartChecks::
 Default is `10`.
@@ -691,7 +691,7 @@ Optional.
 Used in conjunction with stopPort for stopping jetty.
 Useful to use in conjunction with the link:#jetty-stop-goal[stop].
 
-These additional configuration parameters are available when running in FORK or DISTRO mode:
+These additional configuration parameters are available when running in FORK or EXTERNAL mode:
 
 maxChildStartChecks::
 Default is `10`.
@@ -704,7 +704,7 @@ This is the time in milliseconds between checks on the startup of the forked jet
 [[jetty-stop-goal]]
 ==== jetty:stop
 
-The stop goal stops a FORK or DISTRO mode running instance of Jetty.
+The stop goal stops a FORK or EXTERNAL mode running instance of Jetty.
 To use it, you need to configure the plugin with a special port number and key.
 That same port number and key will also be used by the other goals that start jetty.
 

--- a/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <jetty.port.file>${project.build.directory}/jetty-start-distro-port.txt</jetty.port.file>
     <jetty.jvmArgs>@jetty.jvmArgs@</jetty.jvmArgs>
-    <jetty.deployMode>HOME</jetty.deployMode>
+    <jetty.deployMode>DISTRO</jetty.deployMode>
   </properties>
 
   <dependencies>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
@@ -72,7 +72,8 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
     {
         EMBED,
         FORK,
-        HOME
+        HOME,
+        DISTRO //alias for HOME
     }
 
     /**
@@ -439,6 +440,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
                 break;
             }
             case HOME:
+            case DISTRO:
             {
                 startJettyHome();
                 break;

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
@@ -72,20 +72,21 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
     {
         EMBED,
         FORK,
-        HOME,
-        DISTRO //alias for HOME
+        HOME, //alias for EXTERNAL
+        DISTRO, //alias for EXTERNAL
+        EXTERNAL
     }
 
     /**
      * Max number of times to check to see if jetty has started correctly
-     * when running in FORK or HOME mode.
+     * when running in FORK or EXTERNAL mode.
      */
     @Parameter (defaultValue = "10")
     protected int maxChildStartChecks;
 
     /**
      * How long to wait in msec between checks to see if jetty has started
-     * correctly when running in FORK or HOME mode.
+     * correctly when running in FORK or EXTERNAL mode.
      */
     @Parameter (defaultValue = "200")
     protected long maxChildStartCheckMs;
@@ -223,7 +224,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
     protected Map<String, String> systemProperties;
 
     /**
-     * Controls how to run jetty. Valid values are EMBED,FORK,HOME.
+     * Controls how to run jetty. Valid values are EMBED,FORK,EXTERNAL.
      */
     @Parameter (property = "jetty.deployMode", defaultValue = "EMBED") 
     protected DeploymentMode deployMode;
@@ -268,7 +269,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
     //End of EMBED only
     
 
-    //Start of parameters only valid for FORK/HOME
+    //Start of parameters only valid for FORK/EXTERNAL
     /**
      * Extra environment variables to be passed to the forked process
      */
@@ -297,9 +298,9 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
      */
     @Parameter
     protected String stopKey;
-    //End of FORK or HOME parameters
+    //End of FORK or EXTERNAL parameters
 
-    //Start of parameters only valid for HOME
+    //Start of parameters only valid for EXTERNAL
     /**
      * Location of jetty home directory
      */
@@ -318,7 +319,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
      */
     @Parameter
     protected String[] modules;
-    //End of HOME only parameters
+    //End of EXTERNAL only parameters
 
     //Start of parameters only valid for FORK
     /**
@@ -439,9 +440,12 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
                 startJettyForked();
                 break;
             }
-            case HOME:
             case DISTRO:
+            case HOME:
+            case EXTERNAL:
             {
+                if (deployMode != DeploymentMode.EXTERNAL)
+                    getLog().warn(deployMode + " mode is deprecated, use mode EXTERNAL");
                 startJettyHome();
                 break;
             }

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -367,6 +367,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
                 break;
             }
             case HOME:
+            case DISTRO:
             {
                 verifyPomConfiguration();
                 if (reconfigure)

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -69,7 +69,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
 
     /**
      * Only one of the following will be used, depending the mode
-     * the mojo is started in: EMBED, FORK, HOME
+     * the mojo is started in: EMBED, FORK, EXTERNAL
      */
     protected JettyEmbedder embedder;
     protected JettyForker forker;
@@ -366,9 +366,12 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
                     scanner.start();
                 break;
             }
-            case HOME:
             case DISTRO:
+            case HOME:
+            case EXTERNAL:
             {
+                if (deployMode != DeploymentMode.EXTERNAL)
+                    getLog().warn(deployMode + " mode is deprecated, use mode EXTERNAL");
                 verifyPomConfiguration();
                 if (reconfigure)
                 {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
@@ -264,7 +264,10 @@ public class JettyRunWarMojo extends AbstractWebAppMojo
             }
             case HOME:
             case DISTRO:
+            case EXTERNAL:
             {
+                if (deployMode != DeploymentMode.EXTERNAL)
+                    getLog().warn(deployMode + " mode is deprecated, use mode EXTERNAL");
                 verifyPomConfiguration();
                 if (reconfigure)
                 {

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunWarMojo.java
@@ -263,6 +263,7 @@ public class JettyRunWarMojo extends AbstractWebAppMojo
                 break;
             }
             case HOME:
+            case DISTRO:
             {
                 verifyPomConfiguration();
                 if (reconfigure)


### PR DESCRIPTION
The enum `DISTRO` signifying running the jetty maven plugin with an externally downloaded release of jetty was changed to the enum `HOME` with https://github.com/eclipse/jetty.project/commit/63736990c5150cc78ab02b3c6bc43a7ffea347f9.

`HOME` should have been at most a synonym for `DISTRO`.

Bear in mind that the `DISTRO` option is the jetty-10 replacement for the jetty-9.4 goal` jetty:run-distro` and simply means run the plugin with an externally downloaded jetty, not the version of jetty available embedded with the plugin.

This PR makes `HOME` a synonym for `DISTRO`.

