### PR TITLE
Fixes #6272 - Reduce allocation in HttpClient when notifying content …

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -72,8 +72,8 @@ public abstract class HttpReceiver
 
     private final AutoLock lock = new AutoLock();
     private final AtomicReference<ResponseState> responseState = new AtomicReference<>(ResponseState.IDLE);
+    private final ContentListeners contentListeners = new ContentListeners();
     private final HttpChannel channel;
-    private ContentListeners contentListeners;
     private Decoder decoder;
     private Throwable failure;
     private long demand;
@@ -291,7 +291,7 @@ public abstract class HttpReceiver
         ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
         List<Response.ResponseListener> responseListeners = exchange.getConversation().getResponseListeners();
         notifier.notifyHeaders(responseListeners, response);
-        contentListeners = new ContentListeners(responseListeners);
+        contentListeners.reset(responseListeners);
         contentListeners.notifyBeforeContent(response);
 
         if (!contentListeners.isEmpty())
@@ -508,7 +508,7 @@ public abstract class HttpReceiver
 
     private void cleanup()
     {
-        contentListeners = null;
+        contentListeners.clear();
         if (decoder != null)
             decoder.destroy();
         decoder = null;
@@ -653,15 +653,22 @@ public abstract class HttpReceiver
     {
         private final Map<Object, Long> demands = new ConcurrentHashMap<>();
         private final LongConsumer demand = HttpReceiver.this::demand;
-        private final List<Response.DemandedContentListener> listeners;
+        private final List<Response.DemandedContentListener> listeners = new ArrayList<>(2);
 
-        private ContentListeners(List<Response.ResponseListener> responseListeners)
+        private void clear()
         {
-            listeners = new ArrayList<>(responseListeners.size());
-            responseListeners.stream()
-                .filter(Response.DemandedContentListener.class::isInstance)
-                .map(Response.DemandedContentListener.class::cast)
-                .forEach(listeners::add);
+            demands.clear();
+            listeners.clear();
+        }
+
+        private void reset(List<Response.ResponseListener> responseListeners)
+        {
+            clear();
+            for (Response.ResponseListener listener : responseListeners)
+            {
+                if (listener instanceof Response.DemandedContentListener)
+                    listeners.add((Response.DemandedContentListener)listener);
+            }
         }
 
         private boolean isEmpty()


### PR DESCRIPTION
…listeners.

Avoid to allocate ContentListeners for every response.
Avoid using Java streams to reduce allocation.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>