### PR TITLE
Fixes #6372 - Review socket options configuration.

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -82,6 +82,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -1972,6 +1973,45 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
         assertTrue(clientResultLatch.await(5, TimeUnit.SECONDS), "clientResultLatch didn't finish");
         assertTrue(serverOnErrorLatch.await(5, TimeUnit.SECONDS), "serverOnErrorLatch didn't finish");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testBindAddress(Scenario scenario) throws Exception
+    {
+        String bindAddress = "127.0.0.2";
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, org.eclipse.jetty.server.Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                assertEquals(bindAddress, request.getRemoteAddr());
+            }
+        });
+
+        client.setBindAddress(new InetSocketAddress(bindAddress, 0));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/1")
+            .onRequestBegin(r ->
+            {
+                client.newRequest("localhost", connector.getLocalPort())
+                    .scheme(scenario.getScheme())
+                    .path("/2")
+                    .send(result ->
+                    {
+                        assertTrue(result.isSucceeded());
+                        assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+                        latch.countDown();
+                    });
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(HttpStatus.OK_200, response.getStatus());
     }
 
     private void assertCopyRequest(Request original)

--- a/jetty-http2/http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
+++ b/jetty-http2/http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
@@ -127,6 +127,7 @@ public class HTTP2Client extends ContainerLifeCycle
     private long connectTimeout = 10000;
     private boolean connectBlocking;
     private SocketAddress bindAddress;
+    private boolean tcpNoDelay = true;
     private int inputBufferSize = 8192;
     private List<String> protocols = Arrays.asList("h2", "h2-17", "h2-16", "h2-15", "h2-14");
     private int initialSessionRecvWindow = 16 * 1024 * 1024;
@@ -295,6 +296,16 @@ public class HTTP2Client extends ContainerLifeCycle
     public void setBindAddress(SocketAddress bindAddress)
     {
         this.bindAddress = bindAddress;
+    }
+
+    public boolean isTCPNoDelay()
+    {
+        return tcpNoDelay;
+    }
+
+    public void setTCPNoDelay(boolean tcpNoDelay)
+    {
+        this.tcpNoDelay = tcpNoDelay;
     }
 
     @ManagedAttribute("The size of the buffer used to read from the network")
@@ -471,7 +482,7 @@ public class HTTP2Client extends ContainerLifeCycle
 
     protected void configure(SocketChannel channel) throws IOException
     {
-        channel.socket().setTcpNoDelay(true);
+        channel.socket().setTcpNoDelay(isTCPNoDelay());
     }
 
     private class ClientSelectorManager extends SelectorManager

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -98,6 +98,9 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
             client.setConnectTimeout(httpClient.getConnectTimeout());
             client.setIdleTimeout(httpClient.getIdleTimeout());
             client.setInputBufferSize(httpClient.getResponseBufferSize());
+            client.setConnectBlocking(httpClient.isConnectBlocking());
+            client.setBindAddress(httpClient.getBindAddress());
+            client.setTCPNoDelay(httpClient.isTCPNoDelay());
         }
         addBean(client);
         super.doStart();


### PR DESCRIPTION
Made HTTP2Client.tcpNoDelay configurable.
Fixed copying of configuration in HttpClientTransportOverHTTP2.
Added test case for bindAddress.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>