### PR TITLE
Update CVE releated issues with CVE number

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -53,6 +53,7 @@ This release process will produce releases:
 - [ ] Prepare release announcement for mailing lists.
 - [ ] Publish any [security advisories](https://github.com/eclipse/jetty.project/security/advisories).
   + [ ] Edit `VERSION.txt` to include any actual CVE number next to correspondent issue.
+  + [ ] Edit any issues for CVEs in github with their CVE number
 - [ ] Notify downstream maintainers.
   + [ ] Eclipse p2 maintainer.
   + [ ] Docker maintainer.


### PR DESCRIPTION
It can be hard to find issues associated with CVEs after the fact.  We should update the issue description to include the CVE number once published.