### PR TITLE
Issue #7109 - Deprecate UnixSocket JNR support.

### DIFF
--- a/jetty-unixsocket/jetty-unixsocket-client/src/main/java/module-info.java
+++ b/jetty-unixsocket/jetty-unixsocket-client/src/main/java/module-info.java
@@ -11,6 +11,7 @@
 // ========================================================================
 //
 
+@Deprecated(forRemoval = true)
 module org.eclipse.jetty.unixsocket.client
 {
     requires org.eclipse.jetty.unixsocket.common;

--- a/jetty-unixsocket/jetty-unixsocket-client/src/main/java/org/eclipse/jetty/unixsocket/client/HttpClientTransportOverUnixSockets.java
+++ b/jetty-unixsocket/jetty-unixsocket-client/src/main/java/org/eclipse/jetty/unixsocket/client/HttpClientTransportOverUnixSockets.java
@@ -22,6 +22,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -32,6 +33,7 @@ import org.eclipse.jetty.client.AbstractConnectorHttpClientTransport;
 import org.eclipse.jetty.client.DuplexConnectionPool;
 import org.eclipse.jetty.client.DuplexHttpDestination;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.Origin;
@@ -47,7 +49,10 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: this class needs a thorough review.
+/**
+ * @deprecated use any {@link HttpClientTransport} with {@link ClientConnector#forUnixDomain(Path)} instead (requires Java 16 or later)
+ */
+@Deprecated(forRemoval = true)
 public class HttpClientTransportOverUnixSockets extends AbstractConnectorHttpClientTransport
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpClientTransportOverUnixSockets.class);

--- a/jetty-unixsocket/jetty-unixsocket-common/src/main/java/module-info.java
+++ b/jetty-unixsocket/jetty-unixsocket-common/src/main/java/module-info.java
@@ -11,6 +11,7 @@
 // ========================================================================
 //
 
+@Deprecated(forRemoval = true)
 module org.eclipse.jetty.unixsocket.common
 {
     requires org.slf4j;

--- a/jetty-unixsocket/jetty-unixsocket-common/src/main/java/org/eclipse/jetty/unixsocket/common/UnixSocketEndPoint.java
+++ b/jetty-unixsocket/jetty-unixsocket-common/src/main/java/org/eclipse/jetty/unixsocket/common/UnixSocketEndPoint.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(forRemoval = true)
 public class UnixSocketEndPoint extends SocketChannelEndPoint
 {
     private static final Logger LOG = LoggerFactory.getLogger(UnixSocketEndPoint.class);

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-forwarded.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-forwarded.mod
@@ -5,8 +5,13 @@ Adds a forwarded request customizer for the  Unix Domain Socket connector.
 For use when behind a proxy operating in HTTP mode that adds forwarded-for style HTTP headers. 
 Typically this is an alternate to the Proxy Protocol used mostly for TCP mode.
 
+[deprecated]
+Module 'unixsocket-forwarded' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
+deprecated
 
 [depend]
 unixsocket-http

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-http.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-http.mod
@@ -6,9 +6,14 @@ It should be used when a proxy is forwarding either HTTP or decrypted
 HTTPS traffic to the connector and may be used with the 
 unix-socket-http2c modules to upgrade to HTTP/2.
 
+[deprecated]
+Module 'unixsocket-http' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
 http
+deprecated
 
 [depend]
 unixsocket

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-http2c.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-http2c.mod
@@ -5,9 +5,14 @@ Adds an HTTP2C connetion factory to the Unix Domain Socket Connector.
 It can be used when either the proxy forwards direct
 HTTP/2C (unecrypted) or decrypted HTTP/2 traffic.
 
+[deprecated]
+Module 'unixsocket-http2c' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
 http2
+deprecated
 
 [depend]
 unixsocket-http

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-prefix.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-prefix.mod
@@ -8,8 +8,13 @@ as they reduce data copies, avoid needless fragmentation and have better dispatc
 When enabled with corresponding support modules, the connector can 
 accept HTTP, HTTPS or HTTP2C traffic.
 
+[deprecated]
+Module 'unixsocket' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
+deprecated
 
 [depend]
 server

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-proxy-protocol.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-proxy-protocol.mod
@@ -10,8 +10,13 @@ SSL properties may be interpreted by the unixsocket-secure
 module to indicate secure HTTPS traffic. Typically this
 is an alternate to the forwarded module.
 
+[deprecated]
+Module 'unixsocket-proxy-protocol' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
+deprecated
 
 [depend]
 unixsocket

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-secure.mod
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/modules/unixsocket-secure.mod
@@ -7,11 +7,16 @@ This looks for a secure scheme transported either by the
 unixsocket-forwarded, unixsocket-proxy-protocol or in a
 HTTP2 request.
 
+[deprecated]
+Module 'unixsocket-secure' is deprecated for removal.
+Use 'unixdomain-http' instead (requires Java 16 or later).
+
 [tags]
 connector
 
 [depend]
 unixsocket-http
+deprecated
 
 [xml]
 etc/jetty-unixsocket-secure.xml

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/java/module-info.java
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/java/module-info.java
@@ -11,6 +11,7 @@
 // ========================================================================
 //
 
+@Deprecated(forRemoval = true)
 module org.eclipse.jetty.unixsocket.server
 {
     requires org.slf4j;

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/java/org/eclipse/jetty/unixsocket/server/UnixSocketConnector.java
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/java/org/eclipse/jetty/unixsocket/server/UnixSocketConnector.java
@@ -50,7 +50,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p>A server-side connector for UNIX sockets.</p>
+ *
+ * @deprecated Use UnixDomainServerConnector from the jetty-unixdomain-server module instead (requires Java 16 or later).
  */
+@Deprecated(forRemoval = true)
 @ManagedObject("Connector using UNIX Socket")
 public class UnixSocketConnector extends AbstractConnector
 {


### PR DESCRIPTION
Deprecated for removal classes and JPMS modules.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>