### PR TITLE
Fixes #6049 - Default provider [files] section always executed

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -39,7 +39,7 @@ import org.eclipse.jetty.start.fileinits.TestFileInitializer;
 import org.eclipse.jetty.start.fileinits.UriFileInitializer;
 
 /**
- * Build a start configuration in <code>${jetty.base}</code>, including
+ * Build a start configuration in {@code ${jetty.base}}, including
  * ini files, directories, and libs. Also handles License management.
  */
 public class BaseBuilder
@@ -47,7 +47,7 @@ public class BaseBuilder
     public static interface Config
     {
         /**
-         * Add a module to the start environment in <code>${jetty.base}</code>
+         * Add a module to the start environment in {@code ${jetty.base}}
          *
          * @param module the module to add
          * @param props The properties to substitute into a template
@@ -163,7 +163,7 @@ public class BaseBuilder
         }
 
         // generate the files
-        List<FileArg> files = new ArrayList<FileArg>();
+        List<FileArg> files = new ArrayList<>();
         AtomicReference<BaseBuilder.Config> builder = new AtomicReference<>();
         AtomicBoolean modified = new AtomicBoolean();
 
@@ -184,12 +184,12 @@ public class BaseBuilder
             if (Files.exists(startd))
             {
                 // Copy start.d files into start.ini
-                DirectoryStream.Filter<Path> filter = new DirectoryStream.Filter<Path>()
+                DirectoryStream.Filter<Path> filter = new DirectoryStream.Filter<>()
                 {
-                    PathMatcher iniMatcher = PathMatchers.getMatcher("glob:**/start.d/*.ini");
+                    private final PathMatcher iniMatcher = PathMatchers.getMatcher("glob:**/start.d/*.ini");
 
                     @Override
-                    public boolean accept(Path entry) throws IOException
+                    public boolean accept(Path entry)
                     {
                         return iniMatcher.matches(entry);
                     }
@@ -271,6 +271,9 @@ public class BaseBuilder
             StartLog.warn("Use of both %s and %s is deprecated", getBaseHome().toShortForm(startd), getBaseHome().toShortForm(startini));
 
         builder.set(useStartD ? new StartDirBuilder(this) : new StartIniBuilder(this));
+
+        // Collect the filesystem operations to perform,
+        // only for those modules that are enabled.
         newlyAdded.stream()
             .map(modules::get)
             .filter(Module::isEnabled)
@@ -386,7 +389,7 @@ public class BaseBuilder
      * @param files the list of {@link FileArg}s to process
      * @return true if base directory modified, false if left untouched
      */
-    private boolean processFileResources(List<FileArg> files) throws IOException
+    private boolean processFileResources(List<FileArg> files)
     {
         if ((files == null) || (files.isEmpty()))
         {

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -279,8 +279,6 @@ public class BaseBuilder
             .filter(Module::isEnabled)
             .forEach(module ->
             {
-                StartLog.debug("%s.isEnabled() = %b", module.getName(), module.isEnabled());
-
                 String ini = null;
                 try
                 {

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -552,7 +551,7 @@ public class Modules implements Iterable<Module>
         Set<Module> providers = _provided.get(name);
         StartLog.debug("Providers of [%s] are %s", name, providers);
         if (providers == null || providers.isEmpty())
-            return Collections.emptySet();
+            return Set.of();
 
         providers = new HashSet<>(providers);
 

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -52,14 +52,8 @@ import org.eclipse.jetty.util.ManifestUtils;
 public class StartArgs
 {
     public static final String VERSION;
-    public static final Set<String> ALL_PARTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-        "java",
-        "opts",
-        "path",
-        "main",
-        "args")));
-    public static final Set<String> ARG_PARTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-        "args")));
+    public static final Set<String> ALL_PARTS = Set.of("java", "opts", "path", "main", "args");
+    public static final Set<String> ARG_PARTS = Set.of("args");
 
     static
     {
@@ -126,12 +120,12 @@ public class StartArgs
     /**
      * List of enabled modules
      */
-    private List<String> modules = new ArrayList<>();
+    private final List<String> modules = new ArrayList<>();
 
     /**
      * List of modules to skip [files] section validation
      */
-    private Set<String> skipFileValidationModules = new HashSet<>();
+    private final Set<String> skipFileValidationModules = new HashSet<>();
 
     /**
      * Map of enabled modules to the source of where that activation occurred
@@ -141,56 +135,56 @@ public class StartArgs
     /**
      * List of all active [files] sections from enabled modules
      */
-    private List<FileArg> files = new ArrayList<>();
+    private final List<FileArg> files = new ArrayList<>();
 
     /**
      * List of all active [lib] sections from enabled modules
      */
-    private Classpath classpath;
+    private final Classpath classpath;
 
     /**
      * List of all active [xml] sections from enabled modules
      */
-    private List<Path> xmls = new ArrayList<>();
+    private final List<Path> xmls = new ArrayList<>();
 
     /**
      * List of all active [jpms] sections for enabled modules
      */
-    private Set<String> jmodAdds = new LinkedHashSet<>();
-    private Map<String, Set<String>> jmodPatch = new LinkedHashMap<>();
-    private Map<String, Set<String>> jmodOpens = new LinkedHashMap<>();
-    private Map<String, Set<String>> jmodExports = new LinkedHashMap<>();
-    private Map<String, Set<String>> jmodReads = new LinkedHashMap<>();
+    private final Set<String> jmodAdds = new LinkedHashSet<>();
+    private final Map<String, Set<String>> jmodPatch = new LinkedHashMap<>();
+    private final Map<String, Set<String>> jmodOpens = new LinkedHashMap<>();
+    private final Map<String, Set<String>> jmodExports = new LinkedHashMap<>();
+    private final Map<String, Set<String>> jmodReads = new LinkedHashMap<>();
 
     /**
      * JVM arguments, found via command line and in all active [exec] sections from enabled modules
      */
-    private List<String> jvmArgs = new ArrayList<>();
+    private final List<String> jvmArgs = new ArrayList<>();
 
     /**
      * List of all xml references found directly on command line or start.ini
      */
-    private List<String> xmlRefs = new ArrayList<>();
+    private final List<String> xmlRefs = new ArrayList<>();
 
     /**
      * List of all property references found directly on command line or start.ini
      */
-    private List<String> propertyFileRefs = new ArrayList<>();
+    private final List<String> propertyFileRefs = new ArrayList<>();
 
     /**
      * List of all property files
      */
-    private List<Path> propertyFiles = new ArrayList<>();
+    private final List<Path> propertyFiles = new ArrayList<>();
 
-    private Props properties = new Props();
-    private Map<String, String> systemPropertySource = new HashMap<>();
-    private List<String> rawLibs = new ArrayList<>();
+    private final Props properties = new Props();
+    private final Map<String, String> systemPropertySource = new HashMap<>();
+    private final List<String> rawLibs = new ArrayList<>();
 
     // jetty.base - build out commands
     /**
      * --add-module=[module,[module]]
      */
-    private List<String> startModules = new ArrayList<>();
+    private final List<String> startModules = new ArrayList<>();
 
     // module inspection commands
     /**


### PR DESCRIPTION
Keeping only enabled modules when processing the modules,
so that default provider modules don't get processed.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>