### PR TITLE
Issue #6327 Ensure TempDirTest runs in envs other than CI

### DIFF
--- a/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/TempDirTest.java
+++ b/jetty-webapp/src/test/java/org/eclipse/jetty/webapp/TempDirTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -289,9 +290,11 @@ public class TempDirTest
 
     /**
      * ServletContext.TEMPDIR has invalid <code>String</code> directory value (wrong permission to write into it)
-     * IllegalStateException
+     *
+     * Note that if run in the CI environment, the test will fail, because it runs as root,
+     * so we _will_ have permission to write to this directory.
      */
-    @Disabled("Jenkins will run as root so we do have permission to write to this directory.")
+    @DisabledIfSystemProperty(named = "env", matches = "ci")
     @Test
     public void attributeWithInvalidPermissions()
     {

--- a/pom.xml
+++ b/pom.xml
@@ -1458,6 +1458,9 @@
               <version>${maven.surefire.version}</version>
               <configuration>
                 <excludedGroups>external, large-disk-resource</excludedGroups>
+                <systemPropertyVariables>
+                  <env>ci</env>
+                </systemPropertyVariables>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
Only disable the TempDirTest.attributeWithInvalidPermissions on CI, otherwise run it.

Part of #6327 