### PR TITLE
Fix flaky HttpOutputTest.testEmptyBufferKnown

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpOutputTest.java
@@ -851,7 +851,7 @@ public class HttpOutputTest
     }
 
     @Test
-    public void testEmptyBufferKnown() throws Exception
+    public void testEmptyBufferWithZeroContentLength() throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
         AbstractHandler handler = new AbstractHandler()


### PR DESCRIPTION
Fixes #6605 

Make sure the assertion does not happen before the committed flag is read.