### PR TITLE
Issue #7313 Add AttributeContainerMap as bean to server for all constructors

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -106,7 +106,6 @@ public class Server extends HandlerWrapper implements Attributes
         ServerConnector connector = new ServerConnector(this);
         connector.setPort(port);
         setConnectors(new Connector[]{connector});
-        addBean(_attributes);
     }
 
     /**
@@ -129,6 +128,7 @@ public class Server extends HandlerWrapper implements Attributes
     {
         _threadPool = pool != null ? pool : new QueuedThreadPool();
         addBean(_threadPool);
+        addBean(_attributes);
         setServer(this);
     }
 


### PR DESCRIPTION
Closes #7313 

Looks like `addBean(_attributes)` should have been called for all `Server` constructors, not just `Server(int port)`.