### PR TITLE
Issue  #6752 DefaultSessionCache more extensible using ConcurrentMap

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/DefaultSessionCache.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.server.session;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 
@@ -27,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * DefaultSessionCache
  *
- * A session store that keeps its sessions in memory in a hashmap
+ * A session store that keeps its sessions in memory in a concurrent map
  */
 @ManagedObject
 public class DefaultSessionCache extends AbstractSessionCache
@@ -35,9 +36,9 @@ public class DefaultSessionCache extends AbstractSessionCache
     private static final Logger LOG = LoggerFactory.getLogger(DefaultSessionCache.class);
 
     /**
-     * The cache of sessions in a hashmap
+     * The cache of sessions in a concurrent map
      */
-    protected ConcurrentHashMap<String, Session> _sessions = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, Session> _sessions = new ConcurrentHashMap<>();
 
     private final CounterStatistic _stats = new CounterStatistic();
 


### PR DESCRIPTION
DefaultSessionCache is designed to be extended, by virtue of its protected session map. Subclasses can set their own map instance instead. However the session map is specified as ConcurrentHashMap, when it only needs to be ConcurrentMap.
Changed data type to ConcurrentMap to allow for wider options for subclasses, such as those wanted to use Caffeine's asMap() method which returns ConcurrentMap.
Although changing to even more relaxed Map would work, that does not provide as much clarity that the map will be used concurrently - therefore used ConcurrentMap instead.

Resolves #6752 

Signed-off-by: Padraic Renaghan <padraic@renaghan.com>