### PR TITLE
Update log4j version to 2.17.0 in Jetty 9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <jsp.version>8.5.70</jsp.version>
     <junit.version>5.8.2</junit.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <logback.version>1.2.9</logback.version>
     <maven.version>3.8.4</maven.version>
     <maven.plugin-tools.version>3.6.2</maven.plugin-tools.version>


### PR DESCRIPTION
Update log4j version from `2.15.0` to `2.17.0` in Jetty 9.4