### PR TITLE
Issue #6520 - Fixing ErrorHandler output of text/html

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -386,7 +386,7 @@ public class ErrorHandler extends AbstractHandler
             writeErrorPageStacks(request, writer);
 
         Request.getBaseRequest(request).getHttpChannel().getHttpConfiguration()
-            .writePoweredBy(writer, "<hr>", "<hr/>\n");
+            .writePoweredBy(writer, "<hr/>", "<hr/>\n");
     }
 
     protected void writeErrorPageMessage(HttpServletRequest request, Writer writer, int code, String message, String uri)


### PR DESCRIPTION
Cherry-pick of PR #6525 for Jetty 10.0.x

+ Updating tests to ensure that output is xml verified
+ Updating output to use `<hr>` element properly.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>