### PR TITLE
Issue #6973 - Setup Request/Response for success with RequestLog

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1282,6 +1282,14 @@ public interface HttpFields extends Iterable<HttpField>
             _fields[_size] = null;
         }
 
+        public void setAll(HttpFields httpFields)
+        {
+            for (HttpField field : httpFields)
+            {
+                put(field);
+            }
+        }
+
         public int size()
         {
             return _size;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1037,19 +1037,6 @@ public interface HttpFields extends Iterable<HttpField>
         }
 
         /**
-         * Set all the fields in one go
-         *
-         * @param httpFields the fields to set
-         */
-        public void putAll(HttpFields httpFields)
-        {
-            for (HttpField field : httpFields)
-            {
-                put(field);
-            }
-        }
-
-        /**
          * Sets the value of a date field.
          *
          * @param name the field name

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1037,6 +1037,19 @@ public interface HttpFields extends Iterable<HttpField>
         }
 
         /**
+         * Set all the fields in one go
+         *
+         * @param httpFields the fields to set
+         */
+        public void putAll(HttpFields httpFields)
+        {
+            for (HttpField field : httpFields)
+            {
+                put(field);
+            }
+        }
+
+        /**
          * Sets the value of a date field.
          *
          * @param name the field name
@@ -1280,14 +1293,6 @@ public interface HttpFields extends Iterable<HttpField>
             _size--;
             System.arraycopy(_fields, i + 1, _fields, i, _size - i);
             _fields[_size] = null;
-        }
-
-        public void setAll(HttpFields httpFields)
-        {
-            for (HttpField field : httpFields)
-            {
-                put(field);
-            }
         }
 
         public int size()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -873,7 +873,10 @@ public abstract class HttpChannel implements Runnable, HttpOutput.Interceptor
             LOG.debug("onCompleted for {} written={}", getRequest().getRequestURI(), getBytesWritten());
 
         if (_requestLog != null)
+        {
+            _request.onRequestLog();
             _requestLog.log(_request, _response);
+        }
 
         long idleTO = _configuration.getIdleTimeout();
         if (idleTO >= 0 && getIdleTimeout() != _oldIdleTimeout)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1413,6 +1413,19 @@ public class Request implements HttpServletRequest
         return session.getId();
     }
 
+    protected void onRequestLog()
+    {
+        // Don't allow pulling more parameters
+        _contentParamsExtracted = true;
+
+        // Reset the status code to what was committed
+        MetaData.Response committedResponse = getResponse().getCommittedMetaData();
+        if (committedResponse != null)
+        {
+            getResponse().setStatus(committedResponse.getStatus());
+        }
+    }
+
     /**
      * Called when the request is fully finished being handled.
      * For every session in any context that the session has

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1418,18 +1418,8 @@ public class Request implements HttpServletRequest
         // Don't allow pulling more parameters
         _contentParamsExtracted = true;
 
-        // Reset the response to what it was when committed
-        MetaData.Response committedResponse = getResponse().getCommittedMetaData();
-        if (committedResponse != null)
-        {
-            // restore status
-            getResponse().setStatus(committedResponse.getStatus());
-
-            // restore headers
-            HttpFields.Mutable responseFields = getResponse().getHttpFields();
-            responseFields.clear();
-            responseFields.setAll(committedResponse.getFields());
-        }
+        // Restore the response to what it was when committed
+        getResponse().restoreCommittedMetaData();
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1418,11 +1418,17 @@ public class Request implements HttpServletRequest
         // Don't allow pulling more parameters
         _contentParamsExtracted = true;
 
-        // Reset the status code to what was committed
+        // Reset the response to what it was when committed
         MetaData.Response committedResponse = getResponse().getCommittedMetaData();
         if (committedResponse != null)
         {
+            // restore status
             getResponse().setStatus(committedResponse.getStatus());
+
+            // restore headers
+            HttpFields.Mutable responseFields = getResponse().getHttpFields();
+            responseFields.clear();
+            responseFields.setAll(committedResponse.getFields());
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -651,19 +651,22 @@ public class Response implements HttpServletResponse
     @Override
     public void setHeader(String name, String value)
     {
-        if (isCommitted() || !isMutable())
-            return;
+        boolean allowSetHeader = !isCommitted();
 
         long biInt = _errorSentAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;
             boolean including = AtomicBiInteger.getLo(biInt) > 0;
+            allowSetHeader &= including;
             if (!errorSent && including && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
                 name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
             else
                 return;
         }
+
+        if (!allowSetHeader)
+            return;
 
         if (HttpHeader.CONTENT_TYPE.is(name))
             setContentType(value);
@@ -704,19 +707,22 @@ public class Response implements HttpServletResponse
     @Override
     public void addHeader(String name, String value)
     {
-        if (isCommitted() || !isMutable())
-            return;
+        boolean allowSetHeader = !isCommitted();
 
         long biInt = _errorSentAndIncludes.get();
         if (biInt != 0)
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;
             boolean including = AtomicBiInteger.getLo(biInt) > 0;
+            allowSetHeader &= including;
             if (!errorSent && including && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
                 name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
             else
                 return;
         }
+
+        if (!allowSetHeader)
+            return;
 
         if (HttpHeader.CONTENT_TYPE.is(name))
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -1305,6 +1305,29 @@ public class Response implements HttpServletResponse
         return meta;
     }
 
+    /**
+     * Restore the CommittedMetaData, overwriting the current
+     * metadata in the process.
+     * <p>
+     *     This is useful when you want to see the state of
+     *     the Response object as it was when it was committed.
+     * </p>
+     */
+    public void restoreCommittedMetaData()
+    {
+        MetaData.Response committedResponse = getCommittedMetaData();
+        if (committedResponse != null)
+        {
+            // restore status
+            setStatus(committedResponse.getStatus());
+
+            // restore headers
+            HttpFields.Mutable responseFields = getHttpFields();
+            responseFields.clear();
+            responseFields.putAll(committedResponse.getFields());
+        }
+    }
+
     @Override
     public boolean isCommitted()
     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -683,22 +683,41 @@ public class Response implements HttpServletResponse
         }
     }
 
+    /**
+     * Get the relevant HttpFields based on commit status and state.
+     *
+     * @return the in-progress or committed HttpFields
+     */
+    private HttpFields getActiveHttpFields()
+    {
+        if (isCommitted())
+        {
+            MetaData.Response committed = getCommittedMetaData();
+            if (committed != null)
+            {
+                return committed.getFields();
+            }
+        }
+
+        return getHttpFields();
+    }
+
     @Override
     public Collection<String> getHeaderNames()
     {
-        return _fields.getFieldNamesCollection();
+        return getActiveHttpFields().getFieldNamesCollection();
     }
 
     @Override
     public String getHeader(String name)
     {
-        return _fields.get(name);
+        return getActiveHttpFields().get(name);
     }
 
     @Override
     public Collection<String> getHeaders(String name)
     {
-        Collection<String> i = _fields.getValuesList(name);
+        Collection<String> i = getActiveHttpFields().getValuesList(name);
         if (i == null)
             return Collections.emptyList();
         return i;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
@@ -1,0 +1,290 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Test raw behaviors of RequestLog and how Request / Response objects behave during
+ * the call to a RequestLog implementation.
+ * <p>
+ * This differs from other RequestLog tests as it test the combination of
+ * bad requests, and RequestLog implementations that can cause changes
+ * in the request or response objects.
+ * </p>
+ */
+public class RequestLogTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(RequestLogTest.class);
+
+    public Server createServer(RequestLog requestLog) throws Exception
+    {
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        server.setRequestLog(requestLog);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                response.setCharacterEncoding("UTF-8");
+                response.setContentType("text/plain");
+                response.getWriter().printf("Got %s to %s%n", request.getMethod(), request.getRequestURI());
+                baseRequest.setHandled(true);
+            }
+        });
+
+        return server;
+    }
+
+    @Test
+    public void testNormalGetRequest() throws Exception
+    {
+        Server server = null;
+        try
+        {
+            BlockingArrayQueue<String> requestLogLines = new BlockingArrayQueue<>();
+
+            server = createServer((request, response) ->
+                requestLogLines.add(String.format("method:%s|uri:%s|status:%d", request.getMethod(), request.getRequestURI(), response.getStatus())));
+            server.start();
+
+            URI baseURI = server.getURI();
+
+            try (Socket socket = new Socket(baseURI.getHost(), baseURI.getPort());
+                 OutputStream out = socket.getOutputStream();
+                 InputStream in = socket.getInputStream())
+            {
+                StringBuilder req = new StringBuilder();
+                req.append("GET /hello HTTP/1.1\r\n");
+                req.append("Host: ").append(baseURI.getRawAuthority()).append("\r\n");
+                req.append("Connection: close\r\n");
+                req.append("\r\n");
+
+                byte[] bufRequest = req.toString().getBytes(UTF_8);
+
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Request--\n" + req);
+                out.write(bufRequest);
+                out.flush();
+
+                ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+                IO.copy(in, outBuf);
+                String response = outBuf.toString(UTF_8);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Response--\n" + response);
+
+                List<String> responseLines = response.lines()
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+
+                // Find status code
+                String responseStatusLine = responseLines.get(0);
+                assertThat("Status Code Response", responseStatusLine, containsString("HTTP/1.1 200"));
+
+                // Find body content (always last line)
+                String bodyContent = responseLines.get(responseLines.size() - 1);
+                assertThat("Body Content", bodyContent, containsString("Got GET to /hello"));
+
+                String reqlog = requestLogLines.poll(5, TimeUnit.SECONDS);
+                assertThat("RequestLog", reqlog, containsString("method:GET|uri:/hello|status:200"));
+            }
+        }
+        finally
+        {
+            LifeCycle.stop(server);
+        }
+    }
+
+    @Test
+    public void testNormalPostFormRequest() throws Exception
+    {
+        Server server = null;
+        try
+        {
+            BlockingArrayQueue<String> requestLogLines = new BlockingArrayQueue<>();
+
+            server = createServer((request, response) ->
+            {
+                // Use a Servlet API that would cause a read of the Request inputStream.
+                List<String> paramNames = Collections.list(request.getParameterNames());
+                // This should result in no paramNames, as nothing is read during RequestLog execution
+                requestLogLines.add(String.format("method:%s|uri:%s|paramNames.size:%d|status:%d", request.getMethod(), request.getRequestURI(), paramNames.size(), response.getStatus()));
+            });
+            server.start();
+
+            URI baseURI = server.getURI();
+
+            try (Socket socket = new Socket(baseURI.getHost(), baseURI.getPort());
+                 OutputStream out = socket.getOutputStream();
+                 InputStream in = socket.getInputStream())
+            {
+                StringBuilder form = new StringBuilder();
+                for (int i = 'a'; i < 'j'; i++)
+                {
+                    form.append((char)i).append("=").append(i).append("&");
+                }
+
+                byte[] bufForm = form.toString().getBytes(UTF_8);
+
+                StringBuilder req = new StringBuilder();
+                req.append("POST /hello HTTP/1.1\r\n");
+                req.append("Host: ").append(baseURI.getRawAuthority()).append("\r\n");
+                req.append("Content-Type: ").append(MimeTypes.Type.FORM_ENCODED).append("\r\n");
+                req.append("Content-Length: ").append(bufForm.length).append("\r\n");
+                req.append("Connection: close\r\n");
+                req.append("\r\n");
+
+                byte[] bufRequest = req.toString().getBytes(UTF_8);
+
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Request--\n" + req);
+                out.write(bufRequest);
+                out.write(bufForm);
+                out.flush();
+
+                ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+                IO.copy(in, outBuf);
+                String response = outBuf.toString(UTF_8);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Response--\n" + response);
+
+                List<String> responseLines = response.lines()
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+
+                // Find status code
+                String responseStatusLine = responseLines.get(0);
+                assertThat("Status Code Response", responseStatusLine, containsString("HTTP/1.1 200"));
+
+                // Find body content (always last line)
+                String bodyContent = responseLines.get(responseLines.size() - 1);
+                assertThat("Body Content", bodyContent, containsString("Got POST to /hello"));
+
+                String reqlog = requestLogLines.poll(5, TimeUnit.SECONDS);
+                assertThat("RequestLog", reqlog, containsString("method:POST|uri:/hello|paramNames.size:0|status:200"));
+            }
+        }
+        finally
+        {
+            LifeCycle.stop(server);
+        }
+    }
+
+    @Test
+    public void testBadPostFormRequest() throws Exception
+    {
+        Server server = null;
+        try
+        {
+            BlockingArrayQueue<String> requestLogLines = new BlockingArrayQueue<>();
+
+            server = createServer((request, response) ->
+            {
+                // Use a Servlet API that would cause a read of the Request inputStream.
+                List<String> paramNames = Collections.list(request.getParameterNames());
+                // This should result in no paramNames, as nothing is read during RequestLog execution
+                requestLogLines.add(String.format("method:%s|uri:%s|paramNames.size:%d|status:%d", request.getMethod(), request.getRequestURI(), paramNames.size(), response.getStatus()));
+            });
+            server.start();
+
+            URI baseURI = server.getURI();
+
+            try (Socket socket = new Socket(baseURI.getHost(), baseURI.getPort());
+                 OutputStream out = socket.getOutputStream();
+                 InputStream in = socket.getInputStream())
+            {
+                StringBuilder form = new StringBuilder();
+                for (int i = 'a'; i < 'j'; i++)
+                {
+                    form.append((char)i).append("=").append(i).append("&");
+                }
+
+                byte[] bufForm = form.toString().getBytes(UTF_8);
+
+                StringBuilder req = new StringBuilder();
+                req.append("POST /hello HTTP/1.1\r\n");
+                req.append("Host: ").append(baseURI.getRawAuthority()).append("\r\n");
+                req.append("Content-Type: ").append(MimeTypes.Type.FORM_ENCODED).append("\r\n");
+                req.append("Content-Length: ").append(bufForm.length).append("\r\n");
+                // add extra Transfer-Encoding: chunked header, making the POST request invalid per HTTP spec
+                req.append("Transfer-Encoding: chunked\r\n");
+                req.append("Connection: close\r\n");
+                req.append("\r\n");
+
+                byte[] bufRequest = req.toString().getBytes(UTF_8);
+
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Request--\n" + req);
+                out.write(bufRequest);
+                out.write(bufForm);
+                out.flush();
+
+                ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+                IO.copy(in, outBuf);
+                String response = outBuf.toString(UTF_8);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("--Response--\n" + response);
+
+                List<String> responseLines = response.lines()
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+
+                // Find status code
+                String responseStatusLine = responseLines.get(0);
+                assertThat("Status Code Response", responseStatusLine, containsString("HTTP/1.1 400 Bad Request"));
+
+                // Find body content (always last line)
+                String bodyContent = responseLines.get(responseLines.size() - 1);
+                assertThat("Body Content", bodyContent, containsString("reason: Transfer-Encoding and Content-Length"));
+
+                // We should see a requestlog entry for this 400 response
+                String reqlog = requestLogLines.poll(3, TimeUnit.SECONDS);
+                assertThat("RequestLog", reqlog, containsString("method:POST|uri:/hello|paramNames.size:0|status:400"));
+            }
+        }
+        finally
+        {
+            LifeCycle.stop(server);
+        }
+    }
+}

--- a/jetty-server/src/test/resources/jetty-logging.properties
+++ b/jetty-server/src/test/resources/jetty-logging.properties
@@ -4,3 +4,4 @@
 #org.eclipse.jetty.servlet.LEVEL=DEBUG
 #org.eclipse.jetty.server.ConnectionLimit.LEVEL=DEBUG
 #org.eclipse.jetty.server.AcceptRateLimit.LEVEL=DEBUG
+#org.eclipse.jetty.server.RequestLogTest.LEVEL=DEBUG

--- a/jetty-server/src/test/resources/jetty-logging.properties
+++ b/jetty-server/src/test/resources/jetty-logging.properties
@@ -4,4 +4,4 @@
 #org.eclipse.jetty.servlet.LEVEL=DEBUG
 #org.eclipse.jetty.server.ConnectionLimit.LEVEL=DEBUG
 #org.eclipse.jetty.server.AcceptRateLimit.LEVEL=DEBUG
-#org.eclipse.jetty.server.RequestLogTest.LEVEL=DEBUG
+org.eclipse.jetty.server.RequestLogTest.LEVEL=DEBUG

--- a/jetty-server/src/test/resources/jetty-logging.properties
+++ b/jetty-server/src/test/resources/jetty-logging.properties
@@ -4,4 +4,4 @@
 #org.eclipse.jetty.servlet.LEVEL=DEBUG
 #org.eclipse.jetty.server.ConnectionLimit.LEVEL=DEBUG
 #org.eclipse.jetty.server.AcceptRateLimit.LEVEL=DEBUG
-org.eclipse.jetty.server.RequestLogTest.LEVEL=DEBUG
+#org.eclipse.jetty.server.RequestLogTest.LEVEL=DEBUG

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/IncludedServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/IncludedServletTest.java
@@ -68,6 +68,7 @@ public class IncludedServletTest
                 headerPrefix = "org.eclipse.jetty.server.include.";
 
             resp.setHeader(headerPrefix + "included-page-key", "included-page-value");
+            resp.addHeader(headerPrefix + "added-included-page-key", "added-included-page-value");
             resp.getWriter().println("<h3> This is the included page");
         }
     }
@@ -179,6 +180,7 @@ public class IncludedServletTest
 
             assertThat("Response Header[main-page-key]", connection.getHeaderField("main-page-key"), is("main-page-value"));
             assertThat("Response Header[included-page-key]", connection.getHeaderField("included-page-key"), is("included-page-value"));
+            assertThat("Response Header[added-included-page-key]", connection.getHeaderField("added-included-page-key"), is("added-included-page-value"));
         }
         finally
         {


### PR DESCRIPTION
Adds `Request.onRequestLog()` to reset internals of Request/Response to a place where usage of those objects in `RequestLog.log(Request,Response)` don't cause problems or bad information.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>