### PR TITLE
Issue #6969 - fix mod file filtering for log4j

### DIFF
--- a/jetty-util/src/main/config/modules/log4j2-api.mod
+++ b/jetty-util/src/main/config/modules/log4j2-api.mod
@@ -23,6 +23,6 @@ Log4j is released under the Apache 2.0 license.
 http://www.apache.org/licenses/LICENSE-2.0.html
 
 [ini]
-log4j2.version?=2.14.0
+log4j2.version?=@log4j2.version@
 disruptor.version=3.4.2
 jetty.webapp.addServerClasses+=,${jetty.base.uri}/lib/log4j2/

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <jolokia.version>1.3.3</jolokia.version>
     <jsp.version>8.5.70</jsp.version>
     <junit.version>5.8.1</junit.version>
+    <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.14.0</log4j2.version>
     <logback.version>1.2.6</logback.version>
     <maven.version>3.8.2</maven.version>


### PR DESCRIPTION
## Closes #6969 

We need the `log4j` version in the main pom for the mod file filtering to work.