### PR TITLE
Updated Deployment Not enabled console message 

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -144,7 +144,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
     {
         if (scan < 0)
         {
-            getLog().info("Redeployment Disabled; Default Scan Interval = -1 ; Change Value to <scan>0<scan> for Manual or <scan>${Seconds}<scan> for automatic  ");
+            getLog().info("default deploy mode scan=-1:redeploy disabled; scan=0:redeploy manual on ENTER; scan > 0:redeploy automatic");
             return; //no automatic or manual redeployment
         }
         

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -144,7 +144,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
     {
         if (scan < 0)
         {
-            getLog().info("Redeployment not enabled");
+            getLog().info("Redeployment Disabled; Default Scan Interval = -1 ; Change Value to <scan>0<scan> for Manual or <scan>${Seconds}<scan> for automatic  ");
             return; //no automatic or manual redeployment
         }
         


### PR DESCRIPTION
Updated Deployment console message for a clearer status and instructions to turn on and change redeployment status for better user experience in
jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
