### PR TITLE
Destroy interceptor when content producer gets recycled

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
@@ -19,6 +19,7 @@ import java.util.concurrent.locks.Condition;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,8 @@ class AsyncContentProducer implements ContentProducer
         assertLocked();
         if (LOG.isDebugEnabled())
             LOG.debug("recycling {}", this);
+        if (_interceptor instanceof Destroyable)
+            ((Destroyable)_interceptor).destroy();
         _interceptor = null;
         _rawContent = null;
         _transformedContent = null;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/BlockingContentProducerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/BlockingContentProducerTest.java
@@ -25,8 +25,10 @@ import java.util.zip.GZIPOutputStream;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.handler.gzip.GzipHttpInputInterceptor;
+import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.compression.InflaterPool;
 import org.eclipse.jetty.util.thread.AutoLock;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,6 +53,22 @@ public class BlockingContentProducerTest
     public void tearDown()
     {
         scheduledExecutorService.shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterceptorOnRecycle()
+    {
+        DestroyableInterceptor interceptor = new DestroyableInterceptor();
+
+        BlockingContentProducer contentProducer = new BlockingContentProducer(new AsyncContentProducer(null));
+        try (AutoLock lock = contentProducer.lock())
+        {
+            contentProducer.setInterceptor(interceptor);
+
+            assertThat(interceptor.destroyed, is(false));
+            contentProducer.recycle();
+            assertThat(interceptor.destroyed, is(true));
+        }
     }
 
     @Test
@@ -345,6 +363,23 @@ public class BlockingContentProducerTest
         protected boolean eof()
         {
             return false;
+        }
+    }
+
+    private static class DestroyableInterceptor implements Destroyable, HttpInput.Interceptor
+    {
+        private boolean destroyed = false;
+
+        @Override
+        public void destroy()
+        {
+            destroyed = true;
+        }
+
+        @Override
+        public HttpInput.Content readFrom(HttpInput.Content content)
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
This is a behavior that was present in 9.4 and was mistakenly omitted in 10.0 during the Grand HttpInput Rewrite.