### PR TITLE
Bump jnr-unixsocket from 0.38.3 to 0.38.10 (#6712)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1214,17 +1214,17 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-enxio</artifactId>
-        <version>0.32.1</version>
+        <version>0.32.8</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.9</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-unixsocket</artifactId>
-        <version>0.38.3</version>
+        <version>0.38.10</version>
       </dependency>
       <!-- avoid depending on a range dependency from a transitive dependency -->
       <dependency>


### PR DESCRIPTION
Dependabot should have done this in 10 rather than 11.   cherry pick back to 10.

* Bump jnr-unixsocket from 0.38.3 to 0.38.10

Bumps [jnr-unixsocket](https://github.com/jnr/jnr-unixsocket) from 0.38.3 to 0.38.10.
- [Release notes](https://github.com/jnr/jnr-unixsocket/releases)
- [Commits](https://github.com/jnr/jnr-unixsocket/compare/jnr-unixsocket-0.38.3...jnr-unixsocket-0.38.10)

---
updated-dependencies:
- dependency-name: com.github.jnr:jnr-unixsocket
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* update jnr dependencies

Bring on native unixdomain support!

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Greg Wilkins <gregw@webtide.com>