### PR TITLE
Fixes #6369 - Increment default jetty.http2.rateControl.maxEventsPerS…

### DIFF
--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
@@ -12,7 +12,7 @@
         <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
+            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50"/></Arg>
           </New>
         </Set>
       </New>

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
@@ -8,11 +8,11 @@
         <Arg name="config"><Ref refid="httpConfig"/></Arg>
         <Set name="maxConcurrentStreams" property="jetty.http2c.maxConcurrentStreams"/>
         <Set name="initialStreamRecvWindow" property="jetty.http2c.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
-        <Set name="maxSettingsKeys" property="jetty.http2.maxSettingsKeys"/>
+        <Set name="initialSessionRecvWindow" property="jetty.http2c.initialSessionRecvWindow"/>
+        <Set name="maxSettingsKeys" property="jetty.http2c.maxSettingsKeys"/>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.parser.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="20"/></Arg>
+            <Arg type="int"><Property name="jetty.http2c.rateControl.maxEventsPerSecond" default="50"/></Arg>
           </New>
         </Set>
       </New>

--- a/jetty-http2/http2-server/src/main/config/modules/http2.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2.mod
@@ -33,5 +33,5 @@ etc/jetty-http2.xml
 
 ## Specifies the maximum number of bad frames and pings per second,
 ## after which a session is closed to avoid denial of service attacks.
-# jetty.http2.rateControl.maxEventsPerSecond=20
+# jetty.http2.rateControl.maxEventsPerSecond=50
 # end::documentation[]

--- a/jetty-http2/http2-server/src/main/config/modules/http2c.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2c.mod
@@ -20,16 +20,16 @@ etc/jetty-http2c.xml
 ## Specifies the maximum number of concurrent requests per session.
 # jetty.http2c.maxConcurrentStreams=128
 
-  ## Specifies the initial stream receive window (client to server) in bytes.
+## Specifies the initial stream receive window (client to server) in bytes.
 # jetty.http2c.initialStreamRecvWindow=524288
 
 ## Specifies the initial session receive window (client to server) in bytes.
-# jetty.http2.initialSessionRecvWindow=1232896
+# jetty.http2c.initialSessionRecvWindow=1232896
 
 ## Specifies the maximum number of keys in all SETTINGS frames received by a session.
-# jetty.http2.maxSettingsKeys=64
+# jetty.http2c.maxSettingsKeys=64
 
 ## Specifies the maximum number of bad frames and pings per second,
 ## after which a session is closed to avoid denial of service attacks.
-# jetty.http2.rateControl.maxEventsPerSecond=20
+# jetty.http2c.rateControl.maxEventsPerSecond=50
 # end::documentation[]

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -61,7 +61,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
     private int maxFrameLength = Frame.DEFAULT_MAX_LENGTH;
     private int maxSettingsKeys = SettingsFrame.DEFAULT_MAX_KEYS;
     private boolean connectProtocolEnabled = true;
-    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(20);
+    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(50);
     private FlowControlStrategy.Factory flowControlStrategyFactory = () -> new BufferingFlowControlStrategy(0.5F);
     private long streamIdleTimeout;
     private boolean useInputDirectByteBuffers;


### PR DESCRIPTION
…econd

Incremented rateControl.maxEventsPerSecond to 50.
Fixed mistakes in the http2c module.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 784293aa6d3e8c0bee77264258ac64ac48a4836f)