### PR TITLE
Issue #6008 - fix RequestLog usage with filePath.

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-requestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-requestlog.xml
@@ -18,7 +18,11 @@
           <Arg>
             <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
               <Arg><Property name="jetty.base"/></Arg>
-              <Arg><Property name="jetty.requestlog.dir" default="logs" />/yyyy_mm_dd.request.log</Arg>
+              <Arg>
+                <Property name="jetty.requestlog.filePath">
+                  <Default><Property name="jetty.requestlog.dir" default="logs"/>/yyyy_mm_dd.request.log</Default>
+                </Property>
+              </Arg>
             </Call>
           </Arg>
 

--- a/jetty-server/src/main/config/etc/jetty-requestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-requestlog.xml
@@ -20,7 +20,9 @@
               <Arg><Property name="jetty.base"/></Arg>
               <Arg>
                 <Property name="jetty.requestlog.filePath">
-                  <Default><Property name="jetty.requestlog.dir" default="logs"/>/yyyy_mm_dd.request.log</Default>
+                  <Default>
+                    <Property name="jetty.requestlog.dir" default="logs"/>/yyyy_mm_dd.request.log
+                  </Default>
                 </Property>
               </Arg>
             </Call>

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -16,6 +16,9 @@ etc/jetty-requestlog.xml
 [files]
 logs/
 
+[ini]
+jetty.requestlog.dir?=logs
+
 [ini-template]
 ## Format string
 # jetty.requestlog.formatString=%a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %B "%{Referer}i" "%{User-Agent}i" "%C"

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -16,9 +16,6 @@ etc/jetty-requestlog.xml
 [files]
 logs/
 
-[ini]
-jetty.requestlog.dir?=logs
-
 [ini-template]
 ## Format string
 # jetty.requestlog.formatString=%a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %B "%{Referer}i" "%{User-Agent}i" "%C"


### PR DESCRIPTION
**Closes #6008**

Restore the previous usage of the `jetty.requestlog.filePath` property which was broken with #6022.