### PR TITLE
Issue #7059 - prevent an internal NPE in AllowedResourceAliasChecker doStart

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,10 +63,10 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     {
         _base = getPath(_contextHandler.getBaseResource());
         if (_base == null)
-            _base = Paths.get("/").toAbsolutePath();
+            return;
+
         if (Files.exists(_base, NO_FOLLOW_LINKS))
             _base = _base.toRealPath(FOLLOW_LINKS);
-
         String[] protectedTargets = _contextHandler.getProtectedTargets();
         if (protectedTargets != null)
         {
@@ -86,6 +85,9 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     @Override
     public boolean check(String pathInContext, Resource resource)
     {
+        if (_base == null)
+            return false;
+
         try
         {
             // The existence check resolves the symlinks.
@@ -184,7 +186,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
         {
             if (resource instanceof PathResource)
                 return ((PathResource)resource).getPath();
-            return resource.getFile().toPath();
+            return (resource == null) ? null : resource.getFile().toPath();
         }
         catch (Throwable t)
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -79,7 +79,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
         }
         catch (IOException e)
         {
-            LOG.warn("Initialization failed", e);
+            LOG.warn("Base resource failure ({} is disabled): {}", this.getClass().getName(), _base, e);
             _base = null;
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -228,10 +228,11 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     @Override
     public String toString()
     {
+        String[] protectedTargets = _contextHandler.getProtectedTargets();
         return String.format("%s@%x{base=%s,protected=%s}",
             this.getClass().getSimpleName(),
             hashCode(),
             _base,
-            Arrays.asList(_contextHandler.getProtectedTargets()));
+            (protectedTargets == null) ? null : Arrays.asList(protectedTargets));
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
@@ -40,6 +40,9 @@ public class SymlinkAllowedResourceAliasChecker extends AllowedResourceAliasChec
     @Override
     protected boolean check(String pathInContext, Path path)
     {
+        if (_base == null)
+            return false;
+
         // do not allow any file separation characters in the URI, as we need to know exactly what are the segments
         if (File.separatorChar != '/' && pathInContext.indexOf(File.separatorChar) >= 0)
             return false;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -228,7 +228,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     private final List<ContextScopeListener> _contextListeners = new CopyOnWriteArrayList<>();
     private final Set<EventListener> _durableListeners = new HashSet<>();
     private Index<ProtectedTargetType> _protectedTargets = Index.empty(false);
-    private final List<AliasCheck> _aliasChecks = new ArrayList<>();
+    private final List<AliasCheck> _aliasChecks = new CopyOnWriteArrayList<>();
 
     public enum Availability
     {
@@ -2086,7 +2086,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public List<AliasCheck> getAliasChecks()
     {
-        return List.copyOf(_aliasChecks);
+        return Collections.unmodifiableList(_aliasChecks);
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1700,6 +1700,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void setBaseResource(Resource base)
     {
+        if (isStarting() || isStarted())
+            throw new IllegalStateException("Cannot change base resource after starting");
         _baseResource = base;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -228,7 +228,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     private final List<ContextScopeListener> _contextListeners = new CopyOnWriteArrayList<>();
     private final Set<EventListener> _durableListeners = new HashSet<>();
     private Index<ProtectedTargetType> _protectedTargets = Index.empty(false);
-    private final CopyOnWriteArrayList<AliasCheck> _aliasChecks = new CopyOnWriteArrayList<>();
+    private final List<AliasCheck> _aliasChecks = new ArrayList<>();
 
     public enum Availability
     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1700,8 +1700,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void setBaseResource(Resource base)
     {
-        if (isStarting() || isStarted())
-            throw new IllegalStateException("Cannot change base resource after starting");
+        if (isStarted())
+            throw new IllegalStateException("Cannot call setBaseResource after starting");
         _baseResource = base;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -2074,7 +2074,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void addAliasCheck(AliasCheck check)
     {
-        getAliasChecks().add(check);
+        _aliasChecks.add(check);
         if (check instanceof LifeCycle)
             addManaged((LifeCycle)check);
         else
@@ -2082,11 +2082,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     }
 
     /**
-     * @return Mutable list of Alias checks
+     * @return Immutable list of Alias checks
      */
     public List<AliasCheck> getAliasChecks()
     {
-        return _aliasChecks;
+        return List.copyOf(_aliasChecks);
     }
 
     /**
@@ -2095,7 +2095,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     public void setAliasChecks(List<AliasCheck> checks)
     {
         clearAliasChecks();
-        getAliasChecks().addAll(checks);
+        checks.forEach(this::addAliasCheck);
     }
 
     /**
@@ -2103,9 +2103,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void clearAliasChecks()
     {
-        List<AliasCheck> aliasChecks = getAliasChecks();
-        aliasChecks.forEach(this::removeBean);
-        aliasChecks.clear();
+        _aliasChecks.forEach(this::removeBean);
+        _aliasChecks.clear();
     }
 
     /**

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -60,7 +60,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.resource.PathResource;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -958,8 +957,6 @@ public class DefaultServletTest
     public void testWelcomeRedirectDirWithQuestion() throws Exception
     {
         FS.ensureDirExists(docRoot);
-        context.setBaseResource(new PathResource(docRoot));
-
         Path dir = assumeMkDirSupported(docRoot, "dir?");
 
         Path index = dir.resolve("index.html");
@@ -992,8 +989,6 @@ public class DefaultServletTest
     public void testWelcomeRedirectDirWithSemicolon() throws Exception
     {
         FS.ensureDirExists(docRoot);
-        context.setBaseResource(new PathResource(docRoot));
-
         Path dir = assumeMkDirSupported(docRoot, "dir;");
 
         Path index = dir.resolve("index.html");
@@ -1215,8 +1210,6 @@ public class DefaultServletTest
     public void testDirectFromResourceHttpContent() throws Exception
     {
         FS.ensureDirExists(docRoot);
-        context.setBaseResource(Resource.newResource(docRoot));
-
         Path index = docRoot.resolve("index.html");
         createFile(index, "<h1>Hello World</h1>");
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletLifeCycleTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletLifeCycleTest.java
@@ -130,8 +130,7 @@ public class ServletLifeCycleTest
         server.start();
         context.addEventListener(new EventListener() {});
         listeners = context.getEventListeners();
-        listeners = context.getEventListeners();
-        assertThat(listeners.size(), is(3));
+        assertThat(listeners.size(), is(4));
 
         server.stop();
         listeners = context.getEventListeners();

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
@@ -90,7 +90,6 @@ public class WebSocketStatsTest
         MBeanContainer mbeanContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
         server.addBean(mbeanContainer);
 
-        server.setDumpAfterStart(true);
         server.start();
         client.start();
     }

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStatsTest.java
@@ -90,6 +90,7 @@ public class WebSocketStatsTest
         MBeanContainer mbeanContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
         server.addBean(mbeanContainer);
 
+        server.setDumpAfterStart(true);
         server.start();
         client.start();
     }

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AllowedResourceAliasCheckerTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AllowedResourceAliasCheckerTest.java
@@ -1,0 +1,150 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.AllowedResourceAliasChecker;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.IO;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AllowedResourceAliasCheckerTest
+{
+    private static Server _server;
+    private static ServerConnector _connector;
+    private static HttpClient _client;
+    private static ServletContextHandler _context;
+    private static File _baseDir;
+
+    private static Path getResourceDir() throws Exception
+    {
+        URL url = AllowedResourceAliasCheckerTest.class.getClassLoader().getResource(".");
+        assertNotNull(url);
+        return new File(url.toURI()).toPath();
+    }
+
+    public void start() throws Exception
+    {
+        _server.start();
+        _client.start();
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception
+    {
+        _client = new HttpClient();
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        _context = new ServletContextHandler();
+        _context.setContextPath("/");
+        _context.addServlet(DefaultServlet.class, "/");
+        _server.setHandler(_context);
+
+        _baseDir = getResourceDir().resolve("baseDir").toFile();
+        _baseDir.deleteOnExit();
+        assertFalse(_baseDir.exists());
+        _context.setResourceBase(_baseDir.getAbsolutePath());
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @AfterEach
+    public void afterEach()
+    {
+        IO.delete(_baseDir);
+    }
+
+    public void createBaseDir() throws IOException
+    {
+        assertFalse(_baseDir.exists());
+        assertTrue(_baseDir.mkdir());
+
+        // Create a file in the baseDir.
+        File file = _baseDir.toPath().resolve("file.txt").toFile();
+        file.deleteOnExit();
+        assertTrue(file.createNewFile());
+        try (FileWriter fileWriter = new FileWriter(file))
+        {
+            fileWriter.write("this is a file in the baseDir");
+        }
+
+        // Create a symlink to that file.
+        // Symlink to a directory inside of the webroot.
+        File symlink = _baseDir.toPath().resolve("symlink").toFile();
+        symlink.deleteOnExit();
+        Files.createSymbolicLink(symlink.toPath(), file.toPath());
+        assertTrue(symlink.exists());
+
+    }
+
+    @Test
+    public void testCreateBaseDirBeforeStart() throws Exception
+    {
+        _context.clearAliasChecks();
+        _context.addAliasCheck(new AllowedResourceAliasChecker(_context));
+        createBaseDir();
+        start();
+        assertThat(_context.getAliasChecks().size(), equalTo(1));
+
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/symlink");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), is("this is a file in the baseDir"));
+    }
+
+    @Test
+    public void testCreateBaseDirAfterStart() throws Exception
+    {
+        _context.clearAliasChecks();
+        _context.addAliasCheck(new AllowedResourceAliasChecker(_context));
+        start();
+        createBaseDir();
+        assertThat(_context.getAliasChecks().size(), equalTo(1));
+
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/symlink");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), is("this is a file in the baseDir"));
+    }
+}


### PR DESCRIPTION
## Issue #7059 

- Return null from `AllowedResourceAliasChecker.getPath()` if base resource is null without throwing and catching NPE.
- Do not allow base resource to be set after the `ContextHandler` is started.