### PR TITLE
fix resource leak due to Files.newDirtoryStream

### DIFF
--- a/demos/embedded/src/main/java/org/eclipse/jetty/demos/JettyDemos.java
+++ b/demos/embedded/src/main/java/org/eclipse/jetty/demos/JettyDemos.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
@@ -75,9 +76,9 @@ public class JettyDemos
 
         String version = "unknown";
         Path pomFile = demosDir.resolve("pom.xml");
-        try
+        try (Stream<String> stream = Files.lines(pomFile))
         {
-            String versionLine = Files.lines(pomFile)
+            String versionLine = stream
                 .filter((line) -> line.contains("<version>"))
                 .findFirst()
                 .orElseThrow(() ->

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -195,9 +195,12 @@ public class BaseBuilder
                     }
                 };
                 List<Path> paths = new ArrayList<>();
-                for (Path path : Files.newDirectoryStream(startd, filter))
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(startd, filter))
                 {
-                    paths.add(path);
+                    for (Path path : stream)
+                    {
+                        paths.add(path);
+                    }
                 }
                 paths.sort(new NaturalSort.Paths());
 

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
@@ -136,12 +136,14 @@ public class DirConfigSource implements ConfigSource
                 };
 
                 List<Path> paths = new ArrayList<>();
-
-                for (Path diniFile : Files.newDirectoryStream(startDdir, filter))
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(startDdir, filter))
                 {
-                    if (FS.canReadFile(diniFile))
+                    for (Path diniFile : stream)
                     {
-                        paths.add(diniFile);
+                        if (FS.canReadFile(diniFile))
+                        {
+                            paths.add(diniFile);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Files.newDirectoryStream will open stream and as jdk said:

 

If timely disposal of file system resources is required, the
{@code try}-with-resources construct should be used to ensure that the
stream's {@link Stream#close close} method is invoked after the stream
operations are completed.

we sould close them with try catch

