### PR TITLE
Issue #7063 - Remove logging requirement from Password / Credential

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -18,6 +18,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Fast String Utilities.
@@ -794,7 +795,7 @@ public class StringUtil
 
     public static String toHexString(byte[] b)
     {
-        return toHexString(b, 0, b.length);
+        return toHexString(Objects.requireNonNull(b, "ByteBuffer cannot be null"), 0, b.length);
     }
 
     public static String toHexString(byte[] b, int offset, int length)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -774,6 +774,47 @@ public class StringUtil
         return true;
     }
 
+    public static byte[] fromHexString(String s)
+    {
+        if (s.length() % 2 != 0)
+            throw new IllegalArgumentException(s);
+        byte[] array = new byte[s.length() / 2];
+        for (int i = 0; i < array.length; i++)
+        {
+            int b = Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
+            array[i] = (byte)(0xff & b);
+        }
+        return array;
+    }
+
+    public static String toHexString(byte b)
+    {
+        return toHexString(new byte[]{b}, 0, 1);
+    }
+
+    public static String toHexString(byte[] b)
+    {
+        return toHexString(b, 0, b.length);
+    }
+
+    public static String toHexString(byte[] b, int offset, int length)
+    {
+        StringBuilder buf = new StringBuilder();
+        for (int i = offset; i < offset + length; i++)
+        {
+            int bi = 0xff & b[i];
+            int c = '0' + (bi / 16) % 16;
+            if (c > '9')
+                c = 'A' + (c - '0' - 10);
+            buf.append((char)c);
+            c = '0' + bi % 16;
+            if (c > '9')
+                c = 'a' + (c - '0' - 10);
+            buf.append((char)c);
+        }
+        return buf.toString();
+    }
+
     public static String printable(String name)
     {
         if (name == null)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -401,7 +401,7 @@ public class TypeUtil
     }
 
     /**
-     * @deprecated use {@link #fromHexString(String)} instead
+     * @deprecated use {@link StringUtil#fromHexString(String)} instead
      */
     @Deprecated
     public static byte[] parseBytes(String s, int base)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -400,6 +400,10 @@ public class TypeUtil
         return value;
     }
 
+    /**
+     * @deprecated use {@link #fromHexString(String)} instead
+     */
+    @Deprecated
     public static byte[] parseBytes(String s, int base)
     {
         byte[] bytes = new byte[s.length() / 2];
@@ -507,45 +511,40 @@ public class TypeUtil
         toHex((int)value, buf);
     }
 
+    /**
+     * @deprecated use {@link StringUtil#toHexString(byte)} instead
+     */
+    @Deprecated
     public static String toHexString(byte b)
     {
-        return toHexString(new byte[]{b}, 0, 1);
+        return StringUtil.toHexString(b);
     }
 
+    /**
+     * @deprecated use {@link StringUtil#toHexString(byte[])} instead
+     */
+    @Deprecated
     public static String toHexString(byte[] b)
     {
-        return toHexString(b, 0, b.length);
+        return StringUtil.toHexString(b);
     }
 
+    /**
+     * @deprecated use {@link StringUtil#toHexString(byte[], int, int)} instead
+     */
+    @Deprecated
     public static String toHexString(byte[] b, int offset, int length)
     {
-        StringBuilder buf = new StringBuilder();
-        for (int i = offset; i < offset + length; i++)
-        {
-            int bi = 0xff & b[i];
-            int c = '0' + (bi / 16) % 16;
-            if (c > '9')
-                c = 'A' + (c - '0' - 10);
-            buf.append((char)c);
-            c = '0' + bi % 16;
-            if (c > '9')
-                c = 'a' + (c - '0' - 10);
-            buf.append((char)c);
-        }
-        return buf.toString();
+        return StringUtil.toHexString(b, offset, length);
     }
 
+    /**
+     * @deprecated use {@link StringUtil#fromHexString(String)}
+     */
+    @Deprecated
     public static byte[] fromHexString(String s)
     {
-        if (s.length() % 2 != 0)
-            throw new IllegalArgumentException(s);
-        byte[] array = new byte[s.length() / 2];
-        for (int i = 0; i < array.length; i++)
-        {
-            int b = Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
-            array[i] = (byte)(0xff & b);
-        }
-        return array;
+        return StringUtil.fromHexString(s);
     }
 
     public static void dump(Class<?> c)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
@@ -284,7 +284,7 @@ public abstract class Credential implements Serializable
                 // Intentionally not using TypeUtil.toString() here as TypeUtil
                 // introduces a Logging requirement that is not compatible
                 // with Password command line.
-                final char[] HEX = "0123456789ABCDEF".toCharArray();
+                final char[] HEX = "0123456789abcdef".toCharArray();
                 int len = digest.length;
                 char[] out = new char[len * 2];
                 for (int i = 0; i < len; i++)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
@@ -19,7 +19,6 @@ import java.security.MessageDigest;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -42,7 +41,7 @@ public abstract class Credential implements Serializable
     // Intentionally NOT using TypeUtil.serviceProviderStream
     // as that introduces a Logger requirement that command line Password cannot use.
     private static final List<CredentialProvider> CREDENTIAL_PROVIDERS = ServiceLoader.load(CredentialProvider.class).stream()
-        .flatMap((p) -> Stream.of(p.get()))
+        .map(ServiceLoader.Provider::get)
         .collect(Collectors.toList());
 
     /**
@@ -265,7 +264,7 @@ public abstract class Credential implements Serializable
                         catch (Exception e)
                         {
                             System.err.println("Unable to access MD5 message digest");
-                            e.printStackTrace(System.err);
+                            e.printStackTrace();
                             return null;
                         }
                     }
@@ -280,7 +279,7 @@ public abstract class Credential implements Serializable
             catch (Exception e)
             {
                 System.err.println("Message Digest Failure");
-                e.printStackTrace(System.err);
+                e.printStackTrace();
                 return null;
             }
         }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Credential.java
@@ -134,35 +134,25 @@ public abstract class Credential implements Serializable
     }
 
     /**
-     * <p>Utility to convert a String of hex into an actual byte array</p>
+     * Utility to convert a String of hex into an actual byte array
      * @param hstr the raw string
      * @return the parsed byte array
      */
-    protected static byte[] parseHexToByteArray(String hstr)
+    private static byte[] parseHexToByteArray(String hstr)
     {
         if ((hstr.length() <= 0) || ((hstr.length() % 2) != 0))
         {
             throw new IllegalArgumentException(String.format("Invalid string length of <%d>", hstr.length()));
         }
 
-        int size = hstr.length() / 2;
-        byte[] buf = new byte[size];
-        byte hex;
+        byte[] buf = new byte[hstr.length() / 2];
         int len = hstr.length();
 
-        int idx = (int)Math.floor(((size * 2) - (double)len) / 2);
-        for (int i = 0; i < len; i++)
+        for (int i = 0, idx = 0; i < len; i++)
         {
-            hex = 0;
-            if (i >= 0)
-            {
-                hex = (byte)(Character.digit(hstr.charAt(i), 16) << 4);
-            }
-            i++;
+            byte hex = (byte)(Character.digit(hstr.charAt(i++), 16) << 4);
             hex += (byte)(Character.digit(hstr.charAt(i), 16));
-
-            buf[idx] = hex;
-            idx++;
+            buf[idx++] = hex;
         }
 
         return buf;
@@ -173,7 +163,7 @@ public abstract class Credential implements Serializable
      * @param buf the byte array
      * @return the hex string
      */
-    protected static String formatAsHex(byte[] buf)
+    private static String formatAsHex(byte[] buf)
     {
         int len = buf.length;
         char[] out = new char[len * 2];

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -222,7 +222,7 @@ public class Password extends Credential
             {
                 // only seen with command line input style
                 System.err.println("ERROR: Bad/Invalid password.");
-                e.printStackTrace(System.err);
+                e.printStackTrace();
             }
             if (passwd == null || passwd.length() == 0)
                 passwd = promptDft;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -245,5 +245,6 @@ public class Password extends Credential
         System.err.println(Credential.MD5.digest(p));
         if (arg.length == 2)
             System.err.println(Credential.Crypt.crypt(arg[0], pw.toString()));
+        System.exit(0);
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -17,9 +17,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Password utility class.
  *
@@ -47,8 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Password extends Credential
 {
-    private static final Logger LOG = LoggerFactory.getLogger(Password.class);
-
+    // NOTE: DO NOT INTRODUCE LOGGING TO THIS CLASS
     private static final long serialVersionUID = 5062906681431569445L;
 
     public static final String __OBFUSCATE = "OBF:";
@@ -224,7 +220,9 @@ public class Password extends Credential
             }
             catch (IOException e)
             {
-                LOG.warn("EXCEPTION", e);
+                // only seen with command line input style
+                System.err.println("ERROR: Bad/Invalid password.");
+                e.printStackTrace(System.err);
             }
             if (passwd == null || passwd.length() == 0)
                 passwd = promptDft;

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/StringUtilTest.java
@@ -26,8 +26,10 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -265,5 +267,35 @@ public class StringUtilTest
         assertThat(StringUtil.csvSplit(" ,\n,bbb, , "), arrayContaining("", "", "bbb", ""));
 
         assertThat(StringUtil.csvSplit("\"aaa\", \" b,\\\"\",\"\""), arrayContaining("aaa", " b,\"", ""));
+    }
+
+    @Test
+    public void testFromHexStringGood()
+    {
+        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}, StringUtil.fromHexString("123456789A"));
+    }
+
+    @Test
+    public void testFromHexStringBad()
+    {
+        assertThrows(NumberFormatException.class, () -> StringUtil.fromHexString("Hello World "));
+    }
+
+    @Test
+    public void testToHexStringGood()
+    {
+        assertThat(StringUtil.toHexString(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}), is("123456789a"));
+    }
+
+    @Test
+    public void testToHexStringNull()
+    {
+        assertThrows(NullPointerException.class, () -> StringUtil.toHexString(null));
+    }
+
+    @Test
+    public void testToHexStringEmpty()
+    {
+        assertThat(StringUtil.toHexString(new byte[0]), is(""));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
@@ -22,10 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -188,29 +186,5 @@ public class TypeUtilTest
         // Class from JVM core
         String expectedJavaBase = "/java.base";
         assertThat(TypeUtil.getLocationOfClass(java.lang.ThreadDeath.class).toASCIIString(), containsString(expectedJavaBase));
-    }
-
-    @Test
-    public void testParseBytesGood()
-    {
-        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}, TypeUtil.parseBytes("123456789A", 16));
-    }
-
-    @Test
-    public void testParseBytesBad()
-    {
-        assertThrows(NumberFormatException.class, () -> TypeUtil.parseBytes("Hello World ", 16));
-    }
-
-    @Test
-    public void testFromHexStringGood()
-    {
-        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}, TypeUtil.fromHexString("123456789A"));
-    }
-
-    @Test
-    public void testFromHexStringBad()
-    {
-        assertThrows(NumberFormatException.class, () -> TypeUtil.fromHexString("Hello World "));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -186,5 +188,29 @@ public class TypeUtilTest
         // Class from JVM core
         String expectedJavaBase = "/java.base";
         assertThat(TypeUtil.getLocationOfClass(java.lang.ThreadDeath.class).toASCIIString(), containsString(expectedJavaBase));
+    }
+
+    @Test
+    public void testParseBytesGood()
+    {
+        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}, TypeUtil.parseBytes("123456789A", 16));
+    }
+
+    @Test
+    public void testParseBytesBad()
+    {
+        assertThrows(NumberFormatException.class, () -> TypeUtil.parseBytes("Hello World ", 16));
+    }
+
+    @Test
+    public void testFromHexStringGood()
+    {
+        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78, (byte)0x9A}, TypeUtil.fromHexString("123456789A"));
+    }
+
+    @Test
+    public void testFromHexStringBad()
+    {
+        assertThrows(NumberFormatException.class, () -> TypeUtil.fromHexString("Hello World "));
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/security/CredentialTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/security/CredentialTest.java
@@ -16,6 +16,8 @@ package org.eclipse.jetty.util.security;
 import org.eclipse.jetty.util.security.Credential.Crypt;
 import org.eclipse.jetty.util.security.Credential.MD5;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,5 +100,18 @@ public class CredentialTest
         assertFalse(Credential.byteEquals("fooo".getBytes(), "".getBytes()));
         assertFalse(Credential.byteEquals("".getBytes(), "fooo".getBytes()));
         assertTrue(Credential.byteEquals("".getBytes(), "".getBytes()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v",
+        "MD5:5f4dcc3b5aa765d61d8327deb882cf99",
+        "CRYPT:usjRS48E8ZADM"
+    })
+    public void testGetCredential(String encoded)
+    {
+        Credential credential = Credential.getCredential(encoded);
+        assertTrue(credential.check(Credential.getCredential("password")));
+        assertTrue(credential.check("password"));
     }
 }


### PR DESCRIPTION
Removed / Replaced Logging requirements in Password / Credential to allow for simplified use of `Password` on command line.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>