### PR TITLE
Issue #7250 - Correct `HostHeaderCustomizer` logic and add new `RejectMissingAuthorityCustomizer`

### DIFF
--- a/jetty-server/src/main/config/etc/jetty-host-header-customizer.xml
+++ b/jetty-server/src/main/config/etc/jetty-host-header-customizer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+  <Call name="addCustomizer">
+    <Arg>
+      <New class="org.eclipse.jetty.server.HostHeaderCustomizer">
+        <Arg>
+          <Property name="jetty.hostheader.serverName" />
+        </Arg>
+        <Arg>
+          <Property name="jetty.hostheader.serverPort" />
+        </Arg>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-server/src/main/config/etc/jetty-reject-missing-authority-customizer.xml
+++ b/jetty-server/src/main/config/etc/jetty-reject-missing-authority-customizer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+  <Call name="addCustomizer">
+    <Arg>
+      <New class="org.eclipse.jetty.server.RejectMissingAuthorityCustomizer" />
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-server/src/main/config/modules/host-header-customizer.mod
+++ b/jetty-server/src/main/config/modules/host-header-customizer.mod
@@ -1,0 +1,23 @@
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Adds a Host Header Customizer to the HTTP Connector to enforce a
+Request Host header on HTTP/1.0 and HTTP/2 requests.
+
+[tags]
+connector
+
+[depend]
+http
+
+[xml]
+etc/jetty-host-header-customizer.xml
+
+[ini-template]
+### HostHeaderCustomizer Configuration
+
+## The Server Name to force on null Host headers
+# jetty.hostheader.serverName=serverName
+
+## The Server Port to force on null Host headers
+# jetty.hostheader.serverPort=80

--- a/jetty-server/src/main/config/modules/reject-missing-authority-customizer.mod
+++ b/jetty-server/src/main/config/modules/reject-missing-authority-customizer.mod
@@ -1,0 +1,16 @@
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Reject Missing HTTP Authority Customizer.
+If an HTTP request arrives without a valid Authority it is rejected with a 400 Bad Request.
+This means empty Host headers, missing Host headers, or authority not being set from other
+means such as the ForwardedRequestCustomizer from Forwarding headers.
+
+[tags]
+connector
+
+[depend]
+http
+
+[xml]
+etc/jetty-reject-missing-authority-customizer.xml

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/RejectMissingAuthorityCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/RejectMissingAuthorityCustomizer.java
@@ -1,0 +1,84 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HostPortHttpField;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.util.StringUtil;
+
+/**
+ * Reject requests that have no request level authority.
+ *
+ * <p>
+ * This addresses requests that either have schemes with no authority
+ * per https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+ * Or badly declared requests that have a non-absolute URI in the request line and an empty or missing `Host` header.
+ * </p>
+ *
+ * <p>
+ * This will return a 400 Bad Request on failed authority checks.
+ * </p>
+ */
+public class RejectMissingAuthorityCustomizer implements HttpConfiguration.Customizer
+{
+    @Override
+    public void customize(Connector connector, HttpConfiguration channelConfig, Request request)
+    {
+        if (!hasRequestAuthority(request))
+        {
+            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Missing authority");
+        }
+    }
+
+    private boolean hasRequestAuthority(Request request)
+    {
+        MetaData.Request metadata = request.getMetaData();
+
+        if (metadata != null)
+        {
+            // Investigate HttpURI (eg: from HTTP/2 :authority)?
+            if (StringUtil.isNotBlank(metadata.getURI().getHost()))
+                return true;
+
+            // Investigate Host Header (eg: from HTTP/1 request fields)
+            HttpField host = metadata.getFields().getField(HttpHeader.HOST);
+            if (host != null)
+            {
+                if (!(host instanceof HostPortHttpField) && StringUtil.isNotBlank(host.getValue()))
+                {
+                    return true;
+                }
+
+                if (host instanceof HostPortHttpField)
+                {
+                    HostPortHttpField authority = (HostPortHttpField)host;
+                    metadata.getURI().setAuthority(authority.getHost(), authority.getPort());
+                    if (StringUtil.isNotBlank(authority.getHost()))
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1418,7 +1418,7 @@ public class Request implements HttpServletRequest
         HttpField host = metadata == null ? null : metadata.getFields().getField(HttpHeader.HOST);
         if (host != null)
         {
-            if (!(host instanceof HostPortHttpField) && host.getValue() != null && !host.getValue().isEmpty())
+            if (!(host instanceof HostPortHttpField) && StringUtil.isNotBlank(host.getValue()))
                 host = new HostPortHttpField(host.getValue());
             if (host instanceof HostPortHttpField)
             {
@@ -1472,7 +1472,7 @@ public class Request implements HttpServletRequest
         MetaData.Request metadata = _metaData;
         // Return host from header field
         HttpField host = metadata == null ? null : metadata.getFields().getField(HttpHeader.HOST);
-        if (host != null)
+        if ((host != null) && StringUtil.isNotBlank(host.getValue()))
         {
             // TODO is this needed now?
             HostPortHttpField authority = (host instanceof HostPortHttpField)

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HostHeaderCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HostHeaderCustomizerTest.java
@@ -26,10 +26,13 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +40,115 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HostHeaderCustomizerTest
 {
     @Test
-    public void testHostHeaderCustomizer() throws Exception
+    public void testHostHeaderCustomizerSecondNoHostAuthorityInUriLine() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        final String redirectPath = "/redirect";
+        httpConfig.addCustomizer((connector, channelConfig, request) ->
+        {
+            // Mimic ForwardedRequestCustomizer
+            if (request.getHttpURI().getAuthority() == null)
+            {
+                request.setAuthority("default.eclipse.org", -1);
+            }
+        });
+        httpConfig.addCustomizer(new HostHeaderCustomizer("hostheader.eclipse.org", 9009));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals("jetty.eclipse.org", request.getServerName());
+                assertEquals(8888, request.getServerPort());
+                assertEquals("jetty.eclipse.org:8888", request.getHeader("Host"));
+                response.sendRedirect(redirectPath);
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET http://jetty.eclipse.org:8888/foo HTTP/1.0\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://jetty.eclipse.org:8888%s", redirectPath);
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerNoHostAuthorityInUriLine() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        final String redirectPath = "/redirect";
+        httpConfig.addCustomizer(new HostHeaderCustomizer("test_server_name", 13));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals("jetty.eclipse.org", request.getServerName());
+                assertEquals(8888, request.getServerPort());
+                assertEquals("jetty.eclipse.org:8888", request.getHeader("Host"));
+                response.sendRedirect(redirectPath);
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET http://jetty.eclipse.org:8888/foo HTTP/1.0\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://jetty.eclipse.org:8888%s", redirectPath);
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerNoHost() throws Exception
     {
         Server server = new Server();
         HttpConfiguration httpConfig = new HttpConfiguration();
@@ -55,6 +166,7 @@ public class HostHeaderCustomizerTest
                 baseRequest.setHandled(true);
                 assertEquals(serverName, request.getServerName());
                 assertEquals(serverPort, request.getServerPort());
+                assertEquals(serverName + ":" + serverPort, request.getHeader("Host"));
                 response.sendRedirect(redirectPath);
             }
         });
@@ -73,14 +185,223 @@ public class HostHeaderCustomizerTest
 
                     HttpTester.Input input = HttpTester.from(socket.getInputStream());
                     HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
 
-                    String location = response.get("location");
-                    assertNotNull(location);
-                    String schemePrefix = "http://";
-                    assertTrue(location.startsWith(schemePrefix));
-                    assertTrue(location.endsWith(redirectPath));
-                    String hostPort = location.substring(schemePrefix.length(), location.length() - redirectPath.length());
-                    assertEquals(serverName + ":" + serverPort, hostPort);
+                    assertThat(response.getStatus(), is(302));
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://%s:%d%s", serverName, serverPort, redirectPath);
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerValidAbsoluteHttpUri() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        final String redirectPath = "/redirect";
+        httpConfig.addCustomizer(new HostHeaderCustomizer("test_server_name", 13));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals("jetty.eclipse.org", request.getServerName());
+                assertEquals(8888, request.getServerPort());
+                assertEquals("jetty.eclipse.org:8888", request.getHeader("Host"));
+                response.sendRedirect(redirectPath);
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET http://jetty.eclipse.org:8888/foo HTTP/1.1\r\n" +
+                            "Host: jetty.eclipse.org:8888\r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://jetty.eclipse.org:8888%s", redirectPath);
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerValidHost() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        final String redirectPath = "/redirect";
+        httpConfig.addCustomizer(new HostHeaderCustomizer("test_server_name", 13));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals("jetty.eclipse.org", request.getServerName());
+                assertEquals(8888, request.getServerPort());
+                assertEquals("jetty.eclipse.org:8888", request.getHeader("Host"));
+                response.sendRedirect(redirectPath);
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET /foo HTTP/1.1\r\n" +
+                            "Host: jetty.eclipse.org:8888\r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://jetty.eclipse.org:8888%s", redirectPath);
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerEmptyHost() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        String connectorHost = "127.0.0.1";
+        httpConfig.addCustomizer(new HostHeaderCustomizer("test_server_name", 13));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals(connectorHost, request.getServerName());
+                assertEquals(connector.getLocalPort(), request.getServerPort());
+                assertEquals("", request.getHeader("Host"));
+                response.sendRedirect("/redirect");
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET /foo HTTP/1.1\r\n" +
+                            "Host: \r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://%s:%d/redirect", connectorHost, connector.getLocalPort());
+                    assertThat(actualLocation, is(expectedLocation));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testHostHeaderCustomizerEmptyHostWithPort() throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        String connectorHost = "127.0.0.1";
+        httpConfig.addCustomizer(new HostHeaderCustomizer("test_server_name", 13));
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                assertEquals("", request.getServerName());
+                assertEquals(9999, request.getServerPort());
+                assertEquals(":9999", request.getHeader("Host"));
+                response.sendRedirect("/redirect");
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET /foo HTTP/1.1\r\n" +
+                            "Host: :9999\r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    assertTrue(HttpStatus.isRedirection(response.getStatus()));
+
+                    String actualLocation = response.get("location");
+                    String expectedLocation = String.format("http://:%d/redirect", 9999);
+                    assertThat(actualLocation, is(expectedLocation));
                 }
             }
         }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RejectMissingAuthorityCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RejectMissingAuthorityCustomizerTest.java
@@ -1,0 +1,295 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class RejectMissingAuthorityCustomizerTest
+{
+    public static Stream<Arguments> badHostValues()
+    {
+        List<Arguments> hostValues = new ArrayList<>();
+
+        // No hosts
+        hostValues.add(Arguments.of(""));
+        hostValues.add(Arguments.of(":"));
+        hostValues.add(Arguments.of(":1111"));
+        hostValues.add(Arguments.of("\":\""));
+        hostValues.add(Arguments.of("\":1111\""));
+
+        // Bad Ports
+        hostValues.add(Arguments.of("jetty.eclipse.org:0"));
+        hostValues.add(Arguments.of("jetty.eclipse.org:-1"));
+        hostValues.add(Arguments.of("jetty.eclipse.org:-88"));
+        hostValues.add(Arguments.of("jetty.eclipse.org:880088"));
+        hostValues.add(Arguments.of("jetty.eclipse.org:923479823487953249083252765243"));
+
+        return hostValues.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("badHostValues")
+    public void testHttp11MissingAuthorityBadHostHeader(String hostHeaderValue) throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new RejectMissingAuthorityCustomizer());
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                fail("Should not have reached this handler: serverName=" + request.getServerName());
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET /foo HTTP/1.1\r\n" +
+                            "Host: " + hostHeaderValue + "\r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("badHostValues")
+    public void testHttp10MissingAuthorityBadHostHeader(String hostHeaderValue) throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new RejectMissingAuthorityCustomizer());
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                fail("Should not have reached this handler: serverName=" + request.getServerName());
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET /foo HTTP/1.0\r\n" +
+                            "Host: " + hostHeaderValue + "\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    public static Stream<Arguments> goodAbsoluteUris()
+    {
+        List<Arguments> absUris = new ArrayList<>();
+
+        absUris.add(Arguments.of("http://jetty.eclipse.org:8888/", "jetty.eclipse.org", 8888));
+        absUris.add(Arguments.of("https://jetty.eclipse.org:8443/", "jetty.eclipse.org", 8443));
+        absUris.add(Arguments.of("https://jetty.eclipse.org/", "jetty.eclipse.org", 443));
+        absUris.add(Arguments.of("https://jetty.eclipse.org:8888/", "jetty.eclipse.org", 8888));
+        absUris.add(Arguments.of("http://-/1234", "-", 80));
+        absUris.add(Arguments.of("http://*/1234", "*", 80));
+
+        return absUris.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("goodAbsoluteUris")
+    public void testHttp10ValidAuthorityAbsoluteRequestUriNoHostHeader(String absUri, String expectedServerName, int expectedServerPort) throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new RejectMissingAuthorityCustomizer());
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                response.setCharacterEncoding("utf-8");
+                response.setContentType("text/plain");
+                PrintWriter out = response.getWriter();
+                out.printf("ServerName=[%s]%n", request.getServerName());
+                out.printf("ServerPort=[%d]%n", request.getServerPort());
+                out.printf("RequestURL=[%s]%n", request.getRequestURL());
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET " + absUri + " HTTP/1.0\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    assertThat(response.getStatus(), is(HttpStatus.OK_200));
+                    String responseBody = response.getContent();
+                    assertThat(responseBody, allOf(
+                        containsString("ServerName=[" + expectedServerName + "]"),
+                        containsString("ServerPort=[" + expectedServerPort + "]"),
+                        containsString("RequestURL=[" + absUri + "]")
+                    ));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    public static Stream<Arguments> badAbsoluteUris()
+    {
+        List<Arguments> absUris = new ArrayList<>();
+
+        // schemeless (looks like path atm)
+        absUris.add(Arguments.of("//jetty.eclipse.org:8888/"));
+        // bad ports (HostPort failures)
+        absUris.add(Arguments.of("http://-:-/1234"));
+        absUris.add(Arguments.of("http://-:-80/1234"));
+        absUris.add(Arguments.of("http://-:ffff/1234"));
+        // no authority (valid, reaches RejectMissingAuthorityCustomizer)
+        absUris.add(Arguments.of("file:///1234"));
+        absUris.add(Arguments.of("http:///path"));
+        absUris.add(Arguments.of("mobile:///abcd"));
+
+        return absUris.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("badAbsoluteUris")
+    public void testHttp10MissingAuthorityAbsoluteRequestUriNoHostHeader(String absUri) throws Exception
+    {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new RejectMissingAuthorityCustomizer());
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                baseRequest.setHandled(true);
+                fail("Should not have reached this handler: serverName=" + request.getServerName());
+            }
+        });
+        server.start();
+        try
+        {
+            try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+            {
+                try (OutputStream output = socket.getOutputStream())
+                {
+                    String request =
+                        "GET " + absUri + " HTTP/1.0\r\n" +
+                            "\r\n";
+                    output.write(request.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+
+                    HttpTester.Input input = HttpTester.from(socket.getInputStream());
+                    HttpTester.Response response = HttpTester.parseResponse(input);
+                    assertNotNull(response);
+
+                    assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
+                }
+            }
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+}


### PR DESCRIPTION
This is a minimal version of the draft PR #7251

+ Fixes HostHeaderCustomizer to only do Host
  header on non-HTTP/1.1
+ Introduces RejectMissingAuthorityCustomizer
+ Adds modules + xml for both

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>