### PR TITLE
(10.0.x) ByteBufferPool and RetainableByteBufferPool now reset the buffer's endianness on release

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPool.java
@@ -124,7 +124,7 @@ public class ArrayRetainableByteBufferPool implements RetainableByteBufferPool, 
             {
                 buffer = newRetainableByteBuffer(bucket._capacity, direct, byteBuffer ->
                 {
-                    BufferUtil.clear(byteBuffer);
+                    BufferUtil.reset(byteBuffer);
                     reservedEntry.release();
                 });
                 reservedEntry.enable(buffer, true);

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -187,7 +187,7 @@ public interface ByteBufferPool
         public void release(ByteBuffer buffer)
         {
             resetUpdateTime();
-            BufferUtil.clear(buffer);
+            BufferUtil.reset(buffer);
             if (_size == null || _size.incrementAndGet() <= _maxSize)
             {
                 _queue.offer(buffer);

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.io;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -239,5 +240,16 @@ public class ArrayByteBufferPoolTest
         assertThat(bufferPool.getMemory(true), equalTo(11L * factor));
         assertThat(buckets[2].size(), equalTo(2));
         assertThat(buckets[7].size(), equalTo(1));
+    }
+
+    @Test
+    public void testEndiannessResetOnRelease()
+    {
+        ArrayByteBufferPool bufferPool = new ArrayByteBufferPool();
+        ByteBuffer buffer = bufferPool.acquire(10, true);
+        assertThat(buffer.order(), is(ByteOrder.BIG_ENDIAN));
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        bufferPool.release(buffer);
+        assertThat(buffer.order(), is(ByteOrder.BIG_ENDIAN));
     }
 }

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPoolTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPoolTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.io;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -378,5 +379,16 @@ public class ArrayRetainableByteBufferPoolTest
                 c -> 32 - Integer.numberOfLeadingZeros(c - 1),
                 i -> 1 << i);
         }
+    }
+
+    @Test
+    public void testEndiannessResetOnRelease()
+    {
+        ArrayRetainableByteBufferPool bufferPool = new ArrayRetainableByteBufferPool();
+        RetainableByteBuffer buffer = bufferPool.acquire(10, true);
+        assertThat(buffer.getBuffer().order(), Matchers.is(ByteOrder.BIG_ENDIAN));
+        buffer.getBuffer().order(ByteOrder.LITTLE_ENDIAN);
+        assertThat(buffer.release(), is(true));
+        assertThat(buffer.getBuffer().order(), Matchers.is(ByteOrder.BIG_ENDIAN));
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -21,6 +21,7 @@ import java.io.RandomAccessFile;
 import java.nio.Buffer;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.charset.Charset;
@@ -167,10 +168,27 @@ public class BufferUtil
     }
 
     /**
-     * Clear the buffer to be empty in flush mode.
-     * The position and limit are set to 0;
+     * Resets the buffer's endianness to {@link ByteOrder#BIG_ENDIAN}
+     * and clears the buffer to be empty in flush mode.
+     * The position and limit are set to 0.
      *
-     * @param buffer The buffer to clear.
+     * @param buffer the buffer to reset.
+     */
+    public static void reset(ByteBuffer buffer)
+    {
+        if (buffer != null)
+        {
+            buffer.order(ByteOrder.BIG_ENDIAN);
+            buffer.position(0);
+            buffer.limit(0);
+        }
+    }
+
+    /**
+     * Clears the buffer to be empty in flush mode.
+     * The position and limit are set to 0.
+     *
+     * @param buffer the buffer to clear.
      */
     public static void clear(ByteBuffer buffer)
     {


### PR DESCRIPTION
See #7243.