### PR TITLE
10.0.x: Only release connection when channel got released to avoid double connection release race condition

### DIFF
--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
@@ -106,8 +106,8 @@ public class HttpChannelOverHTTP2 extends HttpChannel
     public void release()
     {
         setStream(null);
-        connection.release(this);
-        getHttpDestination().release(getHttpConnection());
+        if (connection.release(this))
+            getHttpDestination().release(getHttpConnection());
     }
 
     @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -151,7 +151,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         return new HttpChannelOverHTTP2(getHttpDestination(), this, getSession());
     }
 
-    protected void release(HttpChannelOverHTTP2 channel)
+    protected boolean release(HttpChannelOverHTTP2 channel)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Released {}", channel);
@@ -162,10 +162,12 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
                 channel.destroy();
             else if (isRecycleHttpChannels())
                 idleChannels.offer(channel);
+            return true;
         }
         else
         {
             channel.destroy();
+            return false;
         }
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -431,7 +431,13 @@ public class Pool<T> implements AutoCloseable, Dumpable
         // iterate the copy and close its entries
         for (Entry entry : copy)
         {
-            if (entry.tryRemove() && entry.pooled instanceof Closeable)
+            boolean removed = entry.tryRemove();
+            if (!removed)
+            {
+                if (LOGGER.isDebugEnabled())
+                    LOGGER.debug("Pooled object still in use: {}", entry);
+            }
+            if (removed && entry.pooled instanceof Closeable)
                 IO.close((Closeable)entry.pooled);
         }
     }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -432,13 +432,16 @@ public class Pool<T> implements AutoCloseable, Dumpable
         for (Entry entry : copy)
         {
             boolean removed = entry.tryRemove();
-            if (!removed)
+            if (removed)
+            {
+                if (entry.pooled instanceof Closeable)
+                    IO.close((Closeable)entry.pooled);
+            }
+            else
             {
                 if (LOGGER.isDebugEnabled())
                     LOGGER.debug("Pooled object still in use: {}", entry);
             }
-            if (removed && entry.pooled instanceof Closeable)
-                IO.close((Closeable)entry.pooled);
         }
     }
 


### PR DESCRIPTION
10.0.x cherry-picking of https://github.com/eclipse/jetty.project/pull/6286