### PR TITLE
Issue #6696 - don't keep Request object in the WebSocketNegotiation after upgrade

### DIFF
--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketNegotiation.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketNegotiation.java
@@ -31,10 +31,10 @@ import org.eclipse.jetty.websocket.core.WebSocketComponents;
 
 public abstract class WebSocketNegotiation
 {
-    private final Request baseRequest;
     private final HttpServletRequest request;
     private final HttpServletResponse response;
     private final WebSocketComponents components;
+    private Request baseRequest;
     private String version;
     private List<ExtensionConfig> offeredExtensions;
     private List<ExtensionConfig> negotiatedExtensions;
@@ -52,6 +52,11 @@ public abstract class WebSocketNegotiation
     public Request getBaseRequest()
     {
         return baseRequest;
+    }
+
+    public void setBaseRequest(Request baseRequest)
+    {
+        this.baseRequest = baseRequest;
     }
 
     public HttpServletRequest getRequest()

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketNegotiation.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketNegotiation.java
@@ -54,9 +54,9 @@ public abstract class WebSocketNegotiation
         return baseRequest;
     }
 
-    public void setBaseRequest(Request baseRequest)
+    public void upgrade()
     {
-        this.baseRequest = baseRequest;
+        this.baseRequest = null;
     }
 
     public HttpServletRequest getRequest()

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
@@ -167,7 +167,7 @@ public abstract class AbstractHandshaker implements Handshaker
         // Save state from request/response and remove reference to the base request/response.
         upgradeRequest.upgrade();
         upgradeResponse.upgrade();
-        negotiation.setBaseRequest(null);
+        negotiation.upgrade();
 
         if (LOG.isDebugEnabled())
             LOG.debug("upgrade connection={} session={} framehandler={}", connection, coreSession, handler);

--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/AbstractHandshaker.java
@@ -167,6 +167,7 @@ public abstract class AbstractHandshaker implements Handshaker
         // Save state from request/response and remove reference to the base request/response.
         upgradeRequest.upgrade();
         upgradeResponse.upgrade();
+        negotiation.setBaseRequest(null);
 
         if (LOG.isDebugEnabled())
             LOG.debug("upgrade connection={} session={} framehandler={}", connection, coreSession, handler);


### PR DESCRIPTION
Issue #6696 

null out the baseRequest field in `WebSocketNegotiation` after the websocket upgrade is complete.