### PR TITLE
Regularize jetty 12.0.x mongo session package

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/sessions/session-sessiondatastore-mongo.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/sessions/session-sessiondatastore-mongo.adoc
@@ -16,7 +16,7 @@
 
 The `MongoSessionDataStore` supports persistence of `SessionData` in a nosql database.
 
-The best description for the document model for session information is found in the javadoc for the link:{javadoc-url}/org/eclipse/jetty/mongodb/MongoSessionDataStore.html[MongoSessionDataStore].
+The best description for the document model for session information is found in the javadoc for the link:{javadoc-url}/org/eclipse/jetty/session/mongodb/MongoSessionDataStore.html[MongoSessionDataStore].
 In overview, it can be represented thus:
 
 [plantuml]
@@ -68,7 +68,7 @@ An object that is updated every time a session is written out for a context.
 
 ====== Configuration
 
-You can configure either a link:{javadoc-url}/org/eclipse/jetty/mongodb/MongoSessionDataStore.html[MongoSessionDataStore] individually, or a link:{javadoc-url}/org/eclipse/jetty/mongodb/MongoSessionDataStore.html[MongoSessionDataStoreFactory] if you want multiple ``SessionHandler``s to use ``MongoSessionDataStore``s that are identically configured.
+You can configure either a link:{javadoc-url}/org/eclipse/jetty/session/mongodb/MongoSessionDataStore.html[MongoSessionDataStore] individually, or a link:{javadoc-url}/org/eclipse/jetty/session/mongodb/MongoSessionDataStore.html[MongoSessionDataStoreFactory] if you want multiple ``SessionHandler``s to use ``MongoSessionDataStore``s that are identically configured.
 The configuration methods for the `MongoSessionDataStoreFactory` are:
 
 include::session-sessiondatastore.adoc[tag=common-datastore-config]

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/session/SessionDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/session/SessionDocs.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.net.InetSocketAddress;
 
 import org.eclipse.jetty.memcached.session.MemcachedSessionDataMapFactory;
-import org.eclipse.jetty.mongodb.MongoSessionDataStoreFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.session.CachingSessionDataStoreFactory;
@@ -34,6 +33,7 @@ import org.eclipse.jetty.server.session.NullSessionDataStore;
 import org.eclipse.jetty.server.session.SessionCache;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.session.mongodb.MongoSessionDataStoreFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 @SuppressWarnings("unused")

--- a/jetty-session/jetty-mongodb/src/main/config/etc/sessions/mongo/session-store-by-address.xml
+++ b/jetty-session/jetty-mongodb/src/main/config/etc/sessions/mongo/session-store-by-address.xml
@@ -9,7 +9,7 @@
   <!-- ===================================================================== -->
   <Call name="addBean">
    <Arg>
-    <New id="sessionDataStoreFactory" class="org.eclipse.jetty.mongodb.MongoSessionDataStoreFactory">      
+    <New id="sessionDataStoreFactory" class="org.eclipse.jetty.session.mongodb.MongoSessionDataStoreFactory">      
        <Set name="dbName"><Property name="jetty.session.mongo.dbName" default="HttpSessions" /></Set>
        <Set name="collectionName"><Property name="jetty.session.mongo.collectionName" default="jettySessions" /></Set>
        <Set name="gracePeriodSec"><Property name="jetty.session.gracePeriod.seconds" default="3600" /></Set>

--- a/jetty-session/jetty-mongodb/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
+++ b/jetty-session/jetty-mongodb/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
@@ -9,7 +9,7 @@
   <!-- ===================================================================== -->
   <Call name="addBean">
    <Arg>
-    <New id="sessionDataStoreFactory" class="org.eclipse.jetty.mongodb.MongoSessionDataStoreFactory">      
+    <New id="sessionDataStoreFactory" class="org.eclipse.jetty.session.mongodb.MongoSessionDataStoreFactory">      
        <Set name="dbName"><Property name="jetty.session.mongo.dbName" default="HttpSessions" /></Set>
        <Set name="collectionName"><Property name="jetty.session.mongo.collectionName" default="jettySessions" /></Set>
        <Set name="gracePeriodSec"><Property name="jetty.session.gracePeriod.seconds" default="3600" /></Set>

--- a/jetty-session/jetty-mongodb/src/main/java/module-info.java
+++ b/jetty-session/jetty-mongodb/src/main/java/module-info.java
@@ -11,10 +11,10 @@
 // ========================================================================
 //
 
-module org.eclipse.jetty.mongodb
+module org.eclipse.jetty.session.mongodb
 {
     requires transitive mongo.java.driver;
     requires transitive org.eclipse.jetty.server;
 
-    exports org.eclipse.jetty.mongodb;
+    exports org.eclipse.jetty.session.mongodb;
 }

--- a/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStore.java
+++ b/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStore.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStoreFactory.java
+++ b/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStoreFactory.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.net.UnknownHostException;
 

--- a/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoUtils.java
+++ b/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/MongoUtils.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/package-info.java
+++ b/jetty-session/jetty-mongodb/src/main/java/org/eclipse/jetty/session/mongodb/package-info.java
@@ -14,5 +14,5 @@
 /**
  * Jetty NoSql : MongoDB Integration
  */
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/AttributeNameTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/AttributeNameTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredInvalidateSessionTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredInvalidateSessionTest.java
@@ -11,20 +11,16 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
-import org.eclipse.jetty.server.session.AbstractClusteredOrphanedSessionTest;
+import org.eclipse.jetty.server.session.AbstractClusteredInvalidationSessionTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * ClusteredOrphanedSessionTest
- */
 @Testcontainers(disabledWithoutDocker = true)
-public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessionTest
+public class ClusteredInvalidateSessionTest extends AbstractClusteredInvalidationSessionTest
 {
     @BeforeAll
     public static void beforeClass() throws Exception
@@ -43,12 +39,5 @@ public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessi
     public SessionDataStoreFactory createSessionDataStoreFactory()
     {
         return MongoTestHelper.newSessionDataStoreFactory();
-    }
-
-    @Test
-    @Override
-    public void testOrphanedSession() throws Exception
-    {
-        super.testOrphanedSession();
     }
 }

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredOrphanedSessionTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredOrphanedSessionTest.java
@@ -11,16 +11,20 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
-import org.eclipse.jetty.server.session.AbstractClusteredSessionScavengingTest;
+import org.eclipse.jetty.server.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+/**
+ * ClusteredOrphanedSessionTest
+ */
 @Testcontainers(disabledWithoutDocker = true)
-public class ClusteredSessionScavengingTest extends AbstractClusteredSessionScavengingTest
+public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessionTest
 {
     @BeforeAll
     public static void beforeClass() throws Exception
@@ -39,5 +43,12 @@ public class ClusteredSessionScavengingTest extends AbstractClusteredSessionScav
     public SessionDataStoreFactory createSessionDataStoreFactory()
     {
         return MongoTestHelper.newSessionDataStoreFactory();
+    }
+
+    @Test
+    @Override
+    public void testOrphanedSession() throws Exception
+    {
+        super.testOrphanedSession();
     }
 }

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredSessionScavengingTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/ClusteredSessionScavengingTest.java
@@ -11,16 +11,16 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
-import org.eclipse.jetty.server.session.AbstractClusteredInvalidationSessionTest;
+import org.eclipse.jetty.server.session.AbstractClusteredSessionScavengingTest;
 import org.eclipse.jetty.server.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
-public class ClusteredInvalidateSessionTest extends AbstractClusteredInvalidationSessionTest
+public class ClusteredSessionScavengingTest extends AbstractClusteredSessionScavengingTest
 {
     @BeforeAll
     public static void beforeClass() throws Exception

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStoreTest.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/MongoSessionDataStoreTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/MongoTestHelper.java
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/java/org/eclipse/jetty/session/mongodb/MongoTestHelper.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.mongodb;
+package org.eclipse.jetty.session.mongodb;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/tests/test-sessions/test-mongodb-sessions/src/test/resources/simplelogger.properties
+++ b/tests/test-sessions/test-mongodb-sessions/src/test/resources/simplelogger.properties
@@ -1,3 +1,3 @@
 org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.log.org.eclipse.jetty.nosql.mongodb.MongoLogs=error
-org.slf4j.simpleLogger.log.org.eclipse.jetty.nosql.mongodb.MongoTestHelper=info
+org.slf4j.simpleLogger.log.org.eclipse.jetty.session.mongodb.MongoLogs=error
+org.slf4j.simpleLogger.log.org.eclipse.jetty.session.mongodb.MongoTestHelper=info


### PR DESCRIPTION
Change `org.eclipse.jetty.mongodb` to `org.eclipse.jetty.session.mongodb` to be consistent with other session modules.