### PR TITLE
Issue #6347 Fix session-store-gcloud,logging-jcl-capture,logging-log4j1-capture

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-gcloud.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-gcloud.adoc
@@ -62,10 +62,8 @@ The `session-store-gcloud` module provides GCloud support for storing session da
 
 Because the Google Cloud DataStore is not a technology provided by the Eclipse Foundation, when enabling the module you will be prompted to assent to the licenses of the external vendor.
 
-As GCloud requires certain Java Commons Logging features to work correctly, Jetty routes these through SLF4J by transitively enabling the `jcl-slf4j` module during installation.
-Therefore, you will _also_ need to enable one of the SLF4J implementation modules.
-You can either choose one ahead of time and enable it at the same time as the `session-store-gcloud` module, or you can just enable `session-store-gcloud` module and it will print out a list of available SLF4J implementations.
-You can then choose one and enable it.
+As GCloud requires certain Java Commons Logging features to work correctly, Jetty routes these through SLF4J.
+By default Jetty implements the SLF4J api, but you can choose a different logging implementation by following the instructions xref:og-logging[here]
 
 IMPORTANT: If you want to use updated versions of the jar files automatically downloaded during the module enablement, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
 

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
@@ -10,5 +10,5 @@ gcloud
 [depends]
 gcloud
 logging-jcl-capture
-logging-jul
+logging-jul-capture
 

--- a/jetty-home/src/main/resources/modules/logging-jcl-capture.mod
+++ b/jetty-home/src/main/resources/modules/logging-jcl-capture.mod
@@ -14,7 +14,7 @@ logging
 commons-logging
 
 [files]
-maven://org.slf4j/jcl-over-slf4j/%{slf4j.version}|jcl-over-slf4j-${slf4j.version}.jar
+maven://org.slf4j/jcl-over-slf4j/${slf4j.version}|jcl-over-slf4j-${slf4j.version}.jar
 
 [lib]
 lib/logging/jcl-over-slf4j-${slf4j.version}.jar

--- a/jetty-home/src/main/resources/modules/logging-log4j1-capture.mod
+++ b/jetty-home/src/main/resources/modules/logging-log4j1-capture.mod
@@ -14,7 +14,7 @@ logging
 log4j
 
 [files]
-maven://org.slf4j/jcl-over-slf4j/%{slf4j.version}|jcl-over-slf4j-${slf4j.version}.jar
+maven://org.slf4j/jcl-over-slf4j/${slf4j.version}|jcl-over-slf4j-${slf4j.version}.jar
 
 [lib]
 lib/logging/log4j-to-slf4j-${slf4j.version}.jar


### PR DESCRIPTION
closes #6347 

gcloud-datastore.mod depended on wrong jul logging module: was logging-jul but should be logging-jul-capture.

Along the way I discovered that the logging-jul-capture and loggin-jcl-capture were both broken, so fixed those.
