### PR TITLE
Issue #6418 jetty-webapp incorrect osgi manifest for serviceloader

### DIFF
--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -54,8 +54,11 @@
         <configuration>
           <instructions>
             <Require-Capability>
-              osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.webapp.Configuration)";cardinality:=multiple
+              osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.webapp.Configuration)";cardinality:=multiple, osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
             </Require-Capability>
+            <Provide-Capability>
+              osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.webapp.Configuration
+            </Provide-Capability>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Closes #6418

`jetty-webapp/pom.xml` is missing the osgi manifest headers that expose its` META-INF/services` (to itself)