### PR TITLE
Issue #6084 - CompressionPools should not be configured through the GzipHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -891,6 +891,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     @Deprecated
     public void setDeflaterPoolCapacity(int capacity)
     {
+        LOG.warn("DeflaterPool capacity not changed. DeflaterPool should be configured externally and set as a bean on the Server.");
         if (isStarted())
             throw new IllegalStateException(getState());
     }
@@ -914,6 +915,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
     @Deprecated
     public void setInflaterPoolCapacity(int capacity)
     {
+        LOG.warn("InflaterPool capacity not changed. InflaterPool should be configured externally and set as a bean on the Server.");
         if (isStarted())
             throw new IllegalStateException(getState());
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.util.AsciiLowerCaseSet;
 import org.eclipse.jetty.util.IncludeExclude;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.compression.CompressionPool;
 import org.eclipse.jetty.util.compression.DeflaterPool;
 import org.eclipse.jetty.util.compression.InflaterPool;
 import org.slf4j.Logger;
@@ -875,42 +876,46 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
      * Gets the maximum number of Deflaters that the DeflaterPool can hold.
      *
      * @return the Deflater pool capacity
+     * @deprecated DeflaterPool should be configured externally and set as a bean on the server.
      */
+    @Deprecated
     public int getDeflaterPoolCapacity()
     {
-        return _deflaterPool.getCapacity();
+        return (_deflaterPool == null) ? CompressionPool.DEFAULT_CAPACITY : _deflaterPool.getCapacity();
     }
 
     /**
      * Sets the maximum number of Deflaters that the DeflaterPool can hold.
+     * @deprecated DeflaterPool should be configured externally and set as a bean on the server.
      */
+    @Deprecated
     public void setDeflaterPoolCapacity(int capacity)
     {
         if (isStarted())
             throw new IllegalStateException(getState());
-
-        _deflaterPool.setCapacity(capacity);
     }
 
     /**
-     * Gets the maximum number of Inflators that the DeflaterPool can hold.
+     * Gets the maximum number of Inflators that the InflaterPool can hold.
      *
      * @return the Deflater pool capacity
+     * @deprecated InflaterPool should be configured externally and set as a bean on the server.
      */
+    @Deprecated
     public int getInflaterPoolCapacity()
     {
-        return _inflaterPool.getCapacity();
+        return (_inflaterPool == null) ? CompressionPool.DEFAULT_CAPACITY : _inflaterPool.getCapacity();
     }
 
     /**
-     * Sets the maximum number of Inflators that the DeflaterPool can hold.
+     * Sets the maximum number of Inflators that the InflaterPool can hold.
+     * @deprecated InflaterPool should be configured externally and set as a bean on the server.
      */
+    @Deprecated
     public void setInflaterPoolCapacity(int capacity)
     {
         if (isStarted())
             throw new IllegalStateException(getState());
-
-        _inflaterPool.setCapacity(capacity);
     }
 
     @Override


### PR DESCRIPTION
**Closes #6084**

The `InflaterPool` and `DeflaterPool` should be configured externally and set as a bean on the server. The `GzipHandler` should not be configuring them directly as they are shared with other components on the Server.