### PR TITLE
Fix #6860 IPv6 Format (#6861 for jetty-10)

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -50,6 +50,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.SharedBlockingCallback.Blocker;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -120,6 +121,15 @@ public abstract class HttpChannel implements Runnable, HttpOutput.Interceptor
     public boolean isSendError()
     {
         return _state.isSendError();
+    }
+
+    /** Format the address or host returned from Request methods
+     * @param addr The address or host
+     * @return Default implementation returns {@link HostPort#normalizeHost(String)}
+     */
+    protected String formatAddrOrHost(String addr)
+    {
+        return HostPort.normalizeHost(addr);
     }
 
     private HttpInput newHttpInput(HttpChannelState state)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
@@ -144,7 +144,7 @@ public class HostPort
     public static String normalizeHost(String host)
     {
         // if it is normalized IPv6 or could not be IPv6, return
-        if (host.isEmpty() || host.charAt(0) == '[' || host.indexOf(':') < 0)
+        if (host == null || host.isEmpty() || host.charAt(0) == '[' || host.indexOf(':') < 0)
             return host;
 
         // normalize with [ ]


### PR DESCRIPTION
Fix #6860 IPv6 format by adding an extensible HttpChannel method

cherry-pick to 10

Signed-off-by: Greg Wilkins <gregw@webtide.com>
Co-authored-by: Lachlan Roberts <lachlan@webtide.com>
Signed-off-by: Greg Wilkins <gregw@webtide.com>