### PR TITLE
Issue #6309 remove duplicate commented out session test

### DIFF
--- a/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DefaultSessionCacheTest.java
+++ b/tests/test-sessions/test-sessions-common/src/test/java/org/eclipse/jetty/server/session/DefaultSessionCacheTest.java
@@ -210,51 +210,6 @@ public class DefaultSessionCacheTest extends AbstractSessionCacheTest
     }
 
     /**
-     * Test sessions are saved when shutdown with a store.
-     */
-    /*    @Test
-    public void testNoInvalidateOnShutdown()
-        throws Exception
-    {
-        Server server = new Server();
-    
-        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
-        context.setContextPath("/test");
-        context.setServer(server);
-        server.setHandler(context);
-    
-        AbstractSessionCacheFactory cacheFactory = newSessionCacheFactory(SessionCache.NEVER_EVICT, false, false, false, false);
-        DefaultSessionCache cache = (DefaultSessionCache)cacheFactory.getSessionCache(context.getSessionHandler());
-    
-        TestSessionDataStore store = new TestSessionDataStore(true);//fake passivation
-        cache.setSessionDataStore(store);
-        context.getSessionHandler().setSessionCache(cache);
-    
-        server.start();
-    
-        //put a session in the cache and store
-        long now = System.currentTimeMillis();
-        SessionData data = store.newSessionData("1234", now - 20, now - 10, now - 20, TimeUnit.MINUTES.toMillis(10));
-        Session session = cache.newSession(data);
-        TestSessionActivationListener listener = new TestSessionActivationListener();
-        cache.add("1234", session);
-        assertTrue(cache.contains("1234"));
-        session.setAttribute("aaa", listener);
-        cache.release("1234", session);
-    
-        assertTrue(store.exists("1234"));
-        assertTrue(cache.contains("1234"));
-    
-        server.stop(); //calls shutdown
-    
-        assertTrue(store.exists("1234"));
-        assertFalse(cache.contains("1234"));
-        assertEquals(2, listener.passivateCalls);
-        assertEquals(1, listener.activateCalls);
-    }
-    */
-
-    /**
      * Test that a session id can be renewed.
      */
     @Test


### PR DESCRIPTION
Closes #6309

Commented out code was moved to `AbstractSessionTest`, so just remove cruft.