### PR TITLE
Issue #6153 Swap order of jetty maven plugin jvmArgs for EXTERNAL

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/maven/jetty-maven-plugin.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/maven/jetty-maven-plugin.adoc
@@ -189,7 +189,7 @@ Optional.
 Map of key/value pairs to pass as environment to the forked JVM.
 jvmArgs::
 Optional.
-A string representing arbitrary arguments to pass to the forked JVM.
+A space separated string representing arbitrary arguments to pass to the forked JVM.
 forkWebXml::
 Optional.
 Defaults to `target/fork-web.xml`.
@@ -218,9 +218,13 @@ jettyHome::
 Optional.
 The location of an existing unpacked jetty distribution.
 If one does not exist, a fresh jetty distribution will be downloaded from maven and installed to the `target` directory.
+jettyOptions::
+Optional.
+A space separated string representing extra arguments to the synthesized jetty command line.
+Values for these arguments can be found in the section titled "Options" in the output of `java -jar $jetty.home/start.jar --help`.
 jvmArgs::
 Optional.
-A string representing arguments that should be passed to the jvm of the child process running the distro.
+A space separated string representing arguments that should be passed to the jvm of the child process running the distro.
 modules::
 Optional.
 An array of names of additional jetty modules that the jetty child process will activate.

--- a/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/pom.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/pom.xml
@@ -103,6 +103,7 @@
                 <jetty.http.port>0</jetty.http.port>
               </jettyProperties>
               <modules>jsp,jstl,testmod</modules>
+              <jettyOptions>--debug</jettyOptions>
             </configuration>
           </execution>
         </executions>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
@@ -290,7 +290,6 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
     @Parameter
     protected int stopPort;
     
-    
     /**
      * Key to provide when stopping jetty on executing java -DSTOP.KEY=&lt;stopKey&gt; 
      * -DSTOP.PORT=&lt;stopPort&gt; -jar start.jar --stop
@@ -319,6 +318,13 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
      */
     @Parameter
     protected String[] modules;
+
+    /**
+     * Extra options that can be passed to the jetty command line
+     */
+    @Parameter (property = "jetty.options")
+    protected String jettyOptions;
+
     //End of EXTERNAL only parameters
 
     //Start of parameters only valid for FORK
@@ -511,6 +517,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
         jetty.setStopPort(stopPort);
         jetty.setEnv(env);
         jetty.setJvmArgs(jvmArgs);
+        jetty.setJettyOptions(jettyOptions);
         jetty.setJettyXmlFiles(jettyXmls);
         jetty.setJettyProperties(jettyProperties);
         jetty.setModules(modules);

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyHomeForker.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyHomeForker.java
@@ -25,7 +25,6 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -185,9 +184,9 @@ public class JettyHomeForker extends AbstractForker
         cmd.add("java");
 
         //add any args to the jvm
-        if (!StringUtil.isBlank(jvmArgs))
+        if (StringUtil.isNotBlank(jvmArgs))
         {
-            Arrays.stream(jvmArgs.split(" ")).forEach((a) -> cmd.add(a.trim()));
+            Arrays.stream(jvmArgs.split(" ")).filter(a -> StringUtil.isNotBlank(a)).forEach((a) -> cmd.add(a.trim()));
         }
 
         cmd.add("-jar");
@@ -224,9 +223,9 @@ public class JettyHomeForker extends AbstractForker
         cmd.add(tmp.toString());
  
         //put any other jetty options onto the command line
-        if (!StringUtil.isBlank(jettyOptions))
+        if (StringUtil.isNotBlank(jettyOptions))
         {
-            Arrays.stream(jettyOptions.split(" ")).forEach((a) -> cmd.add(a.trim()));
+            Arrays.stream(jettyOptions.split(" ")).filter(a -> StringUtil.isNotBlank(a)).forEach((a) -> cmd.add(a.trim()));
         }
 
         //put any jetty properties onto the command line

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyHomeForker.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyHomeForker.java
@@ -167,12 +167,6 @@ public class JettyHomeForker extends AbstractForker
     {
         List<String> cmd = new ArrayList<>();
         cmd.add("java");
-        cmd.add("-jar");
-        cmd.add(new File(jettyHome, "start.jar").getAbsolutePath());
-
-        cmd.add("-DSTOP.PORT=" + stopPort);
-        if (stopKey != null)
-            cmd.add("-DSTOP.KEY=" + stopKey);
 
         //add any args to the jvm
         if (jvmArgs != null)
@@ -192,6 +186,13 @@ public class JettyHomeForker extends AbstractForker
                 cmd.add("-D" + e.getKey() + "=" + e.getValue());
             }
         }
+
+        cmd.add("-jar");
+        cmd.add(new File(jettyHome, "start.jar").getAbsolutePath());
+
+        cmd.add("-DSTOP.PORT=" + stopPort);
+        if (stopKey != null)
+            cmd.add("-DSTOP.KEY=" + stopKey);
 
         //set up enabled jetty modules
         StringBuilder tmp = new StringBuilder();


### PR DESCRIPTION
Closes #6153

Move the addition of the `jvmArgs` to the forked command up to be just after `java` to ensure that they are interpreted by the jvm and not jetty. 