### PR TITLE
Replace `SharedBlockingCallback` with `Blocking` class

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Blocking.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Blocking.java
@@ -1,0 +1,305 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.jetty.util.thread.Invocable;
+
+/**
+ * Utility class that provides blocking {@link java.lang.Runnable} and {@link org.eclipse.jetty.util.Callback}
+ * instances.  These can either be shared (and mutually excluded from concurrent usage) or single usage.
+ * The instances are autocloseable, so blocking takes place as a try block is exited.  Example usages:
+ *
+ * <h2>Non shared Runnable</h2>
+ * <pre>
+ *     try(Blocking.Runnable onAction = Blocking.runnable())
+ *     {
+ *         someMethod(onAction);
+ *     }
+ * </pre>
+ *
+ * <h2>Shared Runnable</h2>
+ * <pre>
+ *     Blocking.SharedRunnable shared = new Blocking.Shared();
+ *     // ...
+ *     try(Blocking.Runnable onAction = shared.runnable())
+ *     {
+ *         someMethod(onAction);
+ *     }
+ * </pre>
+ *
+ * <h2>Non shared Callback</h2>
+ * <pre>
+ *     try(Blocking.Callback callback = Blocking.callback())
+ *     {
+ *         someMethod(callback);
+ *     }
+ * </pre>
+ *
+ * <h2>Shared Callback</h2>
+ * <pre>
+ *     Blocking.SharedCallback blocker = new Blocking.Shared();
+ *     // ...
+ *     try(Blocking.Runnable onAction = blocker.callback())
+ *     {
+ *         someMethod(onAction);
+ *     }
+ * </pre>
+ */
+public class Blocking
+{
+    private static final Throwable ACQUIRED = new Throwable()
+    {
+        @Override
+        public synchronized Throwable fillInStackTrace()
+        {
+            return this;
+        }
+    };
+    private static final Throwable SUCCEEDED = new Throwable()
+    {
+        @Override
+        public synchronized Throwable fillInStackTrace()
+        {
+            return this;
+        }
+    };
+
+    public interface Runnable extends java.lang.Runnable, AutoCloseable, Invocable
+    {}
+
+    public static Runnable runnable()
+    {
+        return new Runnable()
+        {
+            final CountDownLatch _complete = new CountDownLatch(1);
+
+            @Override
+            public void run()
+            {
+                _complete.countDown();
+            }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return InvocationType.NON_BLOCKING;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                try
+                {
+                    _complete.await();
+                }
+                catch (Throwable t)
+                {
+                    throw IO.rethrow(t);
+                }
+            }
+        };
+    }
+
+    public interface Callback extends org.eclipse.jetty.util.Callback, AutoCloseable, Invocable
+    {}
+
+    public static Callback callback()
+    {
+        return new Callback()
+        {
+            private final CompletableFuture<Throwable> _future = new CompletableFuture<>();
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return InvocationType.NON_BLOCKING;
+            }
+
+            @Override
+            public void succeeded()
+            {
+                _future.complete(SUCCEEDED);
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                _future.complete(x == null ? new Throwable() : x);
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                Throwable result;
+                try
+                {
+                    result = _future.get();
+                }
+                catch (Throwable t)
+                {
+                    result = t;
+                }
+                if (result == SUCCEEDED)
+                    return;
+                throw IO.rethrow(result);
+            }
+        };
+    }
+
+    public static class Shared
+    {
+        private final ReentrantLock _lock = new ReentrantLock();
+        private final Condition _idle = _lock.newCondition();
+        private final Condition _complete = _lock.newCondition();
+        private Throwable _completed;
+        private final Callback _callback = new Callback()
+        {
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return InvocationType.NON_BLOCKING;
+            }
+
+            @Override
+            public void succeeded()
+            {
+                _lock.lock();
+                try
+                {
+                    if (_completed == ACQUIRED)
+                    {
+                        _completed = SUCCEEDED;
+                        _complete.signalAll();
+                    }
+                }
+                finally
+                {
+                    _lock.unlock();
+                }
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                _lock.lock();
+                try
+                {
+                    if (_completed == ACQUIRED)
+                    {
+                        _completed = x;
+                        _complete.signalAll();
+                    }
+                }
+                finally
+                {
+                    _lock.unlock();
+                }
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                _lock.lock();
+                Throwable result;
+                try
+                {
+                    while (_completed == ACQUIRED)
+                    {
+                        _complete.await();
+                    }
+                    result = _completed;
+                }
+                catch (Throwable t)
+                {
+                    result = t;
+                }
+                finally
+                {
+                    _completed = null;
+                    _idle.signalAll();
+                    _lock.unlock();
+                }
+                if (result != SUCCEEDED)
+                    throw IO.rethrow(result);
+            }
+        };
+        private final Runnable _runnable = new Runnable()
+        {
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return InvocationType.NON_BLOCKING;
+            }
+
+            @Override
+            public void run()
+            {
+                _callback.succeeded();
+            }
+
+            @Override
+            public void close() throws Exception
+            {
+                _callback.close();
+            }
+        };
+
+        public Callback callback() throws Exception
+        {
+            _lock.lock();
+            try
+            {
+                while (_completed != null)
+                    _idle.await();
+                _completed = ACQUIRED;
+                return _callback;
+            }
+            catch (InterruptedException x)
+            {
+                throw new InterruptedIOException();
+            }
+            finally
+            {
+                _lock.unlock();
+            }
+        }
+
+        public Runnable runnable() throws IOException
+        {
+            _lock.lock();
+            try
+            {
+                while (_completed != null)
+                    _idle.await();
+                _completed = ACQUIRED;
+                return _runnable;
+            }
+            catch (InterruptedException x)
+            {
+                throw new InterruptedIOException();
+            }
+            finally
+            {
+                _lock.unlock();
+            }
+        }
+    }
+}

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
@@ -271,6 +272,19 @@ public class IO
         {
             copy(in, out);
         }
+    }
+
+    public static IOException rethrow(Throwable cause)
+    {
+        if (cause instanceof IOException)
+            return (IOException)cause;
+        if (cause instanceof Error)
+            throw (Error)cause;
+        if (cause instanceof RuntimeException)
+            throw (RuntimeException)cause;
+        if (cause instanceof InterruptedException)
+            return (InterruptedIOException)new InterruptedIOException().initCause(cause);
+        return new IOException(cause);
     }
 
     /**

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
@@ -40,7 +40,9 @@ import org.slf4j.LoggerFactory;
  *     }
  * }
  * </pre>
+ * @deprecated Use {@link Blocking.Shared#callback()}
  */
+@Deprecated
 public class SharedBlockingCallback
 {
     private static final Logger LOG = LoggerFactory.getLogger(SharedBlockingCallback.class);

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/BlockingTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/BlockingTest.java
@@ -1,0 +1,411 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class BlockingTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SharedBlockingCallback.class);
+
+    final AtomicInteger notComplete = new AtomicInteger();
+    final Blocking.Shared _shared = new Blocking.Shared();
+
+    @Test
+    public void testRunClose() throws Exception
+    {
+        long start;
+        try (Blocking.Runnable runnable = Blocking.runnable())
+        {
+            runnable.run();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(500L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testCloseRun() throws Exception
+    {
+        long start;
+        try (Blocking.Runnable runnable = Blocking.runnable())
+        {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            new Thread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    latch.countDown();
+                    try
+                    {
+                        TimeUnit.MILLISECONDS.sleep(100);
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
+                    runnable.run();
+                }
+            }).start();
+
+            latch.await();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSucceededClose() throws Exception
+    {
+        long start;
+        try (Blocking.Callback callback = Blocking.callback())
+        {
+            callback.succeeded();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(500L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testCloseSucceeded() throws Exception
+    {
+        long start;
+        try (Blocking.Callback callback = Blocking.callback())
+        {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            new Thread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    latch.countDown();
+                    try
+                    {
+                        TimeUnit.MILLISECONDS.sleep(100);
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
+                    callback.succeeded();
+                }
+            }).start();
+
+            latch.await();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testFailedClose() throws Exception
+    {
+        final Exception ex = new Exception("FAILED");
+        long start = Long.MIN_VALUE;
+        try
+        {
+            try (Blocking.Callback callback = Blocking.callback())
+            {
+                callback.failed(ex);
+            }
+            fail("Should have thrown IOException");
+        }
+        catch (IOException e)
+        {
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+            assertEquals(ex, e.getCause());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(100L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testCloseFailed() throws Exception
+    {
+        final Exception ex = new Exception("FAILED");
+        long start = Long.MIN_VALUE;
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        try
+        {
+            try (Blocking.Callback callback = Blocking.callback())
+            {
+
+                new Thread(new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        latch.countDown();
+                        try
+                        {
+                            TimeUnit.MILLISECONDS.sleep(100);
+                        }
+                        catch (Exception e)
+                        {
+                            e.printStackTrace();
+                        }
+                        callback.failed(ex);
+                    }
+                }).start();
+
+                latch.await();
+                start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+            }
+            fail("Should have thrown IOException");
+        }
+        catch (IOException e)
+        {
+            assertEquals(ex, e.getCause());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedRunClose() throws Exception
+    {
+        long start;
+        try (Blocking.Runnable runnable = _shared.runnable())
+        {
+            runnable.run();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(500L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedCloseRun() throws Exception
+    {
+        long start;
+        try (Blocking.Runnable runnable = _shared.runnable())
+        {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            new Thread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    latch.countDown();
+                    try
+                    {
+                        TimeUnit.MILLISECONDS.sleep(100);
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
+                    runnable.run();
+                }
+            }).start();
+
+            latch.await();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedSucceededClose() throws Exception
+    {
+        long start;
+        try (Blocking.Callback callback = _shared.callback())
+        {
+            callback.succeeded();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(500L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedCloseSucceeded() throws Exception
+    {
+        long start;
+        try (Blocking.Callback callback = _shared.callback())
+        {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            new Thread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    latch.countDown();
+                    try
+                    {
+                        TimeUnit.MILLISECONDS.sleep(100);
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
+                    callback.succeeded();
+                }
+            }).start();
+
+            latch.await();
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedFailedClose() throws Exception
+    {
+        final Exception ex = new Exception("FAILED");
+        long start = Long.MIN_VALUE;
+        try
+        {
+            try (Blocking.Callback callback = _shared.callback())
+            {
+                callback.failed(ex);
+            }
+            fail("Should have thrown IOException");
+        }
+        catch (IOException e)
+        {
+            start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+            assertEquals(ex, e.getCause());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(100L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedCloseFailed() throws Exception
+    {
+        final Exception ex = new Exception("FAILED");
+        long start = Long.MIN_VALUE;
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        try
+        {
+            try (Blocking.Callback callback = _shared.callback())
+            {
+
+                new Thread(new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        latch.countDown();
+                        try
+                        {
+                            TimeUnit.MILLISECONDS.sleep(100);
+                        }
+                        catch (Exception e)
+                        {
+                            e.printStackTrace();
+                        }
+                        callback.failed(ex);
+                    }
+                }).start();
+
+                latch.await();
+                start = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+            }
+            fail("Should have thrown IOException");
+        }
+        catch (IOException e)
+        {
+            assertEquals(ex, e.getCause());
+        }
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, greaterThan(10L));
+        assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start, lessThan(1000L));
+        assertEquals(0, notComplete.get());
+    }
+
+    @Test
+    public void testSharedBlocked() throws Exception
+    {
+        Blocking.Callback callback0 = _shared.callback();
+        CountDownLatch latch0 = new CountDownLatch(2);
+        new Thread(() ->
+        {
+            try (Blocking.Callback callback = _shared.callback())
+            {
+                latch0.countDown();
+                callback.succeeded();
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+        }).start();
+        new Thread(() ->
+        {
+            try (Blocking.Runnable runnable = _shared.runnable())
+            {
+                latch0.countDown();
+                runnable.run();
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+        }).start();
+
+        assertFalse(latch0.await(100, TimeUnit.MILLISECONDS));
+        callback0.succeeded();
+        callback0.close();
+        assertTrue(latch0.await(10, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    public void testInterruptedException() throws Exception
+    {
+        try
+        {
+            Blocking.Callback callback = _shared.callback();
+            Thread.currentThread().interrupt();
+            callback.close();
+            fail();
+        }
+        catch (InterruptedIOException ignored)
+        {
+        }
+    }
+}

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/SharedBlockingCallbackTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/SharedBlockingCallbackTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Deprecated
 public class SharedBlockingCallbackTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(SharedBlockingCallback.class);


### PR DESCRIPTION
This single class replaces `SharedBlockingCallback` with the ability to support both `Runnable` and `Callback` APIs, plus single use instances.

