### PR TITLE
Issue #6354 - OSGI manifest for slf4j-api packages lower limit should be 1.7

### DIFF
--- a/demos/demo-jetty-webapp/pom.xml
+++ b/demos/demo-jetty-webapp/pom.xml
@@ -127,15 +127,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
       <version>${project.version}</version>

--- a/demos/demo-jetty-webapp/src/main/java/com/acme/ChatServlet.java
+++ b/demos/demo-jetty-webapp/src/main/java/com/acme/ChatServlet.java
@@ -27,17 +27,12 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 // Simple asynchronous Chat room.
 // This does not handle duplicate usernames or multiple frames/tabs from the same browser
 // Some code is duplicated for clarity.
 @SuppressWarnings("serial")
 public class ChatServlet extends HttpServlet
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ChatServlet.class);
-
     private long asyncTimeout = 10000;
 
     @Override
@@ -63,7 +58,7 @@ public class ChatServlet extends HttpServlet
         @Override
         public void onTimeout(AsyncEvent event) throws IOException
         {
-            LOG.debug("resume request");
+            getServletContext().log("resume request");
             AsyncContext async = _async.get();
             if (async != null && _async.compareAndSet(async, null))
             {
@@ -102,10 +97,10 @@ public class ChatServlet extends HttpServlet
         String message = request.getParameter("message");
         String username = request.getParameter("user");
 
-        LOG.debug("doPost called. join={},message={},username={}", join, message, username);
+        getServletContext().log("doPost called. join=" + join + " message=" + message + " username=" + username);
         if (username == null)
         {
-            LOG.debug("no parameter user set, sending 503");
+            getServletContext().log("no parameter user set, sending 503");
             response.sendError(503, "user==null");
             return;
         }
@@ -125,14 +120,14 @@ public class ChatServlet extends HttpServlet
         {
             synchronized (member)
             {
-                LOG.debug("Queue size: {}", member._queue.size());
+                getServletContext().log("Queue size: " + member._queue.size());
                 if (!member._queue.isEmpty())
                 {
                     sendSingleMessage(response, member);
                 }
                 else
                 {
-                    LOG.debug("starting async");
+                    getServletContext().log("starting async");
                     AsyncContext async = request.startAsync();
                     async.setTimeout(asyncTimeout);
                     async.addListener(member);
@@ -147,7 +142,7 @@ public class ChatServlet extends HttpServlet
         Member member = room.get(username);
         if (member == null)
         {
-            LOG.debug("user: {} in room: {} doesn't exist. Creating new user.", username, room);
+            getServletContext().log("user: " + username + " in room: " + room + " doesn't exist. Creating new user.");
             member = new Member(username);
             room.put(username, member);
         }
@@ -159,7 +154,7 @@ public class ChatServlet extends HttpServlet
         Map<String, Member> room = _rooms.get(path);
         if (room == null)
         {
-            LOG.debug("room: {} doesn't exist. Creating new room.", path);
+            getServletContext().log("room: " + path + " doesn't exist. Creating new room.");
             room = new HashMap<>();
             _rooms.put(path, room);
         }
@@ -192,7 +187,6 @@ public class ChatServlet extends HttpServlet
 
     private void sendMessageToAllMembers(String message, String username, Map<String, Member> room)
     {
-        LOG.debug("Sending message: {} from: {}", message, username);
         for (Member m : room.values())
         {
             synchronized (m)
@@ -202,10 +196,8 @@ public class ChatServlet extends HttpServlet
 
                 // wakeup member if polling
                 AsyncContext async = m._async.get();
-                LOG.debug("Async found: {}", async);
                 if (async != null & m._async.compareAndSet(async, null))
                 {
-                    LOG.debug("dispatch");
                     async.dispatch();
                 }
             }

--- a/demos/demo-jetty-webapp/src/main/java/com/acme/Dump.java
+++ b/demos/demo-jetty-webapp/src/main/java/com/acme/Dump.java
@@ -51,8 +51,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 import javax.servlet.http.Part;
 
-import org.slf4j.LoggerFactory;
-
 /**
  * Dump Servlet Request.
  */
@@ -116,7 +114,7 @@ public class Dump extends HttpServlet
             }
             catch (ServletException e)
             {
-                getServletContext().log(e.toString());
+                getServletContext().log("Login fail", e);
             }
         }
 
@@ -341,12 +339,12 @@ public class Dump extends HttpServlet
                 }
                 catch (IOException e2)
                 {
-                    LoggerFactory.getLogger(Dump.class).trace("IGNORED", e2);
+                    getServletContext().log("Write fail", e2);
                 }
             }
             catch (IOException e)
             {
-                LoggerFactory.getLogger(Dump.class).trace("IGNORED", e);
+                getServletContext().log("Output fail", e);
             }
             return;
         }

--- a/demos/demo-jetty-webapp/src/main/java/com/acme/SecureModeServlet.java
+++ b/demos/demo-jetty-webapp/src/main/java/com/acme/SecureModeServlet.java
@@ -27,17 +27,12 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Dump Servlet Request.
  */
 @SuppressWarnings("serial")
 public class SecureModeServlet extends HttpServlet
 {
-    private static final Logger LOG = LoggerFactory.getLogger(SecureModeServlet.class);
-
     @Override
     public void init(ServletConfig config) throws ServletException
     {
@@ -116,7 +111,7 @@ public class SecureModeServlet extends HttpServlet
         try
         {
             out.println("check ability to log<br/>");
-            LOG.info("testing logging");
+            getServletContext().log("testing logging");
             out.println("status: <b>SUCCESS - expected</b><br/>");
         }
         catch (SecurityException e)

--- a/demos/demo-jetty-webapp/src/main/java/com/acme/TestFilter.java
+++ b/demos/demo-jetty-webapp/src/main/java/com/acme/TestFilter.java
@@ -27,9 +27,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * TestFilter.
  *
@@ -39,8 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class TestFilter implements Filter
 {
-    private static final Logger LOG = LoggerFactory.getLogger(TestFilter.class);
-
     private boolean _remote;
     private ServletContext _context;
     private final Set<String> _allowed = new HashSet<String>();
@@ -54,7 +49,7 @@ public class TestFilter implements Filter
         _allowed.add("/jetty_banner.gif");
         _allowed.add("/remote.html");
 
-        LOG.debug("TestFilter#remote=" + _remote);
+        filterConfig.getServletContext().log("TestFilter#remote=" + _remote);
     }
 
     @Override

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -24,7 +24,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Import-Package>${osgi.common.import.packages},org.eclipse.jetty.alpn;resolution:=optional,*</Import-Package>
+                <Import-Package>${osgi.slf4j.import.packages},org.eclipse.jetty.alpn;resolution:=optional,*</Import-Package>
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client)";resolution:=optional;cardinality:=multiple</Require-Capability>
               </instructions>
             </configuration>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -24,7 +24,7 @@
             </goals>
             <configuration>
               <instructions>
-                <Import-Package>org.eclipse.jetty.alpn;resolution:=optional,*</Import-Package>
+                <Import-Package>${osgi.common.import.packages},org.eclipse.jetty.alpn;resolution:=optional,*</Import-Package>
                 <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional, osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client)";resolution:=optional;cardinality:=multiple</Require-Capability>
               </instructions>
             </configuration>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -52,7 +52,7 @@
         <configuration>
           <instructions>
             <Bundle-Description>Conscrypt Client ALPN</Bundle-Description>
-            <Import-Package>${osgi.common.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
+            <Import-Package>${osgi.slf4j.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
             <Export-Package>*</Export-Package>
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
             <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client</Provide-Capability>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -52,7 +52,7 @@
         <configuration>
           <instructions>
             <Bundle-Description>Conscrypt Client ALPN</Bundle-Description>
-            <Import-Package>org.conscrypt;version="${conscrypt.version}",*</Import-Package>
+            <Import-Package>${osgi.common.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
             <Export-Package>*</Export-Package>
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
             <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Client</Provide-Capability>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -80,7 +80,7 @@
         <configuration>
           <instructions>
             <Bundle-Description>Conscrypt ALPN</Bundle-Description>
-            <Import-Package>${osgi.common.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
+            <Import-Package>${osgi.slf4j.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server</Provide-Capability>
             <_nouses>true</_nouses>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -80,7 +80,7 @@
         <configuration>
           <instructions>
             <Bundle-Description>Conscrypt ALPN</Bundle-Description>
-            <Import-Package>org.conscrypt;version="${conscrypt.version}",*</Import-Package>
+            <Import-Package>${osgi.common.import.packages},org.conscrypt;version="${conscrypt.version}",*</Import-Package>
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.eclipse.jetty.io.ssl.ALPNProcessor$Server</Provide-Capability>
             <_nouses>true</_nouses>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -30,7 +30,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>org.objectweb.asm;version="5",*</Import-Package>
+            <Import-Package>${osgi.common.import.packages},org.objectweb.asm;version="5",*</Import-Package>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=javax.servlet.ServletContainerInitializer)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional
             </Require-Capability>
           </instructions>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -30,7 +30,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>${osgi.common.import.packages},org.objectweb.asm;version="5",*</Import-Package>
+            <Import-Package>${osgi.slf4j.import.packages},org.objectweb.asm;version="5",*</Import-Package>
             <Require-Capability>osgi.serviceloader; filter:="(osgi.serviceloader=javax.servlet.ServletContainerInitializer)";resolution:=optional;cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional
             </Require-Capability>
           </instructions>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -31,7 +31,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>${osgi.common.import.packages},javax.mail.*;resolution:=optional,*</Import-Package>
+            <Import-Package>${osgi.slf4j.import.packages},javax.mail.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -31,7 +31,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>javax.mail.*;resolution:=optional,*</Import-Package>
+            <Import-Package>${osgi.common.import.packages},javax.mail.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -71,30 +71,29 @@
             <Bundle-SymbolicName>org.eclipse.jetty.osgi.boot;singleton:=true</Bundle-SymbolicName>
             <Bundle-Activator>org.eclipse.jetty.osgi.boot.JettyBootstrapActivator</Bundle-Activator>
             <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
-            <Import-Package>javax.mail;version="1.4.0";resolution:=optional,
-                javax.mail.event;version="1.4.0";resolution:=optional,
-                javax.mail.internet;version="1.4.0";resolution:=optional,
-                javax.mail.search;version="1.4.0";resolution:=optional,
-                javax.mail.util;version="1.4.0";resolution:=optional,
-                javax.servlet;version="[$(version;==;${servlet.api.version}),$(version;+;${servlet.api.version}))",
-                javax.servlet.http;version="[$(version;==;${servlet.api.version}),$(version;+;${servlet.api.version}))",
-                javax.transaction;version="1.1.0";resolution:=optional,
-                javax.transaction.xa;version="1.1.0";resolution:=optional,
-                org.objectweb.asm;version="$(version;=;${asm.version})";resolution:=optional,
-                org.osgi.framework,
-                org.osgi.service.cm;version="1.4.0",
-                org.osgi.service.event;version="1.4.0",
-                org.osgi.service.packageadmin,
-                org.osgi.service.startlevel;version="1.0.0",
-                org.osgi.service.url;version="1.0.0",
-                org.osgi.util.tracker;version="1.3.0",
-                org.slf4j;resolution:=optional,
-                org.slf4j.spi;resolution:=optional,
-                org.slf4j.helpers;resolution:=optional,
-                org.xml.sax,
-                org.xml.sax.helpers,
-                org.eclipse.jetty.annotations;resolution:=optional,
-                *
+            <Import-Package>
+              ${osgi.common.import.packages},
+              javax.mail;version="1.4.0";resolution:=optional,
+              javax.mail.event;version="1.4.0";resolution:=optional,
+              javax.mail.internet;version="1.4.0";resolution:=optional,
+              javax.mail.search;version="1.4.0";resolution:=optional,
+              javax.mail.util;version="1.4.0";resolution:=optional,
+              javax.servlet;version="[$(version;==;${servlet.api.version}),$(version;+;${servlet.api.version}))",
+              javax.servlet.http;version="[$(version;==;${servlet.api.version}),$(version;+;${servlet.api.version}))",
+              javax.transaction;version="1.1.0";resolution:=optional,
+              javax.transaction.xa;version="1.1.0";resolution:=optional,
+              org.objectweb.asm;version="$(version;=;${asm.version})";resolution:=optional,
+              org.osgi.framework,
+              org.osgi.service.cm;version="1.4.0",
+              org.osgi.service.event;version="1.4.0",
+              org.osgi.service.packageadmin,
+              org.osgi.service.startlevel;version="1.0.0",
+              org.osgi.service.url;version="1.0.0",
+              org.osgi.util.tracker;version="1.3.0",
+              org.xml.sax,
+              org.xml.sax.helpers,
+              org.eclipse.jetty.annotations;resolution:=optional,
+              *
             </Import-Package>
             <Require-Capability>
               osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -72,7 +72,7 @@
             <Bundle-Activator>org.eclipse.jetty.osgi.boot.JettyBootstrapActivator</Bundle-Activator>
             <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
             <Import-Package>
-              ${osgi.common.import.packages},
+              ${osgi.slf4j.import.packages},
               javax.mail;version="1.4.0";resolution:=optional,
               javax.mail.event;version="1.4.0";resolution:=optional,
               javax.mail.internet;version="1.4.0";resolution:=optional,

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -74,7 +74,18 @@
             compilation time. -->
             <_nouses>true</_nouses>
             <Import-Package>
-              javax.servlet;version="[3.1,4.1)", javax.servlet.resources;version="[3.1,4.1)", org.osgi.framework, org.osgi.service.cm;version="1.2.0", org.osgi.service.packageadmin, org.osgi.service.startlevel;version="1.0.0", org.osgi.service.url;version="1.0.0", org.osgi.util.tracker;version="1.3.0", org.slf4j;resolution:=optional, org.slf4j.spi;resolution:=optional, org.slf4j.helpers;resolution:=optional, org.xml.sax, org.xml.sax.helpers, *
+              ${osgi.common.import.packages},
+              javax.servlet;version="[3.1,4.1)",
+              javax.servlet.resources;version="[3.1,4.1)",
+              org.osgi.framework,
+              org.osgi.service.cm;version="1.2.0",
+              org.osgi.service.packageadmin,
+              org.osgi.service.startlevel;version="1.0.0",
+              org.osgi.service.url;version="1.0.0",
+              org.osgi.util.tracker;version="1.3.0",
+              org.xml.sax,
+              org.xml.sax.helpers,
+              *
             </Import-Package>
             <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;==;${parsedVersion.osgiVersion}),$(version;+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
           </instructions>

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -74,7 +74,7 @@
             compilation time. -->
             <_nouses>true</_nouses>
             <Import-Package>
-              ${osgi.common.import.packages},
+              ${osgi.slf4j.import.packages},
               javax.servlet;version="[3.1,4.1)",
               javax.servlet.resources;version="[3.1,4.1)",
               org.osgi.framework,

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -66,7 +66,7 @@
             compilation time. -->
             <_nouses>true</_nouses>
             <Import-Package>
-              ${osgi.common.import.packages},
+              ${osgi.slf4j.import.packages},
               javax.servlet;version="[3.1,4.1)",
               javax.servlet.resources;version="[3.1,4.1)",
               org.osgi.framework,

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -66,7 +66,18 @@
             compilation time. -->
             <_nouses>true</_nouses>
             <Import-Package>
-              javax.servlet;version="[3.1,4.1)", javax.servlet.resources;version="[3.1,4.1)", org.osgi.framework, org.osgi.service.cm;version="1.2.0", org.osgi.service.packageadmin, org.osgi.service.startlevel;version="1.0.o", org.osgi.service.url;version="1.0.0", org.osgi.util.tracker;version="1.3.0", org.slf4j;resolution:=optional, org.slf4j.spi;resolution:=optional, org.slf4j.helpers;resolution:=optional, org.xml.sax, org.xml.sax.helpers, *
+              ${osgi.common.import.packages},
+              javax.servlet;version="[3.1,4.1)",
+              javax.servlet.resources;version="[3.1,4.1)",
+              org.osgi.framework,
+              org.osgi.service.cm;version="1.2.0",
+              org.osgi.service.packageadmin,
+              org.osgi.service.startlevel;version="1.0.0",
+              org.osgi.service.url;version="1.0.0",
+              org.osgi.util.tracker;version="1.3.0",
+              org.xml.sax,
+              org.xml.sax.helpers,
+              *
             </Import-Package>
             <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;==;${parsedVersion.osgiVersion}),$(version;+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
           </instructions>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -136,6 +136,18 @@
 
     <!-- Jetty OSGi Deps -->
     <dependency>
+       <groupId>org.slf4j</groupId>
+       <artifactId>slf4j-api</artifactId>
+       <version>1.7.30</version>
+       <scope>test</scope>
+     </dependency>
+    <dependency>
+       <groupId>org.slf4j</groupId>
+       <artifactId>slf4j-simple</artifactId>
+       <version>1.7.30</version>
+       <scope>test</scope>
+     </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
       <version>${project.version}</version>

--- a/jetty-osgi/test-jetty-osgi/src/test/resources/simplelogger.properties
+++ b/jetty-osgi/test-jetty-osgi/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=info

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -23,7 +23,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>javax.transaction.*;version="1.1",*</Import-Package>
+            <Import-Package>${osgi.common.import.packages},javax.transaction.*;version="1.1",*</Import-Package>
             <Require-Capability>
               osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
             </Require-Capability>

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -23,7 +23,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>${osgi.common.import.packages},javax.transaction.*;version="1.1",*</Import-Package>
+            <Import-Package>${osgi.slf4j.import.packages},javax.transaction.*;version="1.1",*</Import-Package>
             <Require-Capability>
               osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
             </Require-Capability>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
     <jetty.perf-helper.version>1.0.6</jetty.perf-helper.version>
     <ant.version>1.10.9</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
+    <!-- OSGI import-package -->
+    <osgi.common.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.common.import.packages>
+
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
     <jetty.surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx4g -Xms2g -Xlog:gc:stderr:time,level,tags</jetty.surefire.argLine>
@@ -742,7 +745,7 @@
               <Bundle-Classpath>.</Bundle-Classpath>
               <Bundle-Copyright>Copyright (c) 2008-2021 Mort Bay Consulting Pty Ltd and others.</Bundle-Copyright>
               <Import-Package>
-                org.slf4j.*;version="[1.7,3.0)",
+                ${osgi.common.import.packages}
                 *
               </Import-Package>
               <_provider-policy><![CDATA[$<range;[===,=+)>]]></_provider-policy>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <ant.version>1.10.9</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
     <!-- OSGI import-package -->
-    <osgi.common.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.common.import.packages>
+    <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.slf4j.import.packages>
 
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>
@@ -745,7 +745,7 @@
               <Bundle-Classpath>.</Bundle-Classpath>
               <Bundle-Copyright>Copyright (c) 2008-2021 Mort Bay Consulting Pty Ltd and others.</Bundle-Copyright>
               <Import-Package>
-                ${osgi.common.import.packages},
+                ${osgi.slf4j.import.packages},
                 *
               </Import-Package>
               <_provider-policy><![CDATA[$<range;[===,=+)>]]></_provider-policy>

--- a/pom.xml
+++ b/pom.xml
@@ -745,7 +745,7 @@
               <Bundle-Classpath>.</Bundle-Classpath>
               <Bundle-Copyright>Copyright (c) 2008-2021 Mort Bay Consulting Pty Ltd and others.</Bundle-Copyright>
               <Import-Package>
-                ${osgi.common.import.packages}
+                ${osgi.common.import.packages},
                 *
               </Import-Package>
               <_provider-policy><![CDATA[$<range;[===,=+)>]]></_provider-policy>


### PR DESCRIPTION
The existing OSGi manifests for org.slf4j in Jetty 10.0.4 are broken.

They list only 1 out of the 4 packages that need import, and a few or our modules did not pull in the updated version range properly.

This PR fixes the top level configuration to include all 4 packages, and uses it in modules that declare their own `Import-Package` specifics.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>