### PR TITLE
Fixes #6251 - Use CyclicTimeout for HTTP2Streams.

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
@@ -115,12 +115,11 @@ public abstract class HttpChannel
         HttpExchange exchange = getHttpExchange();
         if (exchange != null)
         {
-            HttpRequest request = exchange.getRequest();
-            long timeoutAt = request.getTimeoutAt();
-            if (timeoutAt != -1)
+            long timeoutAt = exchange.getExpireNanoTime();
+            if (timeoutAt != Long.MAX_VALUE)
             {
                 exchange.getResponseListeners().add(_totalTimeout);
-                _totalTimeout.schedule(request, timeoutAt);
+                _totalTimeout.schedule(exchange.getRequest(), timeoutAt);
             }
             send(exchange);
         }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -535,7 +535,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         }
 
         @Override
-        public Iterator<HttpExchange> iterator()
+        protected Iterator<HttpExchange> iterator()
         {
             return exchanges.iterator();
         }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -17,12 +17,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Destination;
@@ -31,7 +30,7 @@ import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.ClientConnectionFactory;
-import org.eclipse.jetty.io.CyclicTimeout;
+import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.HostPort;
@@ -255,10 +254,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         {
             if (enqueue(exchanges, exchange))
             {
-                long expiresAt = request.getTimeoutAt();
-                if (expiresAt != -1)
-                    requestTimeouts.schedule(expiresAt);
-
+                requestTimeouts.schedule(exchange);
                 if (!client.isRunning() && exchanges.remove(exchange))
                 {
                     request.abort(new RejectedExecutionException(client + " is stopping"));
@@ -531,61 +527,25 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
      * <p>The total timeout for exchanges that are not in the destination queue
      * is enforced in {@link HttpChannel} by {@link TimeoutCompleteListener}.</p>
      */
-    private class RequestTimeouts extends CyclicTimeout
+    private class RequestTimeouts extends CyclicTimeouts<HttpExchange>
     {
-        private final AtomicLong earliestTimeout = new AtomicLong(Long.MAX_VALUE);
-
         private RequestTimeouts(Scheduler scheduler)
         {
             super(scheduler);
         }
 
         @Override
-        public void onTimeoutExpired()
+        public Iterator<HttpExchange> iterator()
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} timeouts check", this);
-
-            long now = System.nanoTime();
-            long earliest = Long.MAX_VALUE;
-            // Reset the earliest timeout so we can expire again.
-            // A concurrent call to schedule(long) may lose an earliest
-            // value, but the corresponding exchange is already enqueued
-            // and will be seen by scanning the exchange queue below.
-            earliestTimeout.set(earliest);
-
-            // Scan the message queue to abort expired exchanges
-            // and to find the exchange that expire the earliest.
-            for (HttpExchange exchange : exchanges)
-            {
-                HttpRequest request = exchange.getRequest();
-                long expiresAt = request.getTimeoutAt();
-                if (expiresAt == -1)
-                    continue;
-                if (expiresAt <= now)
-                    request.abort(new TimeoutException("Total timeout " + request.getTimeout() + " ms elapsed"));
-                else if (expiresAt < earliest)
-                    earliest = expiresAt;
-            }
-
-            if (earliest < Long.MAX_VALUE && client.isRunning())
-                schedule(earliest);
+            return exchanges.iterator();
         }
 
-        private void schedule(long expiresAt)
+        @Override
+        protected boolean onExpired(HttpExchange exchange)
         {
-            // Schedule a timeout for the earliest exchange that may expire.
-            // When the timeout expires, scan the exchange queue for the next
-            // earliest exchange that may expire, and reschedule a new timeout.
-            long prevEarliest = earliestTimeout.getAndUpdate(t -> Math.min(t, expiresAt));
-            if (expiresAt < prevEarliest)
-            {
-                // A new request expires earlier than previous requests, schedule it.
-                long delay = Math.max(0, expiresAt - System.nanoTime());
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} scheduling timeout in {} ms", this, TimeUnit.NANOSECONDS.toMillis(delay));
-                schedule(delay, TimeUnit.NANOSECONDS);
-            }
+            HttpRequest request = exchange.getRequest();
+            request.abort(new TimeoutException("Total timeout " + request.getTimeout() + " ms elapsed"));
+            return false;
         }
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpExchange.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpExchange.java
@@ -18,11 +18,12 @@ import java.util.List;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HttpExchange
+public class HttpExchange implements CyclicTimeouts.Expirable
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpExchange.class);
 
@@ -87,6 +88,12 @@ public class HttpExchange
         {
             return responseFailure;
         }
+    }
+
+    @Override
+    public long getExpireNanoTime()
+    {
+        return request.getTimeoutAt();
     }
 
     /**

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -78,7 +78,7 @@ public class HttpRequest implements Request
     private boolean versionExplicit;
     private long idleTimeout = -1;
     private long timeout;
-    private long timeoutAt;
+    private long timeoutAt = Long.MAX_VALUE;
     private Content content;
     private boolean followRedirects;
     private List<HttpCookie> cookies;
@@ -821,11 +821,12 @@ public class HttpRequest implements Request
     void sent()
     {
         long timeout = getTimeout();
-        timeoutAt = timeout > 0 ? System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout) : -1;
+        if (timeout > 0)
+            timeoutAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout);
     }
 
     /**
-     * @return The nanoTime at which the timeout expires or -1 if there is no timeout.
+     * @return The nanoTime at which the timeout expires or {@link Long#MAX_VALUE} if there is no timeout.
      * @see #timeout(long, TimeUnit)
      */
     long getTimeoutAt()

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2320,7 +2320,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         }
 
         @Override
-        public Iterator<HTTP2Stream> iterator()
+        protected Iterator<HTTP2Stream> iterator()
         {
             return streams.values().stream().map(HTTP2Stream.class::cast).iterator();
         }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -56,6 +57,7 @@ import org.eclipse.jetty.http2.generator.Generator;
 import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.http2.parser.Parser;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.util.AtomicBiInteger;
@@ -89,12 +91,12 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
     private final AtomicInteger sendWindow = new AtomicInteger();
     private final AtomicInteger recvWindow = new AtomicInteger();
     private final AtomicLong bytesWritten = new AtomicLong();
-    private final Scheduler scheduler;
     private final EndPoint endPoint;
     private final Generator generator;
     private final Session.Listener listener;
     private final FlowControlStrategy flowControl;
     private final HTTP2Flusher flusher;
+    private final StreamTimeouts streamTimeouts;
     private int maxLocalStreams;
     private int maxRemoteStreams;
     private long streamIdleTimeout;
@@ -105,12 +107,12 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
     public HTTP2Session(Scheduler scheduler, EndPoint endPoint, Generator generator, Session.Listener listener, FlowControlStrategy flowControl, int initialStreamId)
     {
-        this.scheduler = scheduler;
         this.endPoint = endPoint;
         this.generator = generator;
         this.listener = listener;
         this.flowControl = flowControl;
         this.flusher = new HTTP2Flusher(this);
+        this.streamTimeouts = new StreamTimeouts(scheduler);
         this.maxLocalStreams = -1;
         this.maxRemoteStreams = -1;
         this.localStreamIds.set(initialStreamId);
@@ -613,7 +615,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
     protected IStream newStream(int streamId, MetaData.Request request, boolean local)
     {
-        return new HTTP2Stream(scheduler, this, streamId, request, local);
+        return new HTTP2Stream(this, streamId, request, local);
     }
 
     @Override
@@ -989,6 +991,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "upgrade");
     }
 
+    void scheduleTimeout(HTTP2Stream stream)
+    {
+        streamTimeouts.schedule(stream);
+    }
+
     private void onStreamCreated(int streamId)
     {
         if (LOG.isDebugEnabled())
@@ -1026,6 +1033,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
     private void terminate(Throwable cause)
     {
         flusher.terminate(cause);
+        streamTimeouts.destroy();
         disconnect();
     }
 
@@ -2301,6 +2309,27 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         private class Slot
         {
             private volatile List<HTTP2Flusher.Entry> entries;
+        }
+    }
+
+    private class StreamTimeouts extends CyclicTimeouts<HTTP2Stream>
+    {
+        private StreamTimeouts(Scheduler scheduler)
+        {
+            super(scheduler);
+        }
+
+        @Override
+        public Iterator<HTTP2Stream> iterator()
+        {
+            return streams.values().stream().map(HTTP2Stream.class::cast).iterator();
+        }
+
+        @Override
+        protected boolean onExpired(HTTP2Stream stream)
+        {
+            stream.onIdleExpired(new TimeoutException("Idle timeout " + stream.getIdleTimeout() + " ms elapsed"));
+            return false;
         }
     }
 }

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeout.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeout.java
@@ -39,12 +39,6 @@ import static java.lang.Long.MAX_VALUE;
  * session there is a CyclicTimeout and at the beginning of the
  * request processing the timeout is canceled (via cancel()), but at
  * the end of the request processing the timeout is re-scheduled.</p>
- * <p>Another typical scenario is for a parent entity to manage
- * the timeouts of many children entities; the timeout is scheduled
- * for the child entity that expires the earlier; when the timeout
- * expires, the implementation scans the children entities to find
- * the expired child entities and to find the next child entity
- * that expires the earlier. </p>
  * <p>This implementation has a {@link Timeout} holding the time
  * at which the scheduled task should fire, and a linked list of
  * {@link Wakeup}, each holding the actual scheduled task.</p>
@@ -59,6 +53,8 @@ import static java.lang.Long.MAX_VALUE;
  * When the Wakeup task fires, it will see that the Timeout is now
  * in the future and will attach a new Wakeup with the future time
  * to the Timeout, and submit a scheduler task for the new Wakeup.</p>
+ *
+ * @see CyclicTimeouts
  */
 public abstract class CyclicTimeout implements Destroyable
 {

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
@@ -1,0 +1,147 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>A {@link CyclicTimeout} that manages the timeouts for many entities.</p>
+ * <p>A typical scenario is for a parent entity to manage the timeouts of many children entities.</p>
+ * <p>When a new entity is created, call {@link #schedule(T)} with the new entity so that
+ * this instance can be aware and manage the timeout of the new entity.</p>
+ * <p>Eventually, this instance wakes up and iterates over the entities provided by {@link #iterator()}.
+ * During the iteration, each entity:</p>
+ * <ul>
+ *   <li>may never expire (see {@link Expirable#getExpireNanoTime()}; the entity is ignored</li>
+ *   <li>may be expired; {@link #onExpired(T)} is called with that entity as parameter</li>
+ *   <li>may expire at a future time; the iteration records the earliest expiration time among
+ *   all non-expired entities</li>
+ * </ul>
+ * <p>When the iteration is complete, this instance is re-scheduled with the earliest expiration time
+ * calculated during the iteration.</p>
+ *
+ * @param <T> the entity type
+ */
+public abstract class CyclicTimeouts<T extends CyclicTimeouts.Expirable> extends CyclicTimeout implements Iterable<T>
+{
+    private static final Logger LOG = LoggerFactory.getLogger(CyclicTimeouts.class);
+
+    private final AtomicLong earliestTimeout = new AtomicLong(Long.MAX_VALUE);
+
+    public CyclicTimeouts(Scheduler scheduler)
+    {
+        super(scheduler);
+    }
+
+    /**
+     * @return the entities to iterate over when this instance expires
+     */
+    @Override
+    public abstract Iterator<T> iterator();
+
+    /**
+     * <p>Invoked during the iteration when the given entity is expired.</p>
+     *
+     * @param expirable the entity that is expired
+     * @return whether the entity should be removed from the iterator via {@link Iterator#remove()}
+     */
+    protected abstract boolean onExpired(T expirable);
+
+    @Override
+    public void onTimeoutExpired()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} timeouts check", this);
+
+        long now = System.nanoTime();
+        long earliest = Long.MAX_VALUE;
+        // Reset the earliest timeout so we can expire again.
+        // A concurrent call to schedule(long) may lose an
+        // earliest value, but the corresponding entity will
+        // be seen during the iteration below.
+        earliestTimeout.set(earliest);
+
+        // Scan the entities to abort expired entities
+        // and to find the entity that expires the earliest.
+        Iterator<T> iterator = iterator();
+        while (iterator.hasNext())
+        {
+            T expirable = iterator.next();
+            long expiresAt = expirable.getExpireNanoTime();
+            if (expiresAt == -1)
+                continue;
+            if (expiresAt <= now)
+            {
+                if (onExpired(expirable))
+                    iterator.remove();
+                continue;
+            }
+            earliest = Math.min(earliest, expiresAt);
+        }
+
+        if (earliest < Long.MAX_VALUE)
+            schedule(earliest);
+    }
+
+    /**
+     * <p>Manages the timeout of a new entity.</p>
+     *
+     * @param expirable the new entity to manage the timeout for
+     */
+    public void schedule(T expirable)
+    {
+        long expiresAt = expirable.getExpireNanoTime();
+        if (expiresAt < Long.MAX_VALUE)
+            schedule(expiresAt);
+    }
+
+    private void schedule(long expiresAt)
+    {
+        // Schedule a timeout for the earliest entity that may expire.
+        // When the timeout expires, scan the entities for the next
+        // earliest entity that may expire, and reschedule a new timeout.
+        long prevEarliest = earliestTimeout.getAndUpdate(t -> Math.min(t, expiresAt));
+        if (expiresAt < prevEarliest)
+        {
+            // A new entity expires earlier than previous entities, schedule it.
+            long delay = Math.max(0, expiresAt - System.nanoTime());
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} scheduling timeout in {} ms", this, TimeUnit.NANOSECONDS.toMillis(delay));
+            schedule(delay, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * <p>An entity that may expire.</p>
+     */
+    public interface Expirable
+    {
+        /**
+         * <p>Returns the expiration time in nanoseconds.</p>
+         * <p>The value to return must be calculated taking into account {@link System#nanoTime()},
+         * for example:</p>
+         * {@code expireNanoTime = System.nanoTime() + timeoutNanos}
+         * <p>Returning {@link Long#MAX_VALUE} indicates that this entity does not expire.</p>
+         *
+         * @return the expiration time in nanoseconds, or {@link Long#MAX_VALUE} if this entity does not expire
+         */
+        public long getExpireNanoTime();
+    }
+}

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
@@ -26,13 +26,13 @@ import org.slf4j.LoggerFactory;
  * <p>An implementation of a timeout that manages many {@link Expirable expirable} entities whose
  * timeouts are mostly cancelled or re-scheduled.</p>
  * <p>A typical scenario is for a parent entity to manage the timeouts of many children entities.</p>
- * <p>When a new entity is created, call {@link #schedule(T)} with the new entity so that
+ * <p>When a new entity is created, call {@link #schedule(Expirable)} with the new entity so that
  * this instance can be aware and manage the timeout of the new entity.</p>
  * <p>Eventually, this instance wakes up and iterates over the entities provided by {@link #iterator()}.
  * During the iteration, each entity:</p>
  * <ul>
  *   <li>may never expire (see {@link Expirable#getExpireNanoTime()}; the entity is ignored</li>
- *   <li>may be expired; {@link #onExpired(T)} is called with that entity as parameter</li>
+ *   <li>may be expired; {@link #onExpired(Expirable)} is called with that entity as parameter</li>
  *   <li>may expire at a future time; the iteration records the earliest expiration time among
  *   all non-expired entities</li>
  * </ul>


### PR DESCRIPTION
Introduced CyclicTimeouts to manage many entities that may timeout.
Rewritten HttpDestination request timeouts using CyclicTimeouts.
HTTP2Stream does not inherit from IdleTimeout anymore; now a
CyclicTimeouts in HTTP2Session manages the stream timeouts.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>