### PR TITLE
 #7271 add checks for max capacity in tries

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
@@ -70,6 +70,13 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     private static final int ROW_SIZE = 4;
 
     /**
+     * The maximum capacity of the implementation. Over that,
+     * the 16 bit indexes can overflow and the trie
+     * cannot find existing entries anymore.
+     */
+    private static final int MAX_CAPACITY = Character.MAX_VALUE - 1;
+
+    /**
      * The Trie rows in a single array which allows a lookup of row,character
      * to the next row in the Trie.  This is actually a 2 dimensional
      * array that has been flattened to achieve locality of reference.
@@ -140,9 +147,11 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     public ArrayTernaryTrie(boolean insensitive, int capacity)
     {
         super(insensitive);
-        _value = (V[])new Object[capacity];
-        _tree = new char[capacity * ROW_SIZE];
-        _key = new String[capacity];
+        if (capacity > MAX_CAPACITY)
+            throw new IllegalArgumentException("Capacity " + capacity + " > " + MAX_CAPACITY);
+        _value = (V[])new Object[capacity + 1];
+        _tree = new char[(capacity + 1) * ROW_SIZE];
+        _key = new String[capacity + 1];
     }
 
     /**
@@ -155,6 +164,8 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     {
         super(trie.isCaseInsensitive());
         int capacity = (int)(trie._value.length * factor);
+        if (capacity > MAX_CAPACITY)
+            throw new IllegalArgumentException("Capacity " + capacity + " > " + MAX_CAPACITY);
         _rows = trie._rows;
         _value = Arrays.copyOf(trie._value, capacity);
         _tree = Arrays.copyOf(trie._tree, capacity * ROW_SIZE);
@@ -175,6 +186,8 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     {
         int t = 0;
         int limit = s.length();
+        if (limit > MAX_CAPACITY)
+            return false;
         int last = 0;
         for (int k = 0; k < limit; k++)
         {
@@ -184,17 +197,17 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
 
             while (true)
             {
+                if (_rows == MAX_CAPACITY)
+                    return false;
+
                 int row = ROW_SIZE * t;
 
                 // Do we need to create the new row?
                 if (t == _rows)
                 {
-                    _rows++;
-                    if (_rows >= _key.length)
-                    {
-                        _rows--;
+                    if (_rows == _key.length)
                         return false;
-                    }
+                    _rows++;
                     _tree[row] = c;
                 }
 
@@ -222,12 +235,9 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
         // Do we need to create the new row?
         if (t == _rows)
         {
-            _rows++;
-            if (_rows >= _key.length)
-            {
-                _rows--;
+            if (_rows == _key.length)
                 return false;
-            }
+            _rows++;
         }
 
         // Put the key and value
@@ -530,7 +540,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     @Override
     public boolean isFull()
     {
-        return _rows + 1 == _key.length;
+        return _rows == _key.length;
     }
 
     public static int hilo(int diff)

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
@@ -474,7 +474,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     public String toString()
     {
         StringBuilder buf = new StringBuilder();
-        for (int r = 0; r <= _rows; r++)
+        for (int r = 0; r < _rows; r++)
         {
             if (_key[r] != null && _value[r] != null)
             {
@@ -497,7 +497,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     {
         Set<String> keys = new HashSet<>();
 
-        for (int r = 0; r <= _rows; r++)
+        for (int r = 0; r < _rows; r++)
         {
             if (_key[r] != null && _value[r] != null)
                 keys.add(_key[r]);
@@ -508,7 +508,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     public int size()
     {
         int s = 0;
-        for (int r = 0; r <= _rows; r++)
+        for (int r = 0; r < _rows; r++)
         {
             if (_key[r] != null && _value[r] != null)
                 s++;
@@ -518,7 +518,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
 
     public boolean isEmpty()
     {
-        for (int r = 0; r <= _rows; r++)
+        for (int r = 0; r < _rows; r++)
         {
             if (_key[r] != null && _value[r] != null)
                 return false;
@@ -529,7 +529,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
     public Set<Map.Entry<String, V>> entrySet()
     {
         Set<Map.Entry<String, V>> entries = new HashSet<>();
-        for (int r = 0; r <= _rows; r++)
+        for (int r = 0; r < _rows; r++)
         {
             if (_key[r] != null && _value[r] != null)
                 entries.add(new AbstractMap.SimpleEntry<>(_key[r], _value[r]));
@@ -648,7 +648,10 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
             boolean added = _trie.put(s, v);
             while (!added && _growby > 0)
             {
-                ArrayTernaryTrie<V> bigger = new ArrayTernaryTrie<>(_trie.isCaseInsensitive(), _trie._key.length + _growby);
+                int newCapacity = _trie._key.length + _growby;
+                if (newCapacity > MAX_CAPACITY)
+                    return false;
+                ArrayTernaryTrie<V> bigger = new ArrayTernaryTrie<>(_trie.isCaseInsensitive(), newCapacity);
                 for (Map.Entry<String, V> entry : _trie.entrySet())
                 {
                     bigger.put(entry.getKey(), entry.getValue());

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTrie.java
@@ -58,6 +58,13 @@ public class ArrayTrie<V> extends AbstractTrie<V>
     private static final int ROW_SIZE = 32;
 
     /**
+     * The maximum capacity of the implementation. Over that,
+     * the 16 bit indexes can overflow and the trie
+     * cannot find existing entries anymore.
+     */
+    private static final int MAX_CAPACITY = Character.MAX_VALUE - 1;
+
+    /**
      * The index lookup table, this maps a character as a byte
      * (ISO-8859-1 or UTF8) to an index within a Trie row
      */
@@ -129,9 +136,11 @@ public class ArrayTrie<V> extends AbstractTrie<V>
     public ArrayTrie(int capacity)
     {
         super(true);
-        _value = (V[])new Object[capacity];
-        _rowIndex = new char[capacity * 32];
-        _key = new String[capacity];
+        if (capacity > MAX_CAPACITY)
+            throw new IllegalArgumentException("Capacity " + capacity + " > " + MAX_CAPACITY);
+        _value = (V[])new Object[capacity + 1];
+        _rowIndex = new char[(capacity + 1) * 32];
+        _key = new String[capacity + 1];
     }
 
     @Override
@@ -149,6 +158,8 @@ public class ArrayTrie<V> extends AbstractTrie<V>
         int t = 0;
         int k;
         int limit = s.length();
+        if (limit > MAX_CAPACITY)
+            return false;
         for (k = 0; k < limit; k++)
         {
             char c = s.charAt(k);
@@ -474,6 +485,6 @@ public class ArrayTrie<V> extends AbstractTrie<V>
     @Override
     public boolean isFull()
     {
-        return _rows + 1 >= _key.length;
+        return _rows >= _key.length;
     }
 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/TrieTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/TrieTest.java
@@ -69,6 +69,7 @@ public class TrieTest
         List<Function<Integer, Trie>> tries = new ArrayList<>();
         tries.add(ArrayTrie::new);
         tries.add(ArrayTernaryTrie::new);
+        tries.add(capacity -> new ArrayTernaryTrie.Growing<>(capacity, capacity));
         return tries.stream().map(Arguments::of);
     }
 


### PR DESCRIPTION
Add capacity checks to ArrayTrie and ArrayTernaryTrie and make sure to not overflow `char`.

Closes #7271
Replaces #7273