### PR TITLE
Issue #7160 - Add AMBIGUOUS_PATH_ENCODING to default UriCompliance mode.

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -104,7 +104,9 @@ public final class UriCompliance implements ComplianceViolation.Mode
      * additional violations to avoid most ambiguous URIs.
      * This mode does allow {@link Violation#AMBIGUOUS_PATH_SEPARATOR}, but disallows all out {@link Violation}s.
      */
-    public static final UriCompliance DEFAULT = new UriCompliance("DEFAULT", of(Violation.AMBIGUOUS_PATH_SEPARATOR));
+    public static final UriCompliance DEFAULT = new UriCompliance("DEFAULT",
+        of(Violation.AMBIGUOUS_PATH_SEPARATOR,
+            Violation.AMBIGUOUS_PATH_ENCODING));
 
     /**
      * LEGACY compliance mode that models Jetty-9.4 behavior by allowing {@link Violation#AMBIGUOUS_PATH_SEGMENT},

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -1812,13 +1812,18 @@ public class RequestTest
             "Host: whatever\r\n" +
             "\r\n";
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT);
-        assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 400"));
+        assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.RFC3986);
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));
         _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 200"));
+
+        UriCompliance custom = new UriCompliance("Custom", EnumSet.complementOf(
+            EnumSet.of(UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING)));
+        _connector.getBean(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(custom);
+        assertThat(_connector.getResponse(request), startsWith("HTTP/1.1 400"));
     }
 
     @Test


### PR DESCRIPTION
## Closes #7160

Remove `AMBIGUOUS_PATH_ENCODING` from the default `UriCompliance` mode.

This means that URIs containing the encoded percent character (`%25`) will be allowed in the default mode.