### PR TITLE
Changed exception check by JUnit API usage

### DIFF
--- a/jetty-http/src/test/java/org/eclipse/jetty/http/SyntaxTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/SyntaxTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class SyntaxTest
@@ -61,17 +62,11 @@ public class SyntaxTest
 
         for (String token : tokens)
         {
-            try
-            {
-                Syntax.requireValidRFC2616Token(token, "Test Based");
-                fail("RFC2616 Token [" + token + "] Should have thrown " + IllegalArgumentException.class.getName());
-            }
-            catch (IllegalArgumentException e)
-            {
-                assertThat("Testing Bad RFC2616 Token [" + token + "]", e.getMessage(),
+            Throwable e = assertThrows(IllegalArgumentException.class,
+                    () -> Syntax.requireValidRFC2616Token(token, "Test Based"));
+            assertThat("Testing Bad RFC2616 Token [" + token + "]", e.getMessage(),
                     allOf(containsString("Test Based"),
-                        containsString("RFC2616")));
-            }
+                            containsString("RFC2616")));
         }
     }
 


### PR DESCRIPTION
**Problem:**
The Exception Handling test smell occurs when the test outcome is manually determined through pass or fail method calls, dependent on the production method throwing an exception generally inside a try/catch block. This refactoring proposal aims to make the exception catching a responsibility of the test framework which is already provided by its API. Also, without using try/catch blocks, tests can be more straightforward and possibly more comprehensible and maintainable.

**Solution:**
We propose using JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code. In this particular case, we added the possibly throwable object to test method signature and removed the redundant fail method call and message.

**Result:**
_Before:_
``` java
try
     {
          Syntax.requireValidRFC2616Token(token, "Test Based");
          fail("RFC2616 Token [" + token + "] Should have thrown " + IllegalArgumentException.class.getName());
      }
      catch (IllegalArgumentException e)
      {
           assertThat("Testing Bad RFC2616 Token [" + token + "]", e.getMessage(),
           allOf(containsString("Test Based"),
           containsString("RFC2616")));
       }
```

_After:_
``` java
Throwable e = assertThrows(IllegalArgumentException.class,
                    () -> Syntax.requireValidRFC2616Token(token, "Test Based"));
assertThat("Testing Bad RFC2616 Token [" + token + "]", e.getMessage(),
                    allOf(containsString("Test Based"),
                    containsString("RFC2616")));
```