### PR TITLE
Experiment with different demandContent contract

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Content.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Content.java
@@ -245,7 +245,9 @@ public interface Content
     {
         Content readContent();
 
-        void demandContent(Runnable onContentAvailable);
+        void setOnContentListener(Runnable onContentAvailable);
+
+        void demandContent();
     }
 
     // TODO should these static methods be instance methods?   They are not very buffer efficient
@@ -263,9 +265,10 @@ public interface Content
                     Content c = provider.readContent();
                     if (c == null)
                     {
-                        provider.demandContent(this);
+                        provider.demandContent();
                         return;
                     }
+
                     if (c.hasRemaining())
                     {
                         out.copyBuffer(c.getByteBuffer());
@@ -273,6 +276,7 @@ public interface Content
                     }
                     if (c.isLast())
                     {
+                        provider.setOnContentListener(null);
                         if (c instanceof Content.Error)
                             content.failed(((Content.Error)c).getCause());
                         else
@@ -282,6 +286,7 @@ public interface Content
                 }
             }
         };
+        provider.setOnContentListener(onDataAvailable);
         onDataAvailable.run();
     }
 
@@ -312,7 +317,7 @@ public interface Content
                     Content c = provider.readContent();
                     if (c == null)
                     {
-                        provider.demandContent(this);
+                        provider.demandContent();
                         return;
                     }
                     if (c.hasRemaining())
@@ -322,6 +327,7 @@ public interface Content
                     }
                     if (c.isLast())
                     {
+                        provider.setOnContentListener(null);
                         if (c instanceof Content.Error)
                             content.failed(((Content.Error)c).getCause());
                         else
@@ -331,6 +337,7 @@ public interface Content
                 }
             }
         };
+        provider.setOnContentListener(onDataAvailable);
         onDataAvailable.run();
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -58,7 +58,10 @@ public interface Request extends Attributes, Callback, Executor, Content.Provide
     Content readContent();
 
     @Override
-    void demandContent(Runnable onContentAvailable);
+    void setOnContentListener(Runnable onContentAvailable);
+
+    @Override
+    void demandContent();
 
     void addErrorListener(Consumer<Throwable> onError);
 
@@ -284,9 +287,15 @@ public interface Request extends Attributes, Callback, Executor, Content.Provide
         }
 
         @Override
-        public void demandContent(Runnable onContentAvailable)
+        public void setOnContentListener(Runnable onContentAvailable)
         {
-            _wrapped.demandContent(onContentAvailable);
+            _wrapped.setOnContentListener(onContentAvailable);
+        }
+
+        @Override
+        public void demandContent()
+        {
+            _wrapped.demandContent();
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextRequest.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextRequest.java
@@ -37,9 +37,12 @@ public class ContextRequest extends Request.Wrapper
     }
 
     @Override
-    public void demandContent(Runnable onContentAvailable)
+    public void setOnContentListener(Runnable onContentAvailable)
     {
-        super.demandContent(() -> _context.run(onContentAvailable));
+        if (onContentAvailable == null)
+            super.setOnContentListener(null);
+        else
+            super.setOnContentListener(() -> _context.run(onContentAvailable));
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandleOnContentHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandleOnContentHandler.java
@@ -28,7 +28,8 @@ public class HandleOnContentHandler extends Handler.Wrapper
         if (request.getContentLength() <= 0 && !request.getHeaders().contains(HttpHeader.CONTENT_TYPE))
             return super.handle(request, response);
 
-        request.demandContent(new OnContentRunner(request, response));
+        request.setOnContentListener(new OnContentRunner(request, response));
+        request.demandContent();
         return true;
     }
 
@@ -48,6 +49,7 @@ public class HandleOnContentHandler extends Handler.Wrapper
         {
             try
             {
+                _request.setOnContentListener(null);
                 if (!HandleOnContentHandler.super.handle(_request, _response))
                     _request.failed(new IllegalStateException());
             }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -977,12 +977,18 @@ public class HttpChannelTest
                         contentSize.add(content.remaining());
                         content.release();
                         if (content.isLast())
+                        {
+                            request.setOnContentListener(null);
                             latch.countDown();
+                        }
                         else
-                            request.demandContent(this);
+                        {
+                            request.demandContent();
+                        }
                     }
                 };
-                request.demandContent(onContentAvailable);
+                request.setOnContentListener(onContentAvailable);
+                request.demandContent();
                 if (latch.await(30, TimeUnit.SECONDS))
                 {
                     response.setStatus(200);
@@ -1092,7 +1098,9 @@ public class HttpChannelTest
 
         CountDownLatch demand = new CountDownLatch(1);
         // Callback serialized until after onError task
-        handling.get().demandContent(demand::countDown);
+
+        handling.get().setOnContentListener(demand::countDown);
+        handling.get().demandContent();
 
         FuturePromise<Throwable> callback = new FuturePromise<>();
         // Callback serialized until after onError task

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -1298,12 +1298,17 @@ public class HttpConnectionTest
                         try
                         {
                             CountDownLatch blocker = new CountDownLatch(1);
-                            request.demandContent(blocker::countDown);
+                            request.setOnContentListener(blocker::countDown);
+                            request.demandContent();
                             blocker.await();
                         }
                         catch (InterruptedException e)
                         {
                             // ignored
+                        }
+                        finally
+                        {
+                            request.setOnContentListener(null);
                         }
                         continue;
                     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -335,8 +335,13 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
                     {
                         try (Blocking.Runnable blocker = Blocking.runnable())
                         {
-                            request.demandContent(blocker);
+                            request.setOnContentListener(blocker);
+                            request.demandContent();
                             blocker.block();
+                        }
+                        finally
+                        {
+                            request.setOnContentListener(null);
                         }
                         continue;
                     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -159,8 +159,13 @@ public class HttpServerTestFixture
                 {
                     try (Blocking.Runnable blocker = Blocking.runnable())
                     {
-                        request.demandContent(blocker);
+                        request.setOnContentListener(blocker);
+                        request.demandContent();
                         blocker.block();
+                    }
+                    finally
+                    {
+                        request.setOnContentListener(null);
                     }
                     continue;
                 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -192,9 +192,10 @@ public class ContextHandlerTest
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
 
-                request.demandContent(() ->
+                request.setOnContentListener(() ->
                 {
                     assertInContext(request);
+                    request.setOnContentListener(null);
                     Content content = request.readContent();
                     assertTrue(content.hasRemaining());
                     assertTrue(content.isLast());
@@ -211,6 +212,7 @@ public class ContextHandlerTest
                             throw new IllegalStateException();
                         }), content.getByteBuffer());
                 });
+                request.demandContent();
                 return true;
             }
         };
@@ -261,14 +263,16 @@ public class ContextHandlerTest
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
 
                 CountDownLatch latch = new CountDownLatch(1);
-                request.demandContent(() ->
+                request.setOnContentListener(() ->
                 {
                     assertInContext(request);
                     latch.countDown();
                 });
+                request.demandContent();
 
                 blocking.countDown();
                 assertTrue(latch.await(10, TimeUnit.SECONDS));
+                request.setOnContentListener(null);
                 Content content = request.readContent();
                 assertNotNull(content);
                 assertTrue(content.hasRemaining());

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
@@ -26,9 +26,9 @@ import org.eclipse.jetty.server.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Blocking;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.MultiMap;
-import org.eclipse.jetty.util.Blocking;
 import org.eclipse.jetty.util.UrlEncoded;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.slf4j.Logger;
@@ -97,8 +97,13 @@ public class DumpHandler extends Handler.Abstract
                     {
                         try (Blocking.Runnable blocker = _blocker.runnable())
                         {
-                            request.demandContent(blocker);
+                            request.setOnContentListener(blocker);
+                            request.demandContent();
                             blocker.block();
+                        }
+                        finally
+                        {
+                            request.setOnContentListener(null);
                         }
                         continue;
                     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
@@ -53,6 +53,7 @@ public class EchoHandler extends Handler.Abstract
         {
             _request = request;
             _response = response;
+            _request.setOnContentListener(this::succeeded);
         }
 
         @Override
@@ -61,7 +62,7 @@ public class EchoHandler extends Handler.Abstract
             Content content = _request.readContent();
             if (content == null)
             {
-                _request.demandContent(this::succeeded);
+                _request.demandContent();
                 return Action.SCHEDULED;
             }
 
@@ -75,7 +76,10 @@ public class EchoHandler extends Handler.Abstract
             }
 
             if (!content.hasRemaining() && content.isLast())
+            {
+                _request.setOnContentListener(null);
                 return Action.SUCCEEDED;
+            }
 
             _response.write(content.isLast(), this, content.getByteBuffer());
             return Action.SCHEDULED;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLReadEOFAfterResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLReadEOFAfterResponseTest.java
@@ -71,8 +71,13 @@ public class SSLReadEOFAfterResponseTest
                     {
                         try (Blocking.Runnable blocker = Blocking.runnable())
                         {
-                            request.demandContent(blocker);
+                            request.setOnContentListener(blocker);
+                            request.demandContent();
                             blocker.block();
+                        }
+                        finally
+                        {
+                            request.setOnContentListener(null);
                         }
                         continue;
                     }


### PR DESCRIPTION
Currently the `Content.Provider` contract in Jetty-12.0.x is:
```java    
    interface Provider
    {
        Content readContent();
        void demandContent(Runnable onContentAvailable);
    }
```
which can be used in a simple way like:
```java
    try (Blocking.Runnable blocker = _blocker.runnable())
    {
        request.demandContent(blocker);
        blocker.block();
    }
```

There has been some review of this that dislikes the passing on of the `onContentAvailable` with each call to `demandContent`, since this means that `demandContent` cannot be idempotent and that multiple calls to it are meaningful and may result in a pending exception.  However, unlike lower layers, where the callback can be to a well known instance (eg HttpStream calling HttpChannel.onContentAvailable), there is no well know instance to call as the layer above is the application.   Thus this PR experiments with the contract:

```java
    interface Provider
    {
        Content readContent();
        void setOnContentListener(Runnable onContentAvailable);
        void demandContent();
    }
```

The simple blocking usage of this now becomes:
```java
    try (Blocking.Runnable blocker = _blocker.runnable())
    {
        request.setOnContentListener(blocker);
        request.demandContent();
        blocker.block();
    }
    finally
    {
        request.setOnContentListener(null);
    }
```

**Pros:**
 + The call to `demandContent()` is now idempontent, however there currently are no examples of it needing to be idempotent

**Cons:**
 + The lock has to be grabbed more times. For the simple case shown above the lock is grabbed 3 times instead of once.  In general it is grabbed N+2 times, where N is the number of calls to `demandContent`
 + The simple case code is a lot more verbose.
 + If we are to keep the current strict policing of no pending reads when `request.succeeded()` is called, then users have to remember to set the listener back to null after it has been used.
 + If users don't set the listener to null, then we may hold onto lambdas/instances longer than necessary and if succeeded is called we will generate a warning that a read may have been pending.
 + It doesn't really help with the case of two different concerns trying to read content.  If we ever did have two concerns both trying to call `demandContent(Runnable)` with different Runnables, then the same situation can occur with them both calling `setOnContentListener`.... except the outcome can be a lot more confusing, as instead of getting a demand pending exception, the wrong callback may be called.

In short, I see no benefit to this style.   If we really want to have an idempotent `demandContent()` call, then another solution is needed.

Thoughts?



