### PR TITLE
Fixes #5994 - QueuedThreadPool "free" threads

### DIFF
--- a/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/MBeanContainerLifeCycleTest.java
+++ b/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/MBeanContainerLifeCycleTest.java
@@ -77,12 +77,13 @@ public class MBeanContainerLifeCycleTest
 
         String pkg = bean.getClass().getPackage().getName();
         Set<ObjectName> objectNames = mbeanServer.queryNames(ObjectName.getInstance(pkg + ":*"), null);
-        assertEquals(1, objectNames.size());
+        // QueuedThreadPool and ThreadPoolBudget.
+        assertEquals(2, objectNames.size());
 
         container.stop();
 
         objectNames = mbeanServer.queryNames(ObjectName.getInstance(pkg + ":*"), null);
-        assertEquals(1, objectNames.size());
+        assertEquals(2, objectNames.size());
 
         // Remove the MBeans to start clean on the next test.
         objectNames.forEach(objectName ->
@@ -105,7 +106,8 @@ public class MBeanContainerLifeCycleTest
 
         String pkg = bean.getClass().getPackage().getName();
         Set<ObjectName> objectNames = mbeanServer.queryNames(ObjectName.getInstance(pkg + ":*"), null);
-        assertEquals(1, objectNames.size());
+        // QueuedThreadPool and ThreadPoolBudget.
+        assertEquals(2, objectNames.size());
 
         container.stop();
         container.destroy();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -111,12 +111,18 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
         return _executor;
     }
 
+    /**
+     * @return the maximum number of reserved threads
+     */
     @ManagedAttribute(value = "max number of reserved threads", readonly = true)
     public int getCapacity()
     {
         return _capacity;
     }
 
+    /**
+     * @return the number of threads available to {@link #tryExecute(Runnable)}
+     */
     @ManagedAttribute(value = "available reserved threads", readonly = true)
     public int getAvailable()
     {
@@ -196,8 +202,10 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
     }
 
     /**
-     * @param task The task to run
-     * @return True iff a reserved thread was available and has been assigned the task to run.
+     * <p>Executes the given task if and only if a reserved thread is available.</p>
+     *
+     * @param task the task to run
+     * @return true if and only if a reserved thread was available and has been assigned the task to run.
      */
     @Override
     public boolean tryExecute(Runnable task)

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -21,6 +21,8 @@ package org.eclipse.jetty.util.thread;
 import java.io.Closeable;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -194,7 +196,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         waitForIdle(tp, 2);
 
         // Doesn't shrink to less than min threads
-        Thread.sleep(3 * tp.getIdleTimeout() / 2);
+        Thread.sleep(3L * tp.getIdleTimeout() / 2);
         assertThat(tp.getThreads(), is(2));
         assertThat(tp.getIdleThreads(), is(2));
 
@@ -296,7 +298,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             waitForIdle(tp, 2);
 
             // Doesn't shrink to less than min threads
-            Thread.sleep(3 * tp.getIdleTimeout() / 2);
+            Thread.sleep(3L * tp.getIdleTimeout() / 2);
             waitForThreads(tp, 2);
             waitForIdle(tp, 2);
 
@@ -855,6 +857,77 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             
             //new thread should be set to the classloader of the QueuedThreadPool
             assertThat(t.getContextClassLoader(), Matchers.equalTo(QueuedThreadPool.class.getClassLoader()));
+        }
+    }
+
+    @Test
+    public void testThreadCounts() throws Exception
+    {
+        int maxThreads = 100;
+        QueuedThreadPool tp = new QueuedThreadPool(maxThreads, 0);
+        // Long timeout so it does not expire threads during the test.
+        tp.setIdleTimeout(60000);
+        int reservedThreads = 7;
+        tp.setReservedThreads(reservedThreads);
+        tp.start();
+        int leasedThreads = 5;
+        tp.getThreadPoolBudget().leaseTo(new Object(), leasedThreads);
+        List<RunningJob> leasedJobs = new ArrayList<>();
+        for (int i = 0; i < leasedThreads; ++i)
+        {
+            RunningJob job = new RunningJob("JOB" + i);
+            leasedJobs.add(job);
+            tp.execute(job);
+            assertTrue(job._run.await(5, TimeUnit.SECONDS));
+        }
+
+        // Run some job to spawn threads.
+        for (int i = 0; i < 3; ++i)
+        {
+            tp.tryExecute(() -> {});
+        }
+        int spawned = 13;
+        List<RunningJob> jobs = new ArrayList<>();
+        for (int i = 0; i < spawned; ++i)
+        {
+            RunningJob job = new RunningJob("JOB" + i);
+            jobs.add(job);
+            tp.execute(job);
+            assertTrue(job._run.await(5, TimeUnit.SECONDS));
+        }
+        for (RunningJob job : jobs)
+        {
+            job._stopping.countDown();
+        }
+
+        // Wait for the threads to become idle again.
+        Thread.sleep(1000);
+
+        // Submit less jobs to the queue so we have active and idle threads.
+        jobs.clear();
+        int transientJobs = spawned / 2;
+        for (int i = 0; i < transientJobs; ++i)
+        {
+            RunningJob job = new RunningJob("JOB" + i);
+            jobs.add(job);
+            tp.execute(job);
+            assertTrue(job._run.await(5, TimeUnit.SECONDS));
+        }
+
+        try
+        {
+            assertThat(tp.getMaxReservedThreads(), Matchers.equalTo(reservedThreads));
+            assertThat(tp.getLeasedThreads(), Matchers.equalTo(leasedThreads));
+            assertThat(tp.getReadyThreads(), Matchers.equalTo(tp.getIdleThreads() + tp.getAvailableReservedThreads()));
+            assertThat(tp.getUtilizedThreads(), Matchers.equalTo(transientJobs));
+            assertThat(tp.getThreads(), Matchers.equalTo(tp.getReadyThreads() + tp.getLeasedThreads() + tp.getUtilizedThreads()));
+            assertThat(tp.getBusyThreads(), Matchers.equalTo(tp.getUtilizedThreads() + tp.getLeasedThreads()));
+        }
+        finally
+        {
+            jobs.forEach(job -> job._stopping.countDown());
+            leasedJobs.forEach(job -> job._stopping.countDown());
+            tp.stop();
         }
     }
     


### PR DESCRIPTION
Introduced to QueuedThreadPool:

* getMaxReservedThreads()
* getAvailableReservedThreads()
* getAvailableThreads()
* getReadyThreads()
* getLeasedThreads()

Also few small code cleanups.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>