### PR TITLE
Issue #6148 - update jetty.tag.version behavior

### DIFF
--- a/jetty-start/pom.xml
+++ b/jetty-start/pom.xml
@@ -13,7 +13,30 @@
     <spotbugs.onlyAnalyze>org.eclipse.jetty.start.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-buildnumber</id>
+            <goals>
+              <goal>create</goal>
+            </goals>
+            <configuration>
+              <doCheck>false</doCheck>
+              <doUpdate>false</doUpdate>
+              <revisionOnScmFailure>${nonCanonicalRevision}</revisionOnScmFailure>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Props.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Props.java
@@ -368,11 +368,18 @@ public final class Props implements Iterable<Prop>
         return props.toString();
     }
 
+    public static Props load(ClassLoader classLoader, String resourceName)
+    {
+        StartLog.debug("Looking for classloader resource: %s", resourceName);
+        return load(classLoader.getResource(resourceName));
+    }
+
     public static Props load(URL url)
     {
         Props props = new Props();
         if (url != null)
         {
+            StartLog.debug("Loading Props: %s", url.toExternalForm());
             try (InputStream in = url.openStream())
             {
                 Properties properties = new Properties();

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Props.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Props.java
@@ -19,7 +19,9 @@
 package org.eclipse.jetty.start;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -364,5 +366,26 @@ public final class Props implements Iterable<Prop>
     public String toString()
     {
         return props.toString();
+    }
+
+    public static Props load(URL url)
+    {
+        Props props = new Props();
+        if (url != null)
+        {
+            try (InputStream in = url.openStream())
+            {
+                Properties properties = new Properties();
+                properties.load(in);
+                String urlStr = url.toExternalForm();
+                properties.stringPropertyNames().forEach((name) ->
+                    props.setProperty(name, properties.getProperty(name), urlStr));
+            }
+            catch (IOException x)
+            {
+                StartLog.debug(x);
+            }
+        }
+        return props;
     }
 }

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/build.properties
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/build.properties
@@ -1,0 +1,4 @@
+buildNumber=${buildNumber}
+timestamp=${timestamp}
+version=${project.version}
+scmUrl=${project.scm.connection}


### PR DESCRIPTION
Copied over the build.properties behavior from jetty-util into jetty-start
And updated jetty-start to use this new properties file if the other techniques before it are not found.
Default is no longer "master" as well.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>