### PR TITLE
Fix #5999 ArrayIndexOutOfBounds for unicode in HttpURI segment

### DIFF
--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -337,6 +337,9 @@ public class HttpURITest
                 {"%2f/info", "//info", true},
                 {"%2F/info", "//info", true},
 
+                // Non ascii characters
+                {"http://localhost:9000/x\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32", "/x\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32", false},
+                {"http://localhost:9000/\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32", "/\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32\uD83C\uDF32", false},
             }).map(Arguments::of);
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTrie.java
@@ -204,6 +204,8 @@ public class ArrayTrie<V> extends AbstractTrie<V>
         for (int i = 0; i < len; i++)
         {
             char c = s.charAt(offset + i);
+            if (c > 0x7f)
+                return null;
             int index = __lookup[c & 0x7f];
             if (index >= 0)
             {
@@ -217,7 +219,7 @@ public class ArrayTrie<V> extends AbstractTrie<V>
                 char[] big = _bigIndex == null ? null : _bigIndex[t];
                 if (big == null)
                     return null;
-                t = big[c];
+                t = big[c & 0x7f];
                 if (t == 0)
                     return null;
             }


### PR DESCRIPTION
#5999 Fixed ArrayTrie to not throw if passed a unicode character.