### PR TITLE
Change dependabot interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "jetty-9.4.x"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       # Restrict updates in this branch to jetty in the 9.4.x space
       - dependency-name: "javax.servlet:*"
@@ -29,7 +29,7 @@ updates:
     directory: "/"
     target-branch: "jetty-10.0.x"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       # Restrict updates in this branch to jetty in the 10.x.x space
       - dependency-name: "jakarta.servlet:*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "jetty-9.4.x"


### PR DESCRIPTION
+ Only chose to change branches 9.4.x and 10.0.x to daily.
  Leaving 11.0.x at weekly, so that it's updates can trail behind the 10.0.x ones that are merged forward to 11.0.x

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>