### PR TITLE
disable MaxDuration mechanism in testConnectionMaxUsage

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -562,6 +562,7 @@ public class ConnectionPoolTest
         {
             AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(destination);
             connectionPool.setMaxUsageCount(maxUsageCount);
+            connectionPool.setMaxDuration(0); // Disable max duration expiry as it may expire the connection between the 1st and 2nd request.
             return connectionPool;
         });
         client.setMaxConnectionsPerDestination(1);


### PR DESCRIPTION
The MaxDuration mechanism is fundamentally incompatible with what this test asserts, so let's just disable it for this test.

Fixes  #6455 in branch 9.4.x.