### PR TITLE
Fix #6400 QueuedThreadPool always interrupts threads in stop

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -295,7 +295,9 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
                 }
             }
             else if (job != NOOP)
+            {
                 LOG.warn("Stopped without executing or closing {}", job);
+            }
         }
 
         if (_budget != null)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -326,6 +326,9 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
                 catch (InterruptedException e)
                 {
                     LOG.ignore(e);
+                    // If the wait was interrupted, then STOP if we are not running
+                    if (!isRunning())
+                        return STOP;
                 }
             }
         }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -150,7 +150,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             try
             {
                 _run.countDown();
-                if (_waitMs > 0 )
+                if (_waitMs > 0)
                     _stopping.await(_waitMs, TimeUnit.MILLISECONDS);
                 else
                     _stopping.await();
@@ -440,7 +440,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
     }
 
     @ParameterizedTest
-    @ValueSource(ints={500,0})
+    @ValueSource(ints = {500, 0})
     public void testLifeCycleStop(int stopTimeout) throws Exception
     {
         QueuedThreadPool tp = new QueuedThreadPool();

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -440,7 +440,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {500, 0})
+    @ValueSource(ints = {800, 0})
     public void testLifeCycleStop(int stopTimeout) throws Exception
     {
         QueuedThreadPool tp = new QueuedThreadPool();
@@ -458,7 +458,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
 
         // Run job0 and job1
         RunningJob job0 = new RunningJob();
-        RunningJob job1 = new RunningJob(stopTimeout / 2);
+        RunningJob job1 = new RunningJob(200);
         tp.execute(job0);
         tp.execute(job1);
 
@@ -484,8 +484,9 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         assertTrue(job0._stopped.await(200, TimeUnit.MILLISECONDS));
         assertTrue(job1._stopped.await(200, TimeUnit.MILLISECONDS));
 
-        // first job stopped by interrupt, second job stopped naturally if there was a timeout
+        // first job stopped by interrupt
         assertTrue(job0.wasInterrupted());
+        // second job stops naturally if there was a timeout, else it is interrupted
         assertEquals(stopTimeout == 0, job1.wasInterrupted());
 
         // Verify RunningJobs in the queue have not been run

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.util.log.Log;
@@ -33,12 +34,15 @@ import org.eclipse.jetty.util.log.StacklessLogging;
 import org.eclipse.jetty.util.thread.ThreadPool.SizedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -110,21 +114,34 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         final CountDownLatch _stopped = new CountDownLatch(1);
         final String _name;
         final boolean _fail;
+        final int _waitMs;
+        final AtomicBoolean _interrupted = new AtomicBoolean();
 
         RunningJob()
         {
-            this(null, false);
+            this(null, false, -1);
         }
 
         public RunningJob(String name)
         {
-            this(name, false);
+            this(name, false, -1);
+        }
+
+        public RunningJob(int waitMs)
+        {
+            this(null, false, waitMs);
         }
 
         public RunningJob(String name, boolean fail)
         {
+            this(name, fail, -1);
+        }
+
+        public RunningJob(String name, boolean fail, int waitMs)
+        {
             _name = name;
             _fail = fail;
+            _waitMs = waitMs;
         }
 
         @Override
@@ -133,9 +150,16 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             try
             {
                 _run.countDown();
-                _stopping.await();
+                if (_waitMs > 0 )
+                    _stopping.await(_waitMs, TimeUnit.MILLISECONDS);
+                else
+                    _stopping.await();
                 if (_fail)
                     throw new IllegalStateException("Testing!");
+            }
+            catch (InterruptedException e)
+            {
+                _interrupted.set(true);
             }
             catch (IllegalStateException e)
             {
@@ -158,6 +182,11 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
                 _stopping.countDown();
             if (!_stopped.await(10, TimeUnit.SECONDS))
                 throw new IllegalStateException();
+        }
+
+        public boolean wasInterrupted()
+        {
+            return _interrupted.get();
         }
 
         @Override
@@ -410,15 +439,16 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         tp.stop();
     }
 
-    @Test
-    public void testLifeCycleStop() throws Exception
+    @ParameterizedTest
+    @ValueSource(ints={500,0})
+    public void testLifeCycleStop(int stopTimeout) throws Exception
     {
         QueuedThreadPool tp = new QueuedThreadPool();
         tp.setName("TestPool");
         tp.setMinThreads(1);
         tp.setMaxThreads(2);
         tp.setIdleTimeout(900);
-        tp.setStopTimeout(500);
+        tp.setStopTimeout(stopTimeout);
         tp.setThreadsPriority(Thread.NORM_PRIORITY - 1);
         tp.start();
 
@@ -428,7 +458,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
 
         // Run job0 and job1
         RunningJob job0 = new RunningJob();
-        RunningJob job1 = new RunningJob();
+        RunningJob job1 = new RunningJob(stopTimeout / 2);
         tp.execute(job0);
         tp.execute(job1);
 
@@ -450,9 +480,13 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         tp.stop();
         assertThat(tp.getQueue().size(), is(0));
 
-        // First 2 jobs closed by InterruptedException
+        // First 2 jobs are stopped
         assertTrue(job0._stopped.await(200, TimeUnit.MILLISECONDS));
         assertTrue(job1._stopped.await(200, TimeUnit.MILLISECONDS));
+
+        // first job stopped by interrupt, second job stopped naturally if there was a timeout
+        assertTrue(job0.wasInterrupted());
+        assertEquals(stopTimeout == 0, job1.wasInterrupted());
 
         // Verify RunningJobs in the queue have not been run
         assertFalse(job2._run.await(200, TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Fixes #6400 Even if there is no timeout, always interrupt pool threads to attempt to stop them.