### PR TITLE
Issue #6114 - hot deploy of symlink results in symlink name

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.xml.XmlConfiguration;
-import org.slf4j.LoggerFactory;
 
 /**
  * The webapps directory scanning provider.
@@ -55,11 +54,9 @@ import org.slf4j.LoggerFactory;
  * <p>For XML configured contexts, the ID map will contain a reference to the {@link Server} instance called "Server" and
  * properties for the webapp file as "jetty.webapp" and directory as "jetty.webapps".
  */
-@ManagedObject("Provider for start-up deployement of webapps based on presence in directory")
+@ManagedObject("Provider for start-up deployment of webapps based on presence in directory")
 public class WebAppProvider extends ScanningAppProvider
 {
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(WebAppProvider.class);
-
     private boolean _extractWars = false;
     private boolean _parentLoaderPriority = false;
     private ConfigurationManager _configurationManager;
@@ -375,7 +372,7 @@ public class WebAppProvider extends ScanningAppProvider
             {
                 //if a .xml file exists for it, then redeploy that instead
                 File xml = new File(parent, xmlname);
-                super.fileChanged(xml.getCanonicalPath());
+                super.fileChanged(xml.getAbsolutePath());
                 return;
             }
 
@@ -384,7 +381,7 @@ public class WebAppProvider extends ScanningAppProvider
             {
                 //if a .XML file exists for it, then redeploy that instead
                 File xml = new File(parent, xmlname);
-                super.fileChanged(xml.getCanonicalPath());
+                super.fileChanged(xml.getAbsolutePath());
                 return;
             }
 

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.deploy.providers;
 
 import java.io.File;
-import java.net.URL;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,7 +34,6 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.condition.OS.LINUX;
-import static org.junit.jupiter.api.condition.OS.MAC;
 
 @ExtendWith(WorkDirExtension.class)
 public class WebAppProviderTest
@@ -95,7 +92,6 @@ public class WebAppProviderTest
         jetty.stop();
     }
 
-    @Disabled("See issue #1200")
     @Test
     public void testStartupContext()
     {
@@ -109,10 +105,9 @@ public class WebAppProviderTest
         assertDirNotExists("root of work directory", workDir, "jsp");
 
         // Test for correct behaviour
-        assertTrue(hasJettyGeneratedPath(workDir, "foo.war"), "Should have generated directory in work directory: " + workDir);
+        assertTrue(hasJettyGeneratedPath(workDir, "foo_war"), "Should have generated directory in work directory: " + workDir);
     }
     
-    @Disabled("See issue #1200")
     @Test
     public void testStartupSymlinkContext()
     {
@@ -128,7 +123,7 @@ public class WebAppProviderTest
 
         // Test for expected work/temp directory behaviour
         File workDir = jetty.getJettyDir("workish");
-        assertTrue(hasJettyGeneratedPath(workDir, "bar.war"), "Should have generated directory in work directory: " + workDir);
+        assertTrue(hasJettyGeneratedPath(workDir, "bar_war"), "Should have generated directory in work directory: " + workDir);
     }
     
     @Test

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -170,7 +170,7 @@ public class Scanner extends ContainerLifeCycle
             File f = dir.toFile();
 
             //if we want to report directories and we haven't already seen it
-            if (_reportDirs && !scanInfoMap.containsKey(f.getCanonicalPath()))
+            if (_reportDirs && !scanInfoMap.containsKey(f.getAbsolutePath()))
             {
                 boolean accepted = false;
                 if (rootIncludesExcludes != null && !rootIncludesExcludes.isEmpty())
@@ -216,7 +216,7 @@ public class Scanner extends ContainerLifeCycle
 
             if (accepted)
             {
-                scanInfoMap.put(f.getCanonicalPath(), new MetaData(f.lastModified(), f.isDirectory() ? 0 : f.length()));
+                scanInfoMap.put(f.getAbsolutePath(), new MetaData(f.lastModified(), f.isDirectory() ? 0 : f.length()));
                 if (LOG.isDebugEnabled()) LOG.debug("scan accepted {} mod={}", f, f.lastModified());
             }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -186,7 +186,7 @@ public class Scanner extends ContainerLifeCycle
 
                 if (accepted)
                 {
-                    scanInfoMap.put(f.getCanonicalPath(), new MetaData(f.lastModified(), f.isDirectory() ? 0 : f.length()));
+                    scanInfoMap.put(f.getAbsolutePath(), new MetaData(f.lastModified(), f.isDirectory() ? 0 : f.length()));
                     if (LOG.isDebugEnabled()) LOG.debug("scan accepted dir {} mod={}", f, f.lastModified());
                 }
             }
@@ -203,7 +203,7 @@ public class Scanner extends ContainerLifeCycle
             File f = file.toFile();
             boolean accepted = false;
 
-            if (f.isFile() || (f.isDirectory() && _reportDirs && !scanInfoMap.containsKey(f.getCanonicalPath())))
+            if (f.isFile() || (f.isDirectory() && _reportDirs && !scanInfoMap.containsKey(f.getAbsolutePath())))
             {
                 if (rootIncludesExcludes != null && !rootIncludesExcludes.isEmpty())
                 {


### PR DESCRIPTION
+ Using getAbsolutePath not canonical (too many corner cases with it to be reliable)

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>