### PR TITLE
Issue #6383 - Fix flaky test FileBufferedResponseHandlerTest

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -203,7 +203,7 @@ public class BufferedResponseHandler extends HandlerWrapper
     {
     }
 
-    private class ArrayBufferedInterceptor implements BufferedInterceptor
+    protected class ArrayBufferedInterceptor implements BufferedInterceptor
     {
         private final Interceptor _next;
         private final HttpChannel _channel;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -203,7 +203,7 @@ public class BufferedResponseHandler extends HandlerWrapper
     {
     }
 
-    protected class ArrayBufferedInterceptor implements BufferedInterceptor
+    class ArrayBufferedInterceptor implements BufferedInterceptor
     {
         private final Interceptor _next;
         private final HttpChannel _channel;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandler.java
@@ -71,7 +71,7 @@ public class FileBufferedResponseHandler extends BufferedResponseHandler
         return new FileBufferedInterceptor(httpChannel, interceptor);
     }
 
-    protected class FileBufferedInterceptor implements BufferedResponseHandler.BufferedInterceptor
+    class FileBufferedInterceptor implements BufferedResponseHandler.BufferedInterceptor
     {
         private static final int MAX_MAPPED_BUFFER_SIZE = Integer.MAX_VALUE / 2;
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandler.java
@@ -71,7 +71,7 @@ public class FileBufferedResponseHandler extends BufferedResponseHandler
         return new FileBufferedInterceptor(httpChannel, interceptor);
     }
 
-    private class FileBufferedInterceptor implements BufferedResponseHandler.BufferedInterceptor
+    protected class FileBufferedInterceptor implements BufferedResponseHandler.BufferedInterceptor
     {
         private static final int MAX_MAPPED_BUFFER_SIZE = Integer.MAX_VALUE / 2;
 
@@ -100,7 +100,7 @@ public class FileBufferedResponseHandler extends BufferedResponseHandler
             BufferedInterceptor.super.resetBuffer();
         }
 
-        private void dispose()
+        protected void dispose()
         {
             IO.close(_fileOutputStream);
             _fileOutputStream = null;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandlerTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.server;
+package org.eclipse.jetty.server.handler;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,9 +35,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.eclipse.jetty.server.handler.FileBufferedResponseHandler;
-import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.HttpOutput;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.Callback;


### PR DESCRIPTION
## Closes #6383

Make both `ArrayBufferedInterceptor` and `FileBufferedInterceptor` protected classes so that I can override the `FileBufferedInterceptor.dispose()` method to know the file has actually been deleted when testing.