### PR TITLE
Issue #6109 - Introduce carriers for HttpClient transports

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -159,7 +159,9 @@ public class HttpClient extends ContainerLifeCycle
     {
         this.transport = Objects.requireNonNull(transport);
         addBean(transport);
-        this.connector = ((AbstractHttpClientTransport)transport).getBean(ClientConnector.class);
+        this.connector = ((AbstractHttpClientTransport)transport).getContainedBeans(ClientConnector.class).stream()
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(ClientConnector.class.getName() + " not found in transport " + transport));
         addBean(handlers);
         addBean(decoderFactories);
     }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/dynamic/HttpClientTransportDynamic.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/dynamic/HttpClientTransportDynamic.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connectable;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 
@@ -95,7 +96,7 @@ public class HttpClientTransportDynamic extends AbstractConnectorHttpClientTrans
      * @param connector the ClientConnector used by this transport
      * @param factoryInfos the <em>application protocols</em> that this transport can speak
      */
-    public HttpClientTransportDynamic(ClientConnector connector, ClientConnectionFactory.Info... factoryInfos)
+    public HttpClientTransportDynamic(Connectable connector, ClientConnectionFactory.Info... factoryInfos)
     {
         super(connector);
         addBean(connector);
@@ -179,7 +180,7 @@ public class HttpClientTransportDynamic extends AbstractConnectorHttpClientTrans
         {
             if (destination.isSecure() && protocol.isNegotiate())
             {
-                factory = new ALPNClientConnectionFactory(getClientConnector().getExecutor(), this::newNegotiatedConnection, protocol.getProtocols());
+                factory = new ALPNClientConnectionFactory(getHttpClient().getExecutor(), this::newNegotiatedConnection, protocol.getProtocols());
             }
             else
             {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpClientTransportOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpClientTransportOverHTTP.java
@@ -25,8 +25,8 @@ import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connectable;
 import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
@@ -41,19 +41,25 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
 
     public HttpClientTransportOverHTTP()
     {
-        this(Math.max(1, ProcessorUtils.availableProcessors() / 2));
+        this(1);
     }
 
     public HttpClientTransportOverHTTP(int selectors)
     {
-        this(new ClientConnector());
-        getClientConnector().setSelectors(selectors);
+        this(newClientConnector(selectors));
     }
 
-    public HttpClientTransportOverHTTP(ClientConnector connector)
+    public HttpClientTransportOverHTTP(Connectable connector)
     {
         super(connector);
         setConnectionPoolFactory(destination -> new DuplexConnectionPool(destination, getHttpClient().getMaxConnectionsPerDestination(), destination));
+    }
+
+    private static Connectable newClientConnector(int selectors)
+    {
+        ClientConnector connector = new ClientConnector();
+        connector.setSelectors(selectors);
+        return connector;
     }
 
     @Override

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpClientTransportOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpClientTransportOverFCGI.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.fcgi.FCGI;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connectable;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.Promise;
@@ -47,11 +48,10 @@ public class HttpClientTransportOverFCGI extends AbstractConnectorHttpClientTran
 
     public HttpClientTransportOverFCGI(int selectors, String scriptRoot)
     {
-        this(new ClientConnector(), scriptRoot);
-        getClientConnector().setSelectors(selectors);
+        this(newClientConnector(selectors), scriptRoot);
     }
 
-    public HttpClientTransportOverFCGI(ClientConnector connector, String scriptRoot)
+    public HttpClientTransportOverFCGI(Connectable connector, String scriptRoot)
     {
         super(connector);
         this.scriptRoot = scriptRoot;
@@ -61,6 +61,13 @@ public class HttpClientTransportOverFCGI extends AbstractConnectorHttpClientTran
             int maxConnections = httpClient.getMaxConnectionsPerDestination();
             return new DuplexConnectionPool(destination, maxConnections, destination);
         });
+    }
+
+    private static ClientConnector newClientConnector(int selectors)
+    {
+        ClientConnector connector = new ClientConnector();
+        connector.setSelectors(selectors);
+        return connector;
     }
 
     @ManagedAttribute(value = "The scripts root directory", readonly = true)

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
 import org.eclipse.jetty.client.AbstractHttpClientTransport;
@@ -47,8 +48,8 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
 
     public HttpClientTransportOverHTTP2(HTTP2Client client)
     {
-        this.client = client;
-        addBean(client.getClientConnector(), false);
+        this.client = Objects.requireNonNull(client);
+        addBean(client);
         setConnectionPoolFactory(destination ->
         {
             HttpClient httpClient = getHttpClient();
@@ -93,15 +94,7 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
             client.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
             client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
         }
-        addBean(client);
         super.doStart();
-    }
-
-    @Override
-    protected void doStop() throws Exception
-    {
-        super.doStop();
-        removeBean(client);
     }
 
     @Override

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ClientConnector.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ClientConnector.java
@@ -35,12 +35,10 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ClientConnector extends ContainerLifeCycle
+public class ClientConnector extends ContainerLifeCycle implements Connectable
 {
-    public static final String CLIENT_CONNECTOR_CONTEXT_KEY = "org.eclipse.jetty.client.connector";
     public static final String REMOTE_SOCKET_ADDRESS_CONTEXT_KEY = CLIENT_CONNECTOR_CONTEXT_KEY + ".remoteSocketAddress";
     public static final String CLIENT_CONNECTION_FACTORY_CONTEXT_KEY = CLIENT_CONNECTOR_CONTEXT_KEY + ".clientConnectionFactory";
-    public static final String CONNECTION_PROMISE_CONTEXT_KEY = CLIENT_CONNECTOR_CONTEXT_KEY + ".connectionPromise";
     private static final Logger LOG = LoggerFactory.getLogger(ClientConnector.class);
 
     private Executor executor;
@@ -211,6 +209,7 @@ public class ClientConnector extends ContainerLifeCycle
         return new ClientSelectorManager(getExecutor(), getScheduler(), getSelectors());
     }
 
+    @Override
     public void connect(SocketAddress address, Map<String, Object> context)
     {
         SocketChannel channel = null;

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/Connectable.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/Connectable.java
@@ -1,0 +1,40 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.net.SocketAddress;
+import java.util.Map;
+
+/**
+ * <p>The abstraction that client components implement to
+ * provide a service that connects to remote hosts.</p>
+ */
+public interface Connectable
+{
+    public static final String CLIENT_CONNECTOR_CONTEXT_KEY = "org.eclipse.jetty.client.connector";
+    public static final String CONNECTION_PROMISE_CONTEXT_KEY = CLIENT_CONNECTOR_CONTEXT_KEY + ".connectionPromise";
+
+    /**
+     * <p>Connects to a remote hosts using the information provided
+     * by the given {@code address} and {@code context} map.</p>
+     * <p>The connection may not be established to the given socket address.</p>
+     * <p>Implementations must arrange to notify the {@code Promise<org.eclipse.jetty.io.Connection>},
+     * present in the {@code context} map under the {@link #CONNECTION_PROMISE_CONTEXT_KEY} key,
+     * both in case of successful connection or in case of connection failure.</p>
+     *
+     * @param address the socket address
+     * @param context the context map
+     */
+    public void connect(SocketAddress address, Map<String, Object> context);
+}

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpClientConnectableTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpClientConnectableTest.java
@@ -1,0 +1,242 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http.client;
+
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiPredicate;
+
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.fcgi.client.http.HttpClientTransportOverFCGI;
+import org.eclipse.jetty.fcgi.server.ServerFCGIConnectionFactory;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connectable;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.opentest4j.TestAbortedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttpClientConnectableTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private HttpClient client;
+
+    private void startServer(Transport transport, Handler handler) throws Exception
+    {
+        QueuedThreadPool serverThreads = new QueuedThreadPool();
+        serverThreads.setName("server");
+        server = new Server(serverThreads);
+
+        switch (transport)
+        {
+            case HTTP:
+            {
+                connector = new ServerConnector(server, new HttpConnectionFactory());
+                break;
+            }
+            case HTTPS:
+            {
+                HttpConfiguration httpsConfig = new HttpConfiguration();
+                httpsConfig.addCustomizer(new SecureRequestCustomizer());
+                HttpConnectionFactory https = new HttpConnectionFactory(httpsConfig);
+                SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+                sslContextFactory.setKeyStorePath("src/test/resources/keystore.p12");
+                sslContextFactory.setKeyStorePassword("storepwd");
+                SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, https.getProtocol());
+                connector = new ServerConnector(server, ssl, https);
+                break;
+            }
+            case FCGI:
+            {
+                connector = new ServerConnector(server, new ServerFCGIConnectionFactory(new HttpConfiguration()));
+                break;
+            }
+            case H2C:
+            {
+                connector = new ServerConnector(server, new HTTP2CServerConnectionFactory(new HttpConfiguration()));
+                break;
+            }
+            case H2:
+            {
+                HttpConfiguration httpsConfig = new HttpConfiguration();
+                httpsConfig.addCustomizer(new SecureRequestCustomizer());
+                HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpsConfig);
+                ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+                SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+                sslContextFactory.setKeyStorePath("src/test/resources/keystore.p12");
+                sslContextFactory.setKeyStorePassword("storepwd");
+                SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
+                connector = new ServerConnector(server, ssl, alpn, h2);
+                break;
+            }
+            default:
+            {
+                throw new TestAbortedException("Unsupported transport " + transport);
+            }
+        }
+
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+    }
+
+    private void startClient(Transport transport, MatchingConnectable connectable) throws Exception
+    {
+        ClientConnector connector = new ClientConnector();
+        connectable.addBean(connector);
+
+        QueuedThreadPool clientThreads = new QueuedThreadPool();
+        clientThreads.setName("client");
+        connector.setExecutor(clientThreads);
+
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setTrustStorePath("src/test/resources/keystore.p12");
+        sslContextFactory.setTrustStorePassword("storepwd");
+        connector.setSslContextFactory(sslContextFactory);
+
+        HttpClientTransport clientTransport;
+        switch (transport)
+        {
+            case HTTP:
+            case HTTPS:
+            {
+                clientTransport = new HttpClientTransportOverHTTP(connectable);
+                break;
+            }
+            case H2C:
+            case H2:
+            {
+                clientTransport = new HttpClientTransportOverHTTP2(new HTTP2Client(connectable));
+                break;
+            }
+            case FCGI:
+            {
+                clientTransport = new HttpClientTransportOverFCGI(connectable, "");
+                break;
+            }
+            default:
+            {
+                throw new TestAbortedException("Unsupported transport " + transport);
+            }
+        }
+
+        client = new HttpClient(clientTransport);
+        client.start();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Transport.class)
+    public void testMatchingConnectable(Transport transport) throws Exception
+    {
+        startServer(transport, new EmptyServerHandler());
+
+        MatchingConnectable matcher = new MatchingConnectable();
+        startClient(transport, matcher);
+        ClientConnector clientConnector = matcher.getBean(ClientConnector.class);
+        assertNotNull(clientConnector);
+
+        String scheme = transport.isTlsBased() ? "https" : "http";
+        String host = "localhost";
+        int port = connector.getLocalPort();
+        URI uri = URI.create(scheme + "://" + host + ":" + port + "/path");
+
+        // No matching rules added, request should fail.
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> client.GET(uri));
+        assertThat(exception.getCause(), Matchers.instanceOf(ConnectException.class));
+
+        // Add a matching rule, request should succeed.
+        matcher.rules.add((a, c) ->
+        {
+            clientConnector.connect(a, c);
+            return true;
+        });
+        ContentResponse response = client.GET(uri);
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        matcher.rules.clear();
+
+        URI otherURI = URI.create(scheme + "://" + host + (port + 1) + "/path");
+        // Add a rule that connects to another address.
+        matcher.rules.add((a, c) ->
+        {
+            if (a instanceof InetSocketAddress)
+            {
+                assertEquals(otherURI.getPort(), ((InetSocketAddress)a).getPort());
+                clientConnector.connect(new InetSocketAddress(uri.getHost(), uri.getPort()), c);
+                return true;
+            }
+            return false;
+        });
+        response = client.GET(uri);
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    private static class MatchingConnectable extends ContainerLifeCycle implements Connectable
+    {
+        private final List<BiPredicate<SocketAddress, Map<String, Object>>> rules = new ArrayList<>();
+
+        @Override
+        public void connect(SocketAddress address, Map<String, Object> context)
+        {
+            if (rules.stream().noneMatch(rule -> rule.test(address, context)))
+            {
+                @SuppressWarnings("unchecked")
+                Promise<Connection> promise = (Promise<Connection>)context.get(Connectable.CONNECTION_PROMISE_CONTEXT_KEY);
+                promise.failed(new ConnectException());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduced org.eclipse.jetty.io.Connectable.
Retrofitted HttpClientTransport implementation to take a Connectable
instead of ClientConnector.

In future, a different Connectable implementation can be passed to
HttpClientTransport implementation so that it may delegate to concrete
ClientConnector implementation that use TCP, or Unix Domain sockets,
or QUIC over UDP.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>