### PR TITLE
Use Files.isSameFile to check Resource equality

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -20,7 +20,6 @@ package org.eclipse.jetty.deploy.providers;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,12 +49,11 @@ public abstract class ScanningAppProvider extends AbstractLifeCycle implements A
 {
     private static final Logger LOG = Log.getLogger(ScanningAppProvider.class);
 
-    private Map<String, App> _appMap = new HashMap<String, App>();
+    private final Map<String, App> _appMap = new HashMap<>();
 
     private DeploymentManager _deploymentManager;
     protected FilenameFilter _filenameFilter;
     private final List<Resource> _monitored = new CopyOnWriteArrayList<>();
-    private final List<Resource> _canonicalMonitored = new CopyOnWriteArrayList<>();
     private boolean _recursive = false;
     private int _scanInterval = 10;
     private Scanner _scanner;
@@ -249,33 +247,11 @@ public abstract class ScanningAppProvider extends AbstractLifeCycle implements A
     {
         _monitored.clear();
         _monitored.addAll(resources);
-        _canonicalMonitored.clear();
-        for (Resource r : resources)
-        {
-            Resource canonical = r; //assume original is canonical
-            try
-            {
-                File f = r.getFile(); //if it has a file, ensure it is canonical
-                if (f != null)
-                    canonical = Resource.newResource(f.getCanonicalFile());
-            }
-            catch (IOException e)
-            {
-                //use the original resource
-                LOG.ignore(e);
-            }
-            _canonicalMonitored.add(canonical);   
-        }
     }
 
     public List<Resource> getMonitoredResources()
     {
         return Collections.unmodifiableList(_monitored);
-    }
-    
-    List<Resource> getCanonicalMonitoredResources()
-    {
-        return Collections.unmodifiableList(_canonicalMonitored);
     }
 
     public void setMonitoredDirResource(Resource resource)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -29,7 +29,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.Permission;
 
@@ -182,6 +184,30 @@ public class FileResource extends Resource
 
         _uri = uri;
         _alias = checkFileAlias(_uri, _file);
+    }
+
+    @Override
+    public boolean isSame(Resource resource)
+    {
+        try
+        {
+            if (resource instanceof PathResource)
+            {
+                Path path = ((PathResource)resource).getPath();
+                return Files.isSameFile(getFile().toPath(), path);
+            }
+            if (resource instanceof FileResource)
+            {
+                Path path = ((FileResource)resource).getFile().toPath();
+                return Files.isSameFile(getFile().toPath(), path);
+            }
+        }
+        catch (IOException e)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("ignored", e);
+        }
+        return false;
     }
 
     private static URI normalizeURI(File file, URI uri) throws URISyntaxException

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -341,17 +341,23 @@ public class PathResource extends Resource
     {
         try
         {
-            if (!(resource instanceof PathResource))
-                return false;
-            Path path = ((PathResource)resource).getPath();
-            return Files.isSameFile(getPath(), path);
+            if (resource instanceof PathResource)
+            {
+                Path path = ((PathResource)resource).getPath();
+                return Files.isSameFile(getPath(), path);
+            }
+            if (resource instanceof FileResource)
+            {
+                Path path = ((FileResource)resource).getFile().toPath();
+                return Files.isSameFile(getPath(), path);
+            }
         }
         catch (IOException e)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("ignored", e);
-            return false;
         }
+        return false;
     }
 
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -337,6 +337,24 @@ public class PathResource extends Resource
     }
 
     @Override
+    public boolean isSame(Resource resource)
+    {
+        try
+        {
+            if (!(resource instanceof PathResource))
+                return false;
+            Path path = ((PathResource)resource).getPath();
+            return Files.isSameFile(getPath(), path);
+        }
+        catch(IOException e)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("ignored", e);
+            return false;
+        }
+    }
+
+    @Override
     public Resource addPath(final String subpath) throws IOException
     {
         String cpath = URIUtil.canonicalPath(subpath);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -346,7 +346,7 @@ public class PathResource extends Resource
             Path path = ((PathResource)resource).getPath();
             return Files.isSameFile(getPath(), path);
         }
-        catch(IOException e)
+        catch (IOException e)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("ignored", e);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -312,6 +312,18 @@ public abstract class Resource implements ResourceFactory, Closeable
     public abstract boolean isContainedIn(Resource r) throws MalformedURLException;
 
     /**
+     * Return true if the passed Resource represents the same resource as the Resource.
+     * For many resource types, this is equivalent to {@link #equals(Object)}, however
+     * for resources types that support aliasing, this maybe some other check (e.g. {@link java.nio.file.Files#isSameFile(Path, Path)}).
+     * @param resource The resource to check
+     * @return true if the passed resource represents the same resource.
+     */
+    public boolean isSame(Resource resource)
+    {
+        return equals(resource);
+    }
+
+    /**
      * Release any temporary resources held by the resource.
      *
      * @deprecated use {@link #close()}

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -145,5 +146,22 @@ public class PathResourceTest
 
         File file = resource.getFile();
         assertThat("File for default FileSystem", file, is(exampleJar.toFile()));
+    }
+
+
+    @Test
+    public void testSame() throws Exception
+    {
+        Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
+        Path epath = MavenTestingUtils.getTestResourcePathFile("example.jar");
+        PathResource rPathResource = new PathResource(rpath);
+        FileResource rFileResource = new FileResource(rpath.toFile());
+        PathResource ePathResource = new PathResource(epath);
+        FileResource eFileResource = new FileResource(epath.toFile());
+
+        assertThat(rPathResource.isSame(rPathResource), Matchers.is(true));
+        assertThat(rPathResource.isSame(rFileResource), Matchers.is(true));
+        assertThat(rPathResource.isSame(ePathResource), Matchers.is(false));
+        assertThat(rPathResource.isSame(eFileResource), Matchers.is(false));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -148,7 +148,6 @@ public class PathResourceTest
         assertThat("File for default FileSystem", file, is(exampleJar.toFile()));
     }
 
-
     @Test
     public void testSame() throws Exception
     {


### PR DESCRIPTION
Avoid using canonical and instead use Files.isSameFile

Signed-off-by: Greg Wilkins <gregw@webtide.com>