### PR TITLE
Cleanup HttpInput reopen/recycle

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/BlockingContentProducer.java
@@ -46,6 +46,14 @@ class BlockingContentProducer implements ContentProducer
         if (LOG.isDebugEnabled())
             LOG.debug("recycling {}", this);
         _asyncContentProducer.recycle();
+    }
+
+    @Override
+    public void reopen()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("reopening {}", this);
+        _asyncContentProducer.reopen();
         _semaphore.drainPermits();
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ContentProducer.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.server;
 
+import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.thread.AutoLock;
 
 /**
@@ -27,16 +28,23 @@ import org.eclipse.jetty.util.thread.AutoLock;
 public interface ContentProducer
 {
     /**
-     * Lock this instance. The lock must be held before any method of this instance's
-     * method be called, and must be manually released afterward.
+     * Lock this instance. The lock must be held before any of this instance's
+     * method can be called, and must be released afterward.
      * @return the lock that is guarding this instance.
      */
     AutoLock lock();
 
     /**
-     * Reset all internal state and clear any held resources.
+     * Clear the interceptor and call {@link Destroyable#destroy()} on it if it implements {@link Destroyable}.
+     * A recycled {@link ContentProducer} will only produce special content with a non-null error until
+     * {@link #reopen()} is called.
      */
     void recycle();
+
+    /**
+     * Reset all internal state, making this is instance logically equivalent to a freshly allocated one.
+     */
+    void reopen();
 
     /**
      * Fail all content currently available in this {@link ContentProducer} instance

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -55,8 +55,12 @@ public class HttpInput extends ServletInputStream implements Runnable
 
     public void recycle()
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("recycle {}", this);
+        try (AutoLock lock = _contentProducer.lock())
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("recycle {}", this);
+            _blockingContentProducer.recycle();
+        }
     }
 
     public void reopen()
@@ -65,7 +69,7 @@ public class HttpInput extends ServletInputStream implements Runnable
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("reopen {}", this);
-            _blockingContentProducer.recycle();
+            _blockingContentProducer.reopen();
             _contentProducer = _blockingContentProducer;
             _consumedEof = false;
             _readListener = null;


### PR DESCRIPTION
Introduce `recycle` / `reopen` in `ContentProducer` matching the equivalent `HttpInput`methods. 

This introduces a new state (recycled but not yet reopened) which is handled by producing special content (either pre-existing EOF/error or a specific error content) and an extra check which asserts that `recycle` must not be called while there is still some unconsumed content left in the `ContentProducer`.