### PR TITLE
Issue #6407 - Fix URI validation for WebSocket ClientUpgradeRequest

### DIFF
--- a/jetty-websocket/websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -88,25 +88,17 @@ public abstract class CoreClientUpgradeRequest extends HttpRequest implements Re
 
         // Validate websocket URI
         if (!requestURI.isAbsolute())
-        {
             throw new IllegalArgumentException("WebSocket URI must be absolute");
-        }
 
         if (StringUtil.isBlank(requestURI.getScheme()))
-        {
             throw new IllegalArgumentException("WebSocket URI must include a scheme");
-        }
 
         String scheme = requestURI.getScheme();
         if (!HttpScheme.WS.is(scheme) && !HttpScheme.WSS.is(scheme))
-        {
             throw new IllegalArgumentException("WebSocket URI scheme only supports [ws] and [wss], not [" + scheme + "]");
-        }
 
         if (requestURI.getHost() == null)
-        {
             throw new IllegalArgumentException("Invalid WebSocket URI: host not present");
-        }
 
         this.wsClient = webSocketClient;
         this.futureCoreSession = new CompletableFuture<>();
@@ -437,7 +429,7 @@ public abstract class CoreClientUpgradeRequest extends HttpRequest implements Re
         Negotiated negotiated = new Negotiated(
             request.getURI(),
             negotiatedSubProtocol,
-            HttpScheme.HTTPS.is(request.getScheme()), // TODO better than this?
+            HttpClient.isSchemeSecure(request.getScheme()),
             extensionStack,
             WebSocketConstants.SPEC_VERSION_STRING);
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/Negotiated.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/Negotiated.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.UrlEncoded;
@@ -134,24 +135,14 @@ public class Negotiated
             String httpScheme = uri.getScheme();
             if (httpScheme == null)
                 return uri;
-
-            if ("ws".equalsIgnoreCase(httpScheme) || "wss".equalsIgnoreCase(httpScheme))
-            {
-                // keep as-is
+            if (HttpScheme.WS.is(httpScheme) || HttpScheme.WSS.is(httpScheme))
                 return uri;
-            }
 
-            if ("http".equalsIgnoreCase(httpScheme))
-            {
-                // convert to ws
-                return new URI("ws" + uri.toString().substring(httpScheme.length()));
-            }
-
-            if ("https".equalsIgnoreCase(httpScheme))
-            {
-                // convert to wss
-                return new URI("wss" + uri.toString().substring(httpScheme.length()));
-            }
+            String afterScheme = uri.toString().substring(httpScheme.length());
+            if (HttpScheme.HTTP.is(httpScheme))
+                return new URI("ws" + afterScheme);
+            if (HttpScheme.HTTPS.is(httpScheme))
+                return new URI("wss" + afterScheme);
 
             throw new URISyntaxException(uri.toString(), "Unrecognized HTTP scheme");
         }

--- a/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/util/WSURI.java
+++ b/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/util/WSURI.java
@@ -103,6 +103,9 @@ public final class WSURI
     {
         Objects.requireNonNull(inputUri, "Input URI must not be null");
         String httpScheme = inputUri.getScheme();
+        if (httpScheme == null)
+            throw new URISyntaxException(inputUri.toString(), "Undefined HTTP scheme");
+
         if ("ws".equalsIgnoreCase(httpScheme) || "wss".equalsIgnoreCase(httpScheme))
             return inputUri;
 

--- a/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/util/WSURI.java
+++ b/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/util/WSURI.java
@@ -104,22 +104,13 @@ public final class WSURI
         Objects.requireNonNull(inputUri, "Input URI must not be null");
         String httpScheme = inputUri.getScheme();
         if ("ws".equalsIgnoreCase(httpScheme) || "wss".equalsIgnoreCase(httpScheme))
-        {
-            // keep as-is
             return inputUri;
-        }
 
+        String afterScheme = inputUri.toString().substring(httpScheme.length());
         if ("http".equalsIgnoreCase(httpScheme))
-        {
-            // convert to ws
-            return new URI("ws" + inputUri.toString().substring(httpScheme.length()));
-        }
-
+            return new URI("ws" + afterScheme);
         if ("https".equalsIgnoreCase(httpScheme))
-        {
-            // convert to wss
-            return new URI("wss" + inputUri.toString().substring(httpScheme.length()));
-        }
+            return new URI("wss" + afterScheme);
 
         throw new URISyntaxException(inputUri.toString(), "Unrecognized HTTP scheme");
     }

--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -50,11 +50,12 @@ public final class ClientUpgradeRequest implements UpgradeRequest
         this.host = null;
     }
 
+    @Deprecated
     public ClientUpgradeRequest(URI uri)
     {
         this.requestURI = uri;
         String scheme = uri.getScheme();
-        if (!HttpScheme.WS.is(scheme) || !HttpScheme.WSS.is(scheme))
+        if (!HttpScheme.WS.is(scheme) && !HttpScheme.WSS.is(scheme))
             throw new IllegalArgumentException("URI scheme must be 'ws' or 'wss'");
         this.host = this.requestURI.getHost();
     }

--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -51,8 +51,7 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     }
 
     /**
-     * @deprecated use the no-args constructor instead.
-     * @see ClientUpgradeRequest#ClientUpgradeRequest()
+     * @deprecated use {@link #ClientUpgradeRequest()} instead.
      */
     @Deprecated
     public ClientUpgradeRequest(URI uri)

--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -50,6 +50,10 @@ public final class ClientUpgradeRequest implements UpgradeRequest
         this.host = null;
     }
 
+    /**
+     * @deprecated use the no-args constructor instead.
+     * @see ClientUpgradeRequest#ClientUpgradeRequest()
+     */
     @Deprecated
     public ClientUpgradeRequest(URI uri)
     {


### PR DESCRIPTION
## Closes #6407

- Fix logic for URI validation in the constructor of `ClientUpgradeRequest`.
- Deprecate that constructor as the `URI` is not used and the validation is repeated after calling the `WebSocketClient.connect()` method.