### PR TITLE
Issue #6052 - make ModuleLocation optional on Android

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -51,6 +51,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <minimizeJar>true</minimizeJar>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>hybrid</shadedClassifierName>
               <artifactSet>

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ModuleLocation.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ModuleLocation.java
@@ -23,6 +23,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -53,7 +54,7 @@ import static java.lang.invoke.MethodType.methodType;
  *
  * In Jetty 10, this entire class can be moved to direct calls to java.lang.Module in TypeUtil.getModuleLocation()
  */
-class ModuleLocation
+class ModuleLocation implements Function<Class<?>, URI>
 {
     private static final Logger LOG = Log.getLogger(ModuleLocation.class);
 
@@ -100,7 +101,8 @@ class ModuleLocation
         }
     }
 
-    public URI getModuleLocation(Class<?> clazz)
+    @Override
+    public URI apply(Class<?> clazz)
     {
         try
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -178,12 +178,12 @@ public class TypeUtil
 
     static
     {
-        // Lookup order in LOCATION_METHOD is important.
+        // Lookup order in LOCATION_METHODS is important.
         LOCATION_METHODS.add(TypeUtil::getCodeSourceLocation);
         Function<Class<?>, URI> moduleFunc = null;
         try
         {
-            Class<?> clazzModuleLocation = Class.forName(TypeUtil.class.getPackage().getName() + ".ModuleLocation");
+            Class<?> clazzModuleLocation = TypeUtil.class.getClassLoader().loadClass(TypeUtil.class.getPackage().getName() + ".ModuleLocation");
             Object obj = clazzModuleLocation.getConstructor().newInstance();
             if (obj instanceof Function)
             {


### PR DESCRIPTION
Change how `ModuleLocation` is loaded by `TypeUtil` to allow it be entirely optional.

Also, change `jetty-client-<ver>-hybrid.jar` to generate a minimized jar, which will only include the dependent classes that are actually used, not all classes from http/io/util.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>