### PR TITLE
Issue #6618 - azp claim should not be required for single value aud array

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/JwtDecoder.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/JwtDecoder.java
@@ -35,6 +35,7 @@ public class JwtDecoder
      * @param jwt the JWT to decode.
      * @return the map of claims encoded in the JWT.
      */
+    @SuppressWarnings("unchecked")
     public static Map<String, Object> decode(String jwt)
     {
         if (LOG.isDebugEnabled())
@@ -54,7 +55,6 @@ public class JwtDecoder
         Object parsedJwtHeader = json.fromJSON(jwtHeaderString);
         if (!(parsedJwtHeader instanceof Map))
             throw new IllegalStateException("Invalid JWT header");
-        @SuppressWarnings("unchecked")
         Map<String, Object> jwtHeader = (Map<String, Object>)parsedJwtHeader;
         if (LOG.isDebugEnabled())
             LOG.debug("JWT Header: {}", jwtHeader);

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdCredentialsTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdCredentialsTest.java
@@ -1,0 +1,40 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.security.openid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class OpenIdCredentialsTest
+{
+    @Test
+    public void testSingleAudienceValueInArray() throws Exception
+    {
+        String issuer = "myIssuer123";
+        String clientId = "myClientId456";
+        OpenIdConfiguration configuration = new OpenIdConfiguration(issuer, "", "", clientId, "", new HttpClient());
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("iss", issuer);
+        claims.put("aud", new String[]{clientId});
+        claims.put("exp", System.currentTimeMillis() + 5000);
+
+        assertDoesNotThrow(() -> OpenIdCredentials.validateClaims(claims, configuration));
+    }
+}

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdCredentialsTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdCredentialsTest.java
@@ -35,6 +35,6 @@ public class OpenIdCredentialsTest
         claims.put("aud", new String[]{clientId});
         claims.put("exp", System.currentTimeMillis() + 5000);
 
-        assertDoesNotThrow(() -> OpenIdCredentials.validateClaims(claims, configuration));
+        assertDoesNotThrow(() -> new OpenIdCredentials(claims).redeemAuthCode(configuration));
     }
 }


### PR DESCRIPTION
## Issue #6618

It currently incorrectly assumed that any array for the `aud` claim will contain more than 1 value.

We should only enforce an `azp` claim if the array for `aud` is longer than 1.