### PR TITLE
Issue #6011 Fix syntax for configuration settings in org.eclipse.jetty.osgi.boot/jettyhome/jetty.xml

### DIFF
--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
@@ -78,7 +78,7 @@
     <Call class="org.eclipse.jetty.webapp.Configurations" name="setServerDefault">
       <Arg><Ref refid="Server"/></Arg>
       <Call name="add">
-        <Arg>
+        <Arg name="configClass">
           <Array type="String">
             <Item>org.eclipse.jetty.webapp.FragmentConfiguration</Item>
             <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>


### PR DESCRIPTION
Closes #6011