### PR TITLE
Issue #6473 - Improve alias checking in PathResource.

### DIFF
--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -322,6 +322,7 @@ public class HttpURITest
                 {"/f%6f%6F/bar", "/foo/bar", EnumSet.noneOf(Violation.class)},
                 {"/f%u006f%u006F/bar", "/foo/bar", EnumSet.of(Violation.UTF16)},
                 {"/f%u0001%u0001/bar", "/f\001\001/bar", EnumSet.of(Violation.UTF16)},
+                {"/foo/%u20AC/bar", "/foo/\u20AC/bar", EnumSet.of(Violation.UTF16)},
 
                 // illegal paths
                 {"//host/../path/info", null, EnumSet.noneOf(Violation.class)},
@@ -333,6 +334,9 @@ public class HttpURITest
                 {"/path/%u000X/info", null, EnumSet.noneOf(Violation.class)},
                 {"/path/Fo%u0000/info", null, EnumSet.noneOf(Violation.class)},
                 {"/path/Fo%00/info", null, EnumSet.noneOf(Violation.class)},
+                {"/path/Foo/info%u0000", null, EnumSet.noneOf(Violation.class)},
+                {"/path/Foo/info%00", null, EnumSet.noneOf(Violation.class)},
+                {"/path/%U20AC", null, EnumSet.noneOf(Violation.class)},
                 {"%2e%2e/info", null, EnumSet.noneOf(Violation.class)},
                 {"%u002e%u002e/info", null, EnumSet.noneOf(Violation.class)},
                 {"%2e%2e;/info", null, EnumSet.noneOf(Violation.class)},
@@ -768,5 +772,21 @@ public class HttpURITest
         assertThat("[" + input + "] .query", httpUri.getQuery(), is(javaUri.getRawQuery()));
         assertThat("[" + input + "] .fragment", httpUri.getFragment(), is(javaUri.getFragment()));
         assertThat("[" + input + "] .toString", httpUri.toString(), is(javaUri.toASCIIString()));
+    }
+
+    public static Stream<Arguments> queryData()
+    {
+        return Stream.of(
+            new String[]{"/path?p=%U20AC", "p=%U20AC"},
+            new String[]{"/path?p=%u20AC", "p=%u20AC"}
+        ).map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryData")
+    public void testEncodedQuery(String input, String expectedQuery)
+    {
+        HttpURI httpURI = new HttpURI(input);
+        assertThat("[" + input + "] .query", httpURI.getQuery(), is(expectedQuery));
     }
 }

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectUtil.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectUtil.java
@@ -53,12 +53,12 @@ public final class RedirectUtil
                 String path = request.getRequestURI();
                 String parent = (path.endsWith("/")) ? path : URIUtil.parentPath(path);
                 location = URIUtil.canonicalURI(URIUtil.addEncodedPaths(parent, location));
-                if (!location.startsWith("/"))
+                if (location != null && !location.startsWith("/"))
                     url.append('/');
             }
 
             if (location == null)
-                throw new IllegalStateException("path cannot be above root");
+                throw new IllegalStateException("redirect path cannot be above root");
             url.append(location);
 
             location = url.toString();

--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/ValidUrlRuleTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unused")
@@ -76,6 +77,12 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
     @Test
     public void testInvalidJsp() throws Exception
     {
+        assertThrows(IllegalArgumentException.class, () -> _request.setURIPathQuery("/jsp/bean1.jsp%00"));
+    }
+
+    @Test
+    public void testInvalidJspWithNullByte() throws Exception
+    {
         _rule.setCode("405");
         _rule.setReason("foo");
 
@@ -85,6 +92,12 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
 
         assertEquals(405, _response.getStatus());
         assertEquals("foo", _response.getReason());
+    }
+
+    @Test
+    public void testInvalidShamrock() throws Exception
+    {
+        assertThrows(IllegalArgumentException.class, () -> _request.setURIPathQuery("/jsp/shamrock-%00%E2%98%98.jsp"));
     }
 
     @Test
@@ -110,4 +123,3 @@ public class ValidUrlRuleTest extends AbstractRuleTestCase
         //@checkstyle-enable-check : IllegalTokenText
     }
 }
-

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -2131,9 +2131,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return ContextHandler.this;
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getContext(java.lang.String)
-         */
         @Override
         public ServletContext getContext(String uripath)
         {
@@ -2222,9 +2219,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return null;
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getMimeType(java.lang.String)
-         */
         @Override
         public String getMimeType(String file)
         {
@@ -2233,9 +2227,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return _mimeTypes.getMimeByExtension(file);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getRequestDispatcher(java.lang.String)
-         */
         @Override
         public RequestDispatcher getRequestDispatcher(String uriInContext)
         {
@@ -2248,6 +2239,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
 
             try
             {
+                // The uriInContext will be canonicalized by HttpURI.
                 HttpURI uri = new HttpURI(null, null, 0, uriInContext);
                 String pathInfo = uri.getDecodedPath();
                 String contextPath = getContextPath();
@@ -2263,12 +2255,13 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return null;
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getRealPath(java.lang.String)
-         */
         @Override
         public String getRealPath(String path)
         {
+            // This is an API call from the application which may have arbitrary non canonical paths passed
+            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // ContextHandler.this.getResource(path).
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -2309,9 +2302,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return null;
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getResourceAsStream(java.lang.String)
-         */
         @Override
         public InputStream getResourceAsStream(String path)
         {
@@ -2333,65 +2323,48 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             }
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getResourcePaths(java.lang.String)
-         */
         @Override
         public Set<String> getResourcePaths(String path)
         {
+            // This is an API call from the application which may have arbitrary non canonical paths passed
+            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // ContextHandler.this.getResource(path).
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             return ContextHandler.this.getResourcePaths(path);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#log(java.lang.Exception, java.lang.String)
-         */
         @Override
         public void log(Exception exception, String msg)
         {
             _logger.warn(msg, exception);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#log(java.lang.String)
-         */
         @Override
         public void log(String msg)
         {
             _logger.info(msg);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#log(java.lang.String, java.lang.Throwable)
-         */
         @Override
         public void log(String message, Throwable throwable)
         {
             _logger.warn(message, throwable);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getInitParameter(java.lang.String)
-         */
         @Override
         public String getInitParameter(String name)
         {
             return ContextHandler.this.getInitParameter(name);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getInitParameterNames()
-         */
         @Override
         public Enumeration<String> getInitParameterNames()
         {
             return ContextHandler.this.getInitParameterNames();
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getAttribute(java.lang.String)
-         */
         @Override
         public Object getAttribute(String name)
         {
@@ -2401,9 +2374,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return o;
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getAttributeNames()
-         */
         @Override
         public Enumeration<String> getAttributeNames()
         {
@@ -2422,9 +2392,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             return Collections.enumeration(set);
         }
 
-        /*
-         * @see javax.servlet.ServletContext#setAttribute(java.lang.String, java.lang.Object)
-         */
         @Override
         public void setAttribute(String name, Object value)
         {
@@ -2451,9 +2418,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             }
         }
 
-        /*
-         * @see javax.servlet.ServletContext#removeAttribute(java.lang.String)
-         */
         @Override
         public void removeAttribute(String name)
         {
@@ -2470,9 +2434,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             }
         }
 
-        /*
-         * @see javax.servlet.ServletContext#getServletContextName()
-         */
         @Override
         public String getServletContextName()
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1942,13 +1942,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         if (_baseResource == null)
             return null;
 
-        // Does the path go above the current scope?
-        path = URIUtil.canonicalPath(path);
-        if (path == null)
-            return null;
-
         try
         {
+            // addPath with accept non-canonical paths that don't go above the root,
+            // but will treat them as aliases. So unless allowed by an AliasChecker
+            // they will be rejected below.
             Resource resource = _baseResource.addPath(path);
 
             if (checkAlias(path, resource))
@@ -2299,6 +2297,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
+            // This is an API call from the application which may have arbitrary non canonical paths passed
+            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // ContextHandler.this.getResource(path).
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             Resource resource = ContextHandler.this.getResource(path);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -187,7 +187,9 @@ public class ResourceHandler extends HandlerWrapper implements ResourceFactory, 
                 }
             }
             else if (_context != null)
+            {
                 r = _context.getResource(path);
+            }
 
             if ((r == null || !r.exists()) && path.endsWith("/jetty-dir.css"))
                 r = getStylesheet();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -829,6 +829,12 @@ public class HttpConnectionTest
         Log.getLogger(HttpParser.class).info("badMessage: bad encoding expected ...");
         String response;
 
+        response = connector.getResponse("GET /foo/bar%c0%00 HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "Connection: close\r\n" +
+            "\r\n");
+        checkContains(response, 0, "HTTP/1.1 400");
+
         response = connector.getResponse("GET /bad/utf8%c1 HTTP/1.1\r\n" +
             "Host: localhost\r\n" +
             "Connection: close\r\n" +

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
@@ -235,16 +235,23 @@ public class ContextHandlerGetResourceTest
     @Test
     public void testAlias() throws Exception
     {
-        Resource resource = context.getResource("/./index.html");
-        assertNotNull(resource);
-        assertFalse(resource.isAlias());
-
-        resource = context.getResource("/down/../index.html");
-        assertNotNull(resource);
-        assertFalse(resource.isAlias());
-
-        resource = context.getResource("//index.html");
+        String path = "/./index.html";
+        Resource resource = context.getResource(path);
         assertNull(resource);
+        URL resourceURL = context.getServletContext().getResource(path);
+        assertFalse(resourceURL.getPath().contains("/./"));
+
+        path = "/down/../index.html";
+        resource = context.getResource(path);
+        assertNull(resource);
+        resourceURL = context.getServletContext().getResource(path);
+        assertFalse(resourceURL.getPath().contains("/../"));
+
+        path = "//index.html";
+        resource = context.getResource(path);
+        assertNull(resource);
+        resourceURL = context.getServletContext().getResource(path);
+        assertNull(resourceURL);
     }
 
     @ParameterizedTest

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -890,6 +890,17 @@ public class URIUtil
     }
 
     /**
+     * @param path the encoded URI from the path onwards, which may contain query strings and/or fragments
+     * @return the canonical path, or null if path traversal above root.
+     * @deprecated Use {@link #canonicalURI(String)}
+     */
+    @Deprecated
+    public static String canonicalEncodedPath(String path)
+    {
+        return canonicalURI(path);
+    }
+
+    /**
      * Convert a decoded URI path to a canonical form.
      * <p>
      * All segments of "." and ".." are factored out.

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -789,7 +789,6 @@ public class URIUtil
      * @param uri the encoded URI from the path onwards, which may contain query strings and/or fragments
      * @return the canonical path, or null if path traversal above root.
      * @see #canonicalPath(String)
-     * @see #canonicalURI(String)
      */
     public static String canonicalURI(String uri)
     {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -537,7 +537,6 @@ public class URIUtil
         {
             throw new IllegalArgumentException("cannot decode URI", e);
         }
-
     }
 
     /* Decode a URI path and strip parameters of ISO-8859-1 path

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileResource.java
@@ -270,8 +270,11 @@ public class FileResource extends Resource
     {
         assertValidPath(path);
 
-        if (path == null)
-            throw new MalformedURLException();
+        // Check that the path is within the root,
+        // but use the original path to create the
+        // resource, to preserve aliasing.
+        if (URIUtil.canonicalPath(path) == null)
+            throw new MalformedURLException(path);
 
         if ("/".equals(path))
             return this;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -94,8 +94,11 @@ public class PathResource extends Resource
         if (!abs.isAbsolute())
             abs = path.toAbsolutePath();
 
+        // Any normalization difference means it's an alias,
+        // and we don't want to bother further to follow
+        // symlinks as it's an alias anyway.
         Path normal = path.normalize();
-        if (!abs.equals(normal))
+        if (!isSameName(abs, normal))
             return normal;
 
         try
@@ -105,11 +108,8 @@ public class PathResource extends Resource
             if (Files.exists(path))
             {
                 Path real = abs.toRealPath(FOLLOW_LINKS);
-
                 if (!isSameName(abs, real))
-                {
                     return real;
-                }
             }
         }
         catch (IOException e)
@@ -361,20 +361,23 @@ public class PathResource extends Resource
     }
 
     @Override
-    public Resource addPath(final String subpath) throws IOException
+    public Resource addPath(final String subPath) throws IOException
     {
-        if ((subpath == null) || (subpath.length() == 0))
-            throw new MalformedURLException(subpath);
+        // Check that the path is within the root,
+        // but use the original path to create the
+        // resource, to preserve aliasing.
+        if (URIUtil.canonicalPath(subPath) == null)
+            throw new MalformedURLException(subPath);
 
-        if ("/".equals(subpath))
+        if ("/".equals(subPath))
             return this;
 
-        // subpaths are always under PathResource
-        // compensate for input subpaths like "/subdir"
+        // Sub-paths are always under PathResource
+        // compensate for input sub-paths like "/subdir"
         // where default resolve behavior would be
         // to treat that like an absolute path
 
-        return new PathResource(this, subpath);
+        return new PathResource(this, subPath);
     }
 
     private void assertValidPath(Path path)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -459,10 +459,12 @@ public abstract class Resource implements ResourceFactory, Closeable
      * Returns the resource contained inside the current resource with the
      * given name.
      *
-     * @param path The path segment to add, which is not encoded
+     * @param path The path segment to add, which is not encoded.  The path may be non canonical, but if so then
+     * the resulting Resource will return true from {@link #isAlias()}.
      * @return the Resource for the resolved path within this Resource.
      * @throws IOException if unable to resolve the path
-     * @throws MalformedURLException if the resolution of the path fails because the input path parameter is malformed.
+     * @throws MalformedURLException if the resolution of the path fails because the input path parameter is malformed, or
+     * a relative path attempts to access above the root resource.
      */
     public abstract Resource addPath(String path)
         throws IOException, MalformedURLException;
@@ -555,6 +557,8 @@ public abstract class Resource implements ResourceFactory, Closeable
      */
     public String getListHTML(String base, boolean parent, String query) throws IOException
     {
+        // This method doesn't check aliases, so it is OK to canonicalize here.
+        base = URIUtil.canonicalPath(base);
         if (base == null || !isDirectory())
             return null;
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java
@@ -271,8 +271,11 @@ public class URLResource extends Resource
     public Resource addPath(String path)
         throws IOException
     {
-        if (path == null)
-            throw new MalformedURLException("null path");
+        // Check that the path is within the root,
+        // but use the original path to create the
+        // resource, to preserve aliasing.
+        if (URIUtil.canonicalPath(path) == null)
+            throw new MalformedURLException(path);
 
         return newResource(URIUtil.addEncodedPaths(_url.toExternalForm(), URIUtil.encodePath(path)), _useCaches);
     }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilCanonicalPathTest.java
@@ -151,7 +151,9 @@ public class URIUtilCanonicalPathTest
 
         // Check canonicalURI
         if (expectedResult == null)
+        {
             assertThat(URIUtil.canonicalURI(input), nullValue());
+        }
         else
         {
             // mostly encodedURI will be the same
@@ -162,4 +164,22 @@ public class URIUtilCanonicalPathTest
         }
     }
 
+    public static Stream<Arguments> queries()
+    {
+        String[][] data =
+            {
+                {"/ctx/../dir?/../index.html", "/dir?/../index.html"},
+                {"/get-files?file=/etc/passwd", "/get-files?file=/etc/passwd"},
+                {"/get-files?file=../../../../../passwd", "/get-files?file=../../../../../passwd"}
+            };
+        return Stream.of(data).map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("queries")
+    public void testQuery(String input, String expectedPath)
+    {
+        String actual = URIUtil.canonicalURI(input);
+        assertThat(actual, is(expectedPath));
+    }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -21,6 +21,7 @@ package org.eclipse.jetty.util.resource;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
@@ -45,6 +46,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceTest
 {
@@ -324,5 +327,20 @@ public class ResourceTest
         Resource rb = Resource.newResource(b);
 
         assertEquals(rb, ra);
+    }
+
+    @Test
+    public void testClimbAboveBase() throws Exception
+    {
+        Resource resource = Resource.newResource("/foo/bar");
+        assertThrows(MalformedURLException.class, () -> resource.addPath(".."));
+
+        Resource same = resource.addPath(".");
+        assertNotNull(same);
+        assertTrue(same.isAlias());
+
+        assertThrows(MalformedURLException.class, () -> resource.addPath("./.."));
+
+        assertThrows(MalformedURLException.class, () -> resource.addPath("./../bar"));
     }
 }


### PR DESCRIPTION
## Issue #6473

* Reverted %-escape handling for URI query parts.
* Performing canonicalization in ServletContext.getResource(),
  and improving alias checking in ContextHandler.getResource().
* Performing canonicalization checks in Resource.addPath() to avoid
  navigation above of the root.
* Test added and fixed.
* Various cleanups.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>