### PR TITLE
Issue #6138 Fix flakey DuplicateCookieTest

### DIFF
--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateCookieTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateCookieTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.server.session;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -54,6 +55,8 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
@@ -70,6 +73,8 @@ public class DuplicateCookieTest
             assertEquals(0, s4422.getRequests());
 
             //make a request with another session cookie in there that does not exist
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=123")); //doesn't exist
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=4422")); //does exist
@@ -77,6 +82,10 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals("4422", response.getContentAsString());
 
+            //ensure request has finished processing so session will be completed
+            latch.await(5, TimeUnit.SECONDS);
+
+            //check session is drained of requests
             assertEquals(0, s4422.getRequests());
         }
         finally
@@ -101,6 +110,8 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
@@ -127,6 +138,8 @@ public class DuplicateCookieTest
             assertEquals(0, s2255.getRequests());
 
             //make a request where the valid session cookie is first
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=1122")); //is valid
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=2233")); //is invalid
@@ -135,6 +148,10 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals("1122", response.getContentAsString());
 
+            //ensure request has finished processing so session will be completed
+            latch.await(5, TimeUnit.SECONDS);
+
+            //check valid session is drained of requests
             assertEquals(0, s1122.getRequests());
         }
         finally
@@ -159,6 +176,8 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
@@ -185,6 +204,9 @@ public class DuplicateCookieTest
             assertEquals(0, s2255.getRequests());
 
             //make a request with the valid session cookie last
+            // Create the session
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=2233")); //is invalid
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=2255")); //is invalid
@@ -193,6 +215,10 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals("1122", response.getContentAsString());
 
+            //ensure request has completed so session will be completed
+            latch.await(5, TimeUnit.SECONDS);
+
+            //check valid session drained of requests
             assertEquals(0, s1122.getRequests());
         }
         finally
@@ -217,6 +243,8 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
@@ -243,6 +271,8 @@ public class DuplicateCookieTest
             assertEquals(0, s2255.getRequests());
 
             //make a request with another session cookie with the valid session surrounded by invalids
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=2233")); //is invalid
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=1122")); //is valid
@@ -251,6 +281,10 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
             assertEquals("1122", response.getContentAsString());
 
+            //ensure request has completed so session will be completed
+            latch.await(5, TimeUnit.SECONDS);
+
+            //check valid session drained of requests
             assertEquals(0, s1122.getRequests());
         }
         finally
@@ -275,12 +309,14 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
         try (StacklessLogging ignored = new StacklessLogging(DuplicateCookieTest.class.getPackage()))
         {
-            //create some of unexpired sessions
+            //create some unexpired sessions
             Session s1234 = createUnExpiredSession(contextHandler.getSessionHandler().getSessionCache(),
                 contextHandler.getSessionHandler().getSessionCache().getSessionDataStore(),
                 "1234");
@@ -300,13 +336,18 @@ public class DuplicateCookieTest
             assertEquals(0, s9111.getRequests());
 
             //make a request with multiple valid session ids
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=1234"));
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=5678"));
             ContentResponse response = request.send();
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
 
-            //check that all valid sessions have their request counts decremented correctly after the request, back to 0
+            //ensure request has completed so any session will be completed
+            latch.await(5, TimeUnit.SECONDS);
+
+            //check that all sessions have their request counts decremented correctly after the request, back to 0
             assertEquals(0, s1234.getRequests());
             assertEquals(0, s5678.getRequests());
             assertEquals(0, s9111.getRequests());
@@ -333,6 +374,8 @@ public class DuplicateCookieTest
         ServletHolder holder = new ServletHolder(servlet);
         ServletContextHandler contextHandler = server1.addContext(contextPath);
         contextHandler.addServlet(holder, servletMapping);
+        TestHttpChannelCompleteListener scopeListener = new TestHttpChannelCompleteListener();
+        server1.getServerConnector().addBean(scopeListener);
         server1.start();
         int port1 = server1.getPort();
 
@@ -350,11 +393,16 @@ public class DuplicateCookieTest
             assertEquals(0, s1234.getRequests());
 
             //make a request with multiple valid session ids
+            CountDownLatch latch = new CountDownLatch(1);
+            scopeListener.setExitSynchronizer(latch);
             Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=check");
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=1234"));
             request.headers(headers -> headers.add("Cookie", "JSESSIONID=1234"));
             ContentResponse response = request.send();
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+
+            //ensure request has finished processing so session will be completed
+            latch.await(5, TimeUnit.SECONDS);
 
             //check that all valid sessions have their request counts decremented correctly after the request, back to 0
             assertEquals(0, s1234.getRequests());

--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateCookieTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DuplicateCookieTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test having multiple session cookies in a request.
@@ -83,7 +84,7 @@ public class DuplicateCookieTest
             assertEquals("4422", response.getContentAsString());
 
             //ensure request has finished processing so session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check session is drained of requests
             assertEquals(0, s4422.getRequests());
@@ -149,7 +150,7 @@ public class DuplicateCookieTest
             assertEquals("1122", response.getContentAsString());
 
             //ensure request has finished processing so session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check valid session is drained of requests
             assertEquals(0, s1122.getRequests());
@@ -216,7 +217,7 @@ public class DuplicateCookieTest
             assertEquals("1122", response.getContentAsString());
 
             //ensure request has completed so session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check valid session drained of requests
             assertEquals(0, s1122.getRequests());
@@ -282,7 +283,7 @@ public class DuplicateCookieTest
             assertEquals("1122", response.getContentAsString());
 
             //ensure request has completed so session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check valid session drained of requests
             assertEquals(0, s1122.getRequests());
@@ -345,7 +346,7 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
 
             //ensure request has completed so any session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check that all sessions have their request counts decremented correctly after the request, back to 0
             assertEquals(0, s1234.getRequests());
@@ -402,7 +403,7 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
 
             //ensure request has finished processing so session will be completed
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             //check that all valid sessions have their request counts decremented correctly after the request, back to 0
             assertEquals(0, s1234.getRequests());


### PR DESCRIPTION
Closes #6138 

DuplicateCookieTest session tests were flakey:  we need to check the request count of the Session _only_ after the request has fully completed, not just after the content of the response has been returned.