### PR TITLE
Issue #6451 - Request.getServletPath not following spec 3.5

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1386,7 +1386,11 @@ public class Request implements HttpServletRequest
         // INCLUDE dispatch, in which case this method returns the servletPath of the source servlet,
         // which we recover from the IncludeAttributes wrapper.
         ServletPathMapping mapping = findServletPathMapping();
-        return mapping == null ? "" : mapping.getServletPath();
+        // per Servlet spec 3.5, mapping servlet paths of "/*", "/", and "" should return ""
+        if ((mapping == null) || mapping.getServletPath() == null || (mapping.getServletPath().equals("")) || mapping.getServletPath().equals("/") || (mapping.getServletPath().equals("/*")))
+            return "";
+        else
+            return mapping.getServletPath();
     }
 
     public ServletResponse getServletResponse()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1386,11 +1386,7 @@ public class Request implements HttpServletRequest
         // INCLUDE dispatch, in which case this method returns the servletPath of the source servlet,
         // which we recover from the IncludeAttributes wrapper.
         ServletPathMapping mapping = findServletPathMapping();
-        // per Servlet spec 3.5, mapping servlet paths of "/*", "/", and "" should return ""
-        if ((mapping == null) || mapping.getServletPath() == null || (mapping.getServletPath().equals("")) || mapping.getServletPath().equals("/") || (mapping.getServletPath().equals("/*")))
-            return "";
-        else
-            return mapping.getServletPath();
+        return mapping == null ? "" : mapping.getServletPath();
     }
 
     public ServletResponse getServletResponse()

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -1522,8 +1522,10 @@ public class ServletHandler extends ScopedHandler
                 switch (pathSpec.getGroup())
                 {
                     case EXACT:
-                    case ROOT:
                         _servletPathMapping = new ServletPathMapping(_pathSpec, _servletHolder.getName(), _pathSpec.getPrefix());
+                        break;
+                    case ROOT:
+                        _servletPathMapping = new ServletPathMapping(_pathSpec, _servletHolder.getName(), "/");
                         break;
                     default:
                         _servletPathMapping = null;

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -728,8 +728,8 @@ public class ServletContextHandlerTest
      * Address spec "3.5. Request Path Elements" with respect to Servlet Path.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"/*", "/", ""})
-    public void testGetServletPathEmpty(String inputServletPath) throws Exception
+    @ValueSource(strings = {"/*", ""})
+    public void testGetServletPathEmpty(String pathSpec) throws Exception
     {
         ServletContextHandler contextHandler = new ServletContextHandler();
         contextHandler.setContextPath("");
@@ -742,7 +742,7 @@ public class ServletContextHandlerTest
                 resp.setCharacterEncoding("utf-8");
                 resp.getWriter().printf("getServletPath()=[%s]", req.getServletPath());
             }
-        }), inputServletPath);
+        }), pathSpec);
         _server.setHandler(contextHandler);
         _server.start();
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -724,6 +724,39 @@ public class ServletContextHandlerTest
         assertEquals("getContextPath()=[]", response.getContent(), "response content");
     }
 
+    /**
+     * Address spec "3.5. Request Path Elements" with respect to Servlet Path.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/*", "/", ""})
+    public void testGetServletPathEmpty(String inputServletPath) throws Exception
+    {
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        contextHandler.setContextPath("");
+        contextHandler.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setContentType("text/plain");
+                resp.setCharacterEncoding("utf-8");
+                resp.getWriter().printf("getServletPath()=[%s]", req.getServletPath());
+            }
+        }), inputServletPath);
+        _server.setHandler(contextHandler);
+        _server.start();
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET / HTTP/1.1\r\n");
+        rawRequest.append("Host: local\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertEquals(200, response.getStatus(), "response status");
+        assertEquals("getServletPath()=[]", response.getContent(), "response content");
+    }
+
     @Test
     public void testGetSetSessionTimeout() throws Exception
     {


### PR DESCRIPTION
The change in Jetty 10 for supporting ServletPathMappings caused a regression in behavior for the `HttpServletRequest.getServletPath()` method.

This adds a testcase and introduces the special case logic that Servlet spec 3.5 specifies.

Link to section 3.5 in Servlet Spec 5.0 (couldn't find the 4.0 spec doc online)

https://github.com/eclipse-ee4j/servlet-api/blob/5.0.0-RELEASE/spec/src/main/asciidoc/servlet-spec-body.adoc#35-request-path-elements

> Servlet Path: The path section that directly corresponds to the mapping which activated this request. This path starts with a `"/"` character except in the case where the request is matched with the `"/*"` or `""` pattern, in which case it is an empty string.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>