### PR TITLE
Bump (test scoped) net.minidev:json-smart version from 2.3 to 2.4.7

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.3</version>
+      <version>2.4.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
… due to security alert. - https://github.com/advisories/GHSA-v528-7hrm-frqp

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>