### PR TITLE
Fixes #6238 - jetty-keystore Invalid manifest header Bundle-SymbolicN…

### DIFF
--- a/jetty-keystore/pom.xml
+++ b/jetty-keystore/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
+    <artifactId>jetty-project</artifactId>
     <version>10.0.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -12,6 +12,7 @@
   <description>Test keystore with self-signed SSL Certificate.</description>
 
   <properties>
+    <bundle-symbolic-name>${project.groupId}.keystore</bundle-symbolic-name>
     <bouncycastle.version>1.62</bouncycastle.version>
   </properties>
 


### PR DESCRIPTION
…ame.

Added POM property that specifies the bundle name.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>