### PR TITLE
Issue #6554 - create the DefaultIdentityService even if no realmName is provided

### DIFF
--- a/jetty-security/src/main/java/org/eclipse/jetty/security/DefaultAuthenticatorFactory.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/DefaultAuthenticatorFactory.java
@@ -62,7 +62,7 @@ public class DefaultAuthenticatorFactory implements Authenticator.Factory
         String auth = configuration.getAuthMethod();
         Authenticator authenticator = null;
 
-        if (auth == null || Constraint.__BASIC_AUTH.equalsIgnoreCase(auth))
+        if (Constraint.__BASIC_AUTH.equalsIgnoreCase(auth))
             authenticator = new BasicAuthenticator();
         else if (Constraint.__DIGEST_AUTH.equalsIgnoreCase(auth))
             authenticator = new DigestAuthenticator();

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -293,9 +293,6 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
         return getServer().getBean(IdentityService.class);
     }
 
-    /**
-     *
-     */
     @Override
     protected void doStart()
         throws Exception
@@ -349,7 +346,7 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
                 throw new IllegalStateException("LoginService has different IdentityService to " + this);
         }
 
-        if (_authenticator == null && _identityService != null)
+        if (_authenticator == null)
         {
             // If someone has set an authenticator factory only use that, otherwise try the list of discovered factories.
             if (_authenticatorFactory != null)
@@ -396,7 +393,6 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
     }
 
     @Override
-
     protected void doStop() throws Exception
     {
         //if we discovered the services (rather than had them explicitly configured), remove them.

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -334,11 +334,8 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
 
             if (_identityService == null)
             {
-                if (_realmName != null)
-                {
-                    setIdentityService(new DefaultIdentityService());
-                    manage(_identityService);
-                }
+                setIdentityService(new DefaultIdentityService());
+                manage(_identityService);
             }
             else
                 unmanage(_identityService);

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/DefaultIdentityServiceTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/DefaultIdentityServiceTest.java
@@ -1,0 +1,89 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.security;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Server;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class DefaultIdentityServiceTest
+{
+    @Test
+    public void testDefaultIdentityService() throws Exception
+    {
+        Server server = new Server();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
+        TestAuthenticator authenticator = new TestAuthenticator();
+        securityHandler.setAuthenticator(authenticator);
+
+        try
+        {
+            server.setHandler(securityHandler);
+            server.start();
+
+            // The DefaultIdentityService should have been created by default.
+            assertThat(securityHandler.getIdentityService(), instanceOf(DefaultIdentityService.class));
+            assertThat(authenticator.getIdentityService(), instanceOf(DefaultIdentityService.class));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    public static class TestAuthenticator implements Authenticator
+    {
+        private IdentityService _identityService;
+
+        public IdentityService getIdentityService()
+        {
+            return _identityService;
+        }
+
+        @Override
+        public void setConfiguration(AuthConfiguration configuration)
+        {
+            _identityService = configuration.getIdentityService();
+        }
+
+        @Override
+        public String getAuthMethod()
+        {
+            return getClass().getSimpleName();
+        }
+
+        @Override
+        public void prepareRequest(ServletRequest request)
+        {
+        }
+
+        @Override
+        public Authentication validateRequest(ServletRequest request, ServletResponse response, boolean mandatory) throws ServerAuthException
+        {
+            return null;
+        }
+
+        @Override
+        public boolean secureResponse(ServletRequest request, ServletResponse response, boolean mandatory, Authentication.User validatedUser) throws ServerAuthException
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Issue #6554 

- create the `DefaultIdentityService` even if no realmName is provided
- `DefaultAuthenticatorFactory` should not create `BasicAuthenticator` for null AuthMethod