### PR TITLE
Issue #6617 - add support for the client_secret_basic authentication method

### DIFF
--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -26,7 +26,7 @@
     <Arg><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
     <Arg><Property name="jetty.openid.clientId"/></Arg>
     <Arg><Property name="jetty.openid.clientSecret"/></Arg>
-    <Arg><Property name="jetty.openid.basicAuth" default="client_secret_post"/></Arg>
+    <Arg><Property name="jetty.openid.authMethod" default="client_secret_post"/></Arg>
     <Arg><Ref refid="HttpClient"/></Arg>
     <Call name="addScopes">
       <Arg>

--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -26,6 +26,7 @@
     <Arg><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
     <Arg><Property name="jetty.openid.clientId"/></Arg>
     <Arg><Property name="jetty.openid.clientSecret"/></Arg>
+    <Arg><Property name="jetty.openid.basicAuth" default="client_secret_post"/></Arg>
     <Arg><Ref refid="HttpClient"/></Arg>
     <Call name="addScopes">
       <Arg>

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -44,4 +44,4 @@ etc/jetty-openid.xml
 # jetty.openid.sslContextFactory.trustAll=false
 
 ## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
-# jetty.openid.basicAuth=client_secret_post
+# jetty.openid.authMethod=client_secret_post

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -42,3 +42,6 @@ etc/jetty-openid.xml
 
 ## True if all certificates should be trusted by the default SslContextFactory
 # jetty.openid.sslContextFactory.trustAll=false
+
+## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
+# jetty.openid.basicAuth=client_secret_post

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -45,6 +45,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     private final String clientId;
     private final String clientSecret;
     private final List<String> scopes = new ArrayList<>();
+    private final String authMethod;
     private String authEndpoint;
     private String tokenEndpoint;
 
@@ -71,12 +72,29 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint,
                                String clientId, String clientSecret, HttpClient httpClient)
     {
+        this(issuer, authorizationEndpoint, tokenEndpoint, clientId, clientSecret, "post", httpClient);
+    }
+
+    /**
+     * Create an OpenID configuration for a specific OIDC provider.
+     * @param issuer The URL of the OpenID provider.
+     * @param authorizationEndpoint the URL of the OpenID provider's authorization endpoint if configured.
+     * @param tokenEndpoint the URL of the OpenID provider's token endpoint if configured.
+     * @param clientId OAuth 2.0 Client Identifier valid at the Authorization Server.
+     * @param clientSecret The client secret known only by the Client and the Authorization Server.
+     * @param authMethod Authentication method to use with the Token Endpoint.
+     * @param httpClient The {@link HttpClient} instance to use.
+     */
+    public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint,
+                               String clientId, String clientSecret, String authMethod, HttpClient httpClient)
+    {
         this.issuer = issuer;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authEndpoint = authorizationEndpoint;
         this.tokenEndpoint = tokenEndpoint;
         this.httpClient = httpClient != null ? httpClient : newHttpClient();
+        this.authMethod = authMethod;
 
         if (this.issuer == null)
             throw new IllegalArgumentException("Issuer was not configured");
@@ -175,6 +193,11 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public String getTokenEndpoint()
     {
         return tokenEndpoint;
+    }
+
+    public String getAuthMethod()
+    {
+        return authMethod;
     }
 
     public void addScopes(String... scopes)

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -72,7 +72,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint,
                                String clientId, String clientSecret, HttpClient httpClient)
     {
-        this(issuer, authorizationEndpoint, tokenEndpoint, clientId, clientSecret, "post", httpClient);
+        this(issuer, authorizationEndpoint, tokenEndpoint, clientId, clientSecret, "client_secret_post", httpClient);
     }
 
     /**

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -14,12 +14,15 @@
 package org.eclipse.jetty.security.openid;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.client.api.Authentication;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.FormRequestContent;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.ajax.JSON;
@@ -153,14 +156,27 @@ public class OpenIdCredentials implements Serializable
     {
         Fields fields = new Fields();
         fields.add("code", authCode);
-        fields.add("client_id", configuration.getClientId());
-        fields.add("client_secret", configuration.getClientSecret());
         fields.add("redirect_uri", redirectUri);
         fields.add("grant_type", "authorization_code");
+
+        Request request = configuration.getHttpClient().POST(configuration.getTokenEndpoint());
+        switch (configuration.getAuthMethod())
+        {
+            case "client_secret_basic":
+                URI uri = URI.create(configuration.getTokenEndpoint());
+                Authentication.Result authentication = new BasicAuthentication.BasicResult(uri, configuration.getClientId(), configuration.getClientSecret());
+                authentication.apply(request);
+                break;
+            case "client_secret_post":
+                fields.add("client_id", configuration.getClientId());
+                fields.add("client_secret", configuration.getClientSecret());
+                break;
+            default:
+                throw new IllegalStateException(configuration.getAuthMethod());
+        }
+
         FormRequestContent formContent = new FormRequestContent(fields);
-        Request request = configuration.getHttpClient().POST(configuration.getTokenEndpoint())
-                .body(formContent)
-                .timeout(10, TimeUnit.SECONDS);
+        request = request.body(formContent).timeout(10, TimeUnit.SECONDS);
         ContentResponse response = request.send();
         String responseBody = response.getContentAsString();
         if (LOG.isDebugEnabled())


### PR DESCRIPTION
## Issue #6617 

Add support for the `client_secret_basic` authentication method defined in https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication.

I have defined a field `OpenIdConfiguration.authMethod` as a `String`, this is to eventually add support for the other auth methods such as `client_secret_jwt` (see issue #4310).