### PR TITLE
Fixes #6037 - Review logging modules for j.u.l.

### DIFF
--- a/jetty-home/src/main/resources/etc/logging-jul-capture.xml
+++ b/jetty-home/src/main/resources/etc/logging-jul-capture.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
-<Configure id="logging-jul-capture">
-  <Call class="org.slf4j.bridge.SLF4JBridgeHandler" name="install" />
-</Configure>

--- a/jetty-home/src/main/resources/modules/logging-jul-capture.mod
+++ b/jetty-home/src/main/resources/modules/logging-jul-capture.mod
@@ -13,14 +13,15 @@ logging
 [provides]
 java-util-logging
 
-[xml]
-etc/logging-jul-capture.xml
-
 [files]
-maven://org.slf4j/jul-to-slf4j/%{slf4j.version}|jul-to-slf4j-${slf4j.version}.jar
+maven://org.slf4j/jul-to-slf4j/${slf4j.version}|lib/logging/jul-to-slf4j-${slf4j.version}.jar
+basehome:modules/logging/jul/resources/java-util-logging-bridge.properties|resources/java-util-logging.properties
 
 [lib]
 lib/logging/jul-to-slf4j-${slf4j.version}.jar
+
+[exec]
+-Djava.util.logging.config.file=${jetty.base}/resources/java-util-logging.properties
 
 [license]
 SLF4J is distributed under the MIT License.

--- a/jetty-home/src/main/resources/modules/logging-jul.mod
+++ b/jetty-home/src/main/resources/modules/logging-jul.mod
@@ -16,15 +16,17 @@ logging
 java-util-logging
 
 [files]
-basehome:modules/logging/jul
 maven://org.slf4j/slf4j-jdk14/${slf4j.version}|lib/logging/slf4j-jdk14-${slf4j.version}.jar
+basehome:modules/logging/jul/resources/java-util-logging.properties|resources/java-util-logging.properties
 
 [lib]
 lib/logging/slf4j-jdk14-${slf4j.version}.jar
 
+[exec]
+-Djava.util.logging.config.file=${jetty.base}/resources/java-util-logging.properties
+
 [ini]
 slf4j.version?=2.0.0-alpha1
-java.util.logging.config.file=${jetty.base}/resources/java-util-logging.properties
 
 [license]
 SLF4J is distributed under the MIT License.

--- a/jetty-home/src/main/resources/modules/logging/jul/resources/java-util-logging-bridge.properties
+++ b/jetty-home/src/main/resources/modules/logging/jul/resources/java-util-logging-bridge.properties
@@ -1,0 +1,2 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler
+.level=FINEST

--- a/jetty-home/src/main/resources/modules/logging/jul/resources/java-util-logging.properties
+++ b/jetty-home/src/main/resources/modules/logging/jul/resources/java-util-logging.properties
@@ -1,13 +1,14 @@
-.level=INFO
 handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.level=FINEST
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 ## Note: The java.util.logging.SimpleFormatter does NOT have the ability to display
 ## the Thread name of when the logging event occurred, this will make debugging difficult
 ## See https://stackoverflow.com/questions/6889057/printing-thread-name-using-java-util-logging
 java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS [%4$s] (%3$s) - %5$s%6$s%n
-#handlers = java.util.logging.FileHandler
-#java.util.logging.FileHandler.pattern = ${jetty.logging.dir}/jetty%u.log
-#java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 
+# handlers=java.util.logging.FileHandler
+# java.util.logging.FileHandler.pattern=${jetty.logging.dir}/jetty%u.log
+# java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
 
+.level=INFO
+# org.eclipse.jetty.level=FINE

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -53,6 +55,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -533,6 +536,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
     /**
      * This reproduces some classloading issue with MethodHandles in JDK14-110, This has been fixed in JDK16.
+     *
      * @throws Exception if there is an error during the test.
      * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8244090">JDK-8244090</a>
      */
@@ -656,6 +660,111 @@ public class DistributionTests extends AbstractJettyHomeTest
 
                 run2.stop();
                 assertTrue(run2.awaitFor(10, TimeUnit.SECONDS));
+            }
+        }
+    }
+
+    @Test
+    public void testJavaUtilLogging() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        String[] args = {
+            "--approve-all-licenses",
+            "--add-modules=http,logging-jul"
+        };
+
+        try (JettyHomeTester.Run run1 = distribution.start(args))
+        {
+            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertEquals(0, run1.getExitValue());
+
+            Path julConfig = run1.getConfig().getJettyBase().resolve("resources/java-util-logging.properties");
+            assertTrue(Files.exists(julConfig));
+            Files.write(julConfig, Arrays.asList(System.lineSeparator(), "org.eclipse.jetty.level=FINE"), StandardOpenOption.APPEND);
+
+            int port = distribution.freePort();
+            try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
+            {
+                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+                assertThat(run2.getLogs().stream()
+                    // Check that the level formatting is that of the j.u.l. configuration file.
+                    .filter(log -> log.contains("[FINE]"))
+                    .count(), greaterThan(0L));
+
+                startHttpClient();
+                ContentResponse response = client.GET("http://localhost:" + port);
+                assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
+            }
+        }
+    }
+
+    @Test
+    public void testJavaUtilLoggingBridge() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        String[] args = {
+            "--approve-all-licenses",
+            "--add-modules=http,logging-jul-capture"
+        };
+
+        try (JettyHomeTester.Run run1 = distribution.start(args))
+        {
+            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertEquals(0, run1.getExitValue());
+
+            Path jettyBase = run1.getConfig().getJettyBase();
+
+            Path julConfig = jettyBase.resolve("resources/java-util-logging.properties");
+            assertTrue(Files.exists(julConfig));
+
+            Path etc = jettyBase.resolve("etc");
+            Files.createDirectories(etc);
+            Path julXML = etc.resolve("jul.xml");
+            String loggerName = getClass().getName();
+            String message = "test-log-line";
+            String xml = "" +
+                "<?xml version=\"1.0\"?>" +
+                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">" +
+                "<Configure>" +
+                "  <Call name=\"getLogger\" class=\"java.util.logging.Logger\">" +
+                "    <Arg>" + loggerName + "</Arg>" +
+                "    <Call name=\"log\">" +
+                "      <Arg><Get class=\"java.util.logging.Level\" name=\"FINE\" /></Arg>" +
+                "      <Arg>" + message + "</Arg>" +
+                "    </Call>" +
+                "  </Call>" +
+                "</Configure>";
+            Files.write(julXML, List.of(xml), StandardOpenOption.CREATE);
+
+            Path julIni = jettyBase.resolve("start.d/logging-jul-capture.ini");
+            assertTrue(Files.exists(julIni));
+            Files.write(julIni, List.of("etc/jul.xml"), StandardOpenOption.APPEND);
+
+            Path jettyLogConfig = jettyBase.resolve("resources/jetty-logging.properties");
+            Files.write(jettyLogConfig, List.of(loggerName + ".LEVEL=DEBUG"), StandardOpenOption.TRUNCATE_EXISTING);
+
+            int port = distribution.freePort();
+            try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
+            {
+                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+                assertEquals(1, run2.getLogs().stream()
+                    // Check that the level formatting is that of the j.u.l. configuration file.
+                    .filter(log -> log.contains(message))
+                    .count());
+
+                startHttpClient();
+                ContentResponse response = client.GET("http://localhost:" + port);
+                assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
             }
         }
     }


### PR DESCRIPTION
Fixed mistakes in logging-jul-capture.mod.
Introduced java-util-logging-bridge.properties for the bridge module configuration.
Added [exec] sections to specify the jul config file.
Removed logging-jul-capture.xml, not necessary.
Added tests to verify that the fixed modules work fine.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>