### PR TITLE
9.4.x: Improve ByteBufferPool implementations

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -20,9 +20,9 @@ package org.eclipse.jetty.io;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -154,7 +154,7 @@ public interface ByteBufferPool
 
     class Bucket
     {
-        private final Deque<ByteBuffer> _queue = new ConcurrentLinkedDeque<>();
+        private final Queue<ByteBuffer> _queue = new ConcurrentLinkedQueue<>();
         private final ByteBufferPool _pool;
         private final int _capacity;
         private final int _maxSize;
@@ -232,7 +232,7 @@ public interface ByteBufferPool
 
         private void queueOffer(ByteBuffer buffer)
         {
-            _queue.offerFirst(buffer);
+            _queue.offer(buffer);
         }
 
         private ByteBuffer queuePoll()

--- a/jetty-jmh/src/main/java/org/eclipse/jetty/util/ArrayByteBufferPoolBenchmark.java
+++ b/jetty-jmh/src/main/java/org/eclipse/jetty/util/ArrayByteBufferPoolBenchmark.java
@@ -1,0 +1,72 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class ArrayByteBufferPoolBenchmark
+{
+    private ByteBufferPool pool;
+
+    @Setup
+    public void setUp() throws Exception
+    {
+        pool = new ArrayByteBufferPool();
+    }
+
+    @TearDown
+    public void tearDown()
+    {
+        pool = null;
+    }
+
+    @Benchmark
+    public void testAcquireRelease()
+    {
+        ByteBuffer buffer = pool.acquire(2048, true);
+        pool.release(buffer);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(ArrayByteBufferPoolBenchmark.class.getSimpleName())
+            .warmupIterations(3)
+            .measurementIterations(3)
+            .forks(1)
+            .threads(8)
+            // .addProfiler(GCProfiler.class)
+            .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
I also added a simple benchmark that shows the results of this improvement.

Original code:

```
Benchmark                                         Mode  Cnt        Score        Error  Units
ArrayByteBufferPoolBenchmark.testAcquireRelease  thrpt    3  2527727,245 ± 389428,504  ops/s
```

Just replacing `offerFirst` with `offer`, keeping the `ConcurrentLinkedDeque`:

```
Benchmark                                         Mode  Cnt        Score       Error  Units
ArrayByteBufferPoolBenchmark.testAcquireRelease  thrpt    3  3401758,446 ± 66958,678  ops/s
```


Replacing `offerFirst` with `offer` and replacing the `ConcurrentLinkedDeque` with a `ConcurrentLinkedQueue`:

```
Benchmark                                         Mode  Cnt        Score        Error  Units
ArrayByteBufferPoolBenchmark.testAcquireRelease  thrpt    3  4302078,532 ± 108538,319  ops/s
```