### PR TITLE
Explain EatWhatYouKill naming

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java
@@ -52,6 +52,10 @@ import org.eclipse.jetty.util.thread.TryExecutor;
  * indicated it is non-blocking, then this strategy will dispatch the execution of
  * the task and immediately continue production. When operating in this pattern, the
  * sub-strategy is called ProduceExecuteConsume (PEC).</p>
+ * <p>The EatWhatYouKill strategy is named after a hunting proverb, in the
+ * sense that one should kill(produce) only to eat(consume).
+ * The use of this phrase is not an endorsement of hunting nor killing of
+ * wildlife for food or sport.</p>
  */
 @ManagedObject("eat what you kill execution strategy")
 public class EatWhatYouKill extends ContainerLifeCycle implements ExecutionStrategy, Runnable

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java
@@ -53,9 +53,7 @@ import org.eclipse.jetty.util.thread.TryExecutor;
  * the task and immediately continue production. When operating in this pattern, the
  * sub-strategy is called ProduceExecuteConsume (PEC).</p>
  * <p>The EatWhatYouKill strategy is named after a hunting proverb, in the
- * sense that one should kill(produce) only to eat(consume).
- * The use of this phrase is not an endorsement of hunting nor killing of
- * wildlife for food or sport.</p>
+ * sense that one should kill(produce) only to eat(consume).</p>
  */
 @ManagedObject("eat what you kill execution strategy")
 public class EatWhatYouKill extends ContainerLifeCycle implements ExecutionStrategy, Runnable


### PR DESCRIPTION
Some concern has been raised at the EatWhatYouKill strategy name (OK @sbordet you get I told you so rights).
This PR updates the javadoc to be clear about the reason for using that name in that the strategy is named after 
a [hunting proverb](https://www.urbandictionary.com/define.php?term=eat%20what%20you%20kill) in the sense 
that one should only kill to eat. The use of this phrase is not an endorsement of hunting nor killing of wildlife for 
food or sport.
