### PR TITLE
Jetty 9.4.x #6473 normalize only once

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyWebAppContext.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyWebAppContext.java
@@ -39,7 +39,6 @@ import org.eclipse.jetty.servlet.FilterMapping;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletMapping;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.resource.Resource;
@@ -451,16 +450,12 @@ public class JettyWebAppContext extends WebAppContext
         // If no regular resource exists check for access to /WEB-INF/lib or /WEB-INF/classes
         if ((resource == null || !resource.exists()) && uriInContext != null && _classes != null)
         {
-            String uri = URIUtil.canonicalPath(uriInContext);
-            if (uri == null)
-                return null;
-
             try
             {
                 // Replace /WEB-INF/classes with candidates for the classpath
-                if (uri.startsWith(WEB_INF_CLASSES_PREFIX))
+                if (uriInContext.startsWith(WEB_INF_CLASSES_PREFIX))
                 {
-                    if (uri.equalsIgnoreCase(WEB_INF_CLASSES_PREFIX) || uri.equalsIgnoreCase(WEB_INF_CLASSES_PREFIX + "/"))
+                    if (uriInContext.equalsIgnoreCase(WEB_INF_CLASSES_PREFIX) || uriInContext.equalsIgnoreCase(WEB_INF_CLASSES_PREFIX + "/"))
                     {
                         //exact match for a WEB-INF/classes, so preferentially return the resource matching the web-inf classes
                         //rather than the test classes
@@ -476,7 +471,7 @@ public class JettyWebAppContext extends WebAppContext
                         int i = 0;
                         while (res == null && (i < _webInfClasses.size()))
                         {
-                            String newPath = StringUtil.replace(uri, WEB_INF_CLASSES_PREFIX, _webInfClasses.get(i).getPath());
+                            String newPath = StringUtil.replace(uriInContext, WEB_INF_CLASSES_PREFIX, _webInfClasses.get(i).getPath());
                             res = Resource.newResource(newPath);
                             if (!res.exists())
                             {
@@ -487,11 +482,11 @@ public class JettyWebAppContext extends WebAppContext
                         return res;
                     }
                 }
-                else if (uri.startsWith(WEB_INF_LIB_PREFIX))
+                else if (uriInContext.startsWith(WEB_INF_LIB_PREFIX))
                 {
                     // Return the real jar file for all accesses to
                     // /WEB-INF/lib/*.jar
-                    String jarName = StringUtil.strip(uri, WEB_INF_LIB_PREFIX);
+                    String jarName = StringUtil.strip(uriInContext, WEB_INF_LIB_PREFIX);
                     if (jarName.startsWith("/") || jarName.startsWith("\\"))
                         jarName = jarName.substring(1);
                     if (jarName.length() == 0)

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectUtil.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectUtil.java
@@ -45,14 +45,14 @@ public final class RedirectUtil
             if (location.startsWith("/"))
             {
                 // absolute in context
-                location = URIUtil.canonicalEncodedPath(location);
+                location = URIUtil.canonicalURI(location);
             }
             else
             {
                 // relative to request
                 String path = request.getRequestURI();
                 String parent = (path.endsWith("/")) ? path : URIUtil.parentPath(path);
-                location = URIUtil.canonicalPath(URIUtil.addEncodedPaths(parent, location));
+                location = URIUtil.canonicalURI(URIUtil.addEncodedPaths(parent, location));
                 if (!location.startsWith("/"))
                     url.append('/');
             }

--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
@@ -18,8 +18,8 @@
 
 package org.eclipse.jetty.rewrite.handler;
 
+import org.eclipse.jetty.http.HttpURI;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,7 +65,7 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
     {
         _rule.setCode("405");
         _rule.setReason("foo");
-        _request.setURIPathQuery("/%00/");
+        _request.setURIPathQuery("/%01/");
 
         String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
 
@@ -78,20 +78,8 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
     {
         _rule.setCode("405");
         _rule.setReason("foo");
-        _request.setURIPathQuery("/jsp/bean1.jsp%00");
 
-        String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
-
-        assertEquals(405, _response.getStatus());
-        assertEquals("foo", _response.getReason());
-    }
-
-    @Test
-    public void testInvalidShamrock() throws Exception
-    {
-        _rule.setCode("405");
-        _rule.setReason("foo");
-        _request.setURIPathQuery("/jsp/shamrock-%00%E2%98%98.jsp");
+        _request.setHttpURI(new HttpURI("/jsp/bean1.jsp\000"));
 
         String result = _rule.matchAndApply(_request.getRequestURI(), _request, _response);
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -547,14 +547,14 @@ public class Response implements HttpServletResponse
             if (location.startsWith("/"))
             {
                 // absolute in context
-                location = URIUtil.canonicalEncodedPath(location);
+                location = URIUtil.canonicalURI(location);
             }
             else
             {
                 // relative to request
                 String path = _channel.getRequest().getRequestURI();
                 String parent = (path.endsWith("/")) ? path : URIUtil.parentPath(path);
-                location = URIUtil.canonicalEncodedPath(URIUtil.addEncodedPaths(parent, location));
+                location = URIUtil.canonicalURI(URIUtil.addEncodedPaths(parent, location));
                 if (location != null && !location.startsWith("/"))
                     buf.append('/');
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -177,7 +177,6 @@ public class ResourceHandler extends HandlerWrapper implements ResourceFactory, 
 
             if (_baseResource != null)
             {
-                path = URIUtil.canonicalPath(path);
                 r = _baseResource.addPath(path);
 
                 if (r != null && r.isAlias() && (_context == null || !_context.checkAlias(path, r)))

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -829,12 +829,6 @@ public class HttpConnectionTest
         Log.getLogger(HttpParser.class).info("badMessage: bad encoding expected ...");
         String response;
 
-        response = connector.getResponse("GET /foo/bar%c0%00 HTTP/1.1\r\n" +
-            "Host: localhost\r\n" +
-            "Connection: close\r\n" +
-            "\r\n");
-        checkContains(response, 0, "HTTP/1.1 200"); //now fallback to iso-8859-1
-
         response = connector.getResponse("GET /bad/utf8%c1 HTTP/1.1\r\n" +
             "Host: localhost\r\n" +
             "Connection: close\r\n" +

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -223,24 +225,32 @@ public class ContextHandlerGetResourceTest
     }
 
     @Test
-    public void testNormalize() throws Exception
+    public void testDoesNotExistResource() throws Exception
     {
-        final String path = "/down/.././index.html";
-        Resource resource = context.getResource(path);
-        assertEquals("index.html", resource.getFile().getName());
-        assertEquals(docroot, resource.getFile().getParentFile());
-        assertTrue(resource.exists());
-
-        URL url = context.getServletContext().getResource(path);
-        assertEquals(docroot, new File(url.toURI()).getParentFile());
+        Resource resource = context.getResource("/doesNotExist.html");
+        assertNotNull(resource);
+        assertFalse(resource.exists());
     }
 
     @Test
-    public void testTooNormal() throws Exception
+    public void testAlias() throws Exception
     {
-        final String path = "/down/.././../";
-        Resource resource = context.getResource(path);
+        Resource resource = context.getResource("/./index.html");
+        assertNotNull(resource);
+        assertFalse(resource.isAlias());
+
+        resource = context.getResource("/down/../index.html");
+        assertNotNull(resource);
+        assertFalse(resource.isAlias());
+
+        resource = context.getResource("//index.html");
         assertNull(resource);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/down/.././../", "/../down/"})
+    public void testNormalize(String path) throws Exception
+    {
         URL url = context.getServletContext().getResource(path);
         assertNull(url);
     }

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -19,7 +19,6 @@
 package org.eclipse.jetty.servlet;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -424,8 +423,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             }
             else
             {
-                URL u = _servletContext.getResource(pathInContext);
-                r = _contextHandler.newResource(u);
+                return null;
             }
 
             if (LOG.isDebugEnabled())

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/RequestURITest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/RequestURITest.java
@@ -60,11 +60,13 @@ public class RequestURITest
         ret.add(Arguments.of("/hello?type=wo&rld", "/hello", "type=wo&rld"));
         ret.add(Arguments.of("/hello?type=wo%20rld", "/hello", "type=wo%20rld"));
         ret.add(Arguments.of("/hello?type=wo+rld", "/hello", "type=wo+rld"));
+        ret.add(Arguments.of("/hello?type=/a/../b/", "/hello", "type=/a/../b/"));
         ret.add(Arguments.of("/It%27s%20me%21", "/It%27s%20me%21", null));
         // try some slash encoding (with case preservation tests)
         ret.add(Arguments.of("/hello%2fworld", "/hello%2fworld", null));
         ret.add(Arguments.of("/hello%2Fworld", "/hello%2Fworld", null));
         ret.add(Arguments.of("/%2f%2Fhello%2Fworld", "/%2f%2Fhello%2Fworld", null));
+
         // try some "?" encoding (should not see as query string)
         ret.add(Arguments.of("/hello%3Fworld", "/hello%3Fworld", null));
         // try some strange encodings (should preserve them)
@@ -73,7 +75,7 @@ public class RequestURITest
         ret.add(Arguments.of("/hello-euro-%E2%82%AC", "/hello-euro-%E2%82%AC", null));
         ret.add(Arguments.of("/hello-euro?%E2%82%AC", "/hello-euro", "%E2%82%AC"));
         // test the ascii control characters (just for completeness)
-        for (int i = 0x0; i < 0x1f; i++)
+        for (int i = 0x1; i < 0x1f; i++)
         {
             String raw = String.format("/hello%%%02Xworld", i);
             ret.add(Arguments.of(raw, raw, null));

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DataRateLimitedServlet.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DataRateLimitedServlet.java
@@ -39,7 +39,7 @@ import org.eclipse.jetty.server.HttpOutput;
 import org.eclipse.jetty.util.ProcessorUtils;
 
 /**
- * A servlet that uses the Servlet 3.1 asynchronous IO API to server
+ * A demonstration servlet that uses the Servlet 3.1 asynchronous IO API to server
  * static content at a limited data rate.
  * <p>
  * Two implementations are supported: <ul>
@@ -47,8 +47,7 @@ import org.eclipse.jetty.util.ProcessorUtils;
  * APIs, but produces more garbage due to the byte[] nature of the API.
  * <li>the <code>JettyDataStream</code> impl uses a Jetty API to write a ByteBuffer
  * and thus allow the efficient use of file mapped buffers without any
- * temporary buffer copies (I did tell the JSR that this was a good idea to
- * have in the standard!).
+ * temporary buffer copies.
  * </ul>
  * <p>
  * The data rate is controlled by setting init parameters:
@@ -58,7 +57,9 @@ import org.eclipse.jetty.util.ProcessorUtils;
  * <dt>pool</dt><dd>The size of the thread pool used to service the writes (defaults to available processors)</dd>
  * </dl>
  * Thus if buffersize = 1024 and pause = 100, the data rate will be limited to 10KB per second.
+ * @deprecated this is intended as a demonstration and not production quality.
  */
+@Deprecated
 public class DataRateLimitedServlet extends HttpServlet
 {
     private static final long serialVersionUID = -4771757707068097025L;

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PutFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PutFilter.java
@@ -62,6 +62,7 @@ import org.eclipse.jetty.util.URIUtil;
  * <li><b>putAtomic</b> - boolean, if true PUT files are written to a temp location and moved into place.
  * </ul>
  */
+@Deprecated
 public class PutFilter implements Filter
 {
     public static final String __PUT = "PUT";
@@ -85,7 +86,8 @@ public class PutFilter implements Filter
 
         _tmpdir = (File)_context.getAttribute("javax.servlet.context.tempdir");
 
-        if (_context.getRealPath("/") == null)
+        String realPath = _context.getRealPath("/");
+        if (realPath == null)
             throw new UnavailableException("Packed war");
 
         String b = config.getInitParameter("baseURI");
@@ -95,7 +97,7 @@ public class PutFilter implements Filter
         }
         else
         {
-            File base = new File(_context.getRealPath("/"));
+            File base = new File(realPath);
             _baseURI = base.toURI().toString();
         }
 
@@ -289,7 +291,7 @@ public class PutFilter implements Filter
     public void handleMove(HttpServletRequest request, HttpServletResponse response, String pathInContext, File file)
         throws ServletException, IOException, URISyntaxException
     {
-        String newPath = URIUtil.canonicalEncodedPath(request.getHeader("new-uri"));
+        String newPath = URIUtil.canonicalURI(request.getHeader("new-uri"));
         if (newPath == null)
         {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -475,7 +475,8 @@ public class URIUtil
                             char u = path.charAt(i + 1);
                             if (u == 'u')
                             {
-                                // In Jetty-10 UTF16 encoding is only supported with UriCompliance.Violation.UTF16_ENCODINGS.                            // This is wrong. This is a codepoint not a char
+                                // In Jetty-10 UTF16 encoding is only supported with UriCompliance.Violation.UTF16_ENCODINGS.
+                                // This is wrong. This is a codepoint not a char
                                 builder.append((char)(0xffff & TypeUtil.parseInt(path, i + 2, 4, 16)));
                                 i += 5;
                             }
@@ -780,143 +781,128 @@ public class URIUtil
     }
 
     /**
-     * Convert an encoded path to a canonical form.
+     * Convert a partial URI to a canonical form.
      * <p>
-     * All instances of "." and ".." are factored out.
+     * All segments of "." and ".." are factored out.
      * Null is returned if the path tries to .. above its root.
      * </p>
      *
-     * @param path the path to convert, decoded, with path separators '/' and no queries.
+     * @param uri the encoded URI from the path onwards, which may contain query strings and/or fragments
      * @return the canonical path, or null if path traversal above root.
+     * @see #canonicalPath(String)
+     * @see #canonicalURI(String)
      */
-    public static String canonicalPath(String path)
+    public static String canonicalURI(String uri)
     {
-        // See https://tools.ietf.org/html/rfc3986#section-5.2.4
+        if (uri == null || uri.isEmpty())
+            return uri;
 
-        if (path == null || path.isEmpty())
-            return path;
-
-        int end = path.length();
+        boolean slash = true;
+        int end = uri.length();
         int i = 0;
-        int dots = 0;
 
+        // Initially just loop looking if we may need to normalize
         loop: while (i < end)
         {
-            char c = path.charAt(i);
+            char c = uri.charAt(i);
             switch (c)
             {
                 case '/':
-                    dots = 0;
+                    slash = true;
                     break;
 
                 case '.':
-                    if (dots == 0)
-                    {
-                        dots = 1;
+                    if (slash)
                         break loop;
-                    }
-                    dots = -1;
+                    slash = false;
                     break;
 
+                case '?':
+                case '#':
+                    // Nothing to normalize so return original path
+                    return uri;
+
                 default:
-                    dots = -1;
+                    slash = false;
             }
 
             i++;
         }
 
+        // Nothing to normalize so return original path
         if (i == end)
-            return path;
+            return uri;
 
-        StringBuilder canonical = new StringBuilder(path.length());
-        canonical.append(path, 0, i);
+        // We probably need to normalize, so copy to path so far into builder
+        StringBuilder canonical = new StringBuilder(uri.length());
+        canonical.append(uri, 0, i);
 
+        // Loop looking for single and double dot segments
+        int dots = 1;
         i++;
-        while (i <= end)
+        loop : while (i < end)
         {
-            char c = i < end ? path.charAt(i) : '\0';
+            char c = uri.charAt(i);
             switch (c)
             {
-                case '\0':
-                    if (dots == 2)
-                    {
-                        if (canonical.length() < 2)
-                            return null;
-                        canonical.setLength(canonical.length() - 1);
-                        canonical.setLength(canonical.lastIndexOf("/") + 1);
-                    }
-                    break;
-
                 case '/':
-                    switch (dots)
-                    {
-                        case 1:
-                            break;
-
-                        case 2:
-                            if (canonical.length() < 2)
-                                return null;
-                            canonical.setLength(canonical.length() - 1);
-                            canonical.setLength(canonical.lastIndexOf("/") + 1);
-                            break;
-
-                        default:
-                            canonical.append(c);
-                    }
+                    if (doDotsSlash(canonical, dots))
+                        return null;
+                    slash = true;
                     dots = 0;
                     break;
 
+                case '?':
+                case '#':
+                    // finish normalization at a query
+                    break loop;
+
                 case '.':
-                    switch (dots)
-                    {
-                        case 0:
-                            dots = 1;
-                            break;
-                        case 1:
-                            dots = 2;
-                            break;
-                        case 2:
-                            canonical.append("...");
-                            dots = -1;
-                            break;
-                        default:
-                            canonical.append('.');
-                    }
+                    // Count dots only if they are leading in the segment
+                    if (dots > 0)
+                        dots++;
+                    else if (slash)
+                        dots = 1;
+                    else
+                        canonical.append('.');
+                    slash = false;
                     break;
 
                 default:
-                    switch (dots)
-                    {
-                        case 1:
-                            canonical.append('.');
-                            break;
-                        case 2:
-                            canonical.append("..");
-                            break;
-                        default:
-                    }
+                    // Add leading dots to the path
+                    while (dots-- > 0)
+                        canonical.append('.');
                     canonical.append(c);
-                    dots = -1;
+                    dots = 0;
+                    slash = false;
             }
-
             i++;
         }
+
+        // process any remaining dots
+        if (doDots(canonical, dots))
+            return null;
+
+        // append any query
+        if (i < end)
+            canonical.append(uri, i, end);
+
         return canonical.toString();
     }
 
     /**
-     * Convert a path to a cananonical form.
+     * Convert a decoded URI path to a canonical form.
      * <p>
-     * All instances of "." and ".." are factored out.
-     * </p>
-     * <p>
+     * All segments of "." and ".." are factored out.
      * Null is returned if the path tries to .. above its root.
      * </p>
      *
-     * @param path the path to convert (expects URI/URL form, encoded, and with path separators '/')
+     * @param path the decoded URI path to convert. Any special characters (e.g. '?', "#") are assumed to be part of
+     * the path segments.
      * @return the canonical path, or null if path traversal above root.
+     * @see #canonicalURI(String)
      */
-    public static String canonicalEncodedPath(String path)
+    public static String canonicalPath(String path)
     {
         if (path == null || path.isEmpty())
             return path;
@@ -925,8 +911,8 @@ public class URIUtil
         int end = path.length();
         int i = 0;
 
-        loop:
-        while (i < end)
+        // Initially just loop looking if we may need to normalize
+        loop: while (i < end)
         {
             char c = path.charAt(i);
             switch (c)
@@ -941,9 +927,6 @@ public class URIUtil
                     slash = false;
                     break;
 
-                case '?':
-                    return path;
-
                 default:
                     slash = false;
             }
@@ -951,56 +934,31 @@ public class URIUtil
             i++;
         }
 
+        // Nothing to normalize so return original path
         if (i == end)
             return path;
 
+        // We probably need to normalize, so copy to path so far into builder
         StringBuilder canonical = new StringBuilder(path.length());
         canonical.append(path, 0, i);
 
+        // Loop looking for single and double dot segments
         int dots = 1;
         i++;
-        while (i <= end)
+        while (i < end)
         {
-            char c = i < end ? path.charAt(i) : '\0';
+            char c = path.charAt(i);
             switch (c)
             {
-                case '\0':
                 case '/':
-                case '?':
-                    switch (dots)
-                    {
-                        case 0:
-                            if (c != '\0')
-                                canonical.append(c);
-                            break;
-
-                        case 1:
-                            if (c == '?')
-                                canonical.append(c);
-                            break;
-
-                        case 2:
-                            if (canonical.length() < 2)
-                                return null;
-                            canonical.setLength(canonical.length() - 1);
-                            canonical.setLength(canonical.lastIndexOf("/") + 1);
-                            if (c == '?')
-                                canonical.append(c);
-                            break;
-                        default:
-                            while (dots-- > 0)
-                            {
-                                canonical.append('.');
-                            }
-                            if (c != '\0')
-                                canonical.append(c);
-                    }
-
+                    if (doDotsSlash(canonical, dots))
+                        return null;
                     slash = true;
                     dots = 0;
                     break;
 
                 case '.':
+                    // Count dots only if they are leading in the segment
                     if (dots > 0)
                         dots++;
                     else if (slash)
@@ -1011,18 +969,64 @@ public class URIUtil
                     break;
 
                 default:
+                    // Add leading dots to the path
                     while (dots-- > 0)
-                    {
                         canonical.append('.');
-                    }
                     canonical.append(c);
                     dots = 0;
                     slash = false;
             }
-
             i++;
         }
+
+        // process any remaining dots
+        if (doDots(canonical, dots))
+            return null;
+
         return canonical.toString();
+    }
+
+    private static boolean doDots(StringBuilder canonical, int dots)
+    {
+        switch (dots)
+        {
+            case 0:
+            case 1:
+                break;
+            case 2:
+                if (canonical.length() < 2)
+                    return true;
+                canonical.setLength(canonical.length() - 1);
+                canonical.setLength(canonical.lastIndexOf("/") + 1);
+                break;
+            default:
+                while (dots-- > 0)
+                    canonical.append('.');
+        }
+        return false;
+    }
+
+    private static boolean doDotsSlash(StringBuilder canonical, int dots)
+    {
+        switch (dots)
+        {
+            case 0:
+                canonical.append('/');
+                break;
+            case 1:
+                break;
+            case 2:
+                if (canonical.length() < 2)
+                    return true;
+                canonical.setLength(canonical.length() - 1);
+                canonical.setLength(canonical.lastIndexOf("/") + 1);
+                break;
+            default:
+                while (dots-- > 0)
+                    canonical.append('.');
+                canonical.append('/');
+        }
+        return false;
     }
 
     /**

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -217,7 +217,6 @@ public abstract class Utf8Appendable
 
     protected void appendByte(byte b) throws IOException
     {
-
         if (b > 0 && _state == UTF8_ACCEPT)
         {
             _appendable.append((char)(b & 0xFF));

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -269,7 +269,6 @@ public class FileResource extends Resource
         throws IOException
     {
         assertValidPath(path);
-        path = org.eclipse.jetty.util.URIUtil.canonicalPath(path);
 
         if (path == null)
             throw new MalformedURLException();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -555,7 +555,6 @@ public abstract class Resource implements ResourceFactory, Closeable
      */
     public String getListHTML(String base, boolean parent, String query) throws IOException
     {
-        base = URIUtil.canonicalPath(base);
         if (base == null || !isDirectory())
             return null;
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -300,7 +300,8 @@ public class ResourceCollection extends Resource
         {
             return new ResourceCollection(resources.toArray(new Resource[0]));
         }
-        return null;
+
+        throw new MalformedURLException();
     }
 
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
@@ -272,9 +272,7 @@ public class URLResource extends Resource
         throws IOException
     {
         if (path == null)
-            return null;
-
-        path = URIUtil.canonicalPath(path);
+            throw new MalformedURLException("null path");
 
         return newResource(URIUtil.addEncodedPaths(_url.toExternalForm(), URIUtil.encodePath(path)), _useCaches);
     }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
@@ -27,10 +27,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class URIUtilCanonicalPathTest
 {
-    public static Stream<Arguments> data()
+    public static Stream<Arguments> paths()
     {
         String[][] canonical =
             {
@@ -88,6 +89,7 @@ public class URIUtilCanonicalPathTest
                 {"/foo/../bar//", "/bar//"},
                 {"/ctx/../bar/../ctx/all/index.txt", "/ctx/all/index.txt"},
                 {"/down/.././index.html", "/index.html"},
+                {"/aaa/bbb/ccc/..", "/aaa/bbb/"},
 
                 // Path traversal up past root
                 {"..", null},
@@ -100,10 +102,8 @@ public class URIUtilCanonicalPathTest
                 {"a/../..", null},
                 {"/foo/../../bar", null},
 
-                // Query parameter specifics
-                {"/ctx/dir?/../index.html", "/ctx/index.html"},
-                {"/get-files?file=/etc/passwd", "/get-files?file=/etc/passwd"},
-                {"/get-files?file=../../../../../passwd", null},
+                // Encoded ?
+                {"/ctx/dir%3f/../index.html", "/ctx/index.html"},
 
                 // Known windows shell quirks
                 {"file.txt  ", "file.txt  "}, // with spaces
@@ -125,7 +125,6 @@ public class URIUtilCanonicalPathTest
                 {"/%2e%2e/", "/%2e%2e/"},
 
                 // paths with parameters are not elided
-                // canonicalPath() is not responsible for decoding characters
                 {"/foo/.;/bar", "/foo/.;/bar"},
                 {"/foo/..;/bar", "/foo/..;/bar"},
                 {"/foo/..;/..;/bar", "/foo/..;/..;/bar"},
@@ -144,9 +143,23 @@ public class URIUtilCanonicalPathTest
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("paths")
     public void testCanonicalPath(String input, String expectedResult)
     {
+        // Check canonicalPath
         assertThat(URIUtil.canonicalPath(input), is(expectedResult));
+
+        // Check canonicalURI
+        if (expectedResult == null)
+            assertThat(URIUtil.canonicalURI(input), nullValue());
+        else
+        {
+            // mostly encodedURI will be the same
+            assertThat(URIUtil.canonicalURI(input), is(expectedResult));
+            // but will terminate on fragments and queries
+            assertThat(URIUtil.canonicalURI(input + "?/foo/../bar/."), is(expectedResult + "?/foo/../bar/."));
+            assertThat(URIUtil.canonicalURI(input + "#/foo/../bar/."), is(expectedResult + "#/foo/../bar/."));
+        }
     }
+
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
@@ -158,6 +158,35 @@ public class Utf8AppendableTest
 
     @ParameterizedTest
     @MethodSource("implementations")
+    public void testInvalidZeroUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException
+    {
+        // From https://datatracker.ietf.org/doc/html/rfc3629#section-10
+        assertThrows(Utf8Appendable.NotUtf8Exception.class, () ->
+        {
+            Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
+            buffer.append((byte)0xC0);
+            buffer.append((byte)0x80);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("implementations")
+    public void testInvalidAlternateDotEncodingUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException
+    {
+        // From https://datatracker.ietf.org/doc/html/rfc3629#section-10
+        assertThrows(Utf8Appendable.NotUtf8Exception.class, () ->
+        {
+            Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
+            buffer.append((byte)0x2f);
+            buffer.append((byte)0xc0);
+            buffer.append((byte)0xae);
+            buffer.append((byte)0x2e);
+            buffer.append((byte)0x2f);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("implementations")
     public void testFastFail1(Class<Utf8Appendable> impl) throws Exception
     {
         byte[] part1 = TypeUtil.fromHexString("cebae1bdb9cf83cebcceb5");

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -379,7 +379,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         if (uriInContext == null || !uriInContext.startsWith(URIUtil.SLASH))
             throw new MalformedURLException(uriInContext);
 
-        IOException ioe = null;
+        MalformedURLException mue = null;
         Resource resource = null;
         int loop = 0;
         while (uriInContext != null && loop++ < 100)
@@ -392,16 +392,16 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
                 uriInContext = getResourceAlias(uriInContext);
             }
-            catch (IOException e)
+            catch (MalformedURLException e)
             {
                 LOG.ignore(e);
-                if (ioe == null)
-                    ioe = e;
+                if (mue == null)
+                    mue = e;
             }
         }
 
-        if (ioe instanceof MalformedURLException)
-            throw (MalformedURLException)ioe;
+        if (mue != null)
+            throw mue;
 
         return resource;
     }
@@ -1556,6 +1556,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
+            if (path == null)
+                return null;
+
             Resource resource = WebAppContext.this.getResource(path);
             if (resource == null || !resource.exists())
                 return null;


### PR DESCRIPTION
Fix #6473 Reduce multiple canonicalPath calls with single alias check in PathResource 