### PR TITLE
9.4.x: Add defensive check in HttpConnection content production

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -144,6 +144,7 @@ public class HttpParser
 
     private static final EnumSet<State> __idleStates = EnumSet.of(State.START, State.END, State.CLOSE, State.CLOSED);
     private static final EnumSet<State> __completeStates = EnumSet.of(State.END, State.CLOSE, State.CLOSED);
+    private static final EnumSet<State> __terminatedStates = EnumSet.of(State.CLOSE, State.CLOSED);
 
     private final boolean debug = LOG.isDebugEnabled(); // Cache debug to help branch prediction
     private final HttpHandler _handler;
@@ -434,6 +435,11 @@ public class HttpParser
     public boolean isComplete()
     {
         return __completeStates.contains(_state);
+    }
+
+    public boolean isTerminated()
+    {
+        return __terminatedStates.contains(_state);
     }
 
     public boolean isState(State state)
@@ -1570,7 +1576,7 @@ public class HttpParser
                 if (debug && whiteSpace > 0)
                     LOG.debug("Discarded {} CR or LF characters", whiteSpace);
             }
-            else if (isClose() || isClosed())
+            else if (isTerminated())
             {
                 BufferUtil.clear(buffer);
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -316,6 +316,11 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
      */
     protected boolean fillAndParseForContent()
     {
+        // Defensive check to avoid an infinite select/wakeup/fillAndParseForContent/wait loop
+        // in case the parser was mistakenly closed and the connection was not aborted.
+        if (_parser.isClose() || _parser.isClosed())
+            throw new IllegalStateException("Parser is closed: " + _parser);
+
         boolean handled = false;
         while (_parser.inContentState())
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -318,8 +318,8 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
     {
         // Defensive check to avoid an infinite select/wakeup/fillAndParseForContent/wait loop
         // in case the parser was mistakenly closed and the connection was not aborted.
-        if (_parser.isClose() || _parser.isClosed())
-            throw new IllegalStateException("Parser is closed: " + _parser);
+        if (_parser.isTerminated())
+            throw new IllegalStateException("Parser is terminated: " + _parser);
 
         boolean handled = false;
         while (_parser.inContentState())


### PR DESCRIPTION
Currently, if the parser gets closed and the connection isn't aborted, the code enters a select/wakeup/fillAndParseForContent/wait infinite loop.

The above should never happen unless a bug gets introduced, but if such bug would happen at least the situation would be detected and acted upon.

See #6491.