### PR TITLE
Fixes #6072 - jetty server high CPU when client sends TLS record length > 17408 (jetty-9.4.x)

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -729,13 +729,15 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     return filled = -1;
 
                                 case BUFFER_UNDERFLOW:
-                                    if (netFilled > 0)
+                                    if (BufferUtil.space(_encryptedInput) == 0)
                                     {
-                                        if (BufferUtil.space(_encryptedInput) > 0)
-                                            continue; // try filling some more
                                         BufferUtil.clear(_encryptedInput);
                                         throw new SSLHandshakeException("Encrypted buffer max length exceeded");
                                     }
+
+                                    if (netFilled > 0)
+                                        continue; // try filling some more
+
                                     _underflown = true;
                                     if (netFilled < 0 && _sslEngine.getUseClientMode())
                                     {


### PR DESCRIPTION
…408.

Avoid spinning if the input buffer is full.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
Co-authored-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>