### PR TITLE
Fix #6082 Reduce SSL buffer compaction

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -711,12 +711,9 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     return filled = -1;
 
                                 case BUFFER_UNDERFLOW:
-                                    // Can we compact?
-                                    if (_encryptedInput.position() != 0)
-                                    {
-                                        BufferUtil.compact(_encryptedInput);
+                                    // Continue if we can compact?
+                                    if (BufferUtil.compact(_encryptedInput))
                                         continue;
-                                    }
 
                                     // Are we out of space?
                                     if (BufferUtil.space(_encryptedInput) == 0)

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -654,7 +654,6 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                             else
                             {
                                 appIn = _decryptedInput;
-                                BufferUtil.compact(_encryptedInput);
                             }
 
                             // Let's try reading some encrypted data... even if we have some already.
@@ -712,12 +711,21 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     return filled = -1;
 
                                 case BUFFER_UNDERFLOW:
+                                    // Can we compact?
+                                    if (_encryptedInput.position() != 0)
+                                    {
+                                        BufferUtil.compact(_encryptedInput);
+                                        continue;
+                                    }
+
+                                    // Are we out of space?
                                     if (BufferUtil.space(_encryptedInput) == 0)
                                     {
                                         BufferUtil.clear(_encryptedInput);
                                         throw new SSLHandshakeException("Encrypted buffer max length exceeded");
                                     }
 
+                                    // if we just filled some
                                     if (netFilled > 0)
                                         continue; // try filling some more
 


### PR DESCRIPTION
Fix #6082. Only compact when buffer is underflown.  

Note that BufferUtil will also do a cheap "compact" when flipping empty buffers.

Signed-off-by: Greg Wilkins <gregw@webtide.com>