### PR TITLE
Issue #6277 - Protect from Throwables on HttpSessionListener events.

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionManager.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionManager.java
@@ -18,8 +18,6 @@
 
 package org.eclipse.jetty.server.session;
 
-import static java.lang.Math.round;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -28,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.servlet.SessionCookieConfig;
 import javax.servlet.SessionTrackingMode;
 import javax.servlet.http.HttpServletRequest;
@@ -52,6 +49,8 @@ import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.eclipse.jetty.util.statistic.SampleStatistic;
+
+import static java.lang.Math.round;
 
 /**
  * An Abstract implementation of SessionManager.
@@ -703,7 +702,16 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             {
                 HttpSessionEvent event=new HttpSessionEvent(session);
                 for (HttpSessionListener listener : _sessionListeners)
-                    listener.sessionCreated(event);
+                {
+                    try
+                    {
+                        listener.sessionCreated(event);
+                    }
+                    catch (Throwable t)
+                    {
+                        __log.warn("Error during Session created listener", t);
+                    }
+                }
             }
         }
     }
@@ -791,7 +799,14 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
                 HttpSessionEvent event=new HttpSessionEvent(session);      
                 for (int i = _sessionListeners.size()-1; i>=0; i--)
                 {
-                    _sessionListeners.get(i).sessionDestroyed(event);
+                    try
+                    {
+                        _sessionListeners.get(i).sessionDestroyed(event);
+                    }
+                    catch(Throwable t)
+                    {
+                        __log.warn("Error during Session destroy listener", t);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replicating fix (no test) of Issue #6277 but for `jetty-9.3.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>