### PR TITLE
Issue #6167 - Review failure cases of HttpOutput.Interceptor

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -530,7 +530,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             if (_onError != null)
-                IO.throwIOException(_onError);
+                IO.throwCheckedIOException(_onError);
 
             switch (_state)
             {
@@ -621,7 +621,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 // Otherwise the async call to onWriteComplete must abort if there is a failure as onError may not be called.
                 _abortOnCloseError = true;
                 if (_onError != null)
-                    IO.throwIOException(_onError);
+                    IO.throwCheckedIOException(_onError);
             }
             else
             {
@@ -700,6 +700,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         ByteBuffer content = null;
         try (AutoLock l = _channelState.lock())
         {
+            if (_onError != null)
+                IO.throwCheckedIOException(_onError);
+
             switch (_state)
             {
                 case CLOSED:
@@ -753,7 +756,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     private void checkWritable() throws IOException
     {
         if (_onError != null)
-            IO.throwIOException(_onError);
+            IO.throwCheckedIOException(_onError);
 
         if (_softClose)
                 throw new EofException("Closed");

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -750,8 +750,11 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         }
     }
 
-    private void checkWritable() throws EofException
+    private void checkWritable() throws IOException
     {
+        if (_onError != null)
+            IO.throwIOException(_onError);
+
         if (_softClose)
                 throw new EofException("Closed");
 
@@ -764,9 +767,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             default:
                 break;
         }
-
-        if (_onError != null)
-            throw new EofException(_onError);
     }
 
     @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/FileBufferedResponseHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/FileBufferedResponseHandlerTest.java
@@ -511,9 +511,7 @@ public class FileBufferedResponseHandlerTest
         _server.start();
         String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-
-        // Response was aborted.
-        assertThat(response.getStatus(), is(0));
+        assertThat(response.getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
 
         // We failed because of the next interceptor.
         Throwable error = errorFuture.get(5, TimeUnit.SECONDS);
@@ -559,9 +557,7 @@ public class FileBufferedResponseHandlerTest
         _server.start();
         String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-
-        // Response was aborted.
-        assertThat(response.getStatus(), is(0));
+        assertThat(response.getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
 
         // We failed because cannot create the file.
         Throwable error = errorFuture.get(5, TimeUnit.SECONDS);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.server;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -105,7 +106,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 HttpOutput httpOutput = baseRequest.getResponse().getHttpOutput();
                 httpOutput.setBufferSize(content.length * 2);
                 httpOutput.write(content);
@@ -158,7 +159,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 HttpOutput httpOutput = baseRequest.getResponse().getHttpOutput();
                 httpOutput.setBufferSize(content.length * 2);
                 httpOutput.write(content);
@@ -212,7 +213,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 AsyncContext asyncContext = request.startAsync();
                 ServletOutputStream outputStream = response.getOutputStream();
                 baseRequest.getResponse().getHttpOutput().setBufferSize(0);
@@ -285,7 +286,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 AsyncContext asyncContext = request.startAsync();
                 baseRequest.getResponse().getHttpOutput().setBufferSize(content.length * 2);
                 ServletOutputStream outputStream = response.getOutputStream();
@@ -369,7 +370,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 AsyncContext asyncContext = request.startAsync();
                 baseRequest.getResponse().getHttpOutput().setBufferSize(content.length * 2);
                 ServletOutputStream outputStream = response.getOutputStream();
@@ -465,7 +466,7 @@ public class HttpOutputInterceptorTest
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                byte[] content = "content to be written".getBytes();
+                byte[] content = "content to be written".getBytes(StandardCharsets.ISO_8859_1);
                 AsyncContext asyncContext = request.startAsync();
                 ServletOutputStream outputStream = response.getOutputStream();
                 outputStream.setWriteListener(new WriteListener()

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
@@ -186,7 +186,6 @@ public class HttpOutputInterceptorTest
         assertThat(error.getMessage(), containsString("thrown from interceptor"));
     }
 
-
     @Test
     public void testAsyncWriteFailed() throws Exception
     {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
@@ -1,0 +1,447 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpOutputInterceptorTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(HttpOutputInterceptorTest.class);
+
+    private Server _server;
+    private LocalConnector _localConnector;
+    private ServerConnector _serverConnector;
+    private HandlerCollection _handlerCollection;
+    private StacklessLogging _stacklessLogging;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        HttpConfiguration config = new HttpConfiguration();
+        config.setOutputBufferSize(1024);
+        config.setOutputAggregationSize(256);
+
+        _localConnector = new LocalConnector(_server, new HttpConnectionFactory(config));
+        _localConnector.setIdleTimeout(Duration.ofMinutes(1).toMillis());
+        _server.addConnector(_localConnector);
+        _serverConnector = new ServerConnector(_server, new HttpConnectionFactory(config));
+        _server.addConnector(_serverConnector);
+
+        _handlerCollection = new HandlerCollection();
+        _server.setHandler(_handlerCollection);
+        _stacklessLogging = new StacklessLogging(HttpChannel.class);
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _stacklessLogging.close();
+        _server.stop();
+    }
+
+    @Test
+    public void testInterceptorCallbackFailed() throws Exception
+    {
+        addInterceptor(nextInterceptor -> new HttpOutput.Interceptor()
+        {
+            @Override
+            public void write(ByteBuffer content, boolean last, Callback callback)
+            {
+                callback.failed(new RuntimeException("callback failed from interceptor"));
+            }
+
+            @Override
+            public HttpOutput.Interceptor getNextInterceptor()
+            {
+                return nextInterceptor;
+            }
+        });
+
+        CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        _handlerCollection.addHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                byte[] content = "content to be written".getBytes();
+                HttpOutput httpOutput = baseRequest.getResponse().getHttpOutput();
+                httpOutput.setBufferSize(content.length * 2);
+                httpOutput.write(content);
+
+                try
+                {
+                    // The will close will write the output buffered in HttpOutput to the interceptor which will fail the callback.
+                    httpOutput.close();
+                }
+                catch (Throwable t)
+                {
+                    errorFuture.complete(t);
+                    throw t;
+                }
+            }
+        });
+
+        _server.start();
+        String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(500));
+
+        // We failed because of the next interceptor.
+        Throwable error = errorFuture.get(5, TimeUnit.SECONDS);
+        assertThat(error.getMessage(), containsString("callback failed from interceptor"));
+    }
+
+    @Test
+    public void testInterceptorThrows() throws Exception
+    {
+        addInterceptor(nextInterceptor -> new HttpOutput.Interceptor()
+        {
+            @Override
+            public void write(ByteBuffer content, boolean last, Callback callback)
+            {
+                throw new RuntimeException("thrown from interceptor");
+            }
+
+            @Override
+            public HttpOutput.Interceptor getNextInterceptor()
+            {
+                return nextInterceptor;
+            }
+        });
+
+        CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        _handlerCollection.addHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                byte[] content = "content to be written".getBytes();
+                HttpOutput httpOutput = baseRequest.getResponse().getHttpOutput();
+                httpOutput.setBufferSize(content.length * 2);
+                httpOutput.write(content);
+
+                try
+                {
+                    // The will close will write the output buffered in HttpOutput to the interceptor which will throw.
+                    httpOutput.close();
+                }
+                catch (Throwable t)
+                {
+                    errorFuture.complete(t);
+                    throw t;
+                }
+            }
+        });
+
+        _server.start();
+        String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(500));
+
+        // We failed because of the next interceptor.
+        Throwable error = errorFuture.get(5, TimeUnit.SECONDS);
+        assertThat(error.getMessage(), containsString("thrown from interceptor"));
+    }
+
+
+    @Test
+    public void testAsyncWriteFailed() throws Exception
+    {
+        addInterceptor(nextInterceptor -> new HttpOutput.Interceptor()
+        {
+            @Override
+            public void write(ByteBuffer content, boolean last, Callback callback)
+            {
+                callback.failed(new RuntimeException("callback failed from interceptor"));
+            }
+
+            @Override
+            public HttpOutput.Interceptor getNextInterceptor()
+            {
+                return nextInterceptor;
+            }
+        });
+
+        CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        AtomicInteger onErrorCount = new AtomicInteger(0);
+        _handlerCollection.addHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                byte[] content = "content to be written".getBytes();
+                AsyncContext asyncContext = request.startAsync();
+                ServletOutputStream outputStream = response.getOutputStream();
+                baseRequest.getResponse().getHttpOutput().setBufferSize(0);
+                outputStream.setWriteListener(new WriteListener()
+                {
+                    @Override
+                    public void onWritePossible() throws IOException
+                    {
+                        while (outputStream.isReady())
+                        {
+                            outputStream.write(content);
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t)
+                    {
+                        // Record some information for testing.
+                        onErrorCount.incrementAndGet();
+                        errorFuture.complete(t);
+
+                        // Try to send back a 500 response instead of aborting the connection.
+                        if (!response.isCommitted())
+                        {
+                            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+                            response.addHeader("throwableFromOnError", t.getMessage());
+                            response.setContentLength(0);
+                        }
+
+                        asyncContext.complete();
+                    }
+                });
+            }
+        });
+
+        _server.start();
+        String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(500));
+
+        errorFuture.get().printStackTrace();
+
+        assertThat(response.get("throwableFromOnError"), is("callback failed from interceptor"));
+
+        assertThat(onErrorCount.get(), is(1));
+        Throwable error = errorFuture.get(5, TimeUnit.SECONDS);
+        assertThat(error.getMessage(), containsString("callback failed from interceptor"));
+    }
+
+    @Test
+    public void testAsyncCloseFailed() throws Exception
+    {
+        addInterceptor(nextInterceptor -> new HttpOutput.Interceptor()
+        {
+            @Override
+            public void write(ByteBuffer content, boolean last, Callback callback)
+            {
+                callback.failed(new RuntimeException("callback failed from interceptor"));
+            }
+
+            @Override
+            public HttpOutput.Interceptor getNextInterceptor()
+            {
+                return nextInterceptor;
+            }
+        });
+
+        CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        AtomicInteger onErrorCount = new AtomicInteger(0);
+        _handlerCollection.addHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                byte[] content = "content to be written".getBytes();
+                AsyncContext asyncContext = request.startAsync();
+                baseRequest.getResponse().getHttpOutput().setBufferSize(content.length * 2);
+                ServletOutputStream outputStream = response.getOutputStream();
+                outputStream.setWriteListener(new WriteListener()
+                {
+                    private int state = 0;
+
+                    @Override
+                    public void onWritePossible() throws IOException
+                    {
+                        while (outputStream.isReady())
+                        {
+                            switch (state++)
+                            {
+                                case 0:
+                                    outputStream.write(content);
+                                    break;
+                                case 1:
+                                    outputStream.close();
+                                    break;
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t)
+                    {
+                        // Record some information for testing.
+                        onErrorCount.incrementAndGet();
+                        errorFuture.complete(t);
+
+                        // Try to send back a 500 response instead of aborting the connection.
+                        if (!response.isCommitted())
+                        {
+                            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+                            response.addHeader("throwableFromOnError", t.getMessage());
+                            response.setContentLength(0);
+                        }
+
+                        asyncContext.complete();
+                    }
+                });
+            }
+        });
+
+        _server.start();
+        String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(500));
+        assertThat(response.get("throwableFromOnError"), is("callback failed from interceptor"));
+
+        assertThat(onErrorCount.get(), is(1));
+        Throwable error = errorFuture.get(5, TimeUnit.SECONDS);
+        assertThat(error.getMessage(), containsString("callback failed from interceptor"));
+    }
+
+    @Test
+    public void testAsyncFailureAfterClose() throws Exception
+    {
+        CountDownLatch failInterceptor = new CountDownLatch(1);
+        addInterceptor(nextInterceptor -> new HttpOutput.Interceptor()
+        {
+            @Override
+            public void write(ByteBuffer content, boolean last, Callback callback)
+            {
+                new Thread(() ->
+                {
+                    try
+                    {
+                        assertTrue(failInterceptor.await(10, TimeUnit.SECONDS));
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    finally
+                    {
+                        callback.failed(new RuntimeException("callback failed from interceptor"));
+                    }
+                }).start();
+            }
+
+            @Override
+            public HttpOutput.Interceptor getNextInterceptor()
+            {
+                return nextInterceptor;
+            }
+        });
+
+        AtomicInteger onErrorCount = new AtomicInteger(0);
+        _handlerCollection.addHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                byte[] content = "content to be written".getBytes();
+                AsyncContext asyncContext = request.startAsync();
+                ServletOutputStream outputStream = response.getOutputStream();
+                outputStream.setWriteListener(new WriteListener()
+                {
+                    @Override
+                    public void onWritePossible() throws IOException
+                    {
+                        if (outputStream.isReady())
+                        {
+                            outputStream.write(content);
+                            outputStream.close();
+                            asyncContext.complete();
+                            failInterceptor.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t)
+                    {
+                        onErrorCount.incrementAndGet();
+                    }
+                });
+            }
+        });
+
+        _server.start();
+        String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+
+        // Response is aborted (status code 0).
+        // onError() was never called because the failure occurred after asyncContext.complete().
+        assertThat(response.getStatus(), is(0));
+        assertThat(onErrorCount.get(), is(0));
+    }
+
+    public static class InterceptorHolder extends AbstractHandler
+    {
+        Function<HttpOutput.Interceptor, HttpOutput.Interceptor> interceptorCreator;
+
+        public InterceptorHolder(Function<HttpOutput.Interceptor, HttpOutput.Interceptor> interceptorCreator)
+        {
+            this.interceptorCreator = interceptorCreator;
+        }
+
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+        {
+            HttpOutput httpOutput = baseRequest.getResponse().getHttpOutput();
+            httpOutput.setInterceptor(interceptorCreator.apply(httpOutput.getInterceptor()));
+        }
+    }
+
+    public void addInterceptor(Function<HttpOutput.Interceptor, HttpOutput.Interceptor> interceptorCreator)
+    {
+        _handlerCollection.addHandler(new InterceptorHolder(interceptorCreator));
+    }
+}

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputInterceptorTest.java
@@ -51,7 +51,6 @@ public class HttpOutputInterceptorTest
 
     private Server _server;
     private LocalConnector _localConnector;
-    private ServerConnector _serverConnector;
     private HandlerCollection _handlerCollection;
     private StacklessLogging _stacklessLogging;
 
@@ -66,8 +65,8 @@ public class HttpOutputInterceptorTest
         _localConnector = new LocalConnector(_server, new HttpConnectionFactory(config));
         _localConnector.setIdleTimeout(Duration.ofMinutes(1).toMillis());
         _server.addConnector(_localConnector);
-        _serverConnector = new ServerConnector(_server, new HttpConnectionFactory(config));
-        _server.addConnector(_serverConnector);
+        ServerConnector serverConnector = new ServerConnector(_server, new HttpConnectionFactory(config));
+        _server.addConnector(serverConnector);
 
         _handlerCollection = new HandlerCollection();
         _server.setHandler(_handlerCollection);
@@ -241,7 +240,6 @@ public class HttpOutputInterceptorTest
                         {
                             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
                             response.addHeader("throwableFromOnError", t.getMessage());
-                            response.setContentLength(0);
                         }
 
                         asyncContext.complete();
@@ -254,8 +252,6 @@ public class HttpOutputInterceptorTest
         String rawResponse = _localConnector.getResponse("GET /include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(500));
-
-        errorFuture.get().printStackTrace();
 
         assertThat(response.get("throwableFromOnError"), is("callback failed from interceptor"));
 
@@ -327,7 +323,6 @@ public class HttpOutputInterceptorTest
                         {
                             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
                             response.addHeader("throwableFromOnError", t.getMessage());
-                            response.setContentLength(0);
                         }
 
                         asyncContext.complete();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -508,13 +508,12 @@ public class IO
     }
 
     /**
-     * Throw an {@link IOException} given a {@link Throwable}, if the supplied throwable is itself an {@link IOException}
-     * it will be thrown, otherwise it will be wrapped with {@link IOException}. If the supplied throwable is a
-     * {@link RuntimeException} or an {@link Error} it will be thrown without being wrapped in {@link IOException}.
+     * This method will throw the supplied {@link Throwable} if it is an instance of {@link IOException},
+     * {@link RuntimeException} or {@link Error}. Otherwise it will be wrapped in a new {@link IOException} and thrown.
      * @param t the cause of the exception.
      * @throws IOException if supplied throwable is not RuntimeException or Error.
      */
-    public static void throwIOException(Throwable t) throws IOException
+    public static void throwCheckedIOException(Throwable t) throws IOException
     {
         if (t instanceof IOException)
             throw (IOException)t;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -508,6 +508,24 @@ public class IO
     }
 
     /**
+     * Throw an {@link IOException} given a {@link Throwable}, if the supplied throwable is itself an {@link IOException}
+     * it will be thrown, otherwise it will be wrapped with {@link IOException}. If the supplied throwable is a
+     * {@link RuntimeException} or an {@link Error} it will be thrown without being wrapped in {@link IOException}.
+     * @param t the cause of the exception.
+     * @throws IOException if supplied throwable is not RuntimeException or Error.
+     */
+    public static void throwIOException(Throwable t) throws IOException
+    {
+        if (t instanceof IOException)
+            throw (IOException)t;
+        if (t instanceof RuntimeException)
+            throw (RuntimeException)t;
+        if (t instanceof Error)
+            throw (Error)t;
+        throw new IOException(t);
+    }
+
+    /**
      * @return An outputstream to nowhere
      */
     public static OutputStream getNullStream()


### PR DESCRIPTION
**Issue #6167**

This PR adds extra testing around what happens if an `HttpOutput.Interceptor` throws or fails the callback.

Some changes were made to `HttpOutput` so that in most cases we will respond with a 500 response instead of just aborting the connection.