### PR TITLE
Update VERSION.txt with CVE number.

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -33,7 +33,7 @@ jetty-10.0.3 - 20 May 2021
  + 6250 Lazily allocate HTTP2Stream data queue
  + 6251 Use CyclicTimeout for HTTP2Streams
  + 6254 Total timeout not enforced for queued requests
- + 6263 Review URI encoding in ConcatServlet & WelcomeFilter
+ + 6263 Review URI encoding in ConcatServlet & WelcomeFilter (Resolved CVE-2021-28169)
  + 6272 Reduce allocation in HttpClient when notifying content listeners
  + 6277 Better handle exceptions thrown from session destroy listener
  + 6280 Copy ServletHolder class/instance properly during startWebapp


### PR DESCRIPTION
**For security advisory:** https://github.com/eclipse/jetty.project/security/advisories/GHSA-gwcr-j4wh-j3cq and _CVE-2021-28169_

Edit VERSION.txt and so that the CVE number is now recorded against merged PR.

