### PR TITLE
disable MaxDuration mechanism in testConnectionMaxUsage

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -568,6 +568,7 @@ public class ConnectionPoolTest
         {
             AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(destination);
             connectionPool.setMaxUsageCount(maxUsageCount);
+            connectionPool.setMaxDuration(0); // Disable max duration expiry as it may expire the connection between the 1st and 2nd request.
             return connectionPool;
         });
         client.setMaxConnectionsPerDestination(1);


### PR DESCRIPTION
10.0.x port of https://github.com/eclipse/jetty.project/pull/6463