### PR TITLE
Remove WebSocketComponents & HouseKeeper on Server restart.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionIdManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionIdManager.java
@@ -339,6 +339,7 @@ public class DefaultSessionIdManager extends ContainerLifeCycle implements Sessi
         _houseKeeper.stop();
         if (_ownHouseKeeper)
         {
+            removeBean(_houseKeeper);
             _houseKeeper = null;
         }
         _random = null;

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -1195,6 +1195,34 @@ public class ServletHandler extends ScopedHandler
         }
     }
 
+    public void removeFilterHolder(FilterHolder holder)
+    {
+        if (holder == null)
+            return;
+
+        try (AutoLock ignored = lock())
+        {
+            FilterHolder[] holders = Arrays.stream(getFilters())
+                .filter(h -> h != holder)
+                .toArray(FilterHolder[]::new);
+            setFilters(holders);
+        }
+    }
+
+    public void removeFilterMapping(FilterMapping mapping)
+    {
+        if (mapping == null)
+            return;
+
+        try (AutoLock ignored = lock())
+        {
+            FilterMapping[] mappings = Arrays.stream(getFilterMappings())
+                .filter(m -> m != mapping)
+                .toArray(FilterMapping[]::new);
+            setFilterMappings(mappings);
+        }
+    }
+
     protected void updateNameMappings()
     {
         try (AutoLock ignored = lock())

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
@@ -94,7 +94,8 @@ public class WebSocketServerComponents extends WebSocketComponents
         // Don't use ServletContextListener as it will be a durable listener.
         ContextHandler contextHandler = Objects.requireNonNull(ContextHandler.getContextHandler(servletContext));
         LifeCycle.start(serverComponents);
-        contextHandler.addEventListener(new LifeCycle.Listener() {
+        contextHandler.addEventListener(new LifeCycle.Listener()
+        {
             @Override
             public void lifeCycleStopping(LifeCycle event)
             {

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
@@ -91,15 +91,14 @@ public class WebSocketServerComponents extends WebSocketComponents
             serverComponents.unmanage(bufferPool);
 
         // Stop the WebSocketComponents when the ContextHandler stops.
-        // Don't use ServletContextListener as it will be a durable listener.
         ContextHandler contextHandler = Objects.requireNonNull(ContextHandler.getContextHandler(servletContext));
-        LifeCycle.start(serverComponents);
+        contextHandler.addManaged(serverComponents);
         contextHandler.addEventListener(new LifeCycle.Listener()
         {
             @Override
             public void lifeCycleStopping(LifeCycle event)
             {
-                LifeCycle.stop(serverComponents);
+                contextHandler.removeBean(serverComponents);
                 contextHandler.removeEventListener(this);
             }
         });

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
@@ -98,6 +98,7 @@ public class WebSocketServerComponents extends WebSocketComponents
             @Override
             public void lifeCycleStopping(LifeCycle event)
             {
+                servletContext.removeAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE);
                 contextHandler.removeBean(serverComponents);
                 contextHandler.removeEventListener(this);
             }

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.jetty.websocket.core.server;
 
+import java.util.Objects;
 import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
 
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.compression.DeflaterPool;
@@ -90,17 +90,20 @@ public class WebSocketServerComponents extends WebSocketComponents
         if (server.contains(bufferPool))
             serverComponents.unmanage(bufferPool);
 
-        servletContext.setAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE, serverComponents);
+        // Stop the WebSocketComponents when the ContextHandler stops.
+        // Don't use ServletContextListener as it will be a durable listener.
+        ContextHandler contextHandler = Objects.requireNonNull(ContextHandler.getContextHandler(servletContext));
         LifeCycle.start(serverComponents);
-        servletContext.addListener(new ServletContextListener()
-        {
+        contextHandler.addEventListener(new LifeCycle.Listener() {
             @Override
-            public void contextDestroyed(ServletContextEvent sce)
+            public void lifeCycleStopping(LifeCycle event)
             {
                 LifeCycle.stop(serverComponents);
+                contextHandler.removeEventListener(this);
             }
         });
 
+        servletContext.setAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE, serverComponents);
         return serverComponents;
     }
 

--- a/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerContainer.java
+++ b/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerContainer.java
@@ -96,6 +96,8 @@ public class JavaxWebSocketServerContainer extends JavaxWebSocketClientContainer
                 WebSocketMappings.ensureMappings(servletContext),
                 WebSocketServerComponents.getWebSocketComponents(servletContext),
                 coreClientSupplier);
+
+            // Manage the lifecycle (removes itself removed in lifeCycleStopping() method).
             contextHandler.addManaged(container);
             contextHandler.addEventListener(container);
         }

--- a/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerContainer.java
+++ b/jetty-websocket/websocket-javax-server/src/main/java/org/eclipse/jetty/websocket/javax/server/internal/JavaxWebSocketServerContainer.java
@@ -59,48 +59,60 @@ public class JavaxWebSocketServerContainer extends JavaxWebSocketClientContainer
         if (contextHandler.getServer() == null)
             throw new IllegalStateException("Server has not been set on the ServletContextHandler");
 
-        JavaxWebSocketServerContainer container = getContainer(servletContext);
-        if (container == null)
+        JavaxWebSocketServerContainer containerFromServletContext = getContainer(servletContext);
+        if (containerFromServletContext != null)
+            return containerFromServletContext;
+
+        Function<WebSocketComponents, WebSocketCoreClient> coreClientSupplier = (wsComponents) ->
         {
-            Function<WebSocketComponents, WebSocketCoreClient> coreClientSupplier = (wsComponents) ->
+            WebSocketCoreClient coreClient = (WebSocketCoreClient)servletContext.getAttribute(WebSocketCoreClient.WEBSOCKET_CORECLIENT_ATTRIBUTE);
+            if (coreClient == null)
             {
-                WebSocketCoreClient coreClient = (WebSocketCoreClient)servletContext.getAttribute(WebSocketCoreClient.WEBSOCKET_CORECLIENT_ATTRIBUTE);
-                if (coreClient == null)
-                {
-                    // Find Pre-Existing (Shared?) HttpClient and/or executor
-                    HttpClient httpClient = (HttpClient)servletContext.getAttribute(JavaxWebSocketServletContainerInitializer.HTTPCLIENT_ATTRIBUTE);
-                    if (httpClient == null)
-                        httpClient = (HttpClient)contextHandler.getServer().getAttribute(JavaxWebSocketServletContainerInitializer.HTTPCLIENT_ATTRIBUTE);
+                // Find Pre-Existing (Shared?) HttpClient and/or executor
+                HttpClient httpClient = (HttpClient)servletContext.getAttribute(JavaxWebSocketServletContainerInitializer.HTTPCLIENT_ATTRIBUTE);
+                if (httpClient == null)
+                    httpClient = (HttpClient)contextHandler.getServer().getAttribute(JavaxWebSocketServletContainerInitializer.HTTPCLIENT_ATTRIBUTE);
 
-                    Executor executor = httpClient == null ? null : httpClient.getExecutor();
-                    if (executor == null)
-                        executor = (Executor)servletContext.getAttribute("org.eclipse.jetty.server.Executor");
-                    if (executor == null)
-                        executor = contextHandler.getServer().getThreadPool();
+                Executor executor = httpClient == null ? null : httpClient.getExecutor();
+                if (executor == null)
+                    executor = (Executor)servletContext.getAttribute("org.eclipse.jetty.server.Executor");
+                if (executor == null)
+                    executor = contextHandler.getServer().getThreadPool();
 
-                    if (httpClient != null && httpClient.getExecutor() == null)
-                        httpClient.setExecutor(executor);
+                if (httpClient != null && httpClient.getExecutor() == null)
+                    httpClient.setExecutor(executor);
 
-                    // create the core client
-                    coreClient = new WebSocketCoreClient(httpClient, wsComponents);
-                    coreClient.getHttpClient().setName("Javax-WebSocketClient@" + Integer.toHexString(coreClient.getHttpClient().hashCode()));
-                    if (executor != null && httpClient == null)
-                        coreClient.getHttpClient().setExecutor(executor);
-                    servletContext.setAttribute(WebSocketCoreClient.WEBSOCKET_CORECLIENT_ATTRIBUTE, coreClient);
-                }
-                return coreClient;
-            };
+                // create the core client
+                coreClient = new WebSocketCoreClient(httpClient, wsComponents);
+                coreClient.getHttpClient().setName("Javax-WebSocketClient@" + Integer.toHexString(coreClient.getHttpClient().hashCode()));
+                if (executor != null && httpClient == null)
+                    coreClient.getHttpClient().setExecutor(executor);
+                servletContext.setAttribute(WebSocketCoreClient.WEBSOCKET_CORECLIENT_ATTRIBUTE, coreClient);
+            }
+            return coreClient;
+        };
 
-            // Create the Jetty ServerContainer implementation
-            container = new JavaxWebSocketServerContainer(
-                WebSocketMappings.ensureMappings(servletContext),
-                WebSocketServerComponents.getWebSocketComponents(servletContext),
-                coreClientSupplier);
+        // Create the Jetty ServerContainer implementation
+        JavaxWebSocketServerContainer container = new JavaxWebSocketServerContainer(
+            WebSocketMappings.ensureMappings(servletContext),
+            WebSocketServerComponents.getWebSocketComponents(servletContext),
+            coreClientSupplier);
 
-            // Manage the lifecycle (removes itself removed in lifeCycleStopping() method).
-            contextHandler.addManaged(container);
-            contextHandler.addEventListener(container);
-        }
+        // Manage the lifecycle of the Container.
+        contextHandler.addManaged(container);
+        contextHandler.addEventListener(container);
+        contextHandler.addEventListener(new LifeCycle.Listener()
+        {
+            @Override
+            public void lifeCycleStopping(LifeCycle event)
+            {
+                servletContext.removeAttribute(JAVAX_WEBSOCKET_CONTAINER_ATTRIBUTE);
+                contextHandler.removeBean(container);
+                contextHandler.removeEventListener(container);
+                contextHandler.removeEventListener(this);
+            }
+        });
+
         // Store a reference to the ServerContainer per - javax.websocket spec 1.0 final - section 6.4: Programmatic Server Deployment
         servletContext.setAttribute(JAVAX_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
         return container;
@@ -140,18 +152,6 @@ public class JavaxWebSocketServerContainer extends JavaxWebSocketClientContainer
         super(components, coreClientSupplier);
         this.webSocketMappings = webSocketMappings;
         this.frameHandlerFactory = new JavaxWebSocketServerFrameHandlerFactory(this);
-    }
-
-    @Override
-    public void lifeCycleStopping(LifeCycle context)
-    {
-        ContextHandler contextHandler = (ContextHandler)context;
-        JavaxWebSocketServerContainer container = contextHandler.getBean(JavaxWebSocketServerContainer.class);
-        if (container == this)
-        {
-            contextHandler.removeBean(container);
-            LifeCycle.stop(container);
-        }
     }
 
     @Override

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxWebSocketRestartTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxWebSocketRestartTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JavaxWebSocketRestartTest
@@ -65,7 +67,7 @@ public class JavaxWebSocketRestartTest
     }
 
     @Test
-    public void testWebSocketUpgradeFilter() throws Exception
+    public void testWebSocketRestart() throws Exception
     {
         JavaxWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
             container.addEndpoint(EchoSocket.class));
@@ -83,6 +85,8 @@ public class JavaxWebSocketRestartTest
         assertThat(contextHandler.getEventListeners().size(), is(numEventListeners));
         assertThat(contextHandler.getContainedBeans(JavaxWebSocketServerContainer.class).size(), is(1));
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertNotNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNotNull(contextHandler.getServletContext().getAttribute(JavaxWebSocketServerContainer.JAVAX_WEBSOCKET_CONTAINER_ATTRIBUTE));
 
         // We have one filter, and it is a WebSocketUpgradeFilter.
         FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
@@ -94,6 +98,8 @@ public class JavaxWebSocketRestartTest
         assertThat(contextHandler.getEventListeners().size(), is(0));
         assertThat(contextHandler.getContainedBeans(JavaxWebSocketServerContainer.class).size(), is(0));
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNull(contextHandler.getServletContext().getAttribute(JavaxWebSocketServerContainer.JAVAX_WEBSOCKET_CONTAINER_ATTRIBUTE));
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
     }
 

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxWebSocketRestartTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/JavaxWebSocketRestartTest.java
@@ -1,0 +1,114 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.tests;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import javax.websocket.Session;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
+import org.eclipse.jetty.websocket.javax.client.internal.JavaxWebSocketClientContainer;
+import org.eclipse.jetty.websocket.javax.server.config.JavaxWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.javax.server.internal.JavaxWebSocketServerContainer;
+import org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaxWebSocketRestartTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private JavaxWebSocketClientContainer client;
+    private ServletContextHandler contextHandler;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+
+        client = new JavaxWebSocketClientContainer();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testWebSocketUpgradeFilter() throws Exception
+    {
+        JavaxWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+            container.addEndpoint(EchoSocket.class));
+        server.start();
+
+        int numEventListeners = contextHandler.getEventListeners().size();
+        for (int i = 0; i < 100; i++)
+        {
+            server.stop();
+            server.start();
+            testEchoMessage();
+        }
+
+        // We have not accumulated websocket resources by restarting.
+        assertThat(contextHandler.getEventListeners().size(), is(numEventListeners));
+        assertThat(contextHandler.getContainedBeans(JavaxWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+
+        // We have one filter, and it is a WebSocketUpgradeFilter.
+        FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
+        assertThat(filters.length, is(1));
+        assertThat(filters[0].getFilter(), instanceOf(WebSocketUpgradeFilter.class));
+
+        // After stopping the websocket resources are cleaned up.
+        server.stop();
+        assertThat(contextHandler.getEventListeners().size(), is(0));
+        assertThat(contextHandler.getContainedBeans(JavaxWebSocketServerContainer.class).size(), is(0));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
+    }
+
+    private void testEchoMessage() throws Exception
+    {
+        // Test we can upgrade to websocket and send a message.
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
+        EventSocket socket = new EventSocket();
+        try (Session session = client.connectToServer(socket, uri))
+        {
+            session.getBasicRemote().sendText("hello world");
+        }
+        assertTrue(socket.closeLatch.await(10, TimeUnit.SECONDS));
+
+        String msg = socket.textMessages.poll();
+        assertThat(msg, is("hello world"));
+    }
+}

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketRestartTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JettyWebSocketRestartTest
@@ -66,7 +68,7 @@ public class JettyWebSocketRestartTest
     }
 
     @Test
-    public void testWebSocketUpgradeFilter() throws Exception
+    public void testWebSocketRestart() throws Exception
     {
         JettyWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
             container.addMapping("/", EchoSocket.class));
@@ -84,6 +86,8 @@ public class JettyWebSocketRestartTest
         assertThat(contextHandler.getEventListeners().size(), is(numEventListeners));
         assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertNotNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNotNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
 
         // We have one filter, and it is a WebSocketUpgradeFilter.
         FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
@@ -95,6 +99,8 @@ public class JettyWebSocketRestartTest
         assertThat(contextHandler.getEventListeners().size(), is(0));
         assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(0));
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
     }
 

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketRestartTest.java
@@ -1,0 +1,116 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JettyWebSocketRestartTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private WebSocketClient client;
+    private ServletContextHandler contextHandler;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/");
+        server.setHandler(contextHandler);
+
+        client = new WebSocketClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        client.stop();
+        server.stop();
+    }
+
+    @Test
+    public void testWebSocketUpgradeFilter() throws Exception
+    {
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+            container.addMapping("/", EchoSocket.class));
+        server.start();
+
+        int numEventListeners = contextHandler.getEventListeners().size();
+        for (int i = 0; i < 100; i++)
+        {
+            server.stop();
+            server.start();
+            testEchoMessage();
+        }
+
+        // We have not accumulated websocket resources by restarting.
+        assertThat(contextHandler.getEventListeners().size(), is(numEventListeners));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+
+        // We have one filter, and it is a WebSocketUpgradeFilter.
+        FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
+        assertThat(filters.length, is(1));
+        assertThat(filters[0].getFilter(), instanceOf(WebSocketUpgradeFilter.class));
+
+        // After stopping the websocket resources are cleaned up.
+        server.stop();
+        assertThat(contextHandler.getEventListeners().size(), is(0));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(0));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
+    }
+
+    private void testEchoMessage() throws Exception
+    {
+        // Test we can upgrade to websocket and send a message.
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
+        EventSocket socket = new EventSocket();
+        CompletableFuture<Session> connect = client.connect(socket, uri);
+        try (Session session = connect.get(5, TimeUnit.SECONDS))
+        {
+            session.getRemote().sendString("hello world");
+        }
+        assertTrue(socket.closeLatch.await(10, TimeUnit.SECONDS));
+
+        String msg = socket.textMessages.poll();
+        assertThat(msg, is("hello world"));
+    }
+}

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.websocket.servlet;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Objects;
 import javax.servlet.DispatcherType;
@@ -131,19 +130,8 @@ public class WebSocketUpgradeFilter implements Filter, Dumpable
                 @Override
                 public void lifeCycleStopping(LifeCycle event)
                 {
-                    // Remove the FilterHolder.
-                    FilterHolder[] holders = Arrays.stream(servletHandler.getFilters())
-                        .filter(h -> h != holder)
-                        .toArray(FilterHolder[]::new);
-                    servletHandler.setFilters(holders);
-
-                    // Remove the FilterMapping.
-                    FilterMapping[] mappings = Arrays.stream(servletHandler.getFilterMappings())
-                        .filter(m -> m != mapping)
-                        .toArray(FilterMapping[]::new);
-                    servletHandler.setFilterMappings(mappings);
-
-                    // Remove this event listener.
+                    servletHandler.removeFilterHolder(holder);
+                    servletHandler.removeFilterMapping(mapping);
                     contextHandler.removeEventListener(this);
                 }
             });

--- a/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
+++ b/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/WebSocketUpgradeFilter.java
@@ -131,10 +131,20 @@ public class WebSocketUpgradeFilter implements Filter, Dumpable
                 @Override
                 public void lifeCycleStopping(LifeCycle event)
                 {
+                    // Remove the FilterHolder.
                     FilterHolder[] holders = Arrays.stream(servletHandler.getFilters())
                         .filter(h -> h != holder)
                         .toArray(FilterHolder[]::new);
                     servletHandler.setFilters(holders);
+
+                    // Remove the FilterMapping.
+                    FilterMapping[] mappings = Arrays.stream(servletHandler.getFilterMappings())
+                        .filter(m -> m != mapping)
+                        .toArray(FilterMapping[]::new);
+                    servletHandler.setFilterMappings(mappings);
+
+                    // Remove this event listener.
+                    contextHandler.removeEventListener(this);
                 }
             });
 


### PR DESCRIPTION
If I start and stop jetty in a loop 100 times I get a build up of `WebSocketServerComponents` and `HouseKeeper`.

This PR ensures that `WebSocketServerComponents` does not add a durable `ServletContextListener`.
And that `HouseKeeper` beans are removed from the `DefaultSessionIdManager` in `doStop()`.

```
+= o.e.j.s.ServletContextHandler@3ba987b8{/,null,AVAILABLE} - STARTED
|  += org.eclipse.jetty.server.session.SessionHandler1902237905==dftMaxIdleSec=-1 - STARTED
|  |  += ServletHandler@50029372{STARTED} - STARTED
|  |  |  +> listeners ServletHandler@50029372{STARTED} size=10
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@e3b3b2f{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@50f6ac94{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@6cc4cdb9{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@28194a50{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@7f2cfe3f{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@1a5b6f42{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@5038d0b5{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@32115b28{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@2ad48653{src=JAVAX_API:null} - STARTED
|  |  |  |  +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@6bb4dd34{src=JAVAX_API:null} - STARTED
|  |  |  +> filters ServletHandler@50029372{STARTED} size=1
|  |  |  |  +> org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter==org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter@1b11171f{inst=true,async=true,src=EMBEDDED:null} - STARTED
|  |  |  |     +> org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter@7d9f158f
|  |  |  |        +> org.eclipse.jetty.websocket.core.server.WebSocketMappings@45efd90f
|  |  |  |           +> PathMappings[size=1]
|  |  |  |              +> java.util.TreeSet@6d(size=1)
|  |  |  |                 +: MappedResource[pathSpec=ServletPathSpec@4e{/},resource=CreatorNegotiator@383dc82c{org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer$$Lambda$353/0x00000008001ea840@4a07d605,JettyServerFrameHandlerFactory@74287ea3{STARTED}}]
|  |  |  +> filterMappings ServletHandler@50029372{STARTED} size=1
|  |  |  |  +> [/*]/[]/[REQUEST]=>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter
|  |  |  +> servlets ServletHandler@50029372{STARTED} size=1
|  |  |  |  +> org.eclipse.jetty.servlet.ServletHandler$Default404Servlet-14bdbc74==org.eclipse.jetty.servlet.ServletHandler$Default404Servlet@aaf08b97{jsp=null,order=-1,inst=false,async=true,src=EMBEDDED:null} - STARTED
|  |  |  |     +> class org.eclipse.jetty.servlet.ServletHandler$Default404Servlet
|  |  |  +> servletMappings ServletHandler@50029372{STARTED} size=1
|  |  |  |  +> [/]=>org.eclipse.jetty.servlet.ServletHandler$Default404Servlet-14bdbc74
|  |  |  +> durable ServletHandler@50029372{STARTED} size=11
|  |  |     +> org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter==org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter@1b11171f{inst=true,async=true,src=EMBEDDED:null} - STARTED
|  |  |     |  +> org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter@7d9f158f
|  |  |     |     +> org.eclipse.jetty.websocket.core.server.WebSocketMappings@45efd90f
|  |  |     |        +> PathMappings[size=1]
|  |  |     |           +> java.util.TreeSet@6d(size=1)
|  |  |     |              +: MappedResource[pathSpec=ServletPathSpec@4e{/},resource=CreatorNegotiator@383dc82c{org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer$$Lambda$353/0x00000008001ea840@4a07d605,JettyServerFrameHandlerFactory@74287ea3{STARTED}}]
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@e3b3b2f{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@50f6ac94{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@6cc4cdb9{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@28194a50{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@7f2cfe3f{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@1a5b6f42{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@5038d0b5{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@32115b28{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@2ad48653{src=JAVAX_API:null} - STARTED
|  |  |     +> org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@6bb4dd34{src=JAVAX_API:null} - STARTED
|  |  += org.eclipse.jetty.server.session.DefaultSessionCache@81d9a72[evict=-1,removeUnloadable=false,saveOnCreate=false,saveOnInactiveEvict=false] - STARTED
|  |  |  += org.eclipse.jetty.server.session.NullSessionDataStore@747f281[passivating=false,graceSec=3600] - STARTED
|  |  +~ DefaultSessionIdManager@1169afe1{STARTED}[worker=node0] - STARTED
|  += ServletContainerInitializerStarter@2ca26d77{STARTED} - STARTED
|  |  += ContainerInitializer{org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer,interested=[],applicable=[],annotated=[]} - STARTED
|  += JettyWebSocketServerContainer@70e38ce1{STARTED} - STARTED
|  |  += JettyServerFrameHandlerFactory@74287ea3{STARTED} - STARTED
|  |  |  +> java.util.concurrent.ConcurrentHashMap@0{size=0}
|  |  += SessionTracker@2ca923bb{STARTED} - STARTED
|  |     +> java.util.Collections$SetFromMap@0(size=0)
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@13df2a8c
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@1ebea008
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@72d6b3ba
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@1787f2a0
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@7de62196
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@163370c2
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@51bf5add
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@7905a0b8
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@35a3d49f
|  +- org.eclipse.jetty.websocket.core.server.WebSocketServerComponents$1@389b0789
|  +> No ClassLoader
|  +> handler attributes o.e.j.s.ServletContextHandler@3ba987b8{/,null,AVAILABLE} size=1
|  |  +> org.eclipse.jetty.server.Executor=QueuedThreadPool[qtp606508809]@24269709{STARTED,8<=15<=200,i=0,r=-1,q=0}[ReservedThreadExecutor@798162bc{s=0/20,p=0}]
|  +> context attributes o.e.j.s.ServletContextHandler@3ba987b8{/,null,AVAILABLE} size=4
|  |  +> org.eclipse.jetty.util.DecoratedObjectFactory=org.eclipse.jetty.util.DecoratedObjectFactory[decorators=0]
|  |  +> org.eclipse.jetty.websocket.api.WebSocketContainer=JettyWebSocketServerContainer@70e38ce1{STARTED}
|  |  +> org.eclipse.jetty.websocket.core.WebSocketComponents=WebSocketServerComponents@478db956{STARTED}
|  |  +> org.eclipse.jetty.websocket.core.server.WebSocketMappings=org.eclipse.jetty.websocket.core.server.WebSocketMappings@45efd90f
|  +> initparams o.e.j.s.ServletContextHandler@3ba987b8{/,null,AVAILABLE} size=0
+= ErrorHandler@6ca18a14{STARTED} - STARTED
+= InflaterPool@c667f46{STARTED,size=0,capacity=200} - STARTED
+= DeflaterPool@51bd8b5c{STARTED,size=0,capacity=200} - STARTED
+= DefaultSessionIdManager@1169afe1{STARTED}[worker=node0] - STARTED
|  += HouseKeeper@6e6f2380{STOPPED}[interval=600000, ownscheduler=false] - STOPPED
|  += HouseKeeper@71075444{STOPPED}[interval=660000, ownscheduler=false] - STOPPED
|  += HouseKeeper@4e5ed836{STOPPED}[interval=660000, ownscheduler=false] - STOPPED
|  += HouseKeeper@48e1f6c7{STOPPED}[interval=600000, ownscheduler=false] - STOPPED
|  += HouseKeeper@d554c5f{STOPPED}[interval=600000, ownscheduler=false] - STOPPED
|  += HouseKeeper@7b4c50bc{STOPPED}[interval=660000, ownscheduler=false] - STOPPED
|  += HouseKeeper@1b1cfb87{STOPPED}[interval=660000, ownscheduler=false] - STOPPED
|  += HouseKeeper@28cda624{STOPPED}[interval=660000, ownscheduler=false] - STOPPED
|  += HouseKeeper@7d3e8655{STOPPED}[interval=600000, ownscheduler=false] - STOPPED
|  += HouseKeeper@12591ac8{STARTED}[interval=600000, ownscheduler=true] - STARTED
```