### PR TITLE
Issue #7008 - Fix regression in `bin/jetty.sh` on systems using `start-stop-daemon`

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -414,7 +414,7 @@ TMPDIR="`cygpath -w $TMPDIR`"
 ;;
 esac
 
-JAVA_OPTIONS=(${JAVA_OPTIONS[*]} "-Djetty.home=$JETTY_HOME" "-Djetty.base=$JETTY_BASE" "-Djava.io.tmpdir=$TMPDIR")
+JETTY_SYS_PROPS=$(echo -ne "-Djetty.home=$JETTY_HOME" "-Djetty.base=$JETTY_BASE" "-Djava.io.tmpdir=$TMPDIR")
 
 #####################################################
 # This is how the Jetty server will be started
@@ -433,8 +433,8 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$(echo -ne $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
-RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
+RUN_ARGS=$("$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
+RUN_CMD=("$JAVA" $JETTY_SYS_PROPS ${RUN_ARGS[@]})
 
 #####################################################
 # Comment these out after you're happy with what

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -433,7 +433,7 @@ case "`uname`" in
 CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
 esac
 
-RUN_ARGS=$(echo $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
+RUN_ARGS=$(echo -ne $JAVA_OPTIONS ; "$JAVA" -jar "$JETTY_START" --dry-run=opts,path,main,args ${JETTY_ARGS[*]})
 RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 #####################################################
@@ -462,10 +462,16 @@ case "$ACTION" in
       unset CH_USER
       if [ -n "$JETTY_USER" ]
       then
-        CH_USER="-c$JETTY_USER"
+        CH_USER="--chuid $JETTY_USER"
       fi
 
-      start-stop-daemon -S -p"$JETTY_PID" $CH_USER -d"$JETTY_BASE" -b -m -a "$JAVA" -- "${RUN_ARGS[@]}" start-log-file="$JETTY_START_LOG"
+      start-stop-daemon --start $CH_USER \
+       --pidfile "$JETTY_PID" \
+       --chdir "$JETTY_BASE" \
+       --background \
+       --make-pidfile \
+       --startas "$JAVA" \
+       -- ${RUN_ARGS[@]} start-log-file="$JETTY_START_LOG"
 
     else
 


### PR DESCRIPTION
* Using `start-stop-daemon` options properly
* Do not include `JETTY_SYS_PROPS` in `JAVA_OPTIONS` to avoid duplicates that show up in `RUN_ARGS`.
* Only use `JETTY_SYS_PROPS` in `RUN_CMD`.