### PR TITLE
Reduce header cache memory usage on non persistent requests

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1935,6 +1935,7 @@ public class HttpParser
 
     public Index<HttpField> getFieldCache()
     {
+        checkHeaderCache();
         return _fieldCache;
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Index.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Index.java
@@ -259,13 +259,13 @@ public interface Index<V>
      * @param <V> The type of the index
      * @return A case sensitive mutable Index tacking visible ASCII alphabet to a max capacity.
      */
-    static <V> Mutable<V> buildCaseSensitiveMutableVisibleAsciiAlphabet(int maxCapacity)
+    static <V> Mutable<V> buildMutableVisibleAsciiAlphabet(boolean caseSensitive, int maxCapacity)
     {
         if (maxCapacity < 0 || maxCapacity > ArrayTrie.MAX_CAPACITY)
-            return new TreeTrie<>(true);
+            return new TreeTrie<>(caseSensitive);
         if (maxCapacity == 0)
-            return EmptyTrie.instance(true);
-        return new ArrayTrie<>(true, maxCapacity);
+            return EmptyTrie.instance(caseSensitive);
+        return new ArrayTrie<>(caseSensitive, maxCapacity);
     }
 
     static <V> Index<V> empty(boolean caseSensitive)


### PR DESCRIPTION
Fix #6493. Delay creating a header cache until a second request on a parser.

Signed-off-by: Greg Wilkins <gregw@webtide.com>