### PR TITLE
Fixes #6382 - HttpClient TimeoutException message reports transient v…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -327,7 +327,7 @@ public abstract class HttpConnection implements IConnection, Attachable
             if (exchange != null)
             {
                 HttpRequest request = exchange.getRequest();
-                request.abort(new TimeoutException("Total timeout " + request.getTimeout() + " ms elapsed"));
+                request.abort(new TimeoutException("Total timeout " + request.getConversation().getTimeout() + " ms elapsed"));
             }
             return false;
         }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -544,7 +544,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         protected boolean onExpired(HttpExchange exchange)
         {
             HttpRequest request = exchange.getRequest();
-            request.abort(new TimeoutException("Total timeout " + request.getTimeout() + " ms elapsed"));
+            request.abort(new TimeoutException("Total timeout " + request.getConversation().getTimeout() + " ms elapsed"));
             return false;
         }
     }

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
@@ -506,14 +506,16 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
             }
         });
 
-        assertThrows(TimeoutException.class, () ->
+        long timeout = 1000;
+        TimeoutException timeoutException = assertThrows(TimeoutException.class, () ->
         {
             client.setMaxRedirects(-1);
             client.newRequest("localhost", connector.getLocalPort())
                 .scheme(scenario.getScheme())
-                .timeout(1, TimeUnit.SECONDS)
+                .timeout(timeout, TimeUnit.MILLISECONDS)
                 .send();
         });
+        assertThat(timeoutException.getMessage(), Matchers.containsString(String.valueOf(timeout)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
…alues.

Now using consistently HttpConversation.getTimeout() to report the accurate value.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 734d3b672c32a2c9527855885914e87ba721310c)