### PR TITLE
Improvements to the Jetty documentation.

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/index.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/index.adoc
@@ -11,9 +11,8 @@
 // ========================================================================
 //
 
-:doctitle: Eclipse Jetty: Operations Guide
+:doctitle: link:https://eclipse.org/jetty[Eclipse Jetty]: Operations Guide
 :toc-title: Operations Guide
-:breadcrumb: Home:../index.html | Operations Guide:./index.html
 :idprefix: og-
 :docinfo: private-head
 

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/index.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/index.adoc
@@ -11,9 +11,8 @@
 // ========================================================================
 //
 
-:doctitle: Eclipse Jetty: Programming Guide
+:doctitle: link:https://eclipse.org/jetty[Eclipse Jetty]: Programming Guide
 :toc-title: Jetty Programming Guide
-:breadcrumb: Home:../index.html | Programming Guide:./index.html
 :idprefix: pg-
 :docinfo: private-head
 


### PR DESCRIPTION
Added link to Eclipse Jetty main site.
Removed unused "breadcrumb" attribute.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>