### PR TITLE
Fixes #6624 - Non-domain SNI on java17

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -2178,9 +2178,9 @@ public abstract class SslContextFactory extends AbstractLifeCycle implements Dum
                 String host = sslEngine.getPeerHost();
                 if (host != null)
                 {
-                    // TODO Must handle : somehow as java17 SNIHostName never handles:  See #6624
                     // Must use the byte[] constructor, because the character ':' is forbidden when
                     // using the String constructor (but typically present in IPv6 addresses).
+                    // Since Java 17, only letter|digit|hyphen characters are allowed, even by the byte[] constructor.
                     return List.of(new SNIHostName(host.getBytes(StandardCharsets.US_ASCII)));
                 }
             }


### PR DESCRIPTION
Forward port of #6634.

Java 17 only allows letter|digit|hyphen characters for SNI names.

While we could bypass this restriction on the client, when the SNI bytes arrive to the server they will be verified and if not allowed the TLS handshake will fail.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 693663a4ce3ed0f35cc7da66760e02c9e3bc2d97)