### PR TITLE
Issue #6008 - Allow absolute paths to be provided in start.ini for request log directory.

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-requestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-requestlog.xml
@@ -15,11 +15,15 @@
       <!-- Writer -->
       <Arg>
         <New class="org.eclipse.jetty.server.AsyncRequestLogWriter">
-          <Arg><Property name="jetty.base" default="." />/<Property>
-              <Name>jetty.requestlog.filePath</Name>
-              <Default><Property name="jetty.requestlog.dir" default="logs"/>/yyyy_mm_dd.request.log</Default>
-            </Property></Arg>
-          <Arg/>
+          <Arg>
+            <Property name="jetty.requestlog.absoluteFilePath">
+              <Default>
+                <Property name="jetty.base" default="." />/<Property name="jetty.requestlog.filePath">
+                  <Default><Property name="jetty.requestlog.dir" default="logs"/>/yyyy_mm_dd.request.log</Default>
+                </Property>
+              </Default>
+            </Property>
+          </Arg>
 
           <Set name="filenameDateFormat"><Property name="jetty.requestlog.filenameDateFormat" default="yyyy_MM_dd"/></Set>
           <Set name="retainDays"><Property name="jetty.requestlog.retainDays" default="90"/></Set>

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -17,23 +17,26 @@ etc/jetty-requestlog.xml
 logs/
 
 [ini-template]
-## Format string
+## The CustomRequestLog format string (extended NCSA format by default).
 # jetty.requestlog.formatString=%a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %B "%{Referer}i" "%{User-Agent}i" "%C"
 
-## Logging directory (relative to $jetty.base)
+## Logging Directory with Relative Path (relative to $jetty.base).
 # jetty.requestlog.dir=logs
 
-## File path
+## Relative File Path (relative to $jetty.base).
 # jetty.requestlog.filePath=${jetty.requestlog.dir}/yyyy_mm_dd.request.log
 
-## Date format for rollovered files (uses SimpleDateFormat syntax)
+## Absolute File Path (will override the relative file path).
+# jetty.requestlog.absoluteFilePath=${jetty.base}/${jetty.requestlog.filePath}
+
+## Date format for rollovered files (uses SimpleDateFormat syntax).
 # jetty.requestlog.filenameDateFormat=yyyy_MM_dd
 
-## How many days to retain old log files
+## The number of days to retain old log files.
 # jetty.requestlog.retainDays=90
 
-## Whether to append to existing file
+## Whether to append to existing file.
 # jetty.requestlog.append=false
 
-## Timezone of the log file rollover
+## Timezone of the log file rollover.
 # jetty.requestlog.timezone=GMT

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -16,6 +16,10 @@ etc/jetty-requestlog.xml
 [files]
 logs/
 
+[ini]
+jetty.requestlog.dir?=logs
+jetty.requestlog.filePath?=${jetty.requestlog.dir}/yyyy_mm_dd.request.log
+
 [ini-template]
 ## The CustomRequestLog format string (extended NCSA format by default).
 # jetty.requestlog.formatString=%a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %B "%{Referer}i" "%{User-Agent}i" "%C"
@@ -24,9 +28,11 @@ logs/
 # jetty.requestlog.dir=logs
 
 ## Relative File Path (relative to $jetty.base).
+## The string 'yyyy_mm_dd' in the filename will be replaced with the date format specified with ${jetty.requestlog.filenameDateFormat}.
 # jetty.requestlog.filePath=${jetty.requestlog.dir}/yyyy_mm_dd.request.log
 
 ## Absolute File Path (will override the relative file path).
+## The string 'yyyy_mm_dd' in the filename will be replaced with the date format specified with ${jetty.requestlog.filenameDateFormat}.
 # jetty.requestlog.absoluteFilePath=${jetty.base}/${jetty.requestlog.filePath}
 
 ## Date format for rollovered files (uses SimpleDateFormat syntax).


### PR DESCRIPTION
Closes #6008


Adds a new attribute in the .ini file called `jetty.requestlog.absoluteFilePath`.

This can be configured to provide an absolute path for the requestlog directory without changing the xml.