### PR TITLE
Upgrade ant to 1.10.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <hazelcast.version>3.12.10</hazelcast.version>
     <jboss.logging.version>3.4.1.Final</jboss.logging.version>
     <jetty.perf-helper.version>1.0.6</jetty.perf-helper.version>
-    <ant.version>1.10.9</ant.version>
+    <ant.version>1.10.11</ant.version>
     <unix.socket.tmp></unix.socket.tmp>
     <!-- enable or not TestTracker junit5 extension i.e log message when test method is starting -->
     <jetty.testtracker.log>false</jetty.testtracker.log>


### PR DESCRIPTION
Replacement for PR #6582, but on Jetty 9.4.x

Addresses CVE-2021-36373 and CVE-2021-36374