### PR TITLE
Cleanup of Attributes class

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Attributes.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Attributes.java
@@ -13,9 +13,14 @@
 
 package org.eclipse.jetty.util;
 
+import java.util.AbstractSet;
 import java.util.Collections;
-import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Attributes.
@@ -23,19 +28,37 @@ import java.util.Set;
  */
 public interface Attributes
 {
-    void removeAttribute(String name);
+    /**
+     * Remove an attribute
+     * @param name the attribute to remove
+     * @return the value of the attribute if removed, else null
+     */
+    Object removeAttribute(String name);
 
-    void setAttribute(String name, Object attribute);
+    /**
+     * Set an attribute
+     * @param name the attribute to set
+     * @param attribute the value to set
+     * @return the previous value of the attribute if set, else null
+     */
+    Object setAttribute(String name, Object attribute);
 
+    /**
+     * Get an attribute
+     * @param name the attribute to get
+     * @return the value of the attribute
+     */
     Object getAttribute(String name);
 
-    Set<String> getAttributeNameSet();
+    /**
+     * Get the immutable set of attribute names.
+     * @return Set of attribute names
+     */
+    Set<String> getAttributeNames();
 
-    default Enumeration<String> getAttributeNames()
-    {
-        return Collections.enumeration(getAttributeNameSet());
-    }
-
+    /**
+     * Clear all attribute names
+     */
     void clearAttributes();
 
     /** Unwrap all  {@link Wrapper}s of the attributes
@@ -57,6 +80,7 @@ public interface Attributes
      * @param <T> The type of the target  {@link Wrapper}.
      * @return The outermost {@link Wrapper} of the matching type of null if not found.
      */
+    @SuppressWarnings("unchecked")
     static <T extends Attributes.Wrapper> T unwrap(Attributes attributes, Class<T> target)
     {
         while (attributes instanceof Wrapper)
@@ -71,7 +95,7 @@ public interface Attributes
     /**
      * A Wrapper of attributes
      */
-    abstract class Wrapper implements Attributes
+    class Wrapper implements Attributes
     {
         protected final Attributes _attributes;
 
@@ -86,15 +110,15 @@ public interface Attributes
         }
 
         @Override
-        public void removeAttribute(String name)
+        public Object removeAttribute(String name)
         {
-            _attributes.removeAttribute(name);
+            return _attributes.removeAttribute(name);
         }
 
         @Override
-        public void setAttribute(String name, Object attribute)
+        public Object setAttribute(String name, Object attribute)
         {
-            _attributes.setAttribute(name, attribute);
+            return _attributes.setAttribute(name, attribute);
         }
 
         @Override
@@ -104,15 +128,285 @@ public interface Attributes
         }
 
         @Override
-        public Set<String> getAttributeNameSet()
+        public Set<String> getAttributeNames()
         {
-            return _attributes.getAttributeNameSet();
+            return _attributes.getAttributeNames();
         }
 
         @Override
         public void clearAttributes()
         {
             _attributes.clearAttributes();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return _attributes.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return _attributes.equals(obj);
+        }
+    }
+
+    /**
+     * An Attributes implementation backed by a {@link ConcurrentHashMap}.
+     */
+    class Mapped implements Attributes
+    {
+        private final java.util.concurrent.ConcurrentMap<String, Object> _map = new ConcurrentHashMap<>();
+        private final Set<String> _names = Collections.unmodifiableSet(_map.keySet());
+
+        public Mapped()
+        {
+        }
+
+        public Mapped(Mapped attributes)
+        {
+            _map.putAll(attributes._map);
+        }
+
+        @Override
+        public Object removeAttribute(String name)
+        {
+            return _map.remove(name);
+        }
+
+        @Override
+        public Object setAttribute(String name, Object attribute)
+        {
+            if (attribute == null)
+                return _map.remove(name);
+
+            return _map.put(name, attribute);
+        }
+
+        @Override
+        public Object getAttribute(String name)
+        {
+            return _map.get(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNames()
+        {
+            return _names;
+        }
+
+        @Override
+        public void clearAttributes()
+        {
+            _map.clear();
+        }
+
+        public int size()
+        {
+            return _map.size();
+        }
+
+        public Set<Map.Entry<String, Object>> getAttributes()
+        {
+            return _map.entrySet();
+        }
+
+        @Override
+        public String toString()
+        {
+            return _map.toString();
+        }
+
+        public void addAll(Attributes attributes)
+        {
+            for (String name : attributes.getAttributeNames())
+                setAttribute(name, attributes.getAttribute(name));
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return _map.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o instanceof Attributes)
+            {
+                Attributes a = (Attributes)o;
+                for (Map.Entry<String, Object> e : _map.entrySet())
+                {
+                    if (!Objects.equals(e.getValue(), a.getAttribute(e.getKey())))
+                        return false;
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * An Attributes implementation backed by another Attributes instance, which is treated as immutable, but with a
+     * ConcurrentHashMap used as a mutable layer over it.
+     */
+    class Layer implements Attributes
+    {
+        private static final Object REMOVED = "REMOVED";
+        private final Attributes _persistent;
+        private final java.util.concurrent.ConcurrentMap<String, Object> _map = new ConcurrentHashMap<>();
+        private final Set<String> _names;
+
+        public Layer(Attributes persistent)
+        {
+            _persistent = persistent;
+            _names = new LayeredNamesSet();
+        }
+
+        @Override
+        public Object removeAttribute(String name)
+        {
+            if (_persistent.getAttributeNames().contains(name))
+            {
+                Object v = _map.put(name, REMOVED);
+                if (v == REMOVED)
+                    return null;
+                if (v != null)
+                    return v;
+                return _persistent.getAttribute(name);
+            }
+            Object v = _map.remove(name);
+            return v == REMOVED ? null : v;
+        }
+
+        @Override
+        public Object setAttribute(String name, Object attribute)
+        {
+            if (attribute == null)
+                return removeAttribute(name);
+            Object v = _map.put(name, attribute);
+            return v == REMOVED ? null : v;
+        }
+
+        @Override
+        public Object getAttribute(String name)
+        {
+            Object v = _map.get(name);
+            if (v != null)
+                return v == REMOVED ? null : v;
+            return _persistent.getAttribute(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNames()
+        {
+            return _names;
+        }
+
+        @Override
+        public void clearAttributes()
+        {
+            for (String n : _persistent.getAttributeNames())
+                _map.put(n, REMOVED);
+            _map.entrySet().removeIf(e -> e.getValue() != REMOVED);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int hash = super.hashCode();
+            for (String name : getAttributeNames())
+                hash = hash ^ name.hashCode() ^ getAttribute(name).hashCode();
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o instanceof Attributes)
+            {
+                Attributes a = (Attributes)o;
+                for (Map.Entry<String, Object> e : _map.entrySet())
+                {
+                    if (!Objects.equals(e.getValue(), a.getAttribute(e.getKey())))
+                        return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private class LayeredNamesSet extends AbstractSet<String>
+        {
+            @Override
+            public void clear()
+            {
+                clearAttributes();
+            }
+
+            @Override
+            public Iterator<String> iterator()
+            {
+                Iterator<Map.Entry<String, Object>> m = _map.entrySet().iterator();
+                Iterator<String> p = _persistent.getAttributeNames().iterator();
+                return new Iterator<>()
+                {
+                    Object _next;
+
+                    @Override
+                    public boolean hasNext()
+                    {
+                        if (_next == null)
+                        {
+                            while (m.hasNext())
+                            {
+                                Map.Entry<String, Object> next = m.next();
+                                if (next.getValue() != REMOVED)
+                                {
+                                    _next = next.getKey();
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (_next == null)
+                        {
+                            while (p.hasNext())
+                            {
+                                Object next = p.next();
+                                if (_map.containsKey(next))
+                                    continue;
+                                _next = next;
+                                break;
+                            }
+                        }
+
+                        return _next != null;
+                    }
+
+                    @Override
+                    public String next()
+                    {
+                        if (hasNext())
+                        {
+                            String next = String.valueOf(_next);
+                            _next = null;
+                            return next;
+                        }
+                        throw new NoSuchElementException();
+                    }
+                };
+            }
+
+            @Override
+            public int size()
+            {
+                int s = 0;
+                for (Iterator<String> i = iterator(); i.hasNext(); i.next())
+                    s++;
+                return s;
+            }
         }
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/AttributesMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/AttributesMap.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.util.component.Dumpable;
 
+// TODO rename to Attributes.Lazy or perhaps remove? or make it a LazyLayer?
 public class AttributesMap implements Attributes, Dumpable
 {
     private final AtomicReference<ConcurrentMap<String, Object>> _map = new AtomicReference<>();
@@ -60,20 +61,18 @@ public class AttributesMap implements Attributes, Dumpable
     }
 
     @Override
-    public void removeAttribute(String name)
+    public Object removeAttribute(String name)
     {
         Map<String, Object> map = map();
-        if (map != null)
-            map.remove(name);
+        return map == null ? null : map.remove(name);
     }
 
     @Override
-    public void setAttribute(String name, Object attribute)
+    public Object setAttribute(String name, Object attribute)
     {
         if (attribute == null)
-            removeAttribute(name);
-        else
-            ensureMap().put(name, attribute);
+            return removeAttribute(name);
+        return ensureMap().put(name, attribute);
     }
 
     @Override
@@ -84,15 +83,9 @@ public class AttributesMap implements Attributes, Dumpable
     }
 
     @Override
-    public Enumeration<String> getAttributeNames()
+    public Set<String> getAttributeNames()
     {
-        return Collections.enumeration(getAttributeNameSet());
-    }
-
-    @Override
-    public Set<String> getAttributeNameSet()
-    {
-        return keySet();
+        return Collections.unmodifiableSet(keySet());
     }
 
     public Set<Map.Entry<String, Object>> getAttributeEntrySet()
@@ -106,7 +99,7 @@ public class AttributesMap implements Attributes, Dumpable
         if (attrs instanceof AttributesMap)
             return Collections.enumeration(((AttributesMap)attrs).keySet());
 
-        List<String> names = new ArrayList<>(Collections.list(attrs.getAttributeNames()));
+        List<String> names = new ArrayList<>(attrs.getAttributeNames());
         return Collections.enumeration(names);
     }
 
@@ -134,17 +127,13 @@ public class AttributesMap implements Attributes, Dumpable
     private Set<String> keySet()
     {
         Map<String, Object> map = map();
-        return map == null ? Collections.<String>emptySet() : map.keySet();
+        return map == null ? Collections.emptySet() : map.keySet();
     }
 
     public void addAll(Attributes attributes)
     {
-        Enumeration<String> e = attributes.getAttributeNames();
-        while (e.hasMoreElements())
-        {
-            String name = e.nextElement();
+        for (String name : attributes.getAttributeNames())
             setAttribute(name, attributes.getAttribute(name));
-        }
     }
 
     @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/AttributeContainerMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/AttributeContainerMap.java
@@ -14,8 +14,6 @@
 package org.eclipse.jetty.util.component;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -32,23 +30,25 @@ public class AttributeContainerMap extends ContainerLifeCycle implements Attribu
     private final Map<String, Object> _map = new HashMap<>();
 
     @Override
-    public void setAttribute(String name, Object attribute)
+    public Object setAttribute(String name, Object attribute)
     {
         try (AutoLock l = _lock.lock())
         {
             Object old = _map.put(name, attribute);
             updateBean(old, attribute);
+            return old;
         }
     }
 
     @Override
-    public void removeAttribute(String name)
+    public Object removeAttribute(String name)
     {
         try (AutoLock l = _lock.lock())
         {
             Object removed = _map.remove(name);
             if (removed != null)
                 removeBean(removed);
+            return removed;
         }
     }
 
@@ -62,16 +62,7 @@ public class AttributeContainerMap extends ContainerLifeCycle implements Attribu
     }
 
     @Override
-    public Enumeration<String> getAttributeNames()
-    {
-        try (AutoLock l = _lock.lock())
-        {
-            return Collections.enumeration(_map.keySet());
-        }
-    }
-
-    @Override
-    public Set<String> getAttributeNameSet()
+    public Set<String> getAttributeNames()
     {
         try (AutoLock l = _lock.lock())
         {

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/AttributesTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/AttributesTest.java
@@ -1,0 +1,138 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AttributesTest
+{
+    public static Stream<Attributes> attributes()
+    {
+        return Stream.of(
+            new Attributes.Mapped(),
+            new Attributes.Wrapper(new Attributes.Mapped()),
+            new Attributes.Layer(new Attributes.Mapped()),
+            new AttributesMap()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("attributes")
+    public void testAttributes(Attributes attributes)
+    {
+        assertThat(attributes.getAttributeNames(), empty());
+        assertThat(attributes.removeAttribute("A"), nullValue());
+
+        assertThat(attributes.setAttribute("A", "0"), nullValue());
+        assertThat(attributes.getAttributeNames(), hasSize(1));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("A"));
+        assertThat(attributes.getAttribute("A"), equalTo("0"));
+        assertThat(attributes.getAttribute("B"), nullValue());
+
+        assertThat(attributes.setAttribute("A", "1"), equalTo("0"));
+        assertThat(attributes.getAttributeNames(), hasSize(1));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("A"));
+        assertThat(attributes.getAttribute("A"), equalTo("1"));
+        assertThat(attributes.getAttribute("B"), nullValue());
+
+        assertThat(attributes.setAttribute("B", "2"), nullValue());
+        assertThat(attributes.getAttributeNames(), hasSize(2));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("A", "B"));
+        assertThat(attributes.getAttribute("A"), equalTo("1"));
+        assertThat(attributes.getAttribute("B"), equalTo("2"));
+        assertThat(attributes.getAttribute("C"), nullValue());
+
+        assertThat(attributes.setAttribute("C", "3"), nullValue());
+        assertThat(attributes.getAttributeNames(), hasSize(3));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("A", "B", "C"));
+        assertThat(attributes.getAttribute("A"), equalTo("1"));
+        assertThat(attributes.getAttribute("B"), equalTo("2"));
+        assertThat(attributes.getAttribute("C"), equalTo("3"));
+
+        assertThat(attributes.removeAttribute("A"), equalTo("1"));
+        assertThat(attributes.getAttributeNames(), hasSize(2));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("B", "C"));
+        assertThat(attributes.getAttribute("A"), nullValue());
+        assertThat(attributes.getAttribute("B"), equalTo("2"));
+        assertThat(attributes.getAttribute("C"), equalTo("3"));
+
+        assertThat(attributes.setAttribute("B", null), equalTo("2"));
+        assertThat(attributes.getAttributeNames(), hasSize(1));
+        assertThat(attributes.getAttributeNames(), containsInAnyOrder("C"));
+        assertThat(attributes.getAttribute("A"), nullValue());
+        assertThat(attributes.getAttribute("B"), nullValue());
+        assertThat(attributes.getAttribute("C"), equalTo("3"));
+
+        attributes.clearAttributes();
+        assertThat(attributes.getAttributeNames(), hasSize(0));
+        assertThat(attributes.getAttribute("A"), nullValue());
+        assertThat(attributes.getAttribute("B"), nullValue());
+        assertThat(attributes.getAttribute("C"), nullValue());
+    }
+
+    @Test
+    public void testAttributeLayer()
+    {
+        Attributes.Mapped persistent = new Attributes.Mapped();
+        Attributes.Layer layer = new Attributes.Layer(persistent);
+
+        assertThat(persistent.getAttributeNames(), empty());
+        assertThat(persistent.removeAttribute("A"), nullValue());
+        assertThat(layer.getAttributeNames(), empty());
+        assertThat(layer.removeAttribute("A"), nullValue());
+
+        assertThat(persistent.setAttribute("A", "1"), nullValue());
+        assertThat(persistent.setAttribute("B", "2"), nullValue());
+        assertThat(persistent.setAttribute("C", "3"), nullValue());
+
+        assertThat(persistent.getAttributeNames(), hasSize(3));
+        assertThat(persistent.getAttributeNames(), containsInAnyOrder("A", "B", "C"));
+        assertThat(persistent.getAttribute("A"), equalTo("1"));
+        assertThat(persistent.getAttribute("B"), equalTo("2"));
+        assertThat(persistent.getAttribute("C"), equalTo("3"));
+        assertThat(layer.getAttributeNames(), hasSize(3));
+        assertThat(layer.getAttributeNames(), containsInAnyOrder("A", "B", "C"));
+        assertThat(persistent.getAttribute("A"), equalTo("1"));
+        assertThat(persistent.getAttribute("B"), equalTo("2"));
+        assertThat(persistent.getAttribute("C"), equalTo("3"));
+
+        assertThat(layer.removeAttribute("A"), equalTo("1"));
+        assertThat(layer.setAttribute("B", null), equalTo("2"));
+        assertThat(layer.setAttribute("C", null), equalTo("3"));
+        assertThat(persistent.getAttributeNames(), hasSize(3));
+        assertThat(persistent.getAttributeNames(), containsInAnyOrder("A", "B", "C"));
+        assertThat(persistent.getAttribute("A"), equalTo("1"));
+        assertThat(persistent.getAttribute("B"), equalTo("2"));
+        assertThat(persistent.getAttribute("C"), equalTo("3"));
+        assertThat(layer.getAttributeNames(), hasSize(0));
+        assertThat(layer.getAttributeNames(), containsInAnyOrder());
+        assertThat(layer.getAttribute("A"), nullValue());
+        assertThat(layer.getAttribute("B"), nullValue());
+        assertThat(layer.getAttribute("C"), nullValue());
+
+        testAttributes(layer);
+    }
+
+}


### PR DESCRIPTION
 - Added Object returns from remove and set
 - Added simple Mapped type for when lazy creation is not useful
 - Added Layer for use by context persistent vs start/stop attributes
 - removed enumerator as being API specific
 - better unit test with good coverage