### PR TITLE
Issue #6327 Remove/re-enable disabled ShutdownMonitorTest tests

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
@@ -68,21 +68,8 @@ public class ShutdownMonitorTest
         }
     }
 
-    @Disabled("Issue #2626")
     @Test
     public void testStartStopDifferentPortDifferentKey() throws Exception
-    {
-        testStartStop(false);
-    }
-
-    @Disabled("Issue #2626")
-    @Test
-    public void testStartStopSamePortDifferentKey() throws Exception
-    {
-        testStartStop(true);
-    }
-
-    private void testStartStop(boolean reusePort) throws Exception
     {
         ShutdownMonitor monitor = ShutdownMonitor.getInstance();
         // monitor.setDebug(true);
@@ -100,7 +87,7 @@ public class ShutdownMonitorTest
         assertTrue(!monitor.isAlive());
 
         // Should be able to change port and key because it is stopped.
-        monitor.setPort(reusePort ? port : 0);
+        monitor.setPort(0);
         String newKey = "foo";
         monitor.setKey(newKey);
         monitor.start();
@@ -150,7 +137,6 @@ public class ShutdownMonitorTest
     public void testOldStopCommandWithStopOnShutdownTrue() throws Exception
     {
         ShutdownMonitor monitor = ShutdownMonitor.getInstance();
-        // monitor.setDebug(true);
         monitor.setPort(0);
         monitor.setExitVm(false);
         monitor.start();
@@ -211,7 +197,6 @@ public class ShutdownMonitorTest
 
     public void stop(String command, int port, String key, boolean check) throws Exception
     {
-        // System.out.printf("Attempting to send " + command + " to localhost:%d (%b)%n", port, check);
         try (Socket s = new Socket(InetAddress.getByName("127.0.0.1"), port))
         {
             // send stop command


### PR DESCRIPTION
Part of the disabled tests review in #6327 


* testStartStopSamePortDifferentKey() - removed this test, as you cannot know that the port you previously used will still be available to rerun the test
* testStartStopDifferentPortDifferentKey() - re-enabled this test, as I can't see how it would be problematic