### PR TITLE
UriCompliance mode improvements #6132

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -59,7 +59,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
          */
         AMBIGUOUS_PATH_PARAMETER("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI path parameter"),
         /**
-         * Allow Non canonical ambiguous paths. eg <code>/foo/x@2f/%2e%2e%/bar</code> provided to applications as <code>/foo/x/../bar</code>
+         * Allow Non canonical ambiguous paths. eg <code>/foo/x%2f%2e%2e%/bar</code> provided to applications as <code>/foo/x/../bar</code>
          */
         NON_CANONICAL_AMBIGUOUS_PATHS("https://tools.ietf.org/html/rfc3986#section-3.3", "Non canonical ambiguous paths");
 
@@ -106,7 +106,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
 
     /**
      * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations. However ambiguous paths are
-     * normalised.
+     * canonicalized for safety.
      */
     public static final UriCompliance RFC3986 = new UriCompliance("RFC3986", complementOf(of(Violation.NON_CANONICAL_AMBIGUOUS_PATHS)));
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -100,19 +100,18 @@ public final class UriCompliance implements ComplianceViolation.Mode
     public static final UriCompliance DEFAULT = new UriCompliance("DEFAULT", of(Violation.AMBIGUOUS_PATH_SEPARATOR));
 
     /**
-     * LEGACY compliance mode that disallows only ambiguous path parameters as per Jetty-9.4
+     * LEGACY compliance mode that models Jetty-9.4 behavior by allowing {@link Violation#AMBIGUOUS_PATH_SEGMENT} and {@link Violation#AMBIGUOUS_PATH_SEPARATOR}
      */
     public static final UriCompliance LEGACY = new UriCompliance("LEGACY", of(Violation.AMBIGUOUS_PATH_SEGMENT, Violation.AMBIGUOUS_PATH_SEPARATOR));
 
     /**
-     * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations. However ambiguous paths are
-     * canonicalized for safety.
+     * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations,
+     * except {@link Violation#NON_CANONICAL_AMBIGUOUS_PATHS}, thus ambiguous paths are canonicalized for safety.
      */
     public static final UriCompliance RFC3986 = new UriCompliance("RFC3986", complementOf(of(Violation.NON_CANONICAL_AMBIGUOUS_PATHS)));
 
     /**
-     * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations, which may be passed
-     * to the application in non-normal form.
+     * Compliance mode that allows all URI Violations, including allowing ambiguous paths in non canonicalized form.
      */
     public static final UriCompliance UNSAFE = new UriCompliance("UNSAFE", allOf(Violation.class));
 
@@ -222,7 +221,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
     private final String _name;
     private final Set<Violation> _allowed;
 
-    private UriCompliance(String name, Set<Violation> violations)
+    public UriCompliance(String name, Set<Violation> violations)
     {
         Objects.requireNonNull(violations);
         _name = name;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -39,27 +39,29 @@ public final class UriCompliance implements ComplianceViolation.Mode
     protected static final Logger LOG = LoggerFactory.getLogger(UriCompliance.class);
 
     /**
-     * These are URI compliance violations, which may be allowed by the compliance mode. Currently all these
-     * violations are for additional criteria in excess of the strict requirements of rfc3986.
+     * These are URI compliance "violations", which may be allowed by the compliance mode. These are actual
+     * violations of the RFC, as they represent additional requirements in excess of the strict compliance of rfc3986.
+     * A compliance mode that contains one or more of these Violations, allows request to violate the corresponding
+     * additional requirement.
      */
     public enum Violation implements ComplianceViolation
     {
         /**
-         * Ambiguous path segments e.g. <code>/foo/%2e%2e/bar</code>
+         * Allow ambiguous path segments e.g. <code>/foo/%2e%2e/bar</code>
          */
         AMBIGUOUS_PATH_SEGMENT("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI path segment"),
         /**
-         * Ambiguous path separator within a URI segment e.g. <code>/foo/b%2fr</code>
+         * Allow ambiguous path separator within a URI segment e.g. <code>/foo/b%2fr</code>
          */
         AMBIGUOUS_PATH_SEPARATOR("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI path separator"),
         /**
-         * Ambiguous path parameters within a URI segment e.g. <code>/foo/..;/bar</code>
+         * Allow ambiguous path parameters within a URI segment e.g. <code>/foo/..;/bar</code>
          */
         AMBIGUOUS_PATH_PARAMETER("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI path parameter"),
         /**
-         * Non normal ambiguous paths. eg <code>/foo/x@2f/%2e%2e%/bar</code> provided to applications as <code>/foo/x/../bar</code>
+         * Allow Non canonical ambiguous paths. eg <code>/foo/x@2f/%2e%2e%/bar</code> provided to applications as <code>/foo/x/../bar</code>
          */
-        NON_NORMAL_AMBIGUOUS_PATHS("https://tools.ietf.org/html/rfc3986#section-3.3", "Non normal ambiguous paths");
+        NON_CANONICAL_AMBIGUOUS_PATHS("https://tools.ietf.org/html/rfc3986#section-3.3", "Non canonical ambiguous paths");
 
         private final String _url;
         private final String _description;
@@ -93,7 +95,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
      * The default compliance mode that extends RFC3986 compliance with additional violations to avoid most ambiguous URIs.
      * This mode does allow {@link Violation#AMBIGUOUS_PATH_SEPARATOR}, but disallows
      * {@link Violation#AMBIGUOUS_PATH_PARAMETER} and {@link Violation#AMBIGUOUS_PATH_SEGMENT}.
-     * Ambiguous paths are not allowed by {@link Violation#NON_NORMAL_AMBIGUOUS_PATHS}.
+     * Ambiguous paths are not allowed by {@link Violation#NON_CANONICAL_AMBIGUOUS_PATHS}.
      */
     public static final UriCompliance DEFAULT = new UriCompliance("DEFAULT", of(Violation.AMBIGUOUS_PATH_SEPARATOR));
 
@@ -106,7 +108,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
      * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations. However ambiguous paths are
      * normalised.
      */
-    public static final UriCompliance RFC3986 = new UriCompliance("RFC3986", complementOf(of(Violation.NON_NORMAL_AMBIGUOUS_PATHS)));
+    public static final UriCompliance RFC3986 = new UriCompliance("RFC3986", complementOf(of(Violation.NON_CANONICAL_AMBIGUOUS_PATHS)));
 
     /**
      * Compliance mode that exactly follows RFC3986, including allowing all additional ambiguous URI Violations, which may be passed
@@ -194,6 +196,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
             {
                 UriCompliance mode = UriCompliance.valueOf(elements[0]);
                 violations = (mode == null) ? noneOf(Violation.class) : copyOf(mode.getAllowed());
+                break;
             }
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1747,7 +1747,7 @@ public class Request implements HttpServletRequest
             // Strictly speaking if a URI is legal and encodes ambiguous segments, then they should be
             // reflected in the decoded string version.  However, it can be ambiguous to provide a decoded path as
             // a string, so we normalize again.  If an application wishes to see ambiguous URIs, then they must
-            // set the NON_NORMAL_AMBIGUOUS_PATHS compliance.
+            // set the {@link UriCompliance.Violation#NON_CANONICAL_AMBIGUOUS_PATHS} compliance.
             if (ambiguous && (compliance == null || !compliance.allows(UriCompliance.Violation.NON_CANONICAL_AMBIGUOUS_PATHS)))
                 path = URIUtil.canonicalPath(path);
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1748,7 +1748,7 @@ public class Request implements HttpServletRequest
             // reflected in the decoded string version.  However, it can be ambiguous to provide a decoded path as
             // a string, so we normalize again.  If an application wishes to see ambiguous URIs, then they must
             // set the NON_NORMAL_AMBIGUOUS_PATHS compliance.
-            if (ambiguous && (compliance == null || !compliance.allows(UriCompliance.Violation.NON_NORMAL_AMBIGUOUS_PATHS)))
+            if (ambiguous && (compliance == null || !compliance.allows(UriCompliance.Violation.NON_CANONICAL_AMBIGUOUS_PATHS)))
                 path = URIUtil.canonicalPath(path);
         }
         else if ("*".equals(encoded) || HttpMethod.CONNECT.is(getMethod()))

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -67,7 +67,6 @@ import javax.servlet.http.WebConnection;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HostPortHttpField;
-import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpCookie.SetCookieHttpField;
 import org.eclipse.jetty.http.HttpField;
@@ -1692,10 +1691,11 @@ public class Request implements HttpServletRequest
         _httpFields = request.getFields();
         final HttpURI uri = request.getURI();
 
+        UriCompliance compliance = null;
         boolean ambiguous = uri.isAmbiguous();
         if (ambiguous)
         {
-            UriCompliance compliance = _channel == null || _channel.getHttpConfiguration() == null ? null : _channel.getHttpConfiguration().getUriCompliance();
+            compliance = _channel == null || _channel.getHttpConfiguration() == null ? null : _channel.getHttpConfiguration().getUriCompliance();
             if (uri.hasAmbiguousSegment() && (compliance == null || !compliance.allows(UriCompliance.Violation.AMBIGUOUS_PATH_SEGMENT)))
                 throw new BadMessageException("Ambiguous segment in URI");
             if (uri.hasAmbiguousSeparator() && (compliance == null || !compliance.allows(UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR)))
@@ -1746,9 +1746,9 @@ public class Request implements HttpServletRequest
             path = (encoded.length() == 1) ? "/" : _uri.getDecodedPath();
             // Strictly speaking if a URI is legal and encodes ambiguous segments, then they should be
             // reflected in the decoded string version.  However, it can be ambiguous to provide a decoded path as
-            // a string, so we normalize again.  If an application wishes to see ambiguous URIs, then they can look
-            // at the encoded form of the URI
-            if (ambiguous)
+            // a string, so we normalize again.  If an application wishes to see ambiguous URIs, then they must
+            // set the NON_NORMAL_AMBIGUOUS_PATHS compliance.
+            if (ambiguous && (compliance == null || !compliance.allows(UriCompliance.Violation.NON_NORMAL_AMBIGUOUS_PATHS)))
                 path = URIUtil.canonicalPath(path);
         }
         else if ("*".equals(encoded) || HttpMethod.CONNECT.is(getMethod()))

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1752,7 +1752,7 @@ public class RequestTest
             response.getOutputStream().println("pathInfo=" + request.getPathInfo());
             return true;
         };
-        String request = "GET /unnormal/.././path/amiguous%2f%2e%2e/%2e;/info HTTP/1.0\r\n" +
+        String request = "GET /unnormal/.././path/ambiguous%2f%2e%2e/%2e;/info HTTP/1.0\r\n" +
             "Host: whatever\r\n" +
             "\r\n";
 
@@ -1768,10 +1768,10 @@ public class RequestTest
             UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
             UriCompliance.Violation.AMBIGUOUS_PATH_SEGMENT,
             UriCompliance.Violation.AMBIGUOUS_PATH_PARAMETER,
-            UriCompliance.Violation.NON_NORMAL_AMBIGUOUS_PATHS)));
+            UriCompliance.Violation.NON_CANONICAL_AMBIGUOUS_PATHS)));
         assertThat(_connector.getResponse(request), Matchers.allOf(
             startsWith("HTTP/1.1 200"),
-            containsString("pathInfo=/path/amiguous/.././info")));
+            containsString("pathInfo=/path/ambiguous/.././info")));
     }
     
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1735,7 +1735,7 @@ public class RequestTest
             "\r\n";
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT);
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));
-        _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.from(EnumSet.noneOf(UriCompliance.Violation.class)));
+        _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(new UriCompliance("Test", EnumSet.noneOf(UriCompliance.Violation.class)));
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 400"));
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));


### PR DESCRIPTION
Fixes #6132 
This PR reverts the default behaviour to allows URIs that contain `%2F`.     I'm only 80% convinced of this and we need to consider really carefully before changing the default again.

The PR also contains a non-string based way to create custom `UriCompliance` instances.
It also introduces a new `Violation` that will allow ambiguous Uri to be passed to the application without extra normalisation.
