### PR TITLE
Fixes #6330 - CustomRequestLog is missing HTTP version format option.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -156,7 +156,7 @@ import static java.lang.invoke.MethodType.methodType;
  *
  * <tr>
  * <td valign="top">%H</td>
- * <td>The request protocol.</td>
+ * <td>The name and version of the request protocol, such as "HTTP/1.1".</td>
  * </tr>
  *
  * <tr>


### PR DESCRIPTION
Improved javadocs for %H.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>