### PR TITLE
Fixes #6219 by adding option to the deploy module.

### DIFF
--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -55,7 +55,7 @@
               </Set>
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="1"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
-              <Set name="stopOnWebappFail"><Property name="jetty.deploy.stopOnWebappFail" default="false"/></Set>
+              <Set name="stopOnFailedDeploy"><Property name="jetty.deploy.stopOnFailedDeploy" default="false"/></Set>
               <Set name="configurationManager">
                 <New class="org.eclipse.jetty.deploy.PropertiesConfigurationManager">
                   <!-- file of context configuration properties

--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -55,6 +55,7 @@
               </Set>
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="1"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
+              <Set name="stopOnWebappFail"><Property name="jetty.deploy.stopOnWebappFail" default="false"/></Set>
               <Set name="configurationManager">
                 <New class="org.eclipse.jetty.deploy.PropertiesConfigurationManager">
                   <!-- file of context configuration properties

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -28,3 +28,7 @@ etc/jetty-deploy.xml
 
 # Whether to extract *.war files
 # jetty.deploy.extractWars=true
+
+# Whether to halt server on startup if webapp fails to deploy
+# false lets server continue running, true halts server
+# jetty.deploy.stopOnWebappFail=false

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -29,6 +29,6 @@ etc/jetty-deploy.xml
 # Whether to extract *.war files
 # jetty.deploy.extractWars=true
 
-# Whether to halt server on startup if webapp fails to deploy
+# Whether to halt server on startup if context fails to deploy
 # false lets server continue running, true halts server
-# jetty.deploy.stopOnWebappFail=false
+# jetty.deploy.stopOnFailedDeploy=false

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -55,13 +55,14 @@ import org.slf4j.LoggerFactory;
  * <p>For XML configured contexts, the ID map will contain a reference to the {@link Server} instance called "Server" and
  * properties for the webapp file as "jetty.webapp" and directory as "jetty.webapps".
  */
-@ManagedObject("Provider for start-up deployement of webapps based on presence in directory")
+@ManagedObject("Provider for start-up deployment of webapps based on presence in directory")
 public class WebAppProvider extends ScanningAppProvider
 {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(WebAppProvider.class);
 
     private boolean _extractWars = false;
     private boolean _parentLoaderPriority = false;
+    private boolean _stopOnWebappFail = false;
     private ConfigurationManager _configurationManager;
     private String _defaultsDescriptor;
     private File _tempDirectory;
@@ -236,6 +237,26 @@ public class WebAppProvider extends ScanningAppProvider
         return _tempDirectory;
     }
 
+    /**
+     * Check if the server should stop on webapp startup fail or not
+     *
+     * @return true of server should halt on webapp fail, false if server should remain running
+     */
+    public boolean isStopOnWebappFail()
+    {
+        return _stopOnWebappFail;
+    }
+
+    /**
+     * Set if server should halt on startup or not when webapp fails
+     *
+     * @param stopOnWebappFail true if webapp deployment fail should halt server
+     */
+    public void setStopOnWebappFail(boolean stopOnWebappFail)
+    {
+        _stopOnWebappFail = stopOnWebappFail;
+    }
+
     protected void initializeWebAppContextDefaults(WebAppContext webapp)
     {
         if (_defaultsDescriptor != null)
@@ -336,6 +357,7 @@ public class WebAppProvider extends ScanningAppProvider
         webAppContext.setDefaultContextPath(context);
         webAppContext.setWar(file.getAbsolutePath());
         initializeWebAppContextDefaults(webAppContext);
+        webAppContext.setThrowUnavailableOnStartupException(_stopOnWebappFail);
 
         return webAppContext;
     }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -62,7 +62,7 @@ public class WebAppProvider extends ScanningAppProvider
 
     private boolean _extractWars = false;
     private boolean _parentLoaderPriority = false;
-    private boolean _stopOnWebappFail = false;
+    private boolean _stopOnFailedDeploy = false;
     private ConfigurationManager _configurationManager;
     private String _defaultsDescriptor;
     private File _tempDirectory;
@@ -242,19 +242,19 @@ public class WebAppProvider extends ScanningAppProvider
      *
      * @return true of server should halt on webapp fail, false if server should remain running
      */
-    public boolean isStopOnWebappFail()
+    public boolean isStopOnFailedDeploy()
     {
-        return _stopOnWebappFail;
+        return _stopOnFailedDeploy;
     }
 
     /**
      * Set if server should halt on startup or not when webapp fails
      *
-     * @param stopOnWebappFail true if webapp deployment fail should halt server
+     * @param stopOnFailedDeploy true if webapp deployment fail should halt server
      */
-    public void setStopOnWebappFail(boolean stopOnWebappFail)
+    public void setStopOnFailedDeploy(boolean stopOnFailedDeploy)
     {
-        _stopOnWebappFail = stopOnWebappFail;
+        _stopOnFailedDeploy = stopOnFailedDeploy;
     }
 
     protected void initializeWebAppContextDefaults(WebAppContext webapp)
@@ -356,8 +356,8 @@ public class WebAppProvider extends ScanningAppProvider
 
         webAppContext.setDefaultContextPath(context);
         webAppContext.setWar(file.getAbsolutePath());
+        webAppContext.setThrowUnavailableOnStartupException(_stopOnFailedDeploy);
         initializeWebAppContextDefaults(webAppContext);
-        webAppContext.setThrowUnavailableOnStartupException(_stopOnWebappFail);
 
         return webAppContext;
     }


### PR DESCRIPTION
Adds a property to the jetty deploy module, defaulting to existing behavior to allows server to easily be configured to halt on deploy when a webapp fails to deploy.