### PR TITLE
consumeAll: fail content with static exception

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
@@ -80,9 +80,9 @@ class BlockingContentProducer implements ContentProducer
     }
 
     @Override
-    public boolean consumeAll(Throwable x)
+    public boolean consumeAll()
     {
-        boolean eof = _asyncContentProducer.consumeAll(x);
+        boolean eof = _asyncContentProducer.consumeAll();
         _semaphore.release();
         return eof;
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
@@ -46,7 +46,7 @@ public interface ContentProducer
      * Doesn't change state.
      * @return true if EOF was reached.
      */
-    boolean consumeAll(Throwable x);
+    boolean consumeAll();
 
     /**
      * Check if the current data rate consumption is above the minimal rate.

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -150,10 +150,9 @@ public class HttpInput extends ServletInputStream implements Runnable
     {
         try (AutoLock lock = _contentProducer.lock())
         {
-            IOException failure = new IOException("Unconsumed content");
             if (LOG.isDebugEnabled())
-                LOG.debug("consumeAll {}", this, failure);
-            boolean atEof = _contentProducer.consumeAll(failure);
+                LOG.debug("consumeAll {}", this);
+            boolean atEof = _contentProducer.consumeAll();
             if (atEof)
                 _consumedEof = true;
 


### PR DESCRIPTION
Simplest possible fix for #6157.

This compares to @gregw 's https://github.com/eclipse/jetty.project/pull/6173.