### PR TITLE
Fix #6562 last written bytebuffer (#6563)

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -780,7 +780,7 @@ public class HttpOutputTest
         handler.start();
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(committed.get(), is(false));
+        assertThat(committed.get(10, TimeUnit.SECONDS), is(false));
     }
 
     @Test
@@ -812,7 +812,7 @@ public class HttpOutputTest
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 0"));
-        assertThat(committed.get(), is(true));
+        assertThat(committed.get(10, TimeUnit.SECONDS), is(true));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -756,7 +756,7 @@ public class HttpOutputTest
     @Test
     public void testEmptyArray() throws Exception
     {
-        AtomicBoolean committed = new AtomicBoolean();
+        FuturePromise<Boolean> committed = new FuturePromise<>();
         AbstractHandler handler = new AbstractHandler()
         {
             @Override
@@ -764,8 +764,15 @@ public class HttpOutputTest
             {
                 baseRequest.setHandled(true);
                 response.setStatus(200);
-                response.getOutputStream().write(new byte[0]);
-                committed.set(response.isCommitted());
+                try
+                {
+                    response.getOutputStream().write(new byte[0]);
+                    committed.succeeded(response.isCommitted());
+                }
+                catch (Throwable t)
+                {
+                    committed.failed(t);
+                }
             }
         };
 
@@ -779,7 +786,7 @@ public class HttpOutputTest
     @Test
     public void testEmptyArrayKnown() throws Exception
     {
-        AtomicBoolean committed = new AtomicBoolean();
+        FuturePromise<Boolean> committed = new FuturePromise<>();
         AbstractHandler handler = new AbstractHandler()
         {
             @Override
@@ -788,8 +795,15 @@ public class HttpOutputTest
                 baseRequest.setHandled(true);
                 response.setStatus(200);
                 response.setContentLength(0);
-                response.getOutputStream().write(new byte[0]);
-                committed.set(response.isCommitted());
+                try
+                {
+                    response.getOutputStream().write(new byte[0]);
+                    committed.succeeded(response.isCommitted());
+                }
+                catch (Throwable t)
+                {
+                    committed.failed(t);
+                }
             }
         };
 


### PR DESCRIPTION
Cherry pick of fix for #6562 from jetty-9 to jetty-10 for the last written `ByteBuffer` calculation.
Also fixed an associated issue with unnecessary flush of an empty when last calculation already signalled last.