### PR TITLE
Issue #5684 Re-enable ValidUrlRuleTest.test(In)ValidShamrock

### DIFF
--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
@@ -83,7 +83,6 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
         assertEquals("foo", _request.getAttribute(Dispatcher.ERROR_MESSAGE));
     }
 
-    @Disabled("Not working in jetty-9")
     @Test
     public void testInvalidShamrock() throws Exception
     {
@@ -97,7 +96,6 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
         assertEquals("foo", _request.getAttribute(Dispatcher.ERROR_MESSAGE));
     }
 
-    @Disabled("Not working in jetty-9")
     @Test
     public void testValidShamrock() throws Exception
     {


### PR DESCRIPTION
There are 2 `@Disabled` tests in ValidUrlRuleTest:

- testValidShamrock
- testInvalidShamrock

comment field says "Not working in jetty-9".

I've uncommented them and run successfully in both jetty-9.4.x and jetty-10.0.x branch.

@joakime  and @gregw  do you know any reason why these 2 tests should remain `@Disabled`?  They should either be re-enabled (as per this PR) or deleted if they are no longer needed or incorrect tests.

