### PR TITLE
Fixes #6369 - Increment default jetty.http2.rateControl.maxEventsPerS…

### DIFF
--- a/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/http2/introduction.adoc
@@ -37,7 +37,7 @@ In mid-2019, there were a link:#security-reports[number of CVEs] were issued war
 
 As a result of these CVEs, Jetty introduced a new, configurable denial of service (DOS) protection feature in Jetty 9.4.22.
 
-Jetty’s HTTP/2 implementation now features a new Rate Control parameter, `jetty.http2.rateControl.maxEventsPerSecond`, that defaults to 20 events per second, per connection for all pings, bad frames, settings frames, priority changes etc.
+Jetty’s HTTP/2 implementation now features a new Rate Control parameter, `jetty.http2.rateControl.maxEventsPerSecond`, that defaults to 50 events per second, per connection for all pings, bad frames, settings frames, priority changes etc.
 
 
 [[http2-modules]]

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
@@ -12,7 +12,7 @@
         <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
+            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50"/></Arg>
           </New>
         </Set>
       </New>

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
@@ -7,11 +7,12 @@
       <New class="org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory">
         <Arg name="config"><Ref refid="httpConfig"/></Arg>
         <Set name="maxConcurrentStreams"><Property name="jetty.http2c.maxConcurrentStreams" deprecated="http2.maxConcurrentStreams" default="1024"/></Set>
-        <Set name="initialStreamRecvWindow"><Property name="jetty.http2c.initialStreamRecvWindow" default="65535"/></Set>
-        <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
+        <Set name="initialStreamRecvWindow"><Property name="jetty.http2c.initialStreamRecvWindow" default="524288"/></Set>
+        <Set name="initialSessionRecvWindow"><Property name="jetty.http2c.initialSessionRecvWindow" default="1048576"/></Set>
+        <Set name="maxSettingsKeys"><Property name="jetty.http2c.maxSettingsKeys" default="64"/></Set>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
+            <Arg type="int"><Property name="jetty.http2c.rateControl.maxEventsPerSecond" default="50"/></Arg>
           </New>
         </Set>
       </New>

--- a/jetty-http2/http2-server/src/main/config/modules/http2.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2.mod
@@ -34,4 +34,4 @@ etc/jetty-http2.xml
 # jetty.http2.maxSettingsKeys=64
 
 ## Max number of bad frames and pings per second
-# jetty.http2.rateControl.maxEventsPerSecond=20
+# jetty.http2.rateControl.maxEventsPerSecond=50

--- a/jetty-http2/http2-server/src/main/config/modules/http2c.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2c.mod
@@ -23,10 +23,13 @@ etc/jetty-http2c.xml
 # jetty.http2c.maxConcurrentStreams=1024
 
 ## Initial stream receive window (client to server)
-# jetty.http2c.initialStreamRecvWindow=65535
+# jetty.http2c.initialStreamRecvWindow=524288
+
+## Initial session receive window (client to server)
+# jetty.http2c.initialSessionRecvWindow=1048576
 
 ## The max number of keys in all SETTINGS frames
-# jetty.http2.maxSettingsKeys=64
+# jetty.http2c.maxSettingsKeys=64
 
 ## Max number of bad frames and pings per second
-# jetty.http2.rateControl.maxEventsPerSecond=20
+# jetty.http2c.rateControl.maxEventsPerSecond=50

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -60,7 +60,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
     private int maxHeaderBlockFragment = 0;
     private int maxFrameLength = Frame.DEFAULT_MAX_LENGTH;
     private int maxSettingsKeys = SettingsFrame.DEFAULT_MAX_KEYS;
-    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(20);
+    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(50);
     private FlowControlStrategy.Factory flowControlStrategyFactory = () -> new BufferingFlowControlStrategy(0.5F);
     private long streamIdleTimeout;
 


### PR DESCRIPTION
…econd

Incremented rateControl.maxEventsPerSecond to 50.
Fixed mistakes in the http2c module.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>