### PR TITLE
9.4.x: Wait for handshake to be done before closing the client socket

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ssl/SslBytesServerTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ssl/SslBytesServerTest.java
@@ -334,7 +334,7 @@ public class SslBytesServerTest extends SslBytesTest
 
         final SSLSocket client2 = newClient(proxy);
 
-        threadPool.submit(() ->
+        Future<Object> handshakeFuture = threadPool.submit(() ->
         {
             client2.startHandshake();
             return null;
@@ -366,6 +366,9 @@ public class SslBytesServerTest extends SslBytesTest
         // Client Done
         TLSRecord doneRecord = proxy.readFromClient();
         assertNotNull(doneRecord);
+
+        // Wait for socket to be done with handshake
+        handshakeFuture.get(5, TimeUnit.SECONDS);
         // Close
         client2.close();
         TLSRecord closeRecord = proxy.readFromClient();


### PR DESCRIPTION
Fixes #6443 in branch 9.4.x.