### PR TITLE
Fix #6562 last written bytebuffer

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -863,12 +863,10 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         // Blocking write
         try
         {
-            boolean complete = false;
             // flush any content from the aggregate
             if (BufferUtil.hasContent(_aggregate))
             {
-                complete = last && len == 0;
-                channelWrite(_aggregate, complete);
+                channelWrite(_aggregate, last && len == 0);
 
                 // should we fill aggregate again from the buffer?
                 if (len > 0 && !last && len <= _commitSize && len <= maximizeAggregateSpace())
@@ -897,10 +895,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                     len -= getBufferSize();
                 }
                 channelWrite(view, last);
-            }
-            else if (last && !complete)
-            {
-                channelWrite(BufferUtil.EMPTY_BUFFER, true);
             }
 
             onWriteComplete(last, null);
@@ -969,18 +963,12 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             {
                 // Blocking write
                 // flush any content from the aggregate
-                boolean complete = false;
                 if (BufferUtil.hasContent(_aggregate))
-                {
-                    complete = last && len == 0;
-                    channelWrite(_aggregate, complete);
-                }
+                    channelWrite(_aggregate, last && len == 0);
 
                 // write any remaining content in the buffer directly
                 if (len > 0)
                     channelWrite(buffer, last);
-                else if (last && !complete)
-                    channelWrite(BufferUtil.EMPTY_BUFFER, true);
 
                 onWriteComplete(last, null);
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -863,10 +863,12 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         // Blocking write
         try
         {
+            boolean complete = false;
             // flush any content from the aggregate
             if (BufferUtil.hasContent(_aggregate))
             {
-                channelWrite(_aggregate, last && len == 0);
+                complete = last && len == 0;
+                channelWrite(_aggregate, complete);
 
                 // should we fill aggregate again from the buffer?
                 if (len > 0 && !last && len <= _commitSize && len <= maximizeAggregateSpace())
@@ -896,7 +898,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 }
                 channelWrite(view, last);
             }
-            else if (last)
+            else if (last && !complete)
             {
                 channelWrite(BufferUtil.EMPTY_BUFFER, true);
             }
@@ -923,7 +925,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         {
             checkWritable();
             long written = _written + len;
-            last = _channel.getResponse().isAllContentWritten(_written);
+            last = _channel.getResponse().isAllContentWritten(written);
             flush = last || len > 0 || BufferUtil.hasContent(_aggregate);
 
             if (last && _state == State.OPEN)
@@ -967,13 +969,17 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             {
                 // Blocking write
                 // flush any content from the aggregate
+                boolean complete = false;
                 if (BufferUtil.hasContent(_aggregate))
-                    channelWrite(_aggregate, last && len == 0);
+                {
+                    complete = last && len == 0;
+                    channelWrite(_aggregate, complete);
+                }
 
                 // write any remaining content in the buffer directly
                 if (len > 0)
                     channelWrite(buffer, last);
-                else if (last)
+                else if (last && !complete)
                     channelWrite(BufferUtil.EMPTY_BUFFER, true);
 
                 onWriteComplete(last, null);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -360,6 +361,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -374,6 +376,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -388,6 +391,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -402,6 +406,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -419,6 +424,7 @@ public class HttpOutputTest
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -433,6 +439,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -447,6 +454,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -461,6 +469,52 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
+    }
+
+    @Test
+    public void testWriteBufferSmallKnown() throws Exception
+    {
+        final Resource big = Resource.newClassPathResource("simple/big.txt");
+        _handler._writeLengthIfKnown = true;
+        _handler._content = BufferUtil.toBuffer(big, false);
+        _handler._byteBuffer = BufferUtil.allocate(8);
+
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("Content-Length"));
+        assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
+    }
+
+    @Test
+    public void testWriteBufferMedKnown() throws Exception
+    {
+        final Resource big = Resource.newClassPathResource("simple/big.txt");
+        _handler._writeLengthIfKnown = true;
+        _handler._content = BufferUtil.toBuffer(big, false);
+        _handler._byteBuffer = BufferUtil.allocate(4000);
+
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("Content-Length"));
+        assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
+    }
+
+    @Test
+    public void testWriteBufferLargeKnown() throws Exception
+    {
+        final Resource big = Resource.newClassPathResource("simple/big.txt");
+        _handler._writeLengthIfKnown = true;
+        _handler._content = BufferUtil.toBuffer(big, false);
+        _handler._byteBuffer = BufferUtil.allocate(8192);
+
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("Content-Length"));
+        assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -476,6 +530,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -491,6 +546,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -506,6 +562,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -521,12 +578,13 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
     public void testAsyncWriteHuge() throws Exception
     {
-        _handler._writeLengthIfKnown = true;
+        _handler._writeLengthIfKnown = false;
         _handler._content = BufferUtil.allocate(4 * 1024 * 1024);
         _handler._content.limit(_handler._content.capacity());
         for (int i = _handler._content.capacity(); i-- > 0; )
@@ -538,7 +596,8 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString("Content-Length"));
+        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -554,6 +613,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -569,6 +629,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -584,6 +645,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -600,6 +662,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
+        assertThat(_handler._closedAfterWrite, is(false));
     }
 
     @Test
@@ -634,6 +697,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 11"));
         assertThat(response, containsString("simple text"));
+        assertThat(_handler._closedAfterWrite, is(true));
     }
 
     @Test
@@ -1048,6 +1112,7 @@ public class HttpOutputTest
         ReadableByteChannel _contentChannel;
         ByteBuffer _content;
         ChainedInterceptor _interceptor;
+        boolean _closedAfterWrite;
 
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
@@ -1068,6 +1133,7 @@ public class HttpOutputTest
             {
                 out.sendContent(_contentInputStream);
                 _contentInputStream = null;
+                _closedAfterWrite = out.isClosed();
                 return;
             }
 
@@ -1075,6 +1141,7 @@ public class HttpOutputTest
             {
                 out.sendContent(_contentChannel);
                 _contentChannel = null;
+                _closedAfterWrite = out.isClosed();
                 return;
             }
 
@@ -1110,6 +1177,7 @@ public class HttpOutputTest
                                     out.write(_arrayBuffer[0]);
                                 else
                                     out.write(_arrayBuffer, 0, len);
+                                _closedAfterWrite = out.isClosed();
                             }
                             // assertFalse(out.isReady());
                         }
@@ -1136,7 +1204,7 @@ public class HttpOutputTest
                     else
                         out.write(_arrayBuffer, 0, len);
                 }
-
+                _closedAfterWrite = out.isClosed();
                 return;
             }
 
@@ -1168,6 +1236,7 @@ public class HttpOutputTest
                                 BufferUtil.put(_content, _byteBuffer);
                                 BufferUtil.flipToFlush(_byteBuffer, 0);
                                 out.write(_byteBuffer);
+                                _closedAfterWrite = out.isClosed();
                                 isFirstWrite = false;
                             }
                         }
@@ -1190,7 +1259,7 @@ public class HttpOutputTest
                     BufferUtil.flipToFlush(_byteBuffer, 0);
                     out.write(_byteBuffer);
                 }
-
+                _closedAfterWrite = out.isClosed();
                 return;
             }
 
@@ -1201,6 +1270,7 @@ public class HttpOutputTest
                 else
                     out.sendContent(_content);
                 _content = null;
+                _closedAfterWrite = out.isClosed();
                 return;
             }
         }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletException;
@@ -41,6 +42,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HotSwapHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.resource.Resource;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -361,7 +363,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -376,7 +378,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -391,7 +393,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -406,7 +408,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -424,7 +426,7 @@ public class HttpOutputTest
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -439,7 +441,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -454,7 +456,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -469,7 +471,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -484,7 +486,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -499,7 +501,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -514,7 +516,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -530,7 +532,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -546,7 +548,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -562,7 +564,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -578,7 +580,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -597,7 +599,7 @@ public class HttpOutputTest
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -613,7 +615,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -629,7 +631,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -645,7 +647,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -662,7 +664,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, Matchers.not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
-        assertThat(_handler._closedAfterWrite, is(false));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -697,7 +699,7 @@ public class HttpOutputTest
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 11"));
         assertThat(response, containsString("simple text"));
-        assertThat(_handler._closedAfterWrite, is(true));
+        assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test
@@ -932,7 +934,7 @@ public class HttpOutputTest
                 aggregated += data.length;
             }
 
-            // write data that will not be aggregated
+            // write data that will not be aggregated because it is too large
             data = new byte[bufferSize + 1];
             Arrays.fill(data, (byte)(fill++));
             expected.write(data);
@@ -1112,7 +1114,7 @@ public class HttpOutputTest
         ReadableByteChannel _contentChannel;
         ByteBuffer _content;
         ChainedInterceptor _interceptor;
-        boolean _closedAfterWrite;
+        final FuturePromise<Boolean> _closedAfterWrite = new FuturePromise<>();
 
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
@@ -1133,7 +1135,7 @@ public class HttpOutputTest
             {
                 out.sendContent(_contentInputStream);
                 _contentInputStream = null;
-                _closedAfterWrite = out.isClosed();
+                _closedAfterWrite.succeeded(out.isClosed());
                 return;
             }
 
@@ -1141,7 +1143,7 @@ public class HttpOutputTest
             {
                 out.sendContent(_contentChannel);
                 _contentChannel = null;
-                _closedAfterWrite = out.isClosed();
+                _closedAfterWrite.succeeded(out.isClosed());
                 return;
             }
 
@@ -1168,6 +1170,7 @@ public class HttpOutputTest
                                     len = _arrayBuffer.length;
                                 if (len == 0)
                                 {
+                                    _closedAfterWrite.succeeded(out.isClosed());
                                     async.complete();
                                     break;
                                 }
@@ -1177,9 +1180,7 @@ public class HttpOutputTest
                                     out.write(_arrayBuffer[0]);
                                 else
                                     out.write(_arrayBuffer, 0, len);
-                                _closedAfterWrite = out.isClosed();
                             }
-                            // assertFalse(out.isReady());
                         }
 
                         @Override
@@ -1204,7 +1205,7 @@ public class HttpOutputTest
                     else
                         out.write(_arrayBuffer, 0, len);
                 }
-                _closedAfterWrite = out.isClosed();
+                _closedAfterWrite.succeeded(out.isClosed());
                 return;
             }
 
@@ -1228,6 +1229,7 @@ public class HttpOutputTest
                                 assertTrue(out.isReady());
                                 if (BufferUtil.isEmpty(_content))
                                 {
+                                    _closedAfterWrite.succeeded(out.isClosed());
                                     async.complete();
                                     break;
                                 }
@@ -1236,7 +1238,6 @@ public class HttpOutputTest
                                 BufferUtil.put(_content, _byteBuffer);
                                 BufferUtil.flipToFlush(_byteBuffer, 0);
                                 out.write(_byteBuffer);
-                                _closedAfterWrite = out.isClosed();
                                 isFirstWrite = false;
                             }
                         }
@@ -1259,7 +1260,7 @@ public class HttpOutputTest
                     BufferUtil.flipToFlush(_byteBuffer, 0);
                     out.write(_byteBuffer);
                 }
-                _closedAfterWrite = out.isClosed();
+                _closedAfterWrite.succeeded(out.isClosed());
                 return;
             }
 
@@ -1270,7 +1271,7 @@ public class HttpOutputTest
                 else
                     out.sendContent(_content);
                 _content = null;
-                _closedAfterWrite = out.isClosed();
+                _closedAfterWrite.succeeded(out.isClosed());
                 return;
             }
         }


### PR DESCRIPTION
Fixes #6562 the last written bytebuffer calculation.
Also fixed an associated issue with unnecessary flush of an empty when last calculation already signalled last.

