### PR TITLE
Update VERSION.txt with CVE number. (Jetty-9.4)

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -9,7 +9,7 @@ jetty-9.4.41.v20210516 - 16 May 2021
  + 6227 Better resolve race between `AsyncListener.onTimeout` and
    `AsyncContext.dispatch`
  + 6254 Total timeout not enforced for queued requests
- + 6263 Review URI encoding in ConcatServlet & WelcomeFilter
+ + 6263 Review URI encoding in ConcatServlet & WelcomeFilter (Resolved CVE-2021-28169)
  + 6277 Better handle exceptions thrown from session destroy listener
  + 6280 Copy ServletHolder class/instance properly during startWebapp
 


### PR DESCRIPTION
**For security advisory:** https://github.com/eclipse/jetty.project/security/advisories/GHSA-gwcr-j4wh-j3cq and _CVE-2021-28169_

Edit VERSION.txt and so that the CVE number is now recorded against merged PR.