### PR TITLE
Fix flakey FCGI test

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -459,6 +459,14 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     @Override
     public void close()
     {
+        // Manually release and remove entries to do our best effort calling the listeners.
+        for (Pool<Connection>.Entry entry : pool.values())
+        {
+            if (entry.release())
+                released(entry.getPooled());
+            if (entry.remove())
+                removed(entry.getPooled());
+        }
         pool.close();
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/LeakTrackingConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/LeakTrackingConnectionPool.java
@@ -42,8 +42,8 @@ public class LeakTrackingConnectionPool extends DuplexConnectionPool
     @Override
     public void close()
     {
-        LifeCycle.stop(this);
         super.close();
+        LifeCycle.stop(this);
     }
 
     @Override


### PR DESCRIPTION
See #7201.

Do a best effort calling released() and removed() listeners when the connection pool gets closed. Note that this is a best effort as there is no way to guarantee that these listeners will be called as this is all racy code.