### PR TITLE
dependabot should ignore jakarta.transaction >= 2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,8 @@ updates:
         versions: [ ">=4.0.0" ]
       - dependency-name: "com.sun.xml.ws:jaxws*"
         versions: [ ">=3.0.0" ]
+      - dependency-name: "jakarta.transaction:*"
+        versions: [ ">=2.0.0" ]
 
 #  - package-ecosystem: "maven"
 #    directory: "/"


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>
