### PR TITLE
Issue #6470 - prevent EOF being released back into pool in MessageInputStream

### DIFF
--- a/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
+++ b/jetty-websocket/websocket-common/src/main/java/org/eclipse/jetty/websocket/common/message/MessageInputStream.java
@@ -163,7 +163,8 @@ public class MessageInputStream extends InputStream implements MessageAppender
 
             for (ByteBuffer buffer : buffers)
             {
-                bufferPool.release(buffer);
+                if (buffer != null && buffer != EOF)
+                    bufferPool.release(buffer);
             }
 
             activeBuffer = null;
@@ -259,7 +260,8 @@ public class MessageInputStream extends InputStream implements MessageAppender
                 synchronized (this)
                 {
                     // Release buffer back to pool.
-                    bufferPool.release(activeBuffer);
+                    if (activeBuffer != null && activeBuffer != EOF)
+                        bufferPool.release(activeBuffer);
                     activeBuffer = null;
 
                     switch (state)


### PR DESCRIPTION
## Issue #6470 

Prevent the static readOnly buffer `EOF` from being released back into the `ByteBufferPool`.

Alternative to #6485