### PR TITLE
Use Files.isSameFile to check Resource equality (#6093)

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.deploy.providers;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,10 +42,10 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     private static final Logger LOG = LoggerFactory.getLogger(ScanningAppProvider.class);
 
     private final Map<String, App> _appMap = new HashMap<>();
+
     private DeploymentManager _deploymentManager;
     private FilenameFilter _filenameFilter;
     private final List<Resource> _monitored = new CopyOnWriteArrayList<>();
-    private final List<Resource> _canonicalMonitored = new CopyOnWriteArrayList<>();
     private int _scanInterval = 10;
     private Scanner _scanner;
 
@@ -238,34 +237,11 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     {
         _monitored.clear();
         _monitored.addAll(resources);
-        _canonicalMonitored.clear();
-        for (Resource r : resources)
-        {
-            Resource canonical = r; //assume original is canonical
-            try
-            {
-                File f = r.getFile(); //if it has a file, ensure it is canonical
-                if (f != null)
-                    canonical = Resource.newResource(f.getCanonicalFile());
-            }
-            catch (IOException e)
-            {
-                //use the original resource
-                if (LOG.isDebugEnabled())
-                    LOG.debug("ignored", e);
-            }
-            _canonicalMonitored.add(canonical);   
-        }
     }
 
     public List<Resource> getMonitoredResources()
     {
         return Collections.unmodifiableList(_monitored);
-    }
-    
-    List<Resource> getCanonicalMonitoredResources()
-    {
-        return Collections.unmodifiableList(_canonicalMonitored);
     }
 
     public void setMonitoredDirResource(Resource resource)

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.deploy.providers;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
 import java.util.Locale;
 
 import org.eclipse.jetty.deploy.App;
@@ -75,62 +74,45 @@ public class WebAppProvider extends ScanningAppProvider
         @Override
         public boolean accept(File dir, String name)
         {
-            if (dir == null)
+            if (dir == null || !dir.exists())
                 return false;
 
-            try
-            {
-                //Always work on canonical files because we need to
-                //check if the file passed in is one of the
-                //monitored resources
-                if (!dir.getCanonicalFile().exists())
-                    return false;
-                
-                String lowerName = name.toLowerCase(Locale.ENGLISH);
+            String lowerName = name.toLowerCase(Locale.ENGLISH);
 
-                File canonical = new File(dir, name).getCanonicalFile();
-                Resource r = Resource.newResource(canonical);
-                if (getCanonicalMonitoredResources().contains(r) && r.isDirectory())
+            Resource resource = Resource.newResource(new File(dir, name));
+            for (Resource m : getMonitoredResources())
+                if (resource.isSame(m))
                     return false;
 
-                // ignore hidden files
-                if (lowerName.startsWith("."))
-                    return false;
-
-                // Ignore some directories
-                if (canonical.isDirectory())
-                {
-                    // is it a nominated config directory
-                    if (lowerName.endsWith(".d"))
-                        return false;
-
-                    // is it an unpacked directory for an existing war file?
-                    if (exists(name + ".war") || exists(name + ".WAR"))
-                        return false;
-
-                    // is it a directory for an existing xml file?
-                    if (exists(name + ".xml") || exists(name + ".XML"))
-                        return false;
-
-                    //is it a sccs dir?
-                    return !"cvs".equals(lowerName) && !"cvsroot".equals(lowerName); // OK to deploy it then
-                }
-
-                // else is it a war file
-                if (lowerName.endsWith(".war"))
-                {
-                    //defer deployment decision to fileChanged()
-                    return true;
-                }
-
-                // else is it a context XML file 
-                return lowerName.endsWith(".xml");
-            }
-            catch (IOException e)
-            {
-                LOG.warn("Cannot accept", e);
+            // ignore hidden files
+            if (lowerName.startsWith("."))
                 return false;
+
+            // Ignore some directories
+            if (resource.isDirectory())
+            {
+                // is it a nominated config directory
+                if (lowerName.endsWith(".d"))
+                    return false;
+
+                // is it an unpacked directory for an existing war file?
+                if (exists(name + ".war") || exists(name + ".WAR"))
+                    return false;
+
+                // is it a directory for an existing xml file?
+                if (exists(name + ".xml") || exists(name + ".XML"))
+                    return false;
+
+                //is it a sccs dir?
+                return !"cvs".equals(lowerName) && !"cvsroot".equals(lowerName); // OK to deploy it then
             }
+
+            // else is it a war file
+            if (lowerName.endsWith(".war"))
+                return true;
+
+            // else is it a context XML file
+            return lowerName.endsWith(".xml");
         }
     }
 

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -25,8 +25,6 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -74,15 +72,14 @@ public class WebAppProvider extends ScanningAppProvider
         @Override
         public boolean accept(File dir, String name)
         {
-            if (dir == null || !dir.exists())
+            if (dir == null || !dir.canRead())
                 return false;
 
             String lowerName = name.toLowerCase(Locale.ENGLISH);
 
             Resource resource = Resource.newResource(new File(dir, name));
-            for (Resource m : getMonitoredResources())
-                if (resource.isSame(m))
-                    return false;
+            if (getMonitoredResources().stream().anyMatch(resource::isSame))
+                return false;
 
             // ignore hidden files
             if (lowerName.startsWith("."))

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -329,6 +329,25 @@ public class PathResource extends Resource
     }
 
     @Override
+    public boolean isSame(Resource resource)
+    {
+        try
+        {
+            if (resource instanceof PathResource)
+            {
+                Path path = ((PathResource)resource).getPath();
+                return Files.isSameFile(getPath(), path);
+            }
+        }
+        catch (IOException e)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("ignored", e);
+        }
+        return false;
+    }
+
+    @Override
     public Resource addPath(final String subpath) throws IOException
     {
         String cpath = URIUtil.canonicalPath(subpath);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -303,6 +303,18 @@ public abstract class Resource implements ResourceFactory, Closeable
     public abstract boolean isContainedIn(Resource r) throws MalformedURLException;
 
     /**
+     * Return true if the passed Resource represents the same resource as the Resource.
+     * For many resource types, this is equivalent to {@link #equals(Object)}, however
+     * for resources types that support aliasing, this maybe some other check (e.g. {@link java.nio.file.Files#isSameFile(Path, Path)}).
+     * @param resource The resource to check
+     * @return true if the passed resource represents the same resource.
+     */
+    public boolean isSame(Resource resource)
+    {
+        return equals(resource);
+    }
+
+    /**
      * Release any temporary resources held by the resource.
      */
     @Override

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -133,7 +133,7 @@ public class PathResourceTest
             Path epath2 = Files.createSymbolicLink(MavenTestingUtils.getTargetPath().resolve("testSame-symlink"), epath.getParent()).resolve("example.jar");
             ePathResource2 = new PathResource(epath2);
         }
-        catch(Throwable th)
+        catch (Throwable th)
         {
             // Assume symbolic links are not supported
         }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -112,5 +113,17 @@ public class PathResourceTest
 
         File file = resource.getFile();
         assertThat("File for default FileSystem", file, is(exampleJar.toFile()));
+    }
+
+    @Test
+    public void testSame() throws Exception
+    {
+        Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
+        Path epath = MavenTestingUtils.getTestResourcePathFile("example.jar");
+        PathResource rPathResource = new PathResource(rpath);
+        PathResource ePathResource = new PathResource(epath);
+
+        assertThat(rPathResource.isSame(rPathResource), Matchers.is(true));
+        assertThat(rPathResource.isSame(ePathResource), Matchers.is(false));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -116,7 +117,7 @@ public class PathResourceTest
     }
 
     @Test
-    public void testSame() throws Exception
+    public void testSame()
     {
         Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
         Path epath = MavenTestingUtils.getTestResourcePathFile("example.jar");
@@ -125,5 +126,21 @@ public class PathResourceTest
 
         assertThat(rPathResource.isSame(rPathResource), Matchers.is(true));
         assertThat(rPathResource.isSame(ePathResource), Matchers.is(false));
+
+        PathResource ePathResource2 = null;
+        try
+        {
+            Path epath2 = Files.createSymbolicLink(MavenTestingUtils.getTargetPath().resolve("testSame-symlink"), epath.getParent()).resolve("example.jar");
+            ePathResource2 = new PathResource(epath2);
+        }
+        catch(Throwable th)
+        {
+            // Assume symbolic links are not supported
+        }
+        if (ePathResource2 != null)
+        {
+            assertThat(ePathResource.isSame(ePathResource2), Matchers.is(true));
+            assertThat(ePathResource.equals(ePathResource2), Matchers.is(false));
+        }
     }
 }


### PR DESCRIPTION
cherry picked from 9
Use Files.isSameFile to check Resource equality
Avoid using canonical and instead use Files.isSameFile

Signed-off-by: Greg Wilkins <gregw@webtide.com>