### PR TITLE
Fix #6476 Use dry run in jetty.sh

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -66,7 +66,8 @@ NAME=$(echo $(basename $0) | sed -e 's/^[SK][0-9]*//' -e 's/\.sh$//')
 #    <Arg><Property name="jetty.home" default="."/>/webapps/jetty.war</Arg>
 #
 # JETTY_BASE
-#   Where your Jetty base directory is.  If not set, the value from
+#   Where your Jetty base directory is.  If not set, then the currently
+#   directory is checked, otherwise the value from
 #   $JETTY_HOME will be used.
 #
 # JETTY_RUN
@@ -238,7 +239,6 @@ then
   fi
 fi
 
-
 ##################################################
 # No JETTY_HOME yet? We're out of luck!
 ##################################################
@@ -247,20 +247,23 @@ if [ -z "$JETTY_HOME" ]; then
   exit 1
 fi
 
+RUN_DIR=$PWD
 cd "$JETTY_HOME"
 JETTY_HOME=$PWD
-
 
 ##################################################
 # Set JETTY_BASE
 ##################################################
+export JETTY_BASE
 if [ -z "$JETTY_BASE" ]; then
-  JETTY_BASE=$JETTY_HOME
+  if [ -d "$RUN_DIR/start.d" -o -f "$RUN_DIR/start.ini" ]; then
+    JETTY_BASE=$RUN_DIR
+  else
+    JETTY_BASE=$JETTY_HOME
+  fi
 fi
-
 cd "$JETTY_BASE"
 JETTY_BASE=$PWD
-
 
 #####################################################
 # Check that jetty is where we think it is
@@ -430,7 +433,7 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=(${JAVA_OPTIONS[@]} -jar "$JETTY_START" ${JETTY_ARGS[*]})
+RUN_ARGS=$("$JAVA" ${JAVA_OPTIONS[@]} -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
 RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 #####################################################

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -433,8 +433,8 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$("$JAVA" ${JAVA_OPTIONS[@]} -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
-RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
+RUN_ARGS=$("$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
+RUN_CMD=("$JAVA" ${JAVA_OPTIONS[@]} ${RUN_ARGS[@]})
 
 #####################################################
 # Comment these out after you're happy with what

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -433,7 +433,7 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]} | tail -1 )
+RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]} | egrep ' org.eclipse.jetty.xml.XmlConfiguration ' )
 RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 #####################################################

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -433,8 +433,8 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$("$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
-RUN_CMD=("$JAVA" ${JAVA_OPTIONS[@]} ${RUN_ARGS[@]})
+RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]} | tail -1 )
+RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 #####################################################
 # Comment these out after you're happy with what

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -247,9 +247,9 @@ if [ -z "$JETTY_HOME" ]; then
   exit 1
 fi
 
-RUN_DIR=$PWD
+RUN_DIR=$(pwd)
 cd "$JETTY_HOME"
-JETTY_HOME=$PWD
+JETTY_HOME=$(pwd)
 
 ##################################################
 # Set JETTY_BASE
@@ -263,7 +263,7 @@ if [ -z "$JETTY_BASE" ]; then
   fi
 fi
 cd "$JETTY_BASE"
-JETTY_BASE=$PWD
+JETTY_BASE=$(pwd)
 
 #####################################################
 # Check that jetty is where we think it is

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -433,7 +433,7 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]} | egrep ' org.eclipse.jetty.xml.XmlConfiguration ' )
+RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
 RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 #####################################################


### PR DESCRIPTION
#6476  Use a --dry-run in jetty.sh to pre-expand the java arguments and thus avoid having two JVMs running in the case of exec.

Also made a small change to allow script to check the current directory for JETTY_BASE, as that allows testing and runs in the same style as direct calls to start.jar

Signed-off-by: Greg Wilkins <gregw@webtide.com>