### PR TITLE
Issue #7034 flaky infinispan tests with CI, do not use udp for infinispan node sync as it is a pain with k8s

### DIFF
--- a/jetty-infinispan/infinispan-remote-query/src/test/java/org/eclipse/jetty/server/session/infinispan/RemoteQueryManagerTest.java
+++ b/jetty-infinispan/infinispan-remote-query/src/test/java/org/eclipse/jetty/server/session/infinispan/RemoteQueryManagerTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -74,10 +75,12 @@ public class RemoteQueryManagerTest
             .withEnv("PASS", "foobar")
             .withEnv("MGMT_USER", "admin")
             .withEnv("MGMT_PASS", "admin")
+            .withEnv("CONFIG_PATH", "/user-config/config.yaml")
             .waitingFor(new LogMessageWaitStrategy()
                 .withRegEx(".*Infinispan Server.*started in.*\\s"))
             .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+            .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
 
     @BeforeEach
     public void setup() throws Exception

--- a/jetty-infinispan/infinispan-remote-query/src/test/resources/config.yaml
+++ b/jetty-infinispan/infinispan-remote-query/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
@@ -34,6 +34,7 @@ import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -64,10 +65,12 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                         .withEnv("PASS", "foobar")
                         .withEnv("MGMT_USER", "admin")
                         .withEnv("MGMT_PASS", "admin")
+                        .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(new LogMessageWaitStrategy()
                                 .withRegEx(".*Infinispan Server.*started in.*\\s"))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+                        .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
         infinispan.start();
         host = infinispan.getContainerIpAddress();
         port = infinispan.getMappedPort(11222);

--- a/tests/test-distribution/src/test/resources/config.yaml
+++ b/tests/test-distribution/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-sessions/test-infinispan-sessions/src/test/java/org/eclipse/jetty/server/session/remote/RemoteInfinispanTestSupport.java
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/java/org/eclipse/jetty/server/session/remote/RemoteInfinispanTestSupport.java
@@ -34,6 +34,7 @@ import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -62,9 +63,11 @@ public class RemoteInfinispanTestSupport
             .withEnv("PASS", "foobar")
             .withEnv("MGMT_USER", "admin")
             .withEnv("MGMT_PASS", "admin")
+            .withEnv("CONFIG_PATH", "/user-config/config.yaml")
             .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
             .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+            .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
 
     private static final String INFINISPAN_VERSION = System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
 

--- a/tests/test-sessions/test-infinispan-sessions/src/test/resources/config.yaml
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-sessions/test-infinispan-sessions/src/test/resources/simplelogger.properties
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/resources/simplelogger.properties
@@ -1,4 +1,5 @@
 org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session.remote.infinispanLogs=info
 org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session.remote.RemoteInfinispanTestSupport=info
 #org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session=trace


### PR DESCRIPTION
- force jgroups to use tcp
