### PR TITLE
Fixes InputStreamResponseListener should have a read timeout #7259

### DIFF
--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -424,7 +424,8 @@ public class HTTPClientDocs
         httpClient.start();
 
         // tag::inputStreamResponseListener[]
-        InputStreamResponseListener listener = new InputStreamResponseListener();
+        long readTimeout = 5000; // milliseconds
+        InputStreamResponseListener listener = new InputStreamResponseListener(readTimeout);
         httpClient.newRequest("http://domain.com/path")
             .send(listener);
 


### PR DESCRIPTION
Added constructor with read timeout parameter.
Updated implementation to honor the read timeout.
Added test case.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>