### PR TITLE
Fixes #6254 - Total timeout not enforced for queued requests.

### DIFF
--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/TransportScenario.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/TransportScenario.java
@@ -266,6 +266,13 @@ public class TransportScenario
             setConnectionIdleTimeout(idleTimeout);
     }
 
+    public void setMaxRequestsPerConnection(int maxRequestsPerConnection)
+    {
+        AbstractHTTP2ServerConnectionFactory h2 = connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class);
+        if (h2 != null)
+            h2.setMaxConcurrentStreams(maxRequestsPerConnection);
+    }
+
     public void start(Handler handler) throws Exception
     {
         start(handler, null);


### PR DESCRIPTION
Fixed logic in HttpDestination.RequestTimeouts, where now a timeout
is scheduled only when the expiration time is less than the existing one.
Various code cleanups.
Renamed HttpDestination.TimeoutTask to RequestTimeouts for clarity.
Improved javadocs, code comments and logging.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 5f23689aa7f44c0660ba2ad92c7c6a15d7c4af15)
(cherry picked from commit da50e06b640d448d42e642c842cf9bc647797a49)
(cherry picked from commit 88ac10439a8b5ec1c34aaab4ccbf0f590aee33f8)