### PR TITLE
Issue #6166 - fix bug in the MessageInputStream byte array read

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/MessageInputStream.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/MessageInputStream.java
@@ -95,7 +95,9 @@ public class MessageInputStream extends InputStream implements MessageSink
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException
     {
-        return read(ByteBuffer.wrap(b, off, len).flip());
+        ByteBuffer buffer = ByteBuffer.wrap(b, off, len).slice();
+        BufferUtil.clear(buffer);
+        return read(buffer);
     }
 
     public int read(ByteBuffer buffer) throws IOException

--- a/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageInputStreamTest.java
+++ b/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageInputStreamTest.java
@@ -70,6 +70,36 @@ public class MessageInputStreamTest
     }
 
     @Test
+    public void testMultipleReadsIntoSingleByteArray() throws IOException
+    {
+        try (MessageInputStream stream = new MessageInputStream())
+        {
+            // Append a single message (simple, short)
+            Frame frame = new Frame(OpCode.TEXT);
+            frame.setPayload("Hello World");
+            frame.setFin(true);
+            stream.accept(frame, Callback.NOOP);
+
+            // Read entire message it from the stream.
+            byte[] bytes = new byte[100];
+
+            int read = stream.read(bytes, 0, 6);
+            assertThat(read, is(6));
+
+            read = stream.read(bytes, 6, 10);
+            assertThat(read, is(5));
+
+            read = stream.read(bytes, 11, 10);
+            assertThat(read, is(-1));
+
+            String message = new String(bytes, 0, 11, StandardCharsets.UTF_8);
+
+            // Test it
+            assertThat("Message", message, is("Hello World"));
+        }
+    }
+
+    @Test
     public void testBlockOnRead() throws Exception
     {
         assertTimeout(Duration.ofMillis(5000), () ->


### PR DESCRIPTION
**Issue #6166**

The code for `MessageInputStream.read(final byte[] b, final int off, final int len)` seems to be wrong. Instead of doing `ByteBuffer.wrap(b, off, len).flip()` we should do something like:

```java
ByteBuffer buffer = ByteBuffer.wrap(b, off, len).slice();
BufferUtil.clear(buffer);
return read(buffer);
```

This will ensure that the buffer we get to represent the byte array always has a position and limit of 0, an offset of `off`, and a capacity of `len`.

The only time when `MessageInputStream.read(ByteBuffer)` will compact is when the buffer already has content and `limit == capacity`. So if we make this change, a call to `MessageInputStream.read(final byte[] b, final int off, final int len)` will never compact as the buffer is always empty with `position == limit`.
