### PR TITLE
Issue #7034 infinispan flaky tests on CI, force TCP over UDP for  jgroups multicasting as it is too slow with kubernetes (#7122)

### DIFF
--- a/jetty-infinispan/infinispan-remote-query/src/test/java/org/eclipse/jetty/server/session/infinispan/RemoteQueryManagerTest.java
+++ b/jetty-infinispan/infinispan-remote-query/src/test/java/org/eclipse/jetty/server/session/infinispan/RemoteQueryManagerTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -81,10 +82,12 @@ public class RemoteQueryManagerTest
             .withEnv("PASS", "foobar")
             .withEnv("MGMT_USER", "admin")
             .withEnv("MGMT_PASS", "admin")
+            .withEnv("CONFIG_PATH", "/user-config/config.yaml")
             .waitingFor(new LogMessageWaitStrategy()
                 .withRegEx(".*Infinispan Server.*started in.*\\s"))
             .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+            .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+            .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
 
     @BeforeEach
     public void setup() throws Exception

--- a/jetty-infinispan/infinispan-remote-query/src/test/resources/config.yaml
+++ b/jetty-infinispan/infinispan-remote-query/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/InfinispanSessionDistributionTests.java
@@ -44,6 +44,7 @@ import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -137,10 +138,12 @@ public class InfinispanSessionDistributionTests extends AbstractDistributionTest
                         .withEnv("PASS", "foobar")
                         .withEnv("MGMT_USER", "admin")
                         .withEnv("MGMT_PASS", "admin")
+                        .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(new LogMessageWaitStrategy()
                                 .withRegEx(".*Infinispan Server.*started in.*\\s"))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+                        .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
         infinispan.start();
         infinispanHost = infinispan.getContainerIpAddress();
         infinispanPort = infinispan.getMappedPort(11222);

--- a/tests/test-distribution/src/test/resources/config.yaml
+++ b/tests/test-distribution/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-sessions/test-infinispan-sessions/src/test/java/org/eclipse/jetty/server/session/remote/RemoteInfinispanTestSupport.java
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/java/org/eclipse/jetty/server/session/remote/RemoteInfinispanTestSupport.java
@@ -38,6 +38,7 @@ import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -69,21 +70,23 @@ public class RemoteInfinispanTestSupport
             String infinispanVersion = System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
             infinispan =
                 new GenericContainer(System.getProperty("infinispan.docker.image.name", "infinispan/server") +
-                    ":" + infinispanVersion)
-                .withEnv("USER", "theuser")
-                .withEnv("PASS", "foobar")
-                .withEnv("MGMT_USER", "admin")
-                .withEnv("MGMT_PASS", "admin")
-                .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
-                .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-                .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+                        ":" + infinispanVersion)
+                        .withEnv("USER", "theuser")
+                        .withEnv("PASS", "foobar")
+                        .withEnv("MGMT_USER", "admin")
+                        .withEnv("MGMT_PASS", "admin")
+                        .withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                        .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
+                        .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
+                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+                        .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
             infinispan.start();
             String host = infinispan.getContainerIpAddress();
             System.setProperty("hotrod.host", host);
             int port = infinispan.getMappedPort(11222);
 
             LOG.info("Infinispan container started for {}:{} - {}ms", host, port,
-                     System.currentTimeMillis() - start);
+                    System.currentTimeMillis() - start);
             SearchMapping mapping = new SearchMapping();
             mapping.entity(SessionData.class).indexed().providedId()
                 .property("expiry", ElementType.METHOD).field();
@@ -104,7 +107,7 @@ public class RemoteInfinispanTestSupport
                     .saslMechanism("DIGEST-MD5")
                     .username("theuser").password("foobar");
             }
-            
+
             configurationBuilder.addContextInitializer(new InfinispanSerializationContextInitializer());
             Configuration configuration = configurationBuilder.build();
 

--- a/tests/test-sessions/test-infinispan-sessions/src/test/resources/config.yaml
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jgroups:
+  transport: tcp
+  dnsPing:
+    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/tests/test-sessions/test-infinispan-sessions/src/test/resources/simplelogger.properties
+++ b/tests/test-sessions/test-infinispan-sessions/src/test/resources/simplelogger.properties
@@ -1,4 +1,5 @@
 org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session.remote.infinispanLogs=info
 org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session.remote.RemoteInfinispanTestSupport=info
 #org.slf4j.simpleLogger.log.org.eclipse.jetty.server.session=trace


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>
