### PR TITLE
Fix possible NPE from WebSocketAdapter

### DIFF
--- a/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketAdapter.java
+++ b/jetty-websocket/websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/WebSocketAdapter.java
@@ -21,10 +21,11 @@ package org.eclipse.jetty.websocket.api;
 public class WebSocketAdapter implements WebSocketListener
 {
     private volatile Session session;
+    private RemoteEndpoint remote;
 
     public RemoteEndpoint getRemote()
     {
-        return session.getRemote();
+        return remote;
     }
 
     public Session getSession()
@@ -34,7 +35,8 @@ public class WebSocketAdapter implements WebSocketListener
 
     public boolean isConnected()
     {
-        return session.isOpen();
+        Session sess = this.session;
+        return (sess != null) && (sess.isOpen());
     }
 
     public boolean isNotConnected()
@@ -58,6 +60,7 @@ public class WebSocketAdapter implements WebSocketListener
     public void onWebSocketConnect(Session sess)
     {
         this.session = sess;
+        this.remote = sess.getRemote();
     }
 
     @Override


### PR DESCRIPTION
originally from PR #7293 by @azurvii 

Fixes potential NPE from `WebSocketAdapter` if used before `onWebSocketConnect()` is called.