### PR TITLE
Regularize package of jetty-hazelcast.

### DIFF
--- a/jetty-session/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
+++ b/jetty-session/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
@@ -10,7 +10,7 @@
   <!-- ===================================================================== -->
   <Call name="addBean">
     <Arg>
-      <New id="sessionDataStoreFactory" class="org.eclipse.jetty.hazelcast.session.HazelcastSessionDataStoreFactory">
+      <New id="sessionDataStoreFactory" class="org.eclipse.jetty.session.hazelcast.HazelcastSessionDataStoreFactory">
         <Set name="mapName" property="jetty.session.hazelcast.mapName"/>
         <Set name="hazelcastInstanceName" property="jetty.session.hazelcast.hazelcastInstanceName"/>
         <Set name="useQueries" property="jetty.session.hazelcast.useQueries"/>

--- a/jetty-session/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
+++ b/jetty-session/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
@@ -9,7 +9,7 @@
   <!-- ===================================================================== -->
   <Call name="addBean">
     <Arg>
-      <New id="sessionDataStoreFactory" class="org.eclipse.jetty.hazelcast.session.HazelcastSessionDataStoreFactory">
+      <New id="sessionDataStoreFactory" class="org.eclipse.jetty.session.hazelcast.HazelcastSessionDataStoreFactory">
         <Set name="mapName" property="jetty.session.hazelcast.mapName"/>
         <Set name="hazelcastInstanceName" property="jetty.session.hazelcast.hazelcastInstanceName"/>
         <Set name="useQueries" property="jetty.session.hazelcast.useQueries"/>

--- a/jetty-session/jetty-hazelcast/src/main/java/module-info.java
+++ b/jetty-session/jetty-hazelcast/src/main/java/module-info.java
@@ -11,11 +11,11 @@
 // ========================================================================
 //
 
-module org.eclipse.jetty.hazelcast.session
+module org.eclipse.jetty.session.hazelcast
 {
     requires transitive com.hazelcast.core;
     requires transitive org.eclipse.jetty.server;
     requires transitive org.eclipse.jetty.util;
 
-    exports org.eclipse.jetty.hazelcast.session;
+    exports org.eclipse.jetty.session.hazelcast;
 }

--- a/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStore.java
+++ b/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStore.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStoreFactory.java
+++ b/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStoreFactory.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/SessionDataSerializer.java
+++ b/jetty-session/jetty-hazelcast/src/main/java/org/eclipse/jetty/session/hazelcast/SessionDataSerializer.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/jetty-session/jetty-hazelcast/src/test/java/org/eclipse/jetty/session/hazelcast/TestHazelcastSessions.java
+++ b/jetty-session/jetty-hazelcast/src/test/java/org/eclipse/jetty/session/hazelcast/TestHazelcastSessions.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/ClusteredOrphanedSessionTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/ClusteredOrphanedSessionTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import org.eclipse.jetty.server.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/ClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/ClusteredSessionScavengingTest.java
@@ -11,24 +11,22 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session.client;
+package org.eclipse.jetty.session.hazelcast;
 
-import org.eclipse.jetty.hazelcast.session.HazelcastTestHelper;
 import org.eclipse.jetty.server.session.AbstractClusteredSessionScavengingTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientSessionScavengingTest
+/**
+ * ClusteredSessionScavengingTest
+ */
+public class ClusteredSessionScavengingTest
     extends AbstractClusteredSessionScavengingTest
 {
-    HazelcastTestHelper _testHelper;
+    HazelcastSessionDataStoreFactory factory;
 
-    @Override
-    public SessionDataStoreFactory createSessionDataStoreFactory()
-    {
-        return _testHelper.createSessionDataStoreFactory(true);
-    }
+    HazelcastTestHelper _testHelper;
 
     @BeforeEach
     public void setUp()
@@ -40,5 +38,11 @@ public class ClientSessionScavengingTest
     public void shutdown()
     {
         _testHelper.tearDown();
+    }
+
+    @Override
+    public SessionDataStoreFactory createSessionDataStoreFactory()
+    {
+        return _testHelper.createSessionDataStoreFactory(false);
     }
 }

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastClusteredInvalidationSessionTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastClusteredInvalidationSessionTest.java
@@ -11,18 +11,15 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
-import org.eclipse.jetty.server.session.AbstractClusteredSessionScavengingTest;
+import org.eclipse.jetty.server.session.AbstractClusteredInvalidationSessionTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * ClusteredSessionScavengingTest
- */
-public class ClusteredSessionScavengingTest
-    extends AbstractClusteredSessionScavengingTest
+public class HazelcastClusteredInvalidationSessionTest
+    extends AbstractClusteredInvalidationSessionTest
 {
     HazelcastSessionDataStoreFactory factory;
 

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStoreTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastSessionDataStoreTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import org.eclipse.jetty.server.session.AbstractSessionDataStoreFactory;
 import org.eclipse.jetty.server.session.AbstractSessionDataStoreTest;

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastTestHelper.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/HazelcastTestHelper.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast;
 
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/ClientOrphanedSessionTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/ClientOrphanedSessionTest.java
@@ -11,19 +11,24 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session;
+package org.eclipse.jetty.session.hazelcast.client;
 
-import org.eclipse.jetty.server.session.AbstractClusteredInvalidationSessionTest;
+import org.eclipse.jetty.server.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
+import org.eclipse.jetty.session.hazelcast.HazelcastTestHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class HazelcastClusteredInvalidationSessionTest
-    extends AbstractClusteredInvalidationSessionTest
+public class ClientOrphanedSessionTest
+    extends AbstractClusteredOrphanedSessionTest
 {
-    HazelcastSessionDataStoreFactory factory;
-
     HazelcastTestHelper _testHelper;
+
+    @Override
+    public SessionDataStoreFactory createSessionDataStoreFactory()
+    {
+        return _testHelper.createSessionDataStoreFactory(true);
+    }
 
     @BeforeEach
     public void setUp()
@@ -35,11 +40,5 @@ public class HazelcastClusteredInvalidationSessionTest
     public void shutdown()
     {
         _testHelper.tearDown();
-    }
-
-    @Override
-    public SessionDataStoreFactory createSessionDataStoreFactory()
-    {
-        return _testHelper.createSessionDataStoreFactory(false);
     }
 }

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/ClientSessionScavengingTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/ClientSessionScavengingTest.java
@@ -11,16 +11,16 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session.client;
+package org.eclipse.jetty.session.hazelcast.client;
 
-import org.eclipse.jetty.hazelcast.session.HazelcastTestHelper;
-import org.eclipse.jetty.server.session.AbstractClusteredOrphanedSessionTest;
+import org.eclipse.jetty.server.session.AbstractClusteredSessionScavengingTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
+import org.eclipse.jetty.session.hazelcast.HazelcastTestHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientOrphanedSessionTest
-    extends AbstractClusteredOrphanedSessionTest
+public class ClientSessionScavengingTest
+    extends AbstractClusteredSessionScavengingTest
 {
     HazelcastTestHelper _testHelper;
 

--- a/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/HazelcastSessionDataStoreTest.java
+++ b/tests/test-sessions/test-hazelcast-sessions/src/test/java/org/eclipse/jetty/session/hazelcast/client/HazelcastSessionDataStoreTest.java
@@ -11,10 +11,8 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.hazelcast.session.client;
+package org.eclipse.jetty.session.hazelcast.client;
 
-import org.eclipse.jetty.hazelcast.session.HazelcastSessionDataStore;
-import org.eclipse.jetty.hazelcast.session.HazelcastTestHelper;
 import org.eclipse.jetty.server.session.AbstractSessionDataStoreFactory;
 import org.eclipse.jetty.server.session.AbstractSessionDataStoreTest;
 import org.eclipse.jetty.server.session.SessionContext;
@@ -23,6 +21,8 @@ import org.eclipse.jetty.server.session.SessionDataStore;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.eclipse.jetty.server.session.UnreadableSessionDataException;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.session.hazelcast.HazelcastSessionDataStore;
+import org.eclipse.jetty.session.hazelcast.HazelcastTestHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Change package from `org.eclipse.jetty.hazelcast.session` to `org.eclipse.jetty.session.hazelcast` to be consistent with other session modules.