### PR TITLE
Fixed #6375 XmlConfiguration always checks for setter method

### DIFF
--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -375,8 +375,8 @@ public class XmlConfigurationTest
         assertThat(e.getMessage(), containsString("setWrongName"));
         assertEquals("default", tc.getTestString());
     }
+    
     @Test
-
     public void testSetWithWrongNameAndNullProperty() throws Exception
     {
         XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"WrongName\" property=\"prop\" id=\"test\"/></Configure>");

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -364,6 +364,32 @@ public class XmlConfigurationTest
     }
 
     @Test
+    public void testSetWithWrongNameAndProperty() throws Exception
+    {
+        XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"WrongName\" property=\"prop\" id=\"test\"/></Configure>");
+        configuration.getProperties().put("prop", "This is a property value");
+        TestConfiguration tc = new TestConfiguration();
+        tc.setTestString("default");
+
+        NoSuchMethodException e = assertThrows(NoSuchMethodException.class, () -> configuration.configure(tc));
+        assertThat(e.getMessage(), containsString("setWrongName"));
+        assertEquals("default", tc.getTestString());
+    }
+    @Test
+
+    public void testSetWithWrongNameAndNullProperty() throws Exception
+    {
+        XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"WrongName\" property=\"prop\" id=\"test\"/></Configure>");
+        configuration.getProperties().remove("prop");
+        TestConfiguration tc = new TestConfiguration();
+        tc.setTestString("default");
+
+        NoSuchMethodException e = assertThrows(NoSuchMethodException.class, () -> configuration.configure(tc));
+        assertThat(e.getMessage(), containsString("setWrongName"));
+        assertEquals("default", tc.getTestString());
+    }
+
+    @Test
     public void testMeaningfullSetException() throws Exception
     {
         XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"PropertyTest\"><Property name=\"null\"/></Set></Configure>");

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -328,6 +328,30 @@ public class XmlConfigurationTest
     }
 
     @Test
+    public void testSetFieldWithProperty() throws Exception
+    {
+        XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"testField1\" property=\"prop\" id=\"test\"/></Configure>");
+        configuration.getProperties().put("prop", "42");
+        TestConfiguration tc = new TestConfiguration();
+        tc.testField1 = -1;
+        configuration.configure(tc);
+        assertEquals(42, tc.testField1);
+        assertEquals(configuration.getIdMap().get("test"), "42");
+    }
+
+    @Test
+    public void testNotSetFieldWithNullProperty() throws Exception
+    {
+        XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"testField1\" property=\"prop\" id=\"test\"/></Configure>");
+        configuration.getProperties().remove("prop");
+        TestConfiguration tc = new TestConfiguration();
+        tc.testField1 = -1;
+        configuration.configure(tc);
+        assertEquals(-1, tc.testField1);
+        assertEquals(configuration.getIdMap().get("test"), null);
+    }
+
+    @Test
     public void testSetWithNullProperty() throws Exception
     {
         XmlConfiguration configuration = asXmlConfiguration("<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\"><Set name=\"TestString\" property=\"prop\" id=\"test\"/></Configure>");
@@ -386,6 +410,7 @@ public class XmlConfigurationTest
 
         NoSuchMethodException e = assertThrows(NoSuchMethodException.class, () -> configuration.configure(tc));
         assertThat(e.getMessage(), containsString("setWrongName"));
+        assertThat(e.getSuppressed()[0], instanceOf(NoSuchFieldException.class));
         assertEquals("default", tc.getTestString());
     }
 


### PR DESCRIPTION
Fix #6375 by making XmlConfiguration Set handling always check for a matching setter, even if the property attribute is given but not set.

Signed-off-by: Greg Wilkins <gregw@webtide.com>