### PR TITLE
Fix #6157 consumeAll optimisation

### DIFF
--- a/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpChannelOverFCGI.java
+++ b/jetty-fcgi/fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/HttpChannelOverFCGI.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.fcgi.FCGI;
 import org.eclipse.jetty.http.HostPortHttpField;
@@ -107,7 +108,7 @@ public class HttpChannelOverFCGI extends HttpChannel
     }
 
     @Override
-    public boolean failAllContent(Throwable failure)
+    public boolean failAllContent(Supplier<Throwable> failure)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("failing all content with {} {}", failure, this);
@@ -117,7 +118,7 @@ public class HttpChannelOverFCGI extends HttpChannel
             copy = new ArrayList<>(_contentQueue);
             _contentQueue.clear();
         }
-        copy.forEach(c -> c.failed(failure));
+        copy.forEach(c -> c.failed(failure.get()));
         boolean atEof;
         try (AutoLock l = _lock.lock())
         {

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -232,7 +233,7 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
     }
 
     @Override
-    public boolean failAllData(Throwable x)
+    public boolean failAllData(Supplier<Throwable> failure)
     {
         List<DataEntry> copy;
         try (AutoLock l = lock.lock())
@@ -241,7 +242,7 @@ public class HTTP2Stream extends IdleTimeout implements IStream, Callback, Dumpa
             copy = new ArrayList<>(dataQueue);
             dataQueue.clear();
         }
-        copy.forEach(dataEntry -> dataEntry.callback.failed(x));
+        copy.forEach(dataEntry -> dataEntry.callback.failed(failure.get()));
         DataEntry lastDataEntry = copy.isEmpty() ? null : copy.get(copy.size() - 1);
         if (lastDataEntry == null)
             return isRemotelyClosed();

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.DataFrame;
@@ -117,10 +118,10 @@ public interface IStream extends Stream, Attachable, Closeable
     /**
      * Fail all data queued in the stream and reset
      * demand to 0.
-     * @param x the exception to fail the data with.
+     * @param failure the exception to fail the data with.
      * @return true if the end of the stream was reached, false otherwise.
      */
-    boolean failAllData(Throwable x);
+    boolean failAllData(Supplier<Throwable> failure);
 
     /**
      * @return whether this stream has been reset (locally or remotely) or has been failed

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpField;
@@ -534,7 +535,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel implements Closeable, Writ
             }
         }
 
-        public boolean failContent(Throwable failure)
+        public boolean failContent(Supplier<Throwable> failure)
         {
             while (true)
             {
@@ -547,7 +548,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel implements Closeable, Writ
                     return c.isEof();
                 if (_content.compareAndSet(c, null))
                 {
-                    c.failed(failure);
+                    c.failed(failure.get());
                     if (LOG.isDebugEnabled())
                         LOG.debug("replacing current content with null succeeded");
                     return false;
@@ -583,7 +584,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel implements Closeable, Writ
     }
 
     @Override
-    public boolean failAllContent(Throwable failure)
+    public boolean failAllContent(Supplier<Throwable> failure)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("failing all content with {} {}", failure, this);

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/authentication/SpnegoAuthenticatorTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/authentication/SpnegoAuthenticatorTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.security.authentication;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.HttpFields;
@@ -83,7 +84,7 @@ public class SpnegoAuthenticatorTest
             }
 
             @Override
-            public boolean failAllContent(Throwable failure)
+            public boolean failAllContent(Supplier<Throwable> failure)
             {
                 return false;
             }
@@ -148,7 +149,7 @@ public class SpnegoAuthenticatorTest
             }
 
             @Override
-            public boolean failAllContent(Throwable failure)
+            public boolean failAllContent(Supplier<Throwable> failure)
             {
                 return false;
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 class AsyncContentProducer implements ContentProducer
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncContentProducer.class);
-    private final static HttpInput.Content EOF = new HttpInput.EofContent();
+    private static final  HttpInput.Content EOF = new HttpInput.EofContent();
 
     private final AutoLock _lock = new AutoLock();
     private final HttpChannel _httpChannel;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
@@ -80,9 +80,9 @@ class BlockingContentProducer implements ContentProducer
     }
 
     @Override
-    public boolean consumeAll(Throwable x)
+    public boolean consumeAll()
     {
-        boolean eof = _asyncContentProducer.consumeAll(x);
+        boolean eof = _asyncContentProducer.consumeAll();
         _semaphore.release();
         return eof;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
@@ -18,7 +18,7 @@ import org.eclipse.jetty.util.thread.AutoLock;
 /**
  * ContentProducer is the bridge between {@link HttpInput} and {@link HttpChannel}.
  * It wraps a {@link HttpChannel} and uses the {@link HttpChannel#needContent()},
- * {@link HttpChannel#produceContent()} and {@link HttpChannel#failAllContent(Throwable)}
+ * {@link HttpChannel#produceContent()} and {@link HttpChannel#failAllContent(java.util.function.Supplier)}
  * methods, tracks the current state of the channel's input by updating the
  * {@link HttpChannelState} and provides the necessary mechanism to unblock
  * the reader thread when using a blocking implementation or to know if the reader thread
@@ -46,7 +46,7 @@ public interface ContentProducer
      * Doesn't change state.
      * @return true if EOF was reached.
      */
-    boolean consumeAll(Throwable x);
+    boolean consumeAll();
 
     /**
      * Check if the current data rate consumption is above the minimal rate.

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.DispatcherType;
@@ -151,7 +152,7 @@ public abstract class HttpChannel implements Runnable, HttpOutput.Interceptor
      * @param failure the failure to fail the content with.
      * @return true if EOF was reached while failing all content, false otherwise.
      */
-    public abstract boolean failAllContent(Throwable failure);
+    public abstract boolean failAllContent(Supplier<Throwable> failure);
 
     /**
      * Fail the channel's input.

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
@@ -122,7 +123,7 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
     }
 
     @Override
-    public boolean failAllContent(Throwable failure)
+    public boolean failAllContent(Supplier<Throwable> failure)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("failing all content with {} {}", failure, this);
@@ -130,7 +131,7 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
         {
             if (_content.isSpecial())
                 return _content.isEof();
-            _content.failed(failure);
+            _content.failed(failure.get());
             _content = _content.isEof() ? EOF : null;
             if (_content == EOF)
                 return true;
@@ -153,7 +154,7 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
                 return atEof;
             }
             c.skip(c.remaining());
-            c.failed(failure);
+            c.failed(failure.get());
             if (c.isEof())
             {
                 _content = EOF;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -150,10 +150,9 @@ public class HttpInput extends ServletInputStream implements Runnable
     {
         try (AutoLock lock = _contentProducer.lock())
         {
-            IOException failure = new IOException("Unconsumed content");
             if (LOG.isDebugEnabled())
-                LOG.debug("consumeAll {}", this, failure);
-            boolean atEof = _contentProducer.consumeAll(failure);
+                LOG.debug("consumeAll {}", this);
+            boolean atEof = _contentProducer.consumeAll();
             if (atEof)
                 _consumedEof = true;
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncContentProducerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/AsyncContentProducerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 import org.eclipse.jetty.io.ArrayByteBufferPool;
@@ -328,7 +329,7 @@ public class AsyncContentProducerTest
         }
 
         @Override
-        public boolean failAllContent(Throwable failure)
+        public boolean failAllContent(Supplier<Throwable> failure)
         {
             nextContent = null;
             counter = byteBuffers.length;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/BlockingContentProducerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/BlockingContentProducerTest.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 import org.eclipse.jetty.io.ArrayByteBufferPool;
@@ -328,7 +329,7 @@ public class BlockingContentProducerTest
         }
 
         @Override
-        public boolean failAllContent(Throwable failure)
+        public boolean failAllContent(Supplier<Throwable> failure)
         {
             nextContent = null;
             counter = byteBuffers.length;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpWriterTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpWriterTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.server;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -56,7 +57,7 @@ public class HttpWriterTest
             }
 
             @Override
-            public boolean failAllContent(Throwable failure)
+            public boolean failAllContent(Supplier<Throwable> failure)
             {
                 return false;
             }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletOutputStream;
@@ -185,7 +186,7 @@ public class ResponseTest
             }
 
             @Override
-            public boolean failAllContent(Throwable failure)
+            public boolean failAllContent(Supplier<Throwable> failure)
             {
                 return false;
             }


### PR DESCRIPTION
Fix #6157 consumeAll no longer always creates a new Throwable

Signed-off-by: Greg Wilkins <gregw@webtide.com>