### PR TITLE
Issue #6558 - Allow configuring return type in JSON array parsing.

### DIFF
--- a/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSON.java
+++ b/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSON.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.TypeUtil;
@@ -84,7 +85,7 @@ public class JSON
 
     private final Map<String, Convertor> _convertors = new ConcurrentHashMap<>();
     private int _stringBufferSize = 1024;
-    private Function<List<?>, Object> _arrayConverter = List::toArray;
+    private Function<List<?>, Object> _arrayConverter = this::defaultArrayConverter;
 
     /**
      * @return the initial stringBuffer size to use when creating JSON strings
@@ -935,6 +936,14 @@ public class JSON
         }
 
         return map;
+    }
+
+    private Object defaultArrayConverter(List<?> list)
+    {
+        // Call newArray() to keep backward compatibility.
+        Object[] objects = newArray(list.size());
+        IntStream.range(0, list.size()).forEach(i -> objects[i] = list.get(i));
+        return objects;
     }
 
     protected Object parseArray(Source source)


### PR DESCRIPTION
Updated JSON implementation to keep backward compatibility
by calling newArray(), now deprecated.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 1d542be610b9d7def8fb5080f6e9cd492d6838bb)