### PR TITLE
Fixes #6603 - HTTP/2 max local stream count exceeded

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -132,12 +132,12 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     protected int getMaxMultiplex()
     {
-        return pool.getMaxInUse();
+        return pool.getMaxMultiplex();
     }
 
     protected void setMaxMultiplex(int maxMultiplex)
     {
-        pool.setMaxInUse(maxMultiplex);
+        pool.setMaxMultiplex(maxMultiplex);
     }
 
     protected int getMaxUsageCount()

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -142,18 +142,11 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     protected void setMaxMultiplex(Connection connection, int maxMultiplex)
     {
-        if (connection == null)
+        if (connection instanceof Attachable)
         {
-            setMaxMultiplex(maxMultiplex);
-        }
-        else
-        {
-            if (connection instanceof Attachable)
-            {
-                Object attachment = ((Attachable)connection).getAttachment();
-                if (attachment instanceof EntryHolder)
-                    ((EntryHolder)attachment).entry.setMaxMultiplex(maxMultiplex);
-            }
+            Object attachment = ((Attachable)connection).getAttachment();
+            if (attachment instanceof EntryHolder)
+                ((EntryHolder)attachment).entry.setMaxMultiplex(maxMultiplex);
         }
     }
 
@@ -545,6 +538,8 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
                 onCreated(connection);
                 pending.decrementAndGet();
                 reserved.enable(connection, false);
+                if (connection instanceof Multiplexable)
+                    setMaxMultiplex(connection, ((ConnectionPool.Multiplexable)connection).getMaxMultiplex());
                 idle(connection, false);
                 complete(null);
                 proceed();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -70,7 +70,12 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     protected AbstractConnectionPool(HttpDestination destination, int maxConnections, boolean cache, Callback requester)
     {
-        this(destination, new Pool<>(Pool.StrategyType.FIRST, maxConnections, cache), requester);
+        this(destination, Pool.StrategyType.FIRST, maxConnections, cache, requester);
+    }
+
+    protected AbstractConnectionPool(HttpDestination destination, Pool.StrategyType strategy, int maxConnections, boolean cache, Callback requester)
+    {
+        this(destination, new Pool<>(strategy, maxConnections, cache), requester);
     }
 
     protected AbstractConnectionPool(HttpDestination destination, Pool<Connection> pool, Callback requester)
@@ -78,6 +83,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         this.destination = destination;
         this.requester = requester;
         this.pool = pool;
+        pool.setMaxMultiplex(1); // Force the use of MultiUseEntry
         addBean(pool);
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -140,6 +140,23 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         pool.setMaxMultiplex(maxMultiplex);
     }
 
+    protected void setMaxMultiplex(Connection connection, int maxMultiplex)
+    {
+        if (connection == null)
+        {
+            setMaxMultiplex(maxMultiplex);
+        }
+        else
+        {
+            if (connection instanceof Attachable)
+            {
+                Object attachment = ((Attachable)connection).getAttachment();
+                if (attachment instanceof EntryHolder)
+                    ((EntryHolder)attachment).entry.setMaxMultiplex(maxMultiplex);
+            }
+        }
+    }
+
     protected int getMaxUsageCount()
     {
         return pool.getMaxUsageCount();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -132,22 +132,12 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     protected int getMaxMultiplex()
     {
-        return pool.getMaxMultiplex();
+        return pool.getMaxInUse();
     }
 
     protected void setMaxMultiplex(int maxMultiplex)
     {
-        pool.setMaxMultiplex(maxMultiplex);
-    }
-
-    protected void setMaxMultiplex(Connection connection, int maxMultiplex)
-    {
-        if (connection instanceof Attachable)
-        {
-            Object attachment = ((Attachable)connection).getAttachment();
-            if (attachment instanceof EntryHolder)
-                ((EntryHolder)attachment).entry.setMaxMultiplex(maxMultiplex);
-        }
+        pool.setMaxInUse(maxMultiplex);
     }
 
     protected int getMaxUsageCount()
@@ -538,8 +528,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
                 onCreated(connection);
                 pending.decrementAndGet();
                 reserved.enable(connection, false);
-                if (connection instanceof Multiplexable)
-                    setMaxMultiplex(connection, ((ConnectionPool.Multiplexable)connection).getMaxMultiplex());
                 idle(connection, false);
                 complete(null);
                 proceed();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
@@ -109,13 +109,22 @@ public interface ConnectionPool extends Closeable
     interface Multiplexable
     {
         /**
-         * @return the max number of requests multiplexable on a single connection
+         * @return the default max number of requests multiplexable on a connection
          */
         int getMaxMultiplex();
 
         /**
-         * @param maxMultiplex the max number of requests multiplexable on a single connection
+         * @param maxMultiplex the default max number of requests multiplexable on a connection
          */
         void setMaxMultiplex(int maxMultiplex);
+
+        /**
+         * @param connection the multiplexed connection
+         * @param maxMultiplex the max number of requests multiplexable on the given connection
+         */
+        default void setMaxMultiplex(Connection connection, int maxMultiplex)
+        {
+            setMaxMultiplex(maxMultiplex);
+        }
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
@@ -104,27 +104,18 @@ public interface ConnectionPool extends Closeable
     }
 
     /**
-     * Marks a connection pool as supporting multiplexed connections.
+     * Marks a connection as supporting multiplexed requests.
      */
     interface Multiplexable
     {
         /**
-         * @return the default max number of requests multiplexable on a connection
+         * @return the max number of requests that can be multiplexed on a connection
          */
         int getMaxMultiplex();
 
         /**
-         * @param maxMultiplex the default max number of requests multiplexable on a connection
+         * @param maxMultiplex the max number of requests that can be multiplexed on a connection
          */
         void setMaxMultiplex(int maxMultiplex);
-
-        /**
-         * @param connection the multiplexed connection
-         * @param maxMultiplex the max number of requests multiplexable on the given connection
-         */
-        default void setMaxMultiplex(Connection connection, int maxMultiplex)
-        {
-            setMaxMultiplex(maxMultiplex);
-        }
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ConnectionPool.java
@@ -102,20 +102,4 @@ public interface ConnectionPool extends Closeable
          */
         ConnectionPool newConnectionPool(HttpDestination destination);
     }
-
-    /**
-     * Marks a connection as supporting multiplexed requests.
-     */
-    interface Multiplexable
-    {
-        /**
-         * @return the max number of requests that can be multiplexed on a connection
-         */
-        int getMaxMultiplex();
-
-        /**
-         * @param maxMultiplex the max number of requests that can be multiplexed on a connection
-         */
-        void setMaxMultiplex(int maxMultiplex);
-    }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/DuplexConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/DuplexConnectionPool.java
@@ -34,9 +34,10 @@ public class DuplexConnectionPool extends AbstractConnectionPool
 
     public DuplexConnectionPool(HttpDestination destination, int maxConnections, boolean cache, Callback requester)
     {
-        this(destination, new Pool<>(Pool.StrategyType.FIRST, maxConnections, cache), requester);
+        super(destination, Pool.StrategyType.FIRST, maxConnections, cache, requester);
     }
 
+    @Deprecated
     public DuplexConnectionPool(HttpDestination destination, Pool<Connection> pool, Callback requester)
     {
         super(destination, pool, requester);

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
 @ManagedObject
-public class MultiplexConnectionPool extends AbstractConnectionPool implements ConnectionPool.Multiplexable
+public class MultiplexConnectionPool extends AbstractConnectionPool
 {
     public MultiplexConnectionPool(HttpDestination destination, int maxConnections, Callback requester, int maxMultiplex)
     {
@@ -54,12 +54,6 @@ public class MultiplexConnectionPool extends AbstractConnectionPool implements C
     public void setMaxMultiplex(int maxMultiplex)
     {
         super.setMaxMultiplex(maxMultiplex);
-    }
-
-    @Override
-    public void setMaxMultiplex(Connection connection, int maxMultiplex)
-    {
-        super.setMaxMultiplex(connection, maxMultiplex);
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexConnectionPool.java
@@ -57,6 +57,12 @@ public class MultiplexConnectionPool extends AbstractConnectionPool implements C
     }
 
     @Override
+    public void setMaxMultiplex(Connection connection, int maxMultiplex)
+    {
+        super.setMaxMultiplex(connection, maxMultiplex);
+    }
+
+    @Override
     @ManagedAttribute(value = "The maximum amount of times a connection is used before it gets closed")
     public int getMaxUsageCount()
     {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
@@ -18,8 +18,6 @@
 
 package org.eclipse.jetty.client;
 
-import org.eclipse.jetty.client.api.Connection;
-
 public abstract class MultiplexHttpDestination extends HttpDestination
 {
     protected MultiplexHttpDestination(HttpClient client, Origin origin)
@@ -40,12 +38,5 @@ public abstract class MultiplexHttpDestination extends HttpDestination
         ConnectionPool connectionPool = getConnectionPool();
         if (connectionPool instanceof AbstractConnectionPool)
             ((AbstractConnectionPool)connectionPool).setMaxMultiplex(maxRequestsPerConnection);
-    }
-
-    public void setMaxRequestsPerConnection(Connection connection, int maxRequestsPerConnection)
-    {
-        ConnectionPool connectionPool = getConnectionPool();
-        if (connectionPool instanceof AbstractConnectionPool)
-            ((AbstractConnectionPool)connectionPool).setMaxMultiplex(connection, maxRequestsPerConnection);
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.client;
 
+import org.eclipse.jetty.client.api.Connection;
+
 public abstract class MultiplexHttpDestination extends HttpDestination
 {
     protected MultiplexHttpDestination(HttpClient client, Origin origin)
@@ -35,8 +37,13 @@ public abstract class MultiplexHttpDestination extends HttpDestination
 
     public void setMaxRequestsPerConnection(int maxRequestsPerConnection)
     {
+        setMaxRequestsPerConnection(null, maxRequestsPerConnection);
+    }
+
+    public void setMaxRequestsPerConnection(Connection connection, int maxRequestsPerConnection)
+    {
         ConnectionPool connectionPool = getConnectionPool();
         if (connectionPool instanceof ConnectionPool.Multiplexable)
-            ((ConnectionPool.Multiplexable)connectionPool).setMaxMultiplex(maxRequestsPerConnection);
+            ((ConnectionPool.Multiplexable)connectionPool).setMaxMultiplex(connection, maxRequestsPerConnection);
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/MultiplexHttpDestination.java
@@ -30,20 +30,22 @@ public abstract class MultiplexHttpDestination extends HttpDestination
     public int getMaxRequestsPerConnection()
     {
         ConnectionPool connectionPool = getConnectionPool();
-        if (connectionPool instanceof ConnectionPool.Multiplexable)
-            return ((ConnectionPool.Multiplexable)connectionPool).getMaxMultiplex();
+        if (connectionPool instanceof AbstractConnectionPool)
+            return ((AbstractConnectionPool)connectionPool).getMaxMultiplex();
         return 1;
     }
 
     public void setMaxRequestsPerConnection(int maxRequestsPerConnection)
     {
-        setMaxRequestsPerConnection(null, maxRequestsPerConnection);
+        ConnectionPool connectionPool = getConnectionPool();
+        if (connectionPool instanceof AbstractConnectionPool)
+            ((AbstractConnectionPool)connectionPool).setMaxMultiplex(maxRequestsPerConnection);
     }
 
     public void setMaxRequestsPerConnection(Connection connection, int maxRequestsPerConnection)
     {
         ConnectionPool connectionPool = getConnectionPool();
-        if (connectionPool instanceof ConnectionPool.Multiplexable)
-            ((ConnectionPool.Multiplexable)connectionPool).setMaxMultiplex(connection, maxRequestsPerConnection);
+        if (connectionPool instanceof AbstractConnectionPool)
+            ((AbstractConnectionPool)connectionPool).setMaxMultiplex(connection, maxRequestsPerConnection);
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/RandomConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/RandomConnectionPool.java
@@ -31,6 +31,6 @@ public class RandomConnectionPool extends MultiplexConnectionPool
 {
     public RandomConnectionPool(HttpDestination destination, int maxConnections, Callback requester, int maxMultiplex)
     {
-        super(destination, new Pool<>(Pool.StrategyType.RANDOM, maxConnections, false), requester, maxMultiplex);
+        super(destination, Pool.StrategyType.RANDOM, maxConnections, false, requester, maxMultiplex);
     }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/RoundRobinConnectionPool.java
@@ -56,7 +56,7 @@ public class RoundRobinConnectionPool extends MultiplexConnectionPool
 
     public RoundRobinConnectionPool(HttpDestination destination, int maxConnections, Callback requester, int maxMultiplex)
     {
-        super(destination, new Pool<>(Pool.StrategyType.ROUND_ROBIN, maxConnections, false), requester, maxMultiplex);
+        super(destination, Pool.StrategyType.ROUND_ROBIN, maxConnections, false, requester, maxMultiplex);
         // If there are queued requests and connections get
         // closed due to idle timeout or overuse, we want to
         // aggressively try to open new connections to replace

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -738,7 +738,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxLocalStreams();
             if (maxCount >= 0 && localCount >= maxCount)
             {
-                promise.failed(new IllegalStateException("Max local stream count " + maxCount + " exceeded"));
+                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create local stream #{} for {}", streamId, this, failure);
+                promise.failed(failure);
                 return null;
             }
             if (localStreamCount.compareAndSet(localCount, localCount + 1))
@@ -751,7 +754,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             stream.setIdleTimeout(getStreamIdleTimeout());
             flowControl.onStreamCreated(stream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created local {}", stream);
+                LOG.debug("Created local {} for {}", stream, this);
             return stream;
         }
         else
@@ -786,6 +789,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxRemoteStreams();
             if (maxCount >= 0 && remoteCount - remoteClosing >= maxCount)
             {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create remote stream #{} for {}", streamId, this);
                 reset(null, new ResetFrame(streamId, ErrorCode.REFUSED_STREAM_ERROR.code), Callback.from(() -> onStreamDestroyed(streamId)));
                 return null;
             }
@@ -799,7 +804,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             stream.setIdleTimeout(getStreamIdleTimeout());
             flowControl.onStreamCreated(stream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created remote {}", stream);
+                LOG.debug("Created remote {} for {}", stream, this);
             return stream;
         }
         else
@@ -945,7 +950,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
     private void onStreamCreated(int streamId)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Created stream #{} for {}", streamId, this);
+            LOG.debug("Creating stream #{} for {}", streamId, this);
         streamsState.onStreamCreated();
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -738,7 +738,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxLocalStreams();
             if (maxCount >= 0 && localCount >= maxCount)
             {
-                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded");
+                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded: " + localCount);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create local stream #{} for {}", streamId, this, failure);
                 promise.failed(failure);
@@ -789,8 +789,9 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxRemoteStreams();
             if (maxCount >= 0 && remoteCount - remoteClosing >= maxCount)
             {
+                IllegalStateException failure = new IllegalStateException("Max remote stream count " + maxCount + " exceeded: " + remoteCount + "+" + remoteClosing);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Could not create remote stream #{} for {}", streamId, this);
+                    LOG.debug("Could not create remote stream #{} for {}", streamId, this, failure);
                 reset(null, new ResetFrame(streamId, ErrorCode.REFUSED_STREAM_ERROR.code), Callback.from(() -> onStreamDestroyed(streamId)));
                 return null;
             }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -737,7 +737,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxLocalStreams();
             if (maxCount >= 0 && localCount >= maxCount)
             {
-                promise.failed(new IllegalStateException("Max local stream count " + maxCount + " exceeded"));
+                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create local stream #{} for {}", streamId, this, failure);
+                promise.failed(failure);
                 return null;
             }
             if (localStreamCount.compareAndSet(localCount, localCount + 1))
@@ -750,7 +753,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             stream.setIdleTimeout(getStreamIdleTimeout());
             flowControl.onStreamCreated(stream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created local {}", stream);
+                LOG.debug("Created local {} for {}", stream, this);
             return stream;
         }
         else
@@ -785,6 +788,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxRemoteStreams();
             if (maxCount >= 0 && remoteCount - remoteClosing >= maxCount)
             {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create remote stream #{} for {}", streamId, this);
                 reset(null, new ResetFrame(streamId, ErrorCode.REFUSED_STREAM_ERROR.code), Callback.from(() -> onStreamDestroyed(streamId)));
                 return null;
             }
@@ -798,7 +803,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             stream.setIdleTimeout(getStreamIdleTimeout());
             flowControl.onStreamCreated(stream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created remote {}", stream);
+                LOG.debug("Created remote {} for {}", stream, this);
             return stream;
         }
         else
@@ -944,7 +949,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
     private void onStreamCreated(int streamId)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Created stream #{} for {}", streamId, this);
+            LOG.debug("Creating stream #{} for {}", streamId, this);
         streamsState.onStreamCreated();
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -737,7 +737,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxLocalStreams();
             if (maxCount >= 0 && localCount >= maxCount)
             {
-                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded");
+                IllegalStateException failure = new IllegalStateException("Max local stream count " + maxCount + " exceeded: " + localCount);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create local stream #{} for {}", streamId, this, failure);
                 promise.failed(failure);
@@ -788,8 +788,9 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             int maxCount = getMaxRemoteStreams();
             if (maxCount >= 0 && remoteCount - remoteClosing >= maxCount)
             {
+                IllegalStateException failure = new IllegalStateException("Max remote stream count " + maxCount + " exceeded: " + remoteCount + "+" + remoteClosing);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Could not create remote stream #{} for {}", streamId, this);
+                    LOG.debug("Could not create remote stream #{} for {}", streamId, this, failure);
                 reset(null, new ResetFrame(streamId, ErrorCode.REFUSED_STREAM_ERROR.code), Callback.from(() -> onStreamDestroyed(streamId)));
                 return null;
             }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -211,26 +211,15 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         @Override
         public void onSettings(Session session, SettingsFrame frame)
         {
-            Map<Integer, Integer> settings = frame.getSettings();
-            Integer maxConcurrentStreams = settings.get(SettingsFrame.MAX_CONCURRENT_STREAMS);
             boolean[] initialized = new boolean[1];
-            Connection connection = this.connection.get(initialized);
-            if (initialized[0])
-            {
-                if (maxConcurrentStreams != null && connection != null)
-                    destination().setMaxRequestsPerConnection(connection, maxConcurrentStreams);
-            }
-            else
-            {
-                onServerPreface(session, maxConcurrentStreams);
-            }
+            this.connection.get(initialized);
+            if (!initialized[0])
+                onServerPreface(session);
         }
 
-        private void onServerPreface(Session session, Integer maxConcurrentStreams)
+        private void onServerPreface(Session session)
         {
             HttpConnectionOverHTTP2 connection = newHttpConnection(destination(), session);
-            if (maxConcurrentStreams != null)
-                connection.setMaxMultiplex(maxConcurrentStreams);
             if (this.connection.compareAndSet(null, connection, false, true))
                 connectionPromise().succeeded(connection);
         }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -212,8 +212,9 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         public void onSettings(Session session, SettingsFrame frame)
         {
             Map<Integer, Integer> settings = frame.getSettings();
-            if (settings.containsKey(SettingsFrame.MAX_CONCURRENT_STREAMS))
-                destination().setMaxRequestsPerConnection(settings.get(SettingsFrame.MAX_CONCURRENT_STREAMS));
+            Integer maxConcurrentStreams = settings.get(SettingsFrame.MAX_CONCURRENT_STREAMS);
+            if (maxConcurrentStreams != null)
+                destination().setMaxRequestsPerConnection(connection.getReference(), maxConcurrentStreams);
             if (!connection.isMarked())
                 onServerPreface(session);
         }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2.java
@@ -60,6 +60,8 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         setConnectionPoolFactory(destination ->
         {
             HttpClient httpClient = getHttpClient();
+            // Start with the minimum maxMultiplex; the SETTINGS frame from the
+            // server preface will override this value before any request is sent.
             return new MultiplexConnectionPool(destination, httpClient.getMaxConnectionsPerDestination(), destination, 1);
         });
     }

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.HttpChannel;
 import org.eclipse.jetty.client.HttpConnection;
 import org.eclipse.jetty.client.HttpDestination;
@@ -42,7 +43,7 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.thread.Sweeper;
 
-public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable
+public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable, ConnectionPool.Multiplexable
 {
     private static final Logger LOG = Log.getLogger(HttpConnection.class);
 
@@ -52,6 +53,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     private final AtomicInteger sweeps = new AtomicInteger();
     private final Session session;
     private boolean recycleHttpChannels = true;
+    private int maxMultiplex = 1;
 
     public HttpConnectionOverHTTP2(HttpDestination destination, Session session)
     {
@@ -72,6 +74,16 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     public void setRecycleHttpChannels(boolean recycleHttpChannels)
     {
         this.recycleHttpChannels = recycleHttpChannels;
+    }
+
+    public int getMaxMultiplex()
+    {
+        return maxMultiplex;
+    }
+
+    public void setMaxMultiplex(int maxMultiplex)
+    {
+        this.maxMultiplex = maxMultiplex;
     }
 
     @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -28,22 +28,23 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.HttpChannel;
 import org.eclipse.jetty.client.HttpConnection;
 import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.MultiplexConnectionPool;
 import org.eclipse.jetty.client.SendFailure;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.thread.Sweeper;
 
-public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable, ConnectionPool.Multiplexable
+public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable, MultiplexConnectionPool.Multiplexable
 {
     private static final Logger LOG = Log.getLogger(HttpConnection.class);
 
@@ -53,7 +54,6 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     private final AtomicInteger sweeps = new AtomicInteger();
     private final Session session;
     private boolean recycleHttpChannels = true;
-    private int maxMultiplex = 1;
 
     public HttpConnectionOverHTTP2(HttpDestination destination, Session session)
     {
@@ -76,14 +76,10 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         this.recycleHttpChannels = recycleHttpChannels;
     }
 
+    @Override
     public int getMaxMultiplex()
     {
-        return maxMultiplex;
-    }
-
-    public void setMaxMultiplex(int maxMultiplex)
-    {
-        this.maxMultiplex = maxMultiplex;
+        return ((HTTP2Session)session).getMaxLocalStreams();
     }
 
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -68,7 +68,10 @@ public class Pool<T> implements AutoCloseable, Dumpable
     private final ThreadLocal<Entry> cache;
     private final AtomicInteger nextIndex;
     private volatile boolean closed;
+
+    @Deprecated
     private volatile int maxUsage = -1;
+    @Deprecated
     private volatile int maxMultiplex = -1;
 
     /**
@@ -175,6 +178,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
      * @return the maximum number of entries
      */
     @ManagedAttribute("The maximum number of entries")
+    @Deprecated
     public int getMaxEntries()
     {
         return maxEntries;
@@ -184,11 +188,13 @@ public class Pool<T> implements AutoCloseable, Dumpable
      * @return the default maximum in-use count of entries
      */
     @ManagedAttribute("The default maximum multiplex count of entries")
+    @Deprecated
     public int getMaxMultiplex()
     {
         return maxMultiplex == -1 ? 1 : maxMultiplex;
     }
 
+    @Deprecated
     protected int getMaxMultiplex(T item)
     {
         return getMaxMultiplex();
@@ -199,6 +205,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
      *
      * @param maxMultiplex the default maximum multiplex count of entries
      */
+    @Deprecated
     public final void setMaxMultiplex(int maxMultiplex)
     {
         if (maxMultiplex < 1)
@@ -222,11 +229,13 @@ public class Pool<T> implements AutoCloseable, Dumpable
      * @return the default maximum usage count of entries
      */
     @ManagedAttribute("The default maximum usage count of entries")
+    @Deprecated
     public int getMaxUsageCount()
     {
         return maxUsage;
     }
 
+    @Deprecated
     protected int getMaxUsageCount(T item)
     {
         return getMaxUsageCount();
@@ -239,6 +248,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
      *
      * @param maxUsageCount the default maximum usage count of entries
      */
+    @Deprecated
     public final void setMaxUsageCount(int maxUsageCount)
     {
         if (maxUsageCount == 0)
@@ -648,6 +658,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
             return false;
         }
 
+        @Deprecated
         public int getUsageCount()
         {
             return isIdle() ? 0 : 1;
@@ -655,9 +666,9 @@ public class Pool<T> implements AutoCloseable, Dumpable
     }
 
     /**
-     * <p>A Pool entry that holds metadata and a pooled object.</p>
+     * <p>A Pool entry that holds metadata and a pooled object, that can only be used one at a time</p>
      */
-    public class SingleUseEntry extends Entry
+    private class SingleUseEntry extends Entry
     {
         // MIN_VALUE == pending; -1 == closed; 0 == idle; 1 == inuse ;
         private final AtomicInteger state;
@@ -778,6 +789,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
         }
     }
 
+    @Deprecated
     class MultiUseEntry extends Entry
     {
 
@@ -934,7 +946,9 @@ public class Pool<T> implements AutoCloseable, Dumpable
             int usageCount = AtomicBiInteger.getHi(encoded);
             int inUseCount = AtomicBiInteger.getLo(encoded);
 
-            String state = usageCount < 0 ? "CLOSED" : inUseCount == 0 ? "IDLE" : "INUSE";
+            String state = usageCount < 0
+                ? (usageCount == Integer.MIN_VALUE ? "PENDING" : "CLOSED")
+                : (inUseCount == 0 ? "IDLE" : "INUSE");
 
             return String.format("%s@%x{%s, used=%d, inUse=%d, pooled=%s}",
                 getClass().getSimpleName(),

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -353,8 +353,10 @@ public class Pool<T> implements AutoCloseable, Dumpable
         }
     }
 
-    protected Entry newEntry()
+    private Entry newEntry()
     {
+        // Do not allow more than 2 implementations of Entry, otherwise call sites in Pool
+        // referencing Entry methods will become mega-morphic and kill the performance.
         if (maxMultiplex >= 0 || maxUsage >= 0)
             return new MultiEntry();
         return new MonoEntry();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -627,7 +627,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
 
         /**
          * <p>Releases this Entry.</p>
-         * <p>This is equivalent to calling {@link Pool#release(Entry)} passing this entry.</p>
+         * <p>This is equivalent to calling {@link Pool#release(Pool.Entry)} passing this entry.</p>
          *
          * @return whether the entry was released
          */
@@ -638,7 +638,7 @@ public class Pool<T> implements AutoCloseable, Dumpable
 
         /**
          * <p>Removes the entry.</p>
-         * <p>This is equivalent to calling {@link Pool#remove(Entry)} passing this entry.</p>
+         * <p>This is equivalent to calling {@link Pool#remove(Pool.Entry)} passing this entry.</p>
          *
          * @return whether the entry was removed
          */

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
@@ -170,7 +170,7 @@ public class PoolTest
     public void testReserve(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(2);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
 
         // Reserve an entry
         Pool<CloseableHolder>.Entry e1 = pool.reserve();
@@ -400,7 +400,7 @@ public class PoolTest
     public void testMaxMultiplex(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(2);
-        pool.setMaxInUse(3);
+        pool.setMaxMultiplex(3);
 
         Map<String, AtomicInteger> counts = new HashMap<>();
         AtomicInteger a = new AtomicInteger();
@@ -434,7 +434,7 @@ public class PoolTest
     public void testRemoveMultiplexed(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -464,7 +464,7 @@ public class PoolTest
     public void testMultiplexRemoveThenAcquireThenReleaseRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -482,7 +482,7 @@ public class PoolTest
     public void testNonMultiplexRemoveAfterAcquire(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -495,7 +495,7 @@ public class PoolTest
     public void testMultiplexRemoveAfterAcquire(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -544,7 +544,7 @@ public class PoolTest
     public void testMultiplexMaxUsageReachedAcquireThenRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.setMaxUsageCount(3);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -565,7 +565,7 @@ public class PoolTest
     public void testMultiplexMaxUsageReachedAcquireThenReleaseThenRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.setMaxUsageCount(3);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -590,7 +590,7 @@ public class PoolTest
     public void testUsageCountAfterReachingMaxMultiplexLimit(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxInUse(2);
+        pool.setMaxMultiplex(2);
         pool.setMaxUsageCount(10);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -645,8 +645,8 @@ public class PoolTest
     @Test
     public void testConfigLimits()
     {
-        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxInUse(0));
-        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxInUse(-1));
+        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxMultiplex(0));
+        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxMultiplex(-1));
         assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxUsageCount(0));
     }
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/PoolTest.java
@@ -170,7 +170,7 @@ public class PoolTest
     public void testReserve(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(2);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
 
         // Reserve an entry
         Pool<CloseableHolder>.Entry e1 = pool.reserve();
@@ -400,7 +400,7 @@ public class PoolTest
     public void testMaxMultiplex(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(2);
-        pool.setMaxMultiplex(3);
+        pool.setMaxInUse(3);
 
         Map<String, AtomicInteger> counts = new HashMap<>();
         AtomicInteger a = new AtomicInteger();
@@ -434,7 +434,7 @@ public class PoolTest
     public void testRemoveMultiplexed(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -464,7 +464,7 @@ public class PoolTest
     public void testMultiplexRemoveThenAcquireThenReleaseRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -482,7 +482,7 @@ public class PoolTest
     public void testNonMultiplexRemoveAfterAcquire(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -495,7 +495,7 @@ public class PoolTest
     public void testMultiplexRemoveAfterAcquire(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
         Pool<CloseableHolder>.Entry e1 = pool.acquire();
@@ -544,7 +544,7 @@ public class PoolTest
     public void testMultiplexMaxUsageReachedAcquireThenRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.setMaxUsageCount(3);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -565,7 +565,7 @@ public class PoolTest
     public void testMultiplexMaxUsageReachedAcquireThenReleaseThenRemove(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.setMaxUsageCount(3);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -590,7 +590,7 @@ public class PoolTest
     public void testUsageCountAfterReachingMaxMultiplexLimit(Factory factory)
     {
         Pool<CloseableHolder> pool = factory.getPool(1);
-        pool.setMaxMultiplex(2);
+        pool.setMaxInUse(2);
         pool.setMaxUsageCount(10);
         pool.reserve().enable(new CloseableHolder("aaa"), false);
 
@@ -645,8 +645,8 @@ public class PoolTest
     @Test
     public void testConfigLimits()
     {
-        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxMultiplex(0));
-        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxMultiplex(-1));
+        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxInUse(0));
+        assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxInUse(-1));
         assertThrows(IllegalArgumentException.class, () -> new Pool<CloseableHolder>(FIRST, 1).setMaxUsageCount(0));
     }
 


### PR DESCRIPTION
Made MAX_CONCURRENT_STREAMS setting work on a per-connection basis.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>