### PR TITLE
Fixes #6652 - Improve ReservedThreadExecutor dump.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -19,6 +19,7 @@
 package org.eclipse.jetty.util.thread;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -196,6 +197,7 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
         _threads.stream()
             .filter(ReservedThread::isReserved)
             .map(t -> t._thread)
+            .filter(Objects::nonNull)
             .forEach(Thread::interrupt);
         _threads.clear();
         _count.getAndSetHi(0);

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -850,7 +850,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         dump = pool.dump();
         assertThat(count(dump, " - STARTED"), is(2));
         assertThat(dump, containsString(",3<=3<=4,i=2,r=2,q=0"));
-        assertThat(dump, containsString("s=0/2"));
+        assertThat(dump, containsString("reserved=0/2"));
         assertThat(dump, containsString("[ReservedThreadExecutor@"));
         assertThat(count(dump, " IDLE"), is(2));
         assertThat(count(dump, " WAITING"), is(1));
@@ -865,7 +865,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         dump = pool.dump();
         assertThat(count(dump, " - STARTED"), is(2));
         assertThat(dump, containsString(",3<=3<=4,i=1,r=2,q=0"));
-        assertThat(dump, containsString("s=1/2"));
+        assertThat(dump, containsString("reserved=1/2"));
         assertThat(dump, containsString("[ReservedThreadExecutor@"));
         assertThat(count(dump, " IDLE"), is(1));
         assertThat(count(dump, " WAITING"), is(1));

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
@@ -360,6 +360,8 @@ public class ReservedThreadExecutorTest
         while (!reserved.tryExecute(() -> {}))
             Thread.yield();
 
+        System.err.println(reserved.dump());
+
         reserved.stop();
         pool.stop();
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/ReservedThreadExecutorTest.java
@@ -360,13 +360,10 @@ public class ReservedThreadExecutorTest
         while (!reserved.tryExecute(() -> {}))
             Thread.yield();
 
-        System.err.println(reserved.dump());
-
         reserved.stop();
         pool.stop();
 
         assertThat(usedReserved.get(), greaterThan(0));
         assertThat(usedReserved.get() + usedPool.get(), is(LOOPS));
-        // System.err.printf("reserved=%d pool=%d total=%d%n", usedReserved.get(), usedPool.get(), LOOPS);
     }
 }


### PR DESCRIPTION
Now adding/removing ReservedThread instances to _threads only in reservedWait().
In this way the window of time in which they can be caught for a dump() is shorter, producing more accurate dumps.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>