### PR TITLE
Jetty 10.0.x 6497 alias checkers alt

### DIFF
--- a/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -43,6 +43,8 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -544,5 +546,60 @@ public class IOTest
                 assertThat(selector.select(), is(0));
             }
         }
+    }
+
+    @Test
+    public void testSymbolicLink(TestInfo testInfo) throws Exception
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+        File realFile = new File(dir, "real");
+        Path realPath = realFile.toPath();
+        FS.touch(realFile);
+
+        File linkFile = new File(dir, "link");
+        Path linkPath = linkFile.toPath();
+        Files.createSymbolicLink(linkPath, realPath);
+        Path targPath = linkPath.toRealPath();
+
+        System.err.printf("realPath = %s%n", realPath);
+        System.err.printf("linkPath = %s%n", linkPath);
+        System.err.printf("targPath = %s%n", targPath);
+
+        assertFalse(Files.isSymbolicLink(realPath));
+        assertTrue(Files.isSymbolicLink(linkPath));
+
+        Resource link = new PathResource(dir).addPath("link");
+        assertThat(link.isAlias(), is(true));
+    }
+
+    @Test
+    public void testSymbolicLinkDir(TestInfo testInfo) throws Exception
+    {
+        File dir = MavenTestingUtils.getTargetTestingDir(testInfo.getDisplayName());
+        FS.ensureEmpty(dir);
+
+        File realDirFile = new File(dir, "real");
+        Path realDirPath = realDirFile.toPath();
+        Files.createDirectories(realDirPath);
+
+        File linkDirFile = new File(dir, "link");
+        Path linkDirPath = linkDirFile.toPath();
+        Files.createSymbolicLink(linkDirPath, realDirPath);
+
+        File realFile = new File(realDirFile, "file");
+        Path realPath = realFile.toPath();
+        FS.touch(realFile);
+
+        File linkFile = new File(linkDirFile, "file");
+        Path linkPath = linkFile.toPath();
+        Path targPath = linkPath.toRealPath();
+
+        System.err.printf("realPath = %s%n", realPath);
+        System.err.printf("linkPath = %s%n", linkPath);
+        System.err.printf("targPath = %s%n", targPath);
+
+        assertFalse(Files.isSymbolicLink(realPath));
+        assertFalse(Files.isSymbolicLink(linkPath));
     }
 }

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/MavenWebAppContext.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/MavenWebAppContext.java
@@ -351,18 +351,18 @@ public class MavenWebAppContext extends WebAppContext
     }
 
     @Override
-    public Resource getResource(String uriInContext) throws MalformedURLException
+    public Resource getResource(String pathInContext) throws MalformedURLException
     {
         Resource resource = null;
         // Try to get regular resource
-        resource = super.getResource(uriInContext);
+        resource = super.getResource(pathInContext);
 
         // If no regular resource exists check for access to /WEB-INF/lib or
         // /WEB-INF/classes
-        if ((resource == null || !resource.exists()) && uriInContext != null && _classes != null)
+        if ((resource == null || !resource.exists()) && pathInContext != null && _classes != null)
         {
             // Canonicalize again to look for the resource inside /WEB-INF subdirectories.
-            String uri = URIUtil.canonicalPath(uriInContext);
+            String uri = URIUtil.canonicalPath(pathInContext);
             if (uri == null)
                 return null;
 

--- a/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/OSGiWebappConstants.java
+++ b/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/OSGiWebappConstants.java
@@ -134,5 +134,5 @@ public class OSGiWebappConstants
     /**
      * Set of extra dirs that must not be served by osgi webapps
      */
-    public static final String[] DEFAULT_PROTECTED_OSGI_TARGETS = {"/osgi-inf", "/osgi-opts"};
+    public static final String[] DEFAULT_PROTECTED_OSGI_TARGETS = {"/OSGI-INF", "/OSGI-OPTS"};
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.server;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -89,10 +88,6 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     {
         try
         {
-            // do not allow any file separation characters in the URI
-            if (File.separatorChar != '/' && pathInContext.indexOf(File.separatorChar) >= 0)
-                return false;
-
             // The existence check resolves the symlinks.
             if (!resource.exists())
                 return false;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -85,7 +85,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     }
 
     @Override
-    public boolean check(String uri, Resource resource)
+    public boolean check(String pathInContext, Resource resource)
     {
         // The existence check resolves the symlinks.
         if (!resource.exists())
@@ -121,8 +121,12 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
 
                 for (Path protectedPath : _protected)
                 {
-                    if (Files.exists(protectedPath, FOLLOW_LINKS) && Files.isSameFile(path, protectedPath))
-                        return false;
+                    if (Files.exists(protectedPath))
+                    {
+                        protectedPath = protectedPath.toRealPath(FOLLOW_LINKS);
+                        if (Files.exists(protectedPath) && Files.isSameFile(path, protectedPath))
+                            return false;
+                    }
                 }
 
                 path = path.getParent();
@@ -151,7 +155,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     public String toString()
     {
         return String.format("%s@%x{base=%s,protected=%s}",
-            AllowedResourceAliasChecker.class.getSimpleName(),
+            this.getClass().getSimpleName(),
             hashCode(),
             _base,
             Arrays.asList(_contextHandler.getProtectedTargets()));

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -111,17 +111,17 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
         }
     }
 
-    protected boolean check(String pathInContext, Path path) throws Exception
+    protected boolean check(String pathInContext, Path path)
     {
         // Allow any aliases (symlinks, 8.3, casing, etc.) so long as
         // the resulting real file is allowed.
-        return isAllowed(path.toRealPath(FOLLOW_LINKS));
+        return isAllowed(getRealPath(path));
     }
 
     protected boolean isAllowed(Path path)
     {
         // If the resource doesn't exist we cannot determine whether it is protected so we assume it is.
-        if (Files.exists(path))
+        if (path != null && Files.exists(path))
         {
             // Walk the path parent links looking for the base resource, but failing if any steps are protected
             while (path != null)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -1,0 +1,228 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.util.resource.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>This will approve any alias to anything inside of the {@link ContextHandler}s resource base which
+ * is not protected by {@link ContextHandler#isProtectedTarget(String)}.</p>
+ * <p>This will approve symlinks to outside of the resource base. This can be optionally configured to check that the
+ * target of the symlinks is also inside of the resource base and is not a protected target.</p>
+ * <p>Aliases approved by this may still be able to bypass SecurityConstraints, so this class would need to be extended
+ * to enforce any additional security constraints that are required.</p>
+ */
+public class AllowedResourceAliasChecker extends AbstractLifeCycle implements ContextHandler.AliasCheck
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AllowedResourceAliasChecker.class);
+    private static final LinkOption[] FOLLOW_LINKS = new LinkOption[0];
+    private static final LinkOption[] NO_FOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
+
+    private final ContextHandler _contextHandler;
+    private final boolean _checkSymlinkTargets;
+    private final HashSet<Path> _protectedPaths = new HashSet<>();
+    private Path _basePath;
+
+    /**
+     * @param contextHandler the context handler to use.
+     */
+    public AllowedResourceAliasChecker(ContextHandler contextHandler)
+    {
+        this(contextHandler, false);
+    }
+
+    /**
+     * @param contextHandler the context handler to use.
+     * @param checkSymlinkTargets true to check that the target of the symlink is an allowed resource.
+     */
+    public AllowedResourceAliasChecker(ContextHandler contextHandler, boolean checkSymlinkTargets)
+    {
+        _contextHandler = contextHandler;
+        _checkSymlinkTargets = checkSymlinkTargets;
+    }
+
+    protected ContextHandler getContextHandler()
+    {
+        return _contextHandler;
+    }
+
+    protected Path getBasePath()
+    {
+        return _basePath;
+    }
+
+    @Override
+    protected void doStart() throws Exception
+    {
+        _basePath = getPath(_contextHandler.getBaseResource());
+        if (_basePath == null)
+            _basePath = Paths.get("/").toAbsolutePath();
+
+        String[] protectedTargets = _contextHandler.getProtectedTargets();
+        if (protectedTargets != null)
+        {
+            for (String s : protectedTargets)
+            {
+                Path path = _basePath.getFileSystem().getPath(_basePath.toString(), s);
+                _protectedPaths.add(path);
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception
+    {
+        _basePath = null;
+        _protectedPaths.clear();
+    }
+
+    @Override
+    public boolean check(String uri, Resource resource)
+    {
+        // The existence check resolves the symlinks.
+        if (!resource.exists())
+            return false;
+
+        Path resourcePath = getPath(resource);
+        if (resourcePath == null)
+            return false;
+
+        try
+        {
+            if (isProtectedPath(resourcePath, NO_FOLLOW_LINKS))
+                return false;
+
+            if (_checkSymlinkTargets && hasSymbolicLink(resourcePath))
+            {
+                if (isProtectedPath(resourcePath, FOLLOW_LINKS))
+                    return false;
+            }
+        }
+        catch (Throwable t)
+        {
+            LOG.warn("Failed to check alias", t);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * <p>Determines whether the provided resource path is protected.</p>
+     *
+     * <p>The resource path is protected if it is under one of the protected targets defined by
+     * {@link ContextHandler#isProtectedTarget(String)} in which case the alias should not be allowed.
+     * The resource path may also attempt to traverse above the root path and should be denied.</p>
+     *
+     * @param resourcePath the resource {@link Path} to be tested.
+     * @param linkOptions an array of {@link LinkOption} to be provided to the {@link Path#toRealPath(LinkOption...)} method.
+     * @return true if the resource path is protected and the alias should not be allowed.
+     * @throws IOException if an I/O error occurs.
+     */
+    protected boolean isProtectedPath(Path resourcePath, LinkOption[] linkOptions) throws IOException
+    {
+        // If the resource doesn't exist we cannot determine whether it is protected so we assume it is.
+        if (!Files.exists(resourcePath, linkOptions))
+            return true;
+
+        Path basePath = _basePath.toRealPath(linkOptions);
+        Path targetPath = resourcePath.toRealPath(linkOptions);
+        String target = targetPath.toString();
+
+        // The target path must be under the base resource directory.
+        if (!targetPath.startsWith(basePath))
+            return true;
+
+        for (Path protectedPath : _protectedPaths)
+        {
+            String protect;
+            if (Files.exists(protectedPath, linkOptions))
+                protect = protectedPath.toRealPath(linkOptions).toString();
+            else if (linkOptions == NO_FOLLOW_LINKS)
+                protect = protectedPath.normalize().toAbsolutePath().toString();
+            else
+                protect = protectedPath.toFile().getCanonicalPath();
+
+            // If the target path is protected then we will not allow it.
+            if (StringUtil.startsWithIgnoreCase(target, protect))
+            {
+                if (target.length() == protect.length())
+                    return true;
+
+                // Check that the target prefix really is a path segment.
+                if (target.charAt(protect.length()) == File.separatorChar)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean hasSymbolicLink(Path path)
+    {
+        return hasSymbolicLink(path.getRoot(), path);
+    }
+
+    protected boolean hasSymbolicLink(Path base, Path path)
+    {
+        Path p = path;
+        while (!base.equals(p))
+        {
+            if (p == null)
+                throw new IllegalArgumentException("path was not child of base");
+
+            if (Files.isSymbolicLink(p))
+                return true;
+
+            p = p.getParent();
+        }
+
+        return false;
+    }
+
+    private Path getPath(Resource resource)
+    {
+        try
+        {
+            if (resource instanceof PathResource)
+                return ((PathResource)resource).getPath();
+            return resource.getFile().toPath();
+        }
+        catch (Throwable t)
+        {
+            LOG.trace("getPath() failed", t);
+            return null;
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x{checkSymlinkTargets=%s}", AllowedResourceAliasChecker.class.getSimpleName(), hashCode(), _checkSymlinkTargets);
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
@@ -39,7 +39,9 @@ import org.slf4j.LoggerFactory;
  * or Linux on XFS) the the actual file could be stored using UTF-16,
  * but be accessed using NFD UTF-8 or NFC UTF-8 for the same file.
  * </p>
+ * @deprecated use {@link org.eclipse.jetty.server.AllowedResourceAliasChecker} instead.
  */
+@Deprecated
 public class SameFileAliasChecker implements AliasCheck
 {
     private static final Logger LOG = LoggerFactory.getLogger(SameFileAliasChecker.class);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SameFileAliasChecker.java
@@ -47,7 +47,7 @@ public class SameFileAliasChecker implements AliasCheck
     private static final Logger LOG = LoggerFactory.getLogger(SameFileAliasChecker.class);
 
     @Override
-    public boolean check(String uri, Resource resource)
+    public boolean check(String pathInContext, Resource resource)
     {
         // Only support PathResource alias checking
         if (!(resource instanceof PathResource))

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
@@ -1,0 +1,66 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.resource.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An extension of {@link AllowedResourceAliasChecker} which only allows aliased resources if they are symlinks.
+ */
+public class SymlinkAllowedResourceAliasChecker extends AllowedResourceAliasChecker
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SymlinkAllowedResourceAliasChecker.class);
+
+    /**
+     * @param contextHandler the context handler to use.
+     */
+    public SymlinkAllowedResourceAliasChecker(ContextHandler contextHandler)
+    {
+        super(contextHandler, false);
+    }
+
+    @Override
+    public boolean check(String uri, Resource resource)
+    {
+        try
+        {
+            // Check the resource is allowed to be accessed.
+            if (!super.check(uri, resource))
+                return false;
+
+            // Approve if path is a symbolic link.
+            Path resourcePath = resource.getFile().toPath();
+            if (Files.isSymbolicLink(resourcePath))
+                return true;
+
+            // Approve if path has symlink in under its resource base.
+            if (super.hasSymbolicLink(getBasePath(), resourcePath))
+                return true;
+        }
+        catch (IOException e)
+        {
+            LOG.trace("Failed to check alias", e);
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
@@ -28,10 +28,17 @@ import org.slf4j.LoggerFactory;
  * to check resources that are aliased to other locations.   The checker uses the
  * Java {@link Files#readSymbolicLink(Path)} and {@link Path#toRealPath(java.nio.file.LinkOption...)}
  * APIs to check if a file is aliased with symbolic links.</p>
+ * @deprecated use {@link org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker} instead.
  */
+@Deprecated
 public class AllowSymLinkAliasChecker implements AliasCheck
 {
     private static final Logger LOG = LoggerFactory.getLogger(AllowSymLinkAliasChecker.class);
+
+    public AllowSymLinkAliasChecker()
+    {
+        LOG.warn("Deprecated, use SymlinkAllowedResourceAliasChecker instead.");
+    }
 
     @Override
     public boolean check(String uri, Resource resource)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasChecker.java
@@ -41,7 +41,7 @@ public class AllowSymLinkAliasChecker implements AliasCheck
     }
 
     @Override
-    public boolean check(String uri, Resource resource)
+    public boolean check(String pathInContext, Resource resource)
     {
         // Only support PathResource alias checking
         if (!(resource instanceof PathResource))

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -63,6 +63,7 @@ import javax.servlet.http.HttpSessionListener;
 
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.ClassLoaderDump;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Dispatcher;
@@ -70,6 +71,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HandlerContainer;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.AttributesMap;
 import org.eclipse.jetty.util.Index;
@@ -81,6 +83,7 @@ import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.eclipse.jetty.util.component.Graceful;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,8 +106,8 @@ import org.slf4j.LoggerFactory;
  * The executor is made available via a context attributed {@code org.eclipse.jetty.server.Executor}.
  * </p>
  * <p>
- * By default, the context is created with alias checkers for {@link AllowSymLinkAliasChecker} (unix only) and {@link ApproveNonExistentDirectoryAliases}. If
- * these alias checkers are not required, then {@link #clearAliasChecks()} or {@link #setAliasChecks(List)} should be called.
+ * By default, the context is created with the {@link AllowedResourceAliasChecker} which is configured to allow symlinks. If
+ * this alias checker is not required, then {@link #clearAliasChecks()} or {@link #setAliasChecks(List)} should be called.
  * </p>
  */
 @ManagedObject("URI Context")
@@ -263,9 +266,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         _scontext = context == null ? new Context() : context;
         _attributes = new AttributesMap();
         _initParams = new HashMap<>();
-        addAliasCheck(new ApproveNonExistentDirectoryAliases());
         if (File.separatorChar == '/')
-            addAliasCheck(new AllowSymLinkAliasChecker());
+            addAliasCheck(new SymlinkAllowedResourceAliasChecker(this));
 
         if (contextPath != null)
             setContextPath(contextPath);
@@ -2071,6 +2073,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     public void addAliasCheck(AliasCheck check)
     {
         getAliasChecks().add(check);
+        if (check instanceof LifeCycle)
+            addManaged((LifeCycle)check);
+        else
+            addBean(check);
     }
 
     /**
@@ -2086,7 +2092,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void setAliasChecks(List<AliasCheck> checks)
     {
-        getAliasChecks().clear();
+        clearAliasChecks();
         getAliasChecks().addAll(checks);
     }
 
@@ -2095,7 +2101,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void clearAliasChecks()
     {
-        getAliasChecks().clear();
+        List<AliasCheck> aliasChecks = getAliasChecks();
+        aliasChecks.forEach(this::removeBean);
+        aliasChecks.clear();
     }
 
     /**
@@ -3028,7 +3036,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
 
     /**
      * Approve all aliases.
+     * @deprecated use {@link org.eclipse.jetty.server.AllowedResourceAliasChecker} instead.
      */
+    @Deprecated
     public static class ApproveAliases implements AliasCheck
     {
         @Override
@@ -3041,6 +3051,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     /**
      * Approve Aliases of a non existent directory. If a directory "/foobar/" does not exist, then the resource is aliased to "/foobar". Accept such aliases.
      */
+    @Deprecated
     public static class ApproveNonExistentDirectoryAliases implements AliasCheck
     {
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1920,14 +1920,14 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     /**
      * Attempt to get a Resource from the Context.
      *
-     * @param path the path within the resource to attempt to get
+     * @param pathInContext the path within the base resource to attempt to get
      * @return the resource, or null if not available.
      * @throws MalformedURLException if unable to form a Resource from the provided path
      */
-    public Resource getResource(String path) throws MalformedURLException
+    public Resource getResource(String pathInContext) throws MalformedURLException
     {
-        if (path == null || !path.startsWith(URIUtil.SLASH))
-            throw new MalformedURLException(path);
+        if (pathInContext == null || !pathInContext.startsWith(URIUtil.SLASH))
+            throw new MalformedURLException(pathInContext);
 
         if (_baseResource == null)
             return null;
@@ -1937,9 +1937,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             // addPath with accept non-canonical paths that don't go above the root,
             // but will treat them as aliases. So unless allowed by an AliasChecker
             // they will be rejected below.
-            Resource resource = _baseResource.addPath(path);
+            Resource resource = _baseResource.addPath(pathInContext);
 
-            if (checkAlias(path, resource))
+            if (checkAlias(pathInContext, resource))
                 return resource;
             return null;
         }
@@ -3027,11 +3027,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         /**
          * Check an alias
          *
-         * @param path The path the aliased resource was created for
+         * @param pathInContext The path the aliased resource was created for
          * @param resource The aliased resourced
          * @return True if the resource is OK to be served.
          */
-        boolean check(String path, Resource resource);
+        boolean check(String pathInContext, Resource resource);
     }
 
     /**
@@ -3042,7 +3042,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     public static class ApproveAliases implements AliasCheck
     {
         @Override
-        public boolean check(String path, Resource resource)
+        public boolean check(String pathInContext, Resource resource)
         {
             return true;
         }
@@ -3055,7 +3055,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     public static class ApproveNonExistentDirectoryAliases implements AliasCheck
     {
         @Override
-        public boolean check(String path, Resource resource)
+        public boolean check(String pathInContext, Resource resource)
         {
             if (resource.exists())
                 return false;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasCheckerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasCheckerTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.BufferUtil;
@@ -179,7 +180,7 @@ public class AllowSymLinkAliasCheckerTest
         fileResourceContext.setBaseResource(new PathResource(rootPath));
 
         fileResourceContext.clearAliasChecks();
-        fileResourceContext.addAliasCheck(new AllowSymLinkAliasChecker());
+        fileResourceContext.addAliasCheck(new SymlinkAllowedResourceAliasChecker(fileResourceContext));
 
         server.setHandler(fileResourceContext);
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.resource.Resource;
@@ -104,11 +105,13 @@ public class ContextHandlerGetResourceTest
         server = new Server();
         context = new ContextHandler("/");
         context.clearAliasChecks();
-        context.addAliasCheck(new ContextHandler.ApproveNonExistentDirectoryAliases());
         context.setBaseResource(Resource.newResource(docroot));
         context.addAliasCheck(new ContextHandler.AliasCheck()
         {
-            final AllowSymLinkAliasChecker symlinkcheck = new AllowSymLinkAliasChecker();
+            final SymlinkAllowedResourceAliasChecker symlinkcheck = new SymlinkAllowedResourceAliasChecker(context);
+            {
+                context.addBean(symlinkcheck);
+            }
 
             @Override
             public boolean check(String path, Resource resource)

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerGetResourceTest.java
@@ -114,12 +114,12 @@ public class ContextHandlerGetResourceTest
             }
 
             @Override
-            public boolean check(String path, Resource resource)
+            public boolean check(String pathInContext, Resource resource)
             {
                 if (allowAliases.get())
                     return true;
                 if (allowSymlinks.get())
-                    return symlinkcheck.check(path, resource);
+                    return symlinkcheck.check(pathInContext, resource);
                 return allowAliases.get();
             }
         });

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -643,7 +643,7 @@ public class ContextHandlerTest
     public void testProtected() throws Exception
     {
         ContextHandler handler = new ContextHandler();
-        String[] protectedTargets = {"/foo-inf", "/bar-inf"};
+        String[] protectedTargets = {"/FOO-INF", "/BAR-INF"};
         handler.setProtectedTargets(protectedTargets);
 
         assertTrue(handler.isProtectedTarget("/foo-inf"));

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -47,13 +47,13 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.ResourceContentFactory;
 import org.eclipse.jetty.server.ResourceService;
-import org.eclipse.jetty.server.SameFileAliasChecker;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
@@ -1081,8 +1081,7 @@ public class DefaultServletTest
             response = HttpTester.parseResponse(rawResponse);
             assertThat(response.toString(), response.getStatus(), is(HttpStatus.NOT_FOUND_404));
 
-            context.addAliasCheck(new AllowSymLinkAliasChecker());
-
+            context.addAliasCheck(new SymlinkAllowedResourceAliasChecker(context));
             rawResponse = connector.getResponse("GET /context/dir/link.txt HTTP/1.0\r\n\r\n");
             response = HttpTester.parseResponse(rawResponse);
             assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
@@ -2056,7 +2055,7 @@ public class DefaultServletTest
         FS.ensureEmpty(docRoot);
 
         context.addServlet(DefaultServlet.class, "/");
-        context.addAliasCheck(new SameFileAliasChecker());
+        context.addAliasCheck(new AllowedResourceAliasChecker(context));
 
         // Create file with UTF-8 NFC format
         String filename = "swedish-" + new String(TypeUtil.fromHexString("C3A5"), UTF_8) + ".txt";
@@ -2096,7 +2095,7 @@ public class DefaultServletTest
         FS.ensureEmpty(docRoot);
 
         context.addServlet(DefaultServlet.class, "/");
-        context.addAliasCheck(new SameFileAliasChecker());
+        context.addAliasCheck(new AllowedResourceAliasChecker(context));
 
         // Create file with UTF-8 NFD format
         String filename = "swedish-a" + new String(TypeUtil.fromHexString("CC8A"), UTF_8) + ".txt";

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -158,7 +158,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     public static final String SERVER_SYS_CLASSES = "org.eclipse.jetty.webapp.systemClasses";
     public static final String SERVER_SRV_CLASSES = "org.eclipse.jetty.webapp.serverClasses";
 
-    private static String[] __dftProtectedTargets = {"/web-inf", "/meta-inf"};
+    private static String[] __dftProtectedTargets = {"/WEB-INF", "/META-INF"};
 
     // System classes are classes that cannot be replaced by
     // the web application, and they are *always* loaded via

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -395,23 +395,23 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     }
 
     @Override
-    public Resource getResource(String uriInContext) throws MalformedURLException
+    public Resource getResource(String pathInContext) throws MalformedURLException
     {
-        if (uriInContext == null || !uriInContext.startsWith(URIUtil.SLASH))
-            throw new MalformedURLException(uriInContext);
+        if (pathInContext == null || !pathInContext.startsWith(URIUtil.SLASH))
+            throw new MalformedURLException(pathInContext);
 
         MalformedURLException mue = null;
         Resource resource = null;
         int loop = 0;
-        while (uriInContext != null && loop++ < 100)
+        while (pathInContext != null && loop++ < 100)
         {
             try
             {
-                resource = super.getResource(uriInContext);
+                resource = super.getResource(pathInContext);
                 if (resource != null && resource.exists())
                     return resource;
 
-                uriInContext = getResourceAlias(uriInContext);
+                pathInContext = getResourceAlias(pathInContext);
             }
             catch (MalformedURLException e)
             {

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -1,0 +1,232 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.AllowedResourceAliasChecker;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
+import org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AliasCheckerSymlinkTest
+{
+    private static Server _server;
+    private static ServerConnector _connector;
+    private static HttpClient _client;
+    private static ServletContextHandler _context;
+
+    private static Path _symlinkFile;
+    private static Path _symlinkExternalFile;
+    private static Path _symlinkDir;
+    private static Path _symlinkParentDir;
+    private static Path _symlinkSiblingDir;
+    private static Path _webInfSymlink;
+    private static Path _webrootSymlink;
+
+    private static Path getResource(String path) throws Exception
+    {
+        URL url = AliasCheckerSymlinkTest.class.getClassLoader().getResource(path);
+        assertNotNull(url);
+        return new File(url.toURI()).toPath();
+    }
+
+    private static void delete(Path path)
+    {
+        IO.delete(path.toFile());
+    }
+
+    private static void setAliasChecker(ContextHandler.AliasCheck aliasChecker)
+    {
+        _context.clearAliasChecks();
+        if (aliasChecker != null)
+            _context.addAliasCheck(aliasChecker);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception
+    {
+        Path webRootPath = getResource("webroot");
+        Path fileInWebroot = webRootPath.resolve("file");
+
+        // Create symlink file that targets inside the webroot directory.
+        _symlinkFile = webRootPath.resolve("symlinkFile");
+        delete(_symlinkFile);
+        Files.createSymbolicLink(_symlinkFile, fileInWebroot).toFile().deleteOnExit();
+
+        // Create symlink file that targets outside the webroot directory.
+        _symlinkExternalFile = webRootPath.resolve("symlinkExternalFile");
+        delete(_symlinkExternalFile);
+        Files.createSymbolicLink(_symlinkExternalFile, getResource("file")).toFile().deleteOnExit();
+
+        // Symlink to a directory inside of the webroot.
+        _symlinkDir = webRootPath.resolve("symlinkDir");
+        delete(_symlinkDir);
+        Files.createSymbolicLink(_symlinkDir, webRootPath.resolve("documents")).toFile().deleteOnExit();
+
+        // Symlink to a directory parent of the webroot.
+        _symlinkParentDir = webRootPath.resolve("symlinkParentDir");
+        delete(_symlinkParentDir);
+        Files.createSymbolicLink(_symlinkParentDir, webRootPath.resolve("..")).toFile().deleteOnExit();
+
+        // Symlink to a directory outside of the webroot.
+        _symlinkSiblingDir = webRootPath.resolve("symlinkSiblingDir");
+        delete(_symlinkSiblingDir);
+        Files.createSymbolicLink(_symlinkSiblingDir, webRootPath.resolve("../sibling")).toFile().deleteOnExit();
+
+        // Symlink to the WEB-INF directory.
+        _webInfSymlink = webRootPath.resolve("webInfSymlink");
+        delete(_webInfSymlink);
+        Files.createSymbolicLink(_webInfSymlink, webRootPath.resolve("WEB-INF")).toFile().deleteOnExit();
+
+        // External symlink to webroot.
+        _webrootSymlink = webRootPath.resolve("../webrootSymlink");
+        delete(_webrootSymlink);
+        Files.createSymbolicLink(_webrootSymlink, webRootPath).toFile().deleteOnExit();
+
+        // Create and start Server and Client.
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+        _context = new ServletContextHandler();
+        _context.setContextPath("/");
+        _context.setBaseResource(new PathResource(webRootPath));
+        _context.setWelcomeFiles(new String[]{"index.html"});
+        _context.setProtectedTargets(new String[]{"/web-inf", "/meta-inf"});
+        _context.getMimeTypes().addMimeMapping("txt", "text/plain;charset=utf-8");
+        _server.setHandler(_context);
+        _context.addServlet(DefaultServlet.class, "/");
+        _context.clearAliasChecks();
+        _server.start();
+
+        _client = new HttpClient();
+        _client.start();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception
+    {
+        // Try to delete all files now so that the symlinks do not confuse other tests.
+        Files.delete(_symlinkFile);
+        Files.delete(_symlinkExternalFile);
+        Files.delete(_symlinkDir);
+        Files.delete(_symlinkParentDir);
+        Files.delete(_symlinkSiblingDir);
+        Files.delete(_webInfSymlink);
+        Files.delete(_webrootSymlink);
+
+        _client.stop();
+        _server.stop();
+    }
+
+    public static Stream<Arguments> testCases()
+    {
+        AllowedResourceAliasChecker allowedResource = new AllowedResourceAliasChecker(_context, false);
+        AllowedResourceAliasChecker allowedResourceTarget = new AllowedResourceAliasChecker(_context, true);
+        SymlinkAllowedResourceAliasChecker symlinkAllowedResource = new SymlinkAllowedResourceAliasChecker(_context);
+        AllowSymLinkAliasChecker allowSymlinks = new AllowSymLinkAliasChecker();
+        ContextHandler.ApproveAliases approveAliases = new ContextHandler.ApproveAliases();
+
+        return Stream.of(
+                // AllowedResourceAliasChecker that does not check the target of symlinks.
+                Arguments.of(allowedResource, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowedResource, "/symlinkExternalFile", HttpStatus.OK_200, "This file is outside webroot."),
+                Arguments.of(allowedResource, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
+                Arguments.of(allowedResource, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowedResource, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+                Arguments.of(allowedResource, "/symlinkSiblingDir/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
+                Arguments.of(allowedResource, "/webInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+
+                // AllowedResourceAliasChecker that checks the target of symlinks.
+                Arguments.of(allowedResourceTarget, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowedResourceTarget, "/symlinkExternalFile", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResourceTarget, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
+                Arguments.of(allowedResourceTarget, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowedResourceTarget, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResourceTarget, "/symlinkSiblingDir/file", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResourceTarget, "/webInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null),
+
+                // SymlinkAllowedResourceAliasChecker that does not check the target of symlinks, but only approves files obtained through a symlink.
+                Arguments.of(symlinkAllowedResource, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(symlinkAllowedResource, "/symlinkExternalFile", HttpStatus.OK_200, "This file is outside webroot."),
+                Arguments.of(symlinkAllowedResource, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
+                Arguments.of(symlinkAllowedResource, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(symlinkAllowedResource, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+                Arguments.of(symlinkAllowedResource, "/symlinkSiblingDir/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
+                Arguments.of(symlinkAllowedResource, "/webInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+
+                // The AllowSymLinkAliasChecker.
+                Arguments.of(allowSymlinks, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowSymlinks, "/symlinkExternalFile", HttpStatus.OK_200, "This file is outside webroot."),
+                Arguments.of(allowSymlinks, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
+                Arguments.of(allowSymlinks, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(allowSymlinks, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+                Arguments.of(allowSymlinks, "/symlinkSiblingDir/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
+                Arguments.of(allowSymlinks, "/webInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+
+                // The ApproveAliases (approves everything regardless).
+                Arguments.of(approveAliases, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(approveAliases, "/symlinkExternalFile", HttpStatus.OK_200, "This file is outside webroot."),
+                Arguments.of(approveAliases, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
+                Arguments.of(approveAliases, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
+                Arguments.of(approveAliases, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+                Arguments.of(approveAliases, "/symlinkSiblingDir/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
+                Arguments.of(approveAliases, "/webInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
+
+                // No alias checker (any symlink should be an alias).
+                Arguments.of(null, "/symlinkFile", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/symlinkExternalFile", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/symlinkDir/file", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/symlinkParentDir/webroot/file", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/symlinkSiblingDir/file", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(null, "/webInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    public void test(ContextHandler.AliasCheck aliasChecker, String path, int httpStatus, String responseContent) throws Exception
+    {
+        setAliasChecker(aliasChecker);
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + path);
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(httpStatus));
+        if (responseContent != null)
+            assertThat(response.getContentAsString(), is(responseContent));
+    }
+}

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -126,7 +126,7 @@ public class AliasCheckerSymlinkTest
         _context.setContextPath("/");
         _context.setBaseResource(new PathResource(webRootPath));
         _context.setWelcomeFiles(new String[]{"index.html"});
-        _context.setProtectedTargets(new String[]{"/web-inf", "/meta-inf"});
+        _context.setProtectedTargets(new String[]{"/WEB-INF", "/META-INF"});
         _context.getMimeTypes().addMimeMapping("txt", "text/plain;charset=utf-8");
         _server.setHandler(_context);
         _context.addServlet(DefaultServlet.class, "/");
@@ -155,30 +155,20 @@ public class AliasCheckerSymlinkTest
 
     public static Stream<Arguments> testCases()
     {
-        AllowedResourceAliasChecker allowedResource = new AllowedResourceAliasChecker(_context, false);
-        AllowedResourceAliasChecker allowedResourceTarget = new AllowedResourceAliasChecker(_context, true);
+        AllowedResourceAliasChecker allowedResource = new AllowedResourceAliasChecker(_context);
         SymlinkAllowedResourceAliasChecker symlinkAllowedResource = new SymlinkAllowedResourceAliasChecker(_context);
         AllowSymLinkAliasChecker allowSymlinks = new AllowSymLinkAliasChecker();
         ContextHandler.ApproveAliases approveAliases = new ContextHandler.ApproveAliases();
 
         return Stream.of(
-                // AllowedResourceAliasChecker that does not check the target of symlinks.
+                // AllowedResourceAliasChecker that checks the target of symlinks.
                 Arguments.of(allowedResource, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
-                Arguments.of(allowedResource, "/symlinkExternalFile", HttpStatus.OK_200, "This file is outside webroot."),
+                Arguments.of(allowedResource, "/symlinkExternalFile", HttpStatus.NOT_FOUND_404, null),
                 Arguments.of(allowedResource, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
                 Arguments.of(allowedResource, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
-                Arguments.of(allowedResource, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
-                Arguments.of(allowedResource, "/symlinkSiblingDir/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
-                Arguments.of(allowedResource, "/webInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file."),
-
-                // AllowedResourceAliasChecker that checks the target of symlinks.
-                Arguments.of(allowedResourceTarget, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
-                Arguments.of(allowedResourceTarget, "/symlinkExternalFile", HttpStatus.NOT_FOUND_404, null),
-                Arguments.of(allowedResourceTarget, "/symlinkDir/file", HttpStatus.OK_200, "This file is inside webroot/documents."),
-                Arguments.of(allowedResourceTarget, "/symlinkParentDir/webroot/file", HttpStatus.OK_200, "This file is inside webroot."),
-                Arguments.of(allowedResourceTarget, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.NOT_FOUND_404, null),
-                Arguments.of(allowedResourceTarget, "/symlinkSiblingDir/file", HttpStatus.NOT_FOUND_404, null),
-                Arguments.of(allowedResourceTarget, "/webInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResource, "/symlinkParentDir/webroot/WEB-INF/web.xml", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResource, "/symlinkSiblingDir/file", HttpStatus.NOT_FOUND_404, null),
+                Arguments.of(allowedResource, "/webInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null),
 
                 // SymlinkAllowedResourceAliasChecker that does not check the target of symlinks, but only approves files obtained through a symlink.
                 Arguments.of(symlinkAllowedResource, "/symlinkFile", HttpStatus.OK_200, "This file is inside webroot."),

--- a/tests/test-integration/src/test/resources/file
+++ b/tests/test-integration/src/test/resources/file
@@ -1,0 +1,1 @@
+This file is outside webroot.

--- a/tests/test-integration/src/test/resources/sibling/file
+++ b/tests/test-integration/src/test/resources/sibling/file
@@ -1,0 +1,1 @@
+This file is inside a sibling dir to webroot.

--- a/tests/test-integration/src/test/resources/webroot/WEB-INF/web.xml
+++ b/tests/test-integration/src/test/resources/webroot/WEB-INF/web.xml
@@ -1,0 +1,1 @@
+This is the web.xml file.

--- a/tests/test-integration/src/test/resources/webroot/documents/file
+++ b/tests/test-integration/src/test/resources/webroot/documents/file
@@ -1,0 +1,1 @@
+This file is inside webroot/documents.

--- a/tests/test-integration/src/test/resources/webroot/file
+++ b/tests/test-integration/src/test/resources/webroot/file
@@ -1,0 +1,1 @@
+This file is inside webroot.

--- a/tests/test-integration/src/test/resources/webroot/index.html
+++ b/tests/test-integration/src/test/resources/webroot/index.html
@@ -1,0 +1,4 @@
+<html>
+<h1>hello world</h1>
+<p>body of index.html</p>
+</html>


### PR DESCRIPTION
An alternative fix for #6497 that avoids using string prefix comparison and instead uses explicit File and Path methods