### PR TITLE
Fix #6565 Deploy Symlinked applications

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -271,8 +271,8 @@ public class WebAppProvider extends ScanningAppProvider
         // Resource aliases (after getting name) to ensure baseResource is not an alias
         if (resource.isAlias())
         {
-            resource = Resource.newResource(resource.getAlias());
-            file = resource.getFile().toPath().toRealPath().toFile();
+            file = new File(resource.getAlias()).toPath().toRealPath().toFile();
+            resource = Resource.newResource(file);
             if (!resource.exists())
                 throw new IllegalStateException("App resource does not exist " + resource);
         }

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.eclipse.jetty.deploy.test.XmlConfiguredJetty;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
@@ -124,9 +125,12 @@ public class WebAppProviderTest
         // Check Server for expected Handlers
         jetty.assertWebAppContextsExists("/bar", "/foo", "/bob");
 
+        // Check that baseResources are not aliases
+        jetty.getServer().getContainedBeans(ContextHandler.class).forEach(h -> assertFalse(h.getBaseResource().isAlias()));
+
         // Test for expected work/temp directory behaviour
         File workDir = jetty.getJettyDir("workish");
-        assertTrue(hasJettyGeneratedPath(workDir, "bar_war"), "Should have generated directory in work directory: " + workDir);
+        assertTrue(hasJettyGeneratedPath(workDir, "_war-_bar"), "Should have generated directory in work directory: " + workDir);
     }
     
     @Test

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -853,10 +853,14 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     @Override
     protected void doStart() throws Exception
     {
-        _availability.set(Availability.STARTING);
-
         if (_contextPath == null)
             throw new IllegalStateException("Null contextPath");
+
+        if (getBaseResource() != null && getBaseResource().isAlias())
+            LOG.warn("BaseResource {} is aliased to {} in {}. May not be supported in future releases.",
+                getBaseResource(), getBaseResource().getAlias(), this);
+
+        _availability.set(Availability.STARTING);
 
         if (_logger == null)
             _logger = LoggerFactory.getLogger(ContextHandler.class.getName() + getLogNameSuffix());


### PR DESCRIPTION
Fix #6565 Deploy Symlinked applications by treating extracting context name (which becomes the default context path) from the base resource and then following aliases, so that base resource will not be an alias.   

Added warning in ContextHandler if the base resource is an alias that we may not support this in future releases.

Signed-off-by: Greg Wilkins <gregw@webtide.com>