### PR TITLE
Issue #4317 - exclude text/event-stream MIME type from GzipHandler

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -195,6 +195,9 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
         _mimeTypes.exclude("application/x-xz");
         _mimeTypes.exclude("application/x-rar-compressed");
 
+        // It is possible to use SSE with GzipHandler but you will need to set _synFlush to true which will impact performance.
+        _mimeTypes.exclude("text/event-stream");
+
         if (LOG.isDebugEnabled())
             LOG.debug("{} mime types {}", this, _mimeTypes);
     }


### PR DESCRIPTION
## Closes #4317

When `GzipHandler` is used with server side events you must set the `syncFlush` setting to true for it to work correctly. However changing this setting will affect compression for all requests to the server. The simplest fix is to exclude `text/event-stream` from `GzipHandler` by default.