### PR TITLE
Issue #7124 - deprecate AbstractLifeCycleListener in 10.0.x

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/ServerListener.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/ServerListener.java
@@ -38,11 +38,6 @@ public class ServerListener implements LifeCycle.Listener
     }
 
     @Override
-    public void lifeCycleStarting(LifeCycle event)
-    {
-    }
-
-    @Override
     public void lifeCycleStarted(LifeCycle event)
     {
         if (_tokenFile != null)
@@ -57,20 +52,5 @@ public class ServerListener implements LifeCycle.Listener
                 throw new IllegalStateException(e);
             }
         }
-    }
-
-    @Override
-    public void lifeCycleFailure(LifeCycle event, Throwable cause)
-    {
-    }
-
-    @Override
-    public void lifeCycleStopping(LifeCycle event)
-    {
-    }
-
-    @Override
-    public void lifeCycleStopped(LifeCycle event)
-    {
     }
 }

--- a/jetty-osgi/test-jetty-osgi-server/src/main/java/com/acme/osgi/Activator.java
+++ b/jetty-osgi/test-jetty-osgi-server/src/main/java/com/acme/osgi/Activator.java
@@ -19,7 +19,6 @@ import java.util.Hashtable;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.util.component.AbstractLifeCycle.AbstractLifeCycleListener;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -41,14 +40,13 @@ public class Activator implements BundleActivator
     {
         //For test purposes, use a random port
         Server server = new Server(0);
-        server.getConnectors()[0].addEventListener(new AbstractLifeCycleListener()
+        server.getConnectors()[0].addEventListener(new LifeCycle.Listener()
         {
 
             @Override
             public void lifeCycleStarted(LifeCycle event)
             {
                 System.setProperty("bundle.server.port", String.valueOf(((ServerConnector)event).getLocalPort()));
-                super.lifeCycleStarted(event);
             }
         });
         ContextHandlerCollection contexts = new ContextHandlerCollection();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
@@ -299,6 +299,10 @@ public abstract class AbstractLifeCycle implements LifeCycle
         }
     }
 
+    /**
+     * @deprecated this class is redundant now that {@link LifeCycle.Listener} has default methods.
+     */
+    @Deprecated
     public abstract static class AbstractLifeCycleListener implements LifeCycle.Listener
     {
         @Override

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/component/StopLifeCycle.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/component/StopLifeCycle.java
@@ -32,11 +32,6 @@ public class StopLifeCycle extends AbstractLifeCycle implements LifeCycle.Listen
     }
 
     @Override
-    public void lifeCycleStarting(LifeCycle lifecycle)
-    {
-    }
-
-    @Override
     public void lifeCycleStarted(LifeCycle lifecycle)
     {
         try
@@ -47,20 +42,5 @@ public class StopLifeCycle extends AbstractLifeCycle implements LifeCycle.Listen
         {
             LOG.warn("Unable to stop", e);
         }
-    }
-
-    @Override
-    public void lifeCycleFailure(LifeCycle lifecycle, Throwable cause)
-    {
-    }
-
-    @Override
-    public void lifeCycleStopping(LifeCycle lifecycle)
-    {
-    }
-
-    @Override
-    public void lifeCycleStopped(LifeCycle lifecycle)
-    {
     }
 }


### PR DESCRIPTION
Merge of some changes from #7143 to `10.0.x`.