### PR TITLE
Jetty 12.0.x 7424 void handle 2

### DIFF
--- a/jetty-connectors/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
+++ b/jetty-connectors/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/HttpChannelOverHTTP2.java
@@ -689,7 +689,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel implements Closeable, Writ
     {
         ContextHandler context = getState().getContextHandler();
         if (context != null)
-            context.handle(getRequest(), this);
+            context.handle(getRequest());
         else
             handle();
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
@@ -33,13 +33,10 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Incoming requests to the Server (itself a Handler) are passed to one or more Handlers
  * until the request is handled and a response is produced.  Handlers are asynchronous,
- * so handling may happen during or after a call to {@link #handle(Request, Response)}.
- * A handler indicates that returns true from the {@link #handle(Request, Response)} method
- * is indicated that it (or one of it's contained handlers) has undertaken to produce the
- * response and ultimately call {@link Request#succeeded()} or {@link Request#failed(Throwable)}
- * to indicate the end of the request handling.
+ * so handling may happen during or after a call to {@link #handle(Request)}.
+ *
  * <p>
- * A call to {@link #handle(Request, Response)} may:
+ * A call to {@link #handle(Request)} may:
  * <ul>
  * <li>Do nothing</li>
  * <li>Completely generate the HTTP Response and call {@link Callback#succeeded()} on the {@link Callback}
@@ -63,10 +60,9 @@ public interface Handler extends LifeCycle, Destroyable
      * or one of it's nested Handlers must call {@link Request#accept()} to indicate that it will ultimately succeed or
      * fail the {@link Callback} returned.
      *
-     * @param response The muttable response
      * @throws Exception Thrown if there is a problem handling.
      */
-    void handle(Request request, Response response) throws Exception;
+    void handle(Request request) throws Exception;
 
     @ManagedAttribute(value = "the jetty server for this handler", readonly = true)
     Server getServer();
@@ -286,11 +282,11 @@ public interface Handler extends LifeCycle, Destroyable
         }
 
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
             Handler next = getHandler();
             if (next != null)
-                next.handle(request, response);
+                next.handle(request);
         }
     }
 
@@ -318,7 +314,7 @@ public interface Handler extends LifeCycle, Destroyable
 
     /**
      * A Handler Container that wraps a list of other Handlers.
-     * By default, each handler is called in turn until one returns true from {@link Handler#handle(Request, Response)}.
+     * By default, each handler is called in turn until one returns true from {@link Handler#handle(Request)}.
      */
     class Collection extends AbstractContainer
     {
@@ -336,12 +332,12 @@ public interface Handler extends LifeCycle, Destroyable
         }
 
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
             for (Handler h : _handlers)
             {
                 if (!request.isAccepted())
-                    h.handle(request, response);
+                    h.handle(request);
             }
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
@@ -43,13 +43,13 @@ import org.slf4j.LoggerFactory;
  * <ul>
  * <li>Do nothing</li>
  * <li>Completely generate the HTTP Response and call {@link Callback#succeeded()} on the {@link Callback}
- * returned from {@link Request#setHandling()}.</li>
- * <li>Call {@link Request#setHandling()} and arrange for an async process to generate the HTTP Response and call
+ * returned from {@link Request#accept()}.</li>
+ * <li>Call {@link Request#accept()} and arrange for an async process to generate the HTTP Response and call
  * {@link Callback#succeeded()} or {@link Callback#failed(Throwable)} on the {@link Callback} returned.</li>
  * <li>Pass the request to one or more other Handlers.</li>
  * <li>Wrap the request and/or response and pass them to one or more other Handlers.</li>
  * <li>Fail the request by calling {@link Callback#failed(Throwable)} on the {@link Callback} returned from
- * {@link Request#setHandling()}.</li>
+ * {@link Request#accept()}.</li>
  * </ul>
  *
  */
@@ -60,7 +60,7 @@ public interface Handler extends LifeCycle, Destroyable
     /**
      * Handle an HTTP request and produce a response.
      * @param request The immutable request, which is also a {@link Callback} used to signal success or failure. The Handler
-     * or one of it's nested Handlers must call {@link Request#setHandling()} to indicate that it will ultimately succeed or
+     * or one of it's nested Handlers must call {@link Request#accept()} to indicate that it will ultimately succeed or
      * fail the {@link Callback} returned.
      *
      * @param response The muttable response
@@ -340,7 +340,7 @@ public interface Handler extends LifeCycle, Destroyable
         {
             for (Handler h : _handlers)
             {
-                if (!request.isHandling())
+                if (!request.isAccepted())
                     h.handle(request, response);
             }
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -272,7 +272,7 @@ public class HttpChannel extends Attributes.Lazy
             Runnable invokeOnError = onError == null ? null : () -> onError.accept(x);
 
             // Serialize all the error actions.
-            return _serializedInvoker.offer(invokeOnContentAvailable, invokeWriteFailure, invokeOnError, () -> request.setHandling().failed(x));
+            return _serializedInvoker.offer(invokeOnContentAvailable, invokeWriteFailure, invokeOnError, () -> request.accept().failed(x));
         }
     }
 
@@ -367,7 +367,7 @@ public class HttpChannel extends Attributes.Lazy
         {
             Request request = _request;
             _server.handle(request, _request._response);
-            if (!request.isHandling())
+            if (!request.isAccepted())
                 throw new IllegalStateException();
         }
     }
@@ -628,7 +628,7 @@ public class HttpChannel extends Attributes.Lazy
         }
 
         @Override
-        public Callback setHandling()
+        public Callback accept()
         {
             try (AutoLock ignored = _lock.lock())
             {
@@ -638,7 +638,7 @@ public class HttpChannel extends Attributes.Lazy
         }
 
         @Override
-        public boolean isHandling()
+        public boolean isAccepted()
         {
             try (AutoLock ignored = _lock.lock())
             {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -34,9 +34,9 @@ import org.eclipse.jetty.util.UrlEncoded;
 // TODO lots of javadoc
 public interface Request extends Attributes, Executor, Content.Provider
 {
-    Callback setHandling();
+    Callback accept();
 
-    boolean isHandling();
+    boolean isAccepted();
 
     String getId();
 
@@ -339,15 +339,15 @@ public interface Request extends Attributes, Executor, Content.Provider
         }
 
         @Override
-        public Callback setHandling()
+        public Callback accept()
         {
-            return _wrapped.setHandling();
+            return _wrapped.accept();
         }
 
         @Override
-        public boolean isHandling()
+        public boolean isAccepted()
         {
-            return _wrapped.isHandling();
+            return _wrapped.isAccepted();
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -32,8 +32,12 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 // TODO lots of javadoc
-public interface Request extends Attributes, Callback, Executor, Content.Provider
+public interface Request extends Attributes, Executor, Content.Provider
 {
+    Callback setHandling();
+
+    boolean isHandling();
+
     String getId();
 
     HttpChannel getChannel();
@@ -335,21 +339,15 @@ public interface Request extends Attributes, Callback, Executor, Content.Provide
         }
 
         @Override
-        public void succeeded()
+        public Callback setHandling()
         {
-            _wrapped.succeeded();
+            return _wrapped.setHandling();
         }
 
         @Override
-        public void failed(Throwable x)
+        public boolean isHandling()
         {
-            _wrapped.failed(x);
-        }
-
-        @Override
-        public InvocationType getInvocationType()
-        {
-            return _wrapped.getInvocationType();
+            return _wrapped.isHandling();
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -34,8 +34,33 @@ import org.eclipse.jetty.util.UrlEncoded;
 // TODO lots of javadoc
 public interface Request extends Attributes, Executor, Content.Provider
 {
-    Callback accept();
+    /**
+     * Accept the request for handling and provide the {@link Response} instance.
+     * @return The response instance or null if the request has already been accepted.
+     */
+    Response accept();
 
+    /**
+     * Test if the request has been accepted.
+     * <p>This should not be used if the caller intends to accept the request.  Specifically
+     * the following is an anti-pattern: <pre>
+     *     if (!request.isAccepted())
+     *     {
+     *         Response response = request.accept();
+     *         // ...
+     *     }
+     * </pre>
+     * Instead, the {@link #accept()} method should be used and tested for a null result: <pre>
+     *     Response response = request.accept();
+     *     if (response != null)
+     *     {
+     *         // ...
+     *     }
+     * </pre>
+     *
+     * @return true if the request has been accepted, else null
+     * @see #accept()
+     */
     boolean isAccepted();
 
     String getId();
@@ -71,6 +96,9 @@ public interface Request extends Attributes, Executor, Content.Provider
 
     void addCompletionListener(Callback onComplete);
 
+    /**
+     * @return The response instance iff this request has been excepted, else null
+     */
     Response getResponse();
 
     default Request getWrapped()
@@ -317,7 +345,7 @@ public interface Request extends Attributes, Executor, Content.Provider
         }
 
         @Override
-        public Callback accept()
+        public Response accept()
         {
             return _wrapped.accept();
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -140,10 +140,11 @@ public interface Response
 
         if (errorHandler != null)
         {
-            Request request = new ErrorHandler.ErrorRequest(getRequest().getWrapper(), status, message, cause, callback);
+            Request errorRequest = new ErrorHandler.ErrorRequest(getRequest().getWrapper(), status, message, cause, callback);
             try
             {
-                if (errorHandler.handle(request, this))
+                errorHandler.handle(errorRequest, this);
+                if (errorRequest.isHandling())
                     return;
             }
             catch (Exception e)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -144,7 +144,7 @@ public interface Response
             try
             {
                 errorHandler.handle(errorRequest, this);
-                if (errorRequest.isHandling())
+                if (errorRequest.isAccepted())
                     return;
             }
             catch (Exception e)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -35,6 +35,8 @@ public interface Response
 {
     Request getRequest();
 
+    Callback getCallback();
+
     int getStatus();
 
     void setStatus(int code);
@@ -136,10 +138,10 @@ public interface Response
 
         if (errorHandler != null)
         {
-            Request errorRequest = new ErrorHandler.ErrorRequest(getRequest(), status, message, cause, callback);
+            Request errorRequest = new ErrorHandler.ErrorRequest(getRequest(), this, status, message, cause, callback);
             try
             {
-                errorHandler.handle(errorRequest, this);
+                errorHandler.handle(errorRequest);
                 if (errorRequest.isAccepted())
                     return;
             }
@@ -164,6 +166,12 @@ public interface Response
         {
             _request = request;
             _wrapped = wrapped;
+        }
+
+        @Override
+        public Callback getCallback()
+        {
+            return _wrapped.getCallback();
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -114,7 +114,7 @@ public class Server extends Handler.Wrapper implements Attributes
     }
 
     @Override
-    public void handle(Request request, Response response)
+    public void handle(Request request)
     {
         if (!isStarted())
             return;
@@ -133,10 +133,13 @@ public class Server extends Handler.Wrapper implements Attributes
             }
 
             // Handle
-            super.handle(customizedRequest, customizedRequest.getResponse());
-            if (!request.isAccepted())
+            super.handle(customizedRequest);
+
+            // Try to accept to test if already accepted
+            Response response = request.accept();
+            if (response != null)
             {
-                Callback callback = request.accept();
+                Callback callback = response.getCallback();
                 if (response.isCommitted())
                     callback.failed(new IllegalStateException("No Handler for committed request"));
                 else
@@ -151,10 +154,11 @@ public class Server extends Handler.Wrapper implements Attributes
             else
                 LOG.warn("handle failed {}", this, t);
 
-            request.accept().failed(t);
+            Response response = request.accept();
+            if (response == null)
+                response = request.getResponse();
+            response.getCallback().failed(t);
         }
-
-        return;
     }
 
     public boolean isDryRun()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -128,15 +128,15 @@ public class Server extends Handler.Wrapper implements Attributes
             {
                 Request customized = customizer.customize(request.getConnectionMetaData().getConnector(), configuration, customizedRequest);
                 customizedRequest = customized == null ? request : customized;
-                if (request.isHandling())
+                if (request.isAccepted())
                     return;
             }
 
             // Handle
             super.handle(customizedRequest, customizedRequest.getResponse());
-            if (!request.isHandling())
+            if (!request.isAccepted())
             {
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 if (response.isCommitted())
                     callback.failed(new IllegalStateException("No Handler for committed request"));
                 else
@@ -151,7 +151,7 @@ public class Server extends Handler.Wrapper implements Attributes
             else
                 LOG.warn("handle failed {}", this, t);
 
-            request.setHandling().failed(t);
+            request.accept().failed(t);
         }
 
         return;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -323,7 +323,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes
                 location += ";" + request.getHttpURI().getQuery();
             response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
             response.getHeaders().add(new HttpField(HttpHeader.LOCATION, location));
-            request.setHandling().succeeded();
+            request.accept().succeeded();
             return;
         }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -302,7 +302,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes
     }
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
         if (getHandler() == null)
             return;
@@ -321,24 +321,26 @@ public class ContextHandler extends Handler.Wrapper implements Attributes
                 location += ";" + request.getHttpURI().getParam();
             if (request.getHttpURI().getQuery() != null)
                 location += ";" + request.getHttpURI().getQuery();
+
+            Response response = request.accept();
             response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
             response.getHeaders().add(new HttpField(HttpHeader.LOCATION, location));
-            request.accept().succeeded();
+            response.getCallback().succeeded();
             return;
         }
 
         // TODO check availability and maybe return a 503
 
-        ContextRequest scoped = wrap(request, response, pathInContext);
+        ContextRequest scoped = wrap(request, pathInContext);
         if (scoped == null)
             return; // TODO 404? 500? Error dispatch ???
 
         _context.call(scoped);
     }
 
-    protected ContextRequest wrap(Request request, Response response, String pathInContext)
+    protected ContextRequest wrap(Request request, String pathInContext)
     {
-        return new ContextRequest(this, request, response, pathInContext);
+        return new ContextRequest(this, request, pathInContext);
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.ArrayUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Index;
@@ -123,7 +122,7 @@ public class ContextHandlerCollection extends Handler.Collection
     }
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
         List<Handler> handlers = getHandlers();
 
@@ -133,7 +132,7 @@ public class ContextHandlerCollection extends Handler.Collection
 
         if (!(handlers instanceof Mapping))
         {
-            super.handle(request, response);
+            super.handle(request);
             return;
         }
 
@@ -142,7 +141,7 @@ public class ContextHandlerCollection extends Handler.Collection
         // handle only a single context.
         if (handlers.size() == 1)
         {
-            handlers.get(0).handle(request, response);
+            handlers.get(0).handle(request);
             return;
         }
 
@@ -154,7 +153,7 @@ public class ContextHandlerCollection extends Handler.Collection
         String path = request.getPath();
         if (!path.startsWith("/"))
         {
-            super.handle(request, response);
+            super.handle(request);
             return;
         }
 
@@ -173,7 +172,7 @@ public class ContextHandlerCollection extends Handler.Collection
             {
                 for (Branch branch : branches.getValue())
                 {
-                    branch.getHandler().handle(request, response);
+                    branch.getHandler().handle(request);
                     if (request.isAccepted())
                         return;
                 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -172,7 +172,16 @@ public class ContextHandlerCollection extends Handler.Collection
             {
                 for (Branch branch : branches.getValue())
                 {
-                    branch.getHandler().handle(request);
+                    try
+                    {
+                        branch.getHandler().handle(request);
+                    }
+                    catch (Throwable t)
+                    {
+                        if (request.isAccepted())
+                            throw t;
+                        LOG.warn("Unaccepted error {}", this, t);
+                    }
                     if (request.isAccepted())
                         return;
                 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -174,7 +174,7 @@ public class ContextHandlerCollection extends Handler.Collection
                 for (Branch branch : branches.getValue())
                 {
                     branch.getHandler().handle(request, response);
-                    if (request.isHandling())
+                    if (request.isAccepted())
                         return;
                 }
             }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -123,31 +123,40 @@ public class ContextHandlerCollection extends Handler.Collection
     }
 
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         List<Handler> handlers = getHandlers();
 
         // Handle no contexts
         if (handlers == null || handlers.isEmpty())
-            return false;
+            return;
 
         if (!(handlers instanceof Mapping))
-            return super.handle(request, response);
+        {
+            super.handle(request, response);
+            return;
+        }
 
         Mapping mapping = (Mapping)getHandlers();
 
         // handle only a single context.
         if (handlers.size() == 1)
-            return handlers.get(0).handle(request, response);
+        {
+            handlers.get(0).handle(request, response);
+            return;
+        }
 
         // handle many contexts
         Index<Map.Entry<String, Branch[]>> pathBranches = mapping._pathBranches;
         if (pathBranches == null)
-            return false;
+            return;
 
         String path = request.getPath();
         if (!path.startsWith("/"))
-            return super.handle(request, response);
+        {
+            super.handle(request, response);
+            return;
+        }
 
         int limit = path.length() - 1;
 
@@ -164,15 +173,14 @@ public class ContextHandlerCollection extends Handler.Collection
             {
                 for (Branch branch : branches.getValue())
                 {
-                    if (branch.getHandler().handle(request, response))
-                        return true;
+                    branch.getHandler().handle(request, response);
+                    if (request.isHandling())
+                        return;
                 }
             }
 
             limit = l - 2;
         }
-
-        return false;
     }
 
     /**

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextResponse.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextResponse.java
@@ -1,0 +1,50 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2021 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+
+class ContextResponse extends Response.Wrapper
+{
+    private final ContextHandler _contextHandler;
+
+    public ContextResponse(ContextHandler contextHandler, Response response)
+    {
+        super(response);
+        _contextHandler = contextHandler;
+    }
+
+    @Override
+    public void write(boolean last, Callback callback, ByteBuffer... content)
+    {
+        Callback contextCallback = new Callback()
+        {
+            @Override
+            public void succeeded()
+            {
+                _contextHandler.getContext().run(callback::succeeded);
+            }
+
+            @Override
+            public void failed(Throwable t)
+            {
+                _contextHandler.getContext().accept(callback::failed, t);
+            }
+        };
+        super.write(last, contextCallback, content);
+    }
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
@@ -84,10 +84,10 @@ public class DefaultHandler extends Handler.Abstract
     }
 
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         if (response.isCommitted())
-            return false;
+            return;
 
         String method = request.getMethod();
 
@@ -106,14 +106,14 @@ public class DefaultHandler extends Handler.Abstract
                 response.setHeader(HttpHeader.CACHE_CONTROL.toString(), "max-age=360000,public");
                 content = _favicon.slice();
             }
-            response.write(true, request, content);
-            return true;
+            response.write(true, request.setHandling(), content);
+            return;
         }
 
         if (!_showContexts || !HttpMethod.GET.is(method) || !request.getPath().equals("/"))
         {
-            response.writeError(HttpStatus.NOT_FOUND_404, null, request);
-            return true;
+            response.writeError(HttpStatus.NOT_FOUND_404, null, request.setHandling());
+            return;
         }
 
         response.setStatus(HttpStatus.NOT_FOUND_404);
@@ -193,8 +193,7 @@ public class DefaultHandler extends Handler.Abstract
             writer.flush();
             ByteBuffer content = BufferUtil.toBuffer(outputStream.toByteArray());
             response.setContentLength(content.remaining());
-            response.write(true, request, content);
-            return true;
+            response.write(true, request.setHandling(), content);
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
@@ -84,9 +84,10 @@ public class DefaultHandler extends Handler.Abstract
     }
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
-        if (response.isCommitted())
+        Response response = request.accept();
+        if (response == null || response.isCommitted())
             return;
 
         String method = request.getMethod();
@@ -106,13 +107,13 @@ public class DefaultHandler extends Handler.Abstract
                 response.setHeader(HttpHeader.CACHE_CONTROL.toString(), "max-age=360000,public");
                 content = _favicon.slice();
             }
-            response.write(true, request.accept(), content);
+            response.write(true, response.getCallback(), content);
             return;
         }
 
         if (!_showContexts || !HttpMethod.GET.is(method) || !request.getPath().equals("/"))
         {
-            response.writeError(HttpStatus.NOT_FOUND_404, null, request.accept());
+            response.writeError(HttpStatus.NOT_FOUND_404, null, response.getCallback());
             return;
         }
 
@@ -193,7 +194,7 @@ public class DefaultHandler extends Handler.Abstract
             writer.flush();
             ByteBuffer content = BufferUtil.toBuffer(outputStream.toByteArray());
             response.setContentLength(content.remaining());
-            response.write(true, request.accept(), content);
+            response.write(true, response.getCallback(), content);
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
@@ -106,13 +106,13 @@ public class DefaultHandler extends Handler.Abstract
                 response.setHeader(HttpHeader.CACHE_CONTROL.toString(), "max-age=360000,public");
                 content = _favicon.slice();
             }
-            response.write(true, request.setHandling(), content);
+            response.write(true, request.accept(), content);
             return;
         }
 
         if (!_showContexts || !HttpMethod.GET.is(method) || !request.getPath().equals("/"))
         {
-            response.writeError(HttpStatus.NOT_FOUND_404, null, request.setHandling());
+            response.writeError(HttpStatus.NOT_FOUND_404, null, request.accept());
             return;
         }
 
@@ -193,7 +193,7 @@ public class DefaultHandler extends Handler.Abstract
             writer.flush();
             ByteBuffer content = BufferUtil.toBuffer(outputStream.toByteArray());
             response.setContentLength(content.remaining());
-            response.write(true, request.setHandling(), content);
+            response.write(true, request.accept(), content);
         }
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -104,7 +104,7 @@ public class ErrorHandler extends Handler.Abstract
 
         if (!errorPageForMethod(request.getMethod()) || HttpStatus.hasNoBody(code))
         {
-            request.setHandling().succeeded();
+            request.accept().succeeded();
         }
         else
         {
@@ -123,7 +123,7 @@ public class ErrorHandler extends Handler.Abstract
         {
             if (request.getHeaders().contains(HttpHeader.ACCEPT))
             {
-                request.setHandling().succeeded();
+                request.accept().succeeded();
                 return;
             }
             acceptable = Collections.singletonList(Type.TEXT_HTML.asString());
@@ -149,7 +149,7 @@ public class ErrorHandler extends Handler.Abstract
             charsets = List.of(StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8);
             if (request.getHeaders().contains(HttpHeader.ACCEPT_CHARSET))
             {
-                request.setHandling().succeeded();
+                request.accept().succeeded();
                 return;
             }
         }
@@ -159,7 +159,7 @@ public class ErrorHandler extends Handler.Abstract
             if (generateAcceptableResponse(request, response, mimeType, charsets, code, message, cause))
                 return;
         }
-        request.setHandling().succeeded();
+        request.accept().succeeded();
     }
 
     protected boolean generateAcceptableResponse(Request request, Response response, String contentType, List<Charset> charsets, int code, String message, Throwable cause)
@@ -246,12 +246,12 @@ public class ErrorHandler extends Handler.Abstract
 
         if (!buffer.hasRemaining())
         {
-            request.setHandling().succeeded();
+            request.accept().succeeded();
             return true;
         }
 
         response.getHeaders().put(type.getContentTypeField(charset));
-        response.write(true, new Callback.Nested(request.setHandling())
+        response.write(true, new Callback.Nested(request.accept())
         {
             @Override
             public void succeeded()
@@ -541,14 +541,14 @@ public class ErrorHandler extends Handler.Abstract
         }
 
         @Override
-        public Callback setHandling()
+        public Callback accept()
         {
             _handled.set(true);
             return _callback;
         }
 
         @Override
-        public boolean isHandling()
+        public boolean isAccepted()
         {
             return _handled.get();
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandleOnContentHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandleOnContentHandler.java
@@ -32,7 +32,7 @@ public class HandleOnContentHandler extends Handler.Wrapper
             super.handle(request, response);
         else
         {
-            request.setHandling();
+            request.accept();
             request.demandContent(new OnContentRunner(request, response));
         }
     }
@@ -57,21 +57,21 @@ public class HandleOnContentHandler extends Handler.Wrapper
                 Request request = new Request.Wrapper(_request)
                 {
                     @Override
-                    public Callback setHandling()
+                    public Callback accept()
                     {
                         handled.set(true);
-                        return super.setHandling();
+                        return super.accept();
                     }
 
                     @Override
-                    public boolean isHandling()
+                    public boolean isAccepted()
                     {
                         return handled.get();
                     }
                 };
                 HandleOnContentHandler.super.handle(request, _response);
-                if (!request.isHandling())
-                    _request.setHandling().failed(new IllegalStateException());
+                if (!request.isAccepted())
+                    _request.accept().failed(new IllegalStateException());
             }
             catch (Exception e)
             {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
@@ -19,13 +19,12 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.HostPort;
 
 public class ProxiedRequestHandler extends Handler.Wrapper
 {
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
         ConnectionMetaData proxiedFor = new ConnectionMetaData.Wrapper(request.getConnectionMetaData())
         {
@@ -72,6 +71,6 @@ public class ProxiedRequestHandler extends Handler.Wrapper
             {
                 return proxiedFor;
             }
-        }, response);
+        });
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.HostPort;
 public class ProxiedRequestHandler extends Handler.Wrapper
 {
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         ConnectionMetaData proxiedFor = new ConnectionMetaData.Wrapper(request.getConnectionMetaData())
         {
@@ -58,7 +58,7 @@ public class ProxiedRequestHandler extends Handler.Wrapper
             }
         };
 
-        return super.handle(new Request.Wrapper(request)
+        super.handle(new Request.Wrapper(request)
         {
             @Override
             public HttpURI getHttpURI()

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
@@ -118,7 +118,7 @@ public class RequestStatsHandler extends Handler.Wrapper
         }
         finally
         {
-            if (request.isHandling())
+            if (request.isAccepted())
                 _handleTimeStats.record(System.nanoTime() - request.getChannel().getStream().getNanoTimeStamp());
             // TODO initial dispatch duration stats collected here.
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
@@ -36,7 +36,7 @@ public class RequestStatsHandler extends Handler.Wrapper
     private final SampleStatistic _handleTimeStats = new SampleStatistic();
 
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         Object connectionStats = _connectionStats.computeIfAbsent(request.getConnectionMetaData().getId(), id ->
         {
@@ -97,7 +97,7 @@ public class RequestStatsHandler extends Handler.Wrapper
 
         try
         {
-            return super.handle(new Request.Wrapper(request)
+            super.handle(new Request.Wrapper(request)
             {
                 // TODO make this wrapper optional. Only needed if requestLog asks for these attributes.
                 @Override
@@ -118,7 +118,8 @@ public class RequestStatsHandler extends Handler.Wrapper
         }
         finally
         {
-            _handleTimeStats.record(System.nanoTime() - request.getChannel().getStream().getNanoTimeStamp());
+            if (request.isHandling())
+                _handleTimeStats.record(System.nanoTime() - request.getChannel().getStream().getNanoTimeStamp());
             // TODO initial dispatch duration stats collected here.
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RequestStatsHandler.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.server.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.eclipse.jetty.util.statistic.SampleStatistic;
@@ -36,7 +35,7 @@ public class RequestStatsHandler extends Handler.Wrapper
     private final SampleStatistic _handleTimeStats = new SampleStatistic();
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
         Object connectionStats = _connectionStats.computeIfAbsent(request.getConnectionMetaData().getId(), id ->
         {
@@ -114,7 +113,7 @@ public class RequestStatsHandler extends Handler.Wrapper
                             return super.getAttribute(name);
                     }
                 }
-            }, response);
+            });
         }
         finally
         {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
@@ -25,7 +25,7 @@ public class RewriteHandler extends Handler.Wrapper
     public void handle(Request request, Response response) throws Exception
     {
         Request rewritten = rewrite(request, response);
-        if (request.isHandling())
+        if (request.isAccepted())
             return;
         super.handle(request, response);
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
@@ -22,12 +22,12 @@ import org.eclipse.jetty.server.Response;
 public class RewriteHandler extends Handler.Wrapper
 {
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         Request rewritten = rewrite(request, response);
-        if (response.isCommitted())
-            return true;
-        return super.handle(request, response);
+        if (request.isHandling())
+            return;
+        super.handle(request, response);
     }
 
     protected Request rewrite(Request request, Response response)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/RewriteHandler.java
@@ -17,20 +17,19 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 public class RewriteHandler extends Handler.Wrapper
 {
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
-        Request rewritten = rewrite(request, response);
+        Request rewritten = rewrite(request);
         if (request.isAccepted())
             return;
-        super.handle(request, response);
+        super.handle(request);
     }
 
-    protected Request rewrite(Request request, Response response)
+    protected Request rewrite(Request request)
     {
         // TODO run the rules, but ultimately wrap for any changes:
         return new Request.Wrapper(request)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -30,14 +30,14 @@ public class GzipHandler extends Handler.Wrapper
     private static final HttpField CONTENT_ENCODING_GZIP = new HttpField(HttpHeader.CONTENT_ENCODING, "gzip");
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
         // TODO more conditions than this
         // TODO handle other encodings
         // TODO more efficient than this
         if (!request.getHeaders().contains(ACCEPT_GZIP) && !request.getHeaders().contains(CONTENT_ENCODING_GZIP))
         {
-            super.handle(request, response);
+            super.handle(request);
             return;
         }
 
@@ -79,14 +79,24 @@ public class GzipHandler extends Handler.Wrapper
                     // TODO inflate data
                     return super.readContent();
                 }
-            },
-            new Response.Wrapper(request, response)
-            {
+
                 @Override
-                public void write(boolean last, Callback callback, ByteBuffer... content)
+                public Response accept()
                 {
-                    // TODO deflate data
-                    super.write(last, callback, content);
+                    Response response = super.accept();
+                    if (response != null)
+                    {
+                        return new Response.Wrapper(request, request.accept())
+                        {
+                            @Override
+                            public void write(boolean last, Callback callback, ByteBuffer... content)
+                            {
+                                // TODO deflate data
+                                super.write(last, callback, content);
+                            }
+                        };
+                    }
+                    return null;
                 }
             });
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -30,13 +30,16 @@ public class GzipHandler extends Handler.Wrapper
     private static final HttpField CONTENT_ENCODING_GZIP = new HttpField(HttpHeader.CONTENT_ENCODING, "gzip");
 
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         // TODO more conditions than this
         // TODO handle other encodings
         // TODO more efficient than this
         if (!request.getHeaders().contains(ACCEPT_GZIP) && !request.getHeaders().contains(CONTENT_ENCODING_GZIP))
-            return super.handle(request, response);
+        {
+            super.handle(request, response);
+            return;
+        }
 
         HttpFields updated = HttpFields.from(request.getHeaders(), f ->
         {
@@ -54,7 +57,7 @@ public class GzipHandler extends Handler.Wrapper
         // TODO look up cached or pool inflaters / deflated
         final Object inflaterAndOrDeflator = request.getChannel().getAttribute("o.e.j.s.h.gzip.cachedCompression");
 
-        return super.handle(
+        super.handle(
             new Request.Wrapper(request)
             {
                 @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -67,7 +67,7 @@ public class ErrorHandlerTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response)
+            public void handle(Request request, Response response)
             {
                 if (request.getPath().startsWith("/badmessage/"))
                 {
@@ -109,8 +109,7 @@ public class ErrorHandlerTest
                     throw new TestException(message);
                 }
 
-                response.writeError(404, request);
-                return true;
+                response.writeError(404, request.setHandling());
             }
         });
         server.start();
@@ -443,14 +442,13 @@ public class ErrorHandlerTest
         server.setErrorHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response)
+            public void handle(Request request, Response response)
             {
                 response.setHeader(HttpHeader.LOCATION, "/error");
                 response.setHeader("X-Error-Message", String.valueOf(request.getAttribute(ErrorHandler.ERROR_MESSAGE)));
                 response.setHeader("X-Error-Status", Integer.toString(response.getStatus()));
                 response.setStatus(302);
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         });
         String rawResponse = connector.getResponse(
@@ -649,29 +647,26 @@ public class ErrorHandlerTest
         context.setErrorHandler(new ErrorHandler()
         {
             @Override
-            public boolean handle(Request request, Response response)
+            public void handle(Request request, Response response)
             {
-                response.write(true, request, BufferUtil.toBuffer("Context Error"));
-                return true;
+                response.write(true, request.setHandling(), BufferUtil.toBuffer("Context Error"));
             }
         });
         context.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response)
+            public void handle(Request request, Response response)
             {
-                response.writeError(444, request);
-                return true;
+                response.writeError(444, request.setHandling());
             }
         });
 
         server.setErrorHandler(new ErrorHandler()
         {
             @Override
-            public boolean handle(Request request, Response response)
+            public void handle(Request request, Response response)
             {
-                response.write(true, request, BufferUtil.toBuffer("Server Error"));
-                return true;
+                response.write(true, request.setHandling(), BufferUtil.toBuffer("Server Error"));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -67,8 +67,10 @@ public class ErrorHandlerTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
+
+                Response response = request.accept();
                 if (request.getPath().startsWith("/badmessage/"))
                 {
                     int code = Integer.parseInt(request.getPath().substring(request.getPath().lastIndexOf('/') + 1));
@@ -109,7 +111,7 @@ public class ErrorHandlerTest
                     throw new TestException(message);
                 }
 
-                response.writeError(404, request.accept());
+                response.writeError(404, response.getCallback());
             }
         });
         server.start();
@@ -442,13 +444,14 @@ public class ErrorHandlerTest
         server.setErrorHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
+                Response response = request.accept();
                 response.setHeader(HttpHeader.LOCATION, "/error");
                 response.setHeader("X-Error-Message", String.valueOf(request.getAttribute(ErrorHandler.ERROR_MESSAGE)));
                 response.setHeader("X-Error-Status", Integer.toString(response.getStatus()));
                 response.setStatus(302);
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         });
         String rawResponse = connector.getResponse(
@@ -647,26 +650,29 @@ public class ErrorHandlerTest
         context.setErrorHandler(new ErrorHandler()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
-                response.write(true, request.accept(), BufferUtil.toBuffer("Context Error"));
+                Response response = request.accept();
+                response.write(true, response.getCallback(), BufferUtil.toBuffer("Context Error"));
             }
         });
         context.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
-                response.writeError(444, request.accept());
+                Response response = request.accept();
+                response.writeError(444, response.getCallback());
             }
         });
 
         server.setErrorHandler(new ErrorHandler()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
-                response.write(true, request.accept(), BufferUtil.toBuffer("Server Error"));
+                Response response = request.accept();
+                response.write(true, response.getCallback(), BufferUtil.toBuffer("Server Error"));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -109,7 +109,7 @@ public class ErrorHandlerTest
                     throw new TestException(message);
                 }
 
-                response.writeError(404, request.setHandling());
+                response.writeError(404, request.accept());
             }
         });
         server.start();
@@ -448,7 +448,7 @@ public class ErrorHandlerTest
                 response.setHeader("X-Error-Message", String.valueOf(request.getAttribute(ErrorHandler.ERROR_MESSAGE)));
                 response.setHeader("X-Error-Status", Integer.toString(response.getStatus()));
                 response.setStatus(302);
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
         String rawResponse = connector.getResponse(
@@ -649,7 +649,7 @@ public class ErrorHandlerTest
             @Override
             public void handle(Request request, Response response)
             {
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("Context Error"));
+                response.write(true, request.accept(), BufferUtil.toBuffer("Context Error"));
             }
         });
         context.setHandler(new Handler.Abstract()
@@ -657,7 +657,7 @@ public class ErrorHandlerTest
             @Override
             public void handle(Request request, Response response)
             {
-                response.writeError(444, request.setHandling());
+                response.writeError(444, request.accept());
             }
         });
 
@@ -666,7 +666,7 @@ public class ErrorHandlerTest
             @Override
             public void handle(Request request, Response response)
             {
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("Server Error"));
+                response.write(true, request.accept(), BufferUtil.toBuffer("Server Error"));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
@@ -144,7 +144,7 @@ public class ExtendedServerTest extends HttpServerTestBase
         public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(200);
-            response.write(true, request.setHandling(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
+            response.write(true, request.accept(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
@@ -141,10 +141,11 @@ public class ExtendedServerTest extends HttpServerTestBase
     protected static class DispatchedAtHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setStatus(200);
-            response.write(true, request.accept(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
+            response.write(true, response.getCallback(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ExtendedServerTest.java
@@ -141,11 +141,10 @@ public class ExtendedServerTest extends HttpServerTestBase
     protected static class DispatchedAtHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(200);
-            response.write(true, request, BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
-            return true;
+            response.write(true, request.setHandling(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1299,18 +1300,18 @@ public class ForwardedRequestCustomizerTest
         private RequestTester requestTester;
 
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
+            Callback callback = request.setHandling();
             if (requestTester != null && requestTester.check(request, response))
             {
                 response.setStatus(200);
-                request.succeeded();
+                callback.succeeded();
             }
             else
             {
-                response.writeError(500, "failed", request);
+                response.writeError(500, "failed", callback);
             }
-            return true;
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -1300,9 +1300,10 @@ public class ForwardedRequestCustomizerTest
         private RequestTester requestTester;
 
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
-            Callback callback = request.accept();
+            Response response = request.accept();
+            Callback callback = response.getCallback();
             if (requestTester != null && requestTester.check(request, response))
             {
                 response.setStatus(200);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -1302,7 +1302,7 @@ public class ForwardedRequestCustomizerTest
         @Override
         public void handle(Request request, Response response) throws Exception
         {
-            Callback callback = request.setHandling();
+            Callback callback = request.accept();
             if (requestTester != null && requestTester.check(request, response))
             {
                 response.setStatus(200);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HandlerTest.java
@@ -262,7 +262,7 @@ public class HandlerTest
         c.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
             }
         });

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HandlerTest.java
@@ -262,9 +262,8 @@ public class HandlerTest
         c.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
-                return false;
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -393,7 +393,7 @@ public class HttpChannelTest
             {
                 response.setStatus(200);
                 response.setContentLength(10);
-                response.write(false, Callback.from(request.setHandling(), () ->
+                response.write(false, Callback.from(request.accept(), () ->
                 {
                     throw new Error("testing");
                 }));
@@ -428,7 +428,7 @@ public class HttpChannelTest
             @Override
             public void handle(Request request, Response response) throws Exception
             {
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("12345"));
+                response.write(true, request.accept(), BufferUtil.toBuffer("12345"));
             }
         };
         _server.setHandler(handler);
@@ -460,7 +460,7 @@ public class HttpChannelTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setContentLength(10);
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("12345"));
+                response.write(true, request.accept(), BufferUtil.toBuffer("12345"));
             }
         };
         _server.setHandler(handler);
@@ -492,7 +492,7 @@ public class HttpChannelTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setContentLength(10);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false, Callback.from(() -> response.write(true, callback)), BufferUtil.toBuffer("12345"));
             }
         };
@@ -524,7 +524,7 @@ public class HttpChannelTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setContentLength(5);
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("1234567890"));
+                response.write(true, request.accept(), BufferUtil.toBuffer("1234567890"));
             }
         };
         _server.setHandler(handler);
@@ -556,7 +556,7 @@ public class HttpChannelTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setContentLength(5);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("567890"))), BufferUtil.toBuffer("1234"));
             }
         };
@@ -624,7 +624,7 @@ public class HttpChannelTest
                 response.setStatus(200);
                 response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
                 response.setContentLength(5);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("12345"))));
             }
         };
@@ -668,7 +668,7 @@ public class HttpChannelTest
                 response.addHeader(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString());
                 response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
                 response.setContentLength(5);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("12345"))));
             }
         };
@@ -978,7 +978,7 @@ public class HttpChannelTest
                     }
                 };
                 request.demandContent(onContentAvailable);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 if (latch.await(30, TimeUnit.SECONDS))
                 {
                     response.setStatus(200);
@@ -1046,7 +1046,7 @@ public class HttpChannelTest
                 request.addErrorListener(t -> {});
                 request.addErrorListener(error::set);
                 request.addErrorListener(t -> {});
-                request.setHandling();
+                request.accept();
             }
         };
         _server.setHandler(handler);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
@@ -665,7 +665,7 @@ public class HttpConfigurationAuthorityOverrideTest
                     out.printf("LocalName=[%s]%n", request.getLocalAddr());
                     out.printf("LocalPort=[%s]%n", request.getLocalPort());
                     out.printf("HttpURI=[%s]%n", request.getHttpURI());
-                    response.write(true, request.setHandling(), stringWriter.getBuffer().toString());
+                    response.write(true, request.accept(), stringWriter.getBuffer().toString());
                 }
             }
         }
@@ -680,7 +680,7 @@ public class HttpConfigurationAuthorityOverrideTest
             {
                 response.setStatus(HttpStatus.MOVED_TEMPORARILY_302);
                 response.setHeader(HttpHeader.LOCATION, HttpURI.build(request.getHttpURI(), "/dump").toString());
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         }
     }
@@ -693,7 +693,7 @@ public class HttpConfigurationAuthorityOverrideTest
             if (request.getPath().startsWith("/error"))
             {
                 response.setContentType("text/plain; charset=utf-8");
-                response.write(true, request.setHandling(), "Generic Error Page.");
+                response.write(true, request.accept(), "Generic Error Page.");
             }
         }
     }
@@ -710,7 +710,7 @@ public class HttpConfigurationAuthorityOverrideTest
             if (scheme == null)
                 scheme = request.getConnectionMetaData().isSecure() ? "https" : "http";
             response.setHeader(HttpHeader.LOCATION, HttpURI.from(scheme, request.getConnectionMetaData().getServerAuthority(), "/error").toString());
-            response.write(true, request.setHandling());
+            response.write(true, request.accept());
         }
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
@@ -651,7 +651,7 @@ public class HttpConfigurationAuthorityOverrideTest
     private static class DumpHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             if (request.getPath().startsWith("/dump"))
             {
@@ -665,49 +665,43 @@ public class HttpConfigurationAuthorityOverrideTest
                     out.printf("LocalName=[%s]%n", request.getLocalAddr());
                     out.printf("LocalPort=[%s]%n", request.getLocalPort());
                     out.printf("HttpURI=[%s]%n", request.getHttpURI());
-                    response.write(true, request, stringWriter.getBuffer().toString());
+                    response.write(true, request.setHandling(), stringWriter.getBuffer().toString());
                 }
-                return true;
             }
-            return false;
         }
     }
 
     private static class RedirectHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             if (request.getPath().startsWith("/redirect"))
             {
                 response.setStatus(HttpStatus.MOVED_TEMPORARILY_302);
                 response.setHeader(HttpHeader.LOCATION, HttpURI.build(request.getHttpURI(), "/dump").toString());
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
-            return false;
         }
     }
 
     private static class ErrorMsgHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             if (request.getPath().startsWith("/error"))
             {
                 response.setContentType("text/plain; charset=utf-8");
-                response.write(true, request, "Generic Error Page.");
-                return true;
+                response.write(true, request.setHandling(), "Generic Error Page.");
             }
-            return false;
         }
     }
 
     public static class RedirectErrorHandler extends ErrorHandler
     {
         @Override
-        public boolean handle(Request request, Response response) throws IOException
+        public void handle(Request request, Response response) throws IOException
         {
             response.setHeader("X-Error-Status", Integer.toString(response.getStatus()));
             response.setHeader("X-Error-Message", String.valueOf(request.getAttribute(ErrorHandler.ERROR_MESSAGE)));
@@ -716,8 +710,7 @@ public class HttpConfigurationAuthorityOverrideTest
             if (scheme == null)
                 scheme = request.getConnectionMetaData().isSecure() ? "https" : "http";
             response.setHeader(HttpHeader.LOCATION, HttpURI.from(scheme, request.getConnectionMetaData().getServerAuthority(), "/error").toString());
-            response.write(true, request);
-            return true;
+            response.write(true, request.setHandling());
         }
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -859,11 +859,10 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 response.setStatus(200);
-                response.write(false, request);
-                return true;
+                response.write(false, request.setHandling());
             }
         });
         server.start();
@@ -1133,19 +1132,18 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
-
+                Callback callback = request.setHandling();
                 response.write(false,
-                    Callback.from(request::succeeded, t ->
+                    Callback.from(callback::succeeded, t ->
                     {
                         checkError.countDown();
-                        request.failed(t);
+                        callback.failed(t);
                     }),
                     BufferUtil.toBuffer("<html><h1>FOO</h1></html>"));
-                return true;
             }
         });
         server.start();
@@ -1184,19 +1182,19 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
 
+                Callback callback = request.setHandling();
                 response.write(false,
-                    Callback.from(request::succeeded, t ->
+                    Callback.from(callback::succeeded, t ->
                     {
                         checkError.countDown();
-                        request.failed(t);
+                        callback.failed(t);
                     }),
                     BufferUtil.toBuffer("<html><h1>FOO</h1></html>"));
-                return true;
             }
         });
         server.start();
@@ -1298,7 +1296,7 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 while (true)
                 {
@@ -1329,8 +1327,7 @@ public class HttpConnectionTest
                 long bytesIn = connection.getBytesIn();
                 assertThat(bytesIn, greaterThan(dataLength));
 
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -859,10 +859,11 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 response.setStatus(200);
-                response.write(false, request.accept());
+                response.write(false, response.getCallback());
             }
         });
         server.start();
@@ -1132,11 +1133,12 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
-                Callback callback = request.accept();
+                Callback callback = response.getCallback();
                 response.write(false,
                     Callback.from(callback::succeeded, t ->
                     {
@@ -1182,12 +1184,13 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
 
-                Callback callback = request.accept();
+                Callback callback = response.getCallback();
                 response.write(false,
                     Callback.from(callback::succeeded, t ->
                     {
@@ -1296,8 +1299,9 @@ public class HttpConnectionTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 while (true)
                 {
                     Content content = request.readContent();
@@ -1327,7 +1331,7 @@ public class HttpConnectionTest
                 long bytesIn = connection.getBytesIn();
                 assertThat(bytesIn, greaterThan(dataLength));
 
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -862,7 +862,7 @@ public class HttpConnectionTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setStatus(200);
-                response.write(false, request.setHandling());
+                response.write(false, request.accept());
             }
         });
         server.start();
@@ -1136,7 +1136,7 @@ public class HttpConnectionTest
             {
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false,
                     Callback.from(callback::succeeded, t ->
                     {
@@ -1187,7 +1187,7 @@ public class HttpConnectionTest
                 response.setHeader(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.setHeader("LongStr", longstr);
 
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 response.write(false,
                     Callback.from(callback::succeeded, t ->
                     {
@@ -1327,7 +1327,7 @@ public class HttpConnectionTest
                 long bytesIn = connection.getBytesIn();
                 assertThat(bytesIn, greaterThan(dataLength));
 
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -366,7 +366,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
 
                     if (content.isLast())
                     {
-                        request.setHandling().succeeded();
+                        request.accept().succeeded();
                         break;
                     }
                 }
@@ -1025,7 +1025,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             for (long t : times)
                 out.append(t).append(",");
 
-            response.write(true, request.setHandling(), BufferUtil.toBuffer(out.toString()));
+            response.write(true, request.accept(), BufferUtil.toBuffer(out.toString()));
         }
     }
 
@@ -1423,7 +1423,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
         public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(304);
-            response.write(false, request.setHandling(), BufferUtil.toBuffer("yuck"));
+            response.write(false, request.accept(), BufferUtil.toBuffer("yuck"));
         }
     }
 
@@ -1434,7 +1434,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
         {
             //don't read the input, just send something back
             response.setStatus(200);
-            request.setHandling().succeeded();
+            request.accept().succeeded();
         }
     }
 
@@ -1556,7 +1556,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
                 }
 
                 response.setStatus(200);
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
 
@@ -1640,9 +1640,9 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
                 }
 
                 @Override
-                public Callback setHandling()
+                public Callback accept()
                 {
-                    return new Callback.Nested(super.setHandling())
+                    return new Callback.Nested(super.accept())
                     {
                         @Override
                         public void succeeded()

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -95,14 +95,15 @@ public class HttpServerTestFixture
     protected static class OptionsHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             if (request.getMethod().equals("OPTIONS"))
                 response.setStatus(200);
             else
                 response.setStatus(500);
             response.setHeader("Allow", "GET");
-            request.accept().succeeded();
+            response.getCallback().succeeded();
         }
     }
 
@@ -123,9 +124,10 @@ public class HttpServerTestFixture
         }
 
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
-            response.writeError(code, message, request.accept());
+            Response response = request.accept();
+            response.writeError(code, message, response.getCallback());
         }
     }
 
@@ -144,8 +146,9 @@ public class HttpServerTestFixture
         }
 
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             long len = expected < 0 ? request.getContentLength() : expected;
             if (len < 0)
                 throw new IllegalStateException();
@@ -178,17 +181,18 @@ public class HttpServerTestFixture
             response.setStatus(200);
             String reply = "Read " + offset + "\r\n";
             response.setContentLength(reply.length());
-            response.write(true, request.accept(), BufferUtil.toBuffer(reply, StandardCharsets.ISO_8859_1));
+            response.write(true, response.getCallback(), BufferUtil.toBuffer(reply, StandardCharsets.ISO_8859_1));
         }
     }
 
     protected static class ReadHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setStatus(200);
-            Callback callback = request.accept();
+            Callback callback = response.getCallback();
             Content.readUtf8String(request, Promise.from(
                 s -> response.write(true, callback, "read %d%n" + s.length()),
                 t -> response.write(true, callback, String.format("caught %s%n", t))
@@ -199,8 +203,9 @@ public class HttpServerTestFixture
     protected static class DataHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setStatus(200);
 
             String input = Content.readUtf8String(request);
@@ -248,7 +253,7 @@ public class HttpServerTestFixture
                     }
                 }
             }
-            request.accept().succeeded();
+            response.getCallback().succeeded();
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -102,7 +102,7 @@ public class HttpServerTestFixture
             else
                 response.setStatus(500);
             response.setHeader("Allow", "GET");
-            request.setHandling().succeeded();
+            request.accept().succeeded();
         }
     }
 
@@ -125,7 +125,7 @@ public class HttpServerTestFixture
         @Override
         public void handle(Request request, Response response) throws Exception
         {
-            response.writeError(code, message, request.setHandling());
+            response.writeError(code, message, request.accept());
         }
     }
 
@@ -178,7 +178,7 @@ public class HttpServerTestFixture
             response.setStatus(200);
             String reply = "Read " + offset + "\r\n";
             response.setContentLength(reply.length());
-            response.write(true, request.setHandling(), BufferUtil.toBuffer(reply, StandardCharsets.ISO_8859_1));
+            response.write(true, request.accept(), BufferUtil.toBuffer(reply, StandardCharsets.ISO_8859_1));
         }
     }
 
@@ -188,7 +188,7 @@ public class HttpServerTestFixture
         public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(200);
-            Callback callback = request.setHandling();
+            Callback callback = request.accept();
             Content.readUtf8String(request, Promise.from(
                 s -> response.write(true, callback, "read %d%n" + s.length()),
                 t -> response.write(true, callback, String.format("caught %s%n", t))
@@ -248,7 +248,7 @@ public class HttpServerTestFixture
                     }
                 }
             }
-            request.setHandling().succeeded();
+            request.accept().succeeded();
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
@@ -82,8 +82,9 @@ public class ProxyCustomizerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
+                Response response = request.accept();
                 response.addHeader("preexisting.attribute", request.getAttribute("some.attribute").toString());
                 ArrayList<String> attributeNames = new ArrayList<>(request.getAttributeNames());
                 Collections.sort(attributeNames);
@@ -98,7 +99,7 @@ public class ProxyCustomizerTest
                 if (remoteAddress != null)
                     response.addHeader("proxyRemoteAddress", remoteAddress + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
 
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         };
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
@@ -98,7 +98,7 @@ public class ProxyCustomizerTest
                 if (remoteAddress != null)
                     response.addHeader("proxyRemoteAddress", remoteAddress + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
 
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         };
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java
@@ -82,10 +82,10 @@ public class ProxyCustomizerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response)
             {
                 response.addHeader("preexisting.attribute", request.getAttribute("some.attribute").toString());
-                ArrayList<String> attributeNames = new ArrayList(request.getAttributeNames());
+                ArrayList<String> attributeNames = new ArrayList<>(request.getAttributeNames());
                 Collections.sort(attributeNames);
                 response.addHeader("attributeNames", String.join(",", attributeNames));
 
@@ -93,13 +93,12 @@ public class ProxyCustomizerTest
                 response.addHeader("remoteAddress", request.getConnectionMetaData().getRemoteAddress().toString());
                 Object localAddress = request.getAttribute(ProxyCustomizer.LOCAL_ADDRESS_ATTRIBUTE_NAME);
                 if (localAddress != null)
-                    response.addHeader("proxyLocalAddress", localAddress.toString() + ":" + request.getAttribute(ProxyCustomizer.LOCAL_PORT_ATTRIBUTE_NAME));
+                    response.addHeader("proxyLocalAddress", localAddress + ":" + request.getAttribute(ProxyCustomizer.LOCAL_PORT_ATTRIBUTE_NAME));
                 Object remoteAddress = request.getAttribute(ProxyCustomizer.REMOTE_ADDRESS_ATTRIBUTE_NAME);
                 if (remoteAddress != null)
-                    response.addHeader("proxyRemoteAddress", remoteAddress.toString() + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
+                    response.addHeader("proxyRemoteAddress", remoteAddress + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
 
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         };
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.ProxyConnectionFactory.ProxyEndPoint;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -62,23 +63,22 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 SocketAddress addr = request.getConnectionMetaData().getRemoteAddress();
+                Callback callback = request.setHandling();
                 if (addr instanceof InetSocketAddress)
                 {
                     InetSocketAddress iAddr = (InetSocketAddress)addr;
                     if (iAddr.getHostString().equals(remoteAddr) && iAddr.getPort() == remotePort)
-                        request.succeeded();
+                        callback.succeeded();
                     else
-                        request.failed(new Throwable("wrong address"));
+                        callback.failed(new Throwable("wrong address"));
                 }
                 else
                 {
-                    request.failed(new Throwable("no inet address"));
+                    callback.failed(new Throwable("no inet address"));
                 }
-
-                return true;
             }
         });
 
@@ -133,15 +133,15 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
+                Callback callback = request.setHandling();
                 if (validateEndPoint(request) &&
                     remoteAddr.equals(request.getRemoteAddr()) &&
                     remotePort == request.getRemotePort())
-                    request.succeeded();
+                    callback.succeeded();
                 else
-                    request.failed(new Throwable());
-                return true;
+                    callback.failed(new Throwable());
             }
 
             private boolean validateEndPoint(Request request) 
@@ -232,10 +232,9 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
@@ -66,7 +66,7 @@ public class ProxyProtocolTest
             public void handle(Request request, Response response) throws Exception
             {
                 SocketAddress addr = request.getConnectionMetaData().getRemoteAddress();
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 if (addr instanceof InetSocketAddress)
                 {
                     InetSocketAddress iAddr = (InetSocketAddress)addr;
@@ -135,7 +135,7 @@ public class ProxyProtocolTest
             @Override
             public void handle(Request request, Response response) throws Exception
             {
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 if (validateEndPoint(request) &&
                     remoteAddr.equals(request.getRemoteAddr()) &&
                     remotePort == request.getRemotePort())
@@ -234,7 +234,7 @@ public class ProxyProtocolTest
             @Override
             public void handle(Request request, Response response) throws Exception
             {
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java
@@ -63,10 +63,11 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
                 SocketAddress addr = request.getConnectionMetaData().getRemoteAddress();
-                Callback callback = request.accept();
+                Response response = request.accept();
+                Callback callback = response.getCallback();
                 if (addr instanceof InetSocketAddress)
                 {
                     InetSocketAddress iAddr = (InetSocketAddress)addr;
@@ -133,9 +134,10 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
-                Callback callback = request.accept();
+                Response response = request.accept();
+                Callback callback = response.getCallback();
                 if (validateEndPoint(request) &&
                     remoteAddr.equals(request.getRemoteAddr()) &&
                     remotePort == request.getRemotePort())
@@ -232,9 +234,10 @@ public class ProxyProtocolTest
         start(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
-                request.accept().succeeded();
+                Response response = request.accept();
+                response.getCallback().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
@@ -80,8 +80,9 @@ public class SSLCloseTest
     private static class WriteHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setStatus(200);
             response.setHeader("test", "value");
 
@@ -93,7 +94,7 @@ public class SSLCloseTest
             data = data + data + data + data;
             byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
 
-            Callback callback = request.accept();
+            Callback callback = response.getCallback();
             response.write(false,
                 Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer(bytes)), callback::failed),
                 BufferUtil.toBuffer(bytes));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
@@ -80,7 +80,7 @@ public class SSLCloseTest
     private static class WriteHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(200);
             response.setHeader("test", "value");
@@ -93,10 +93,10 @@ public class SSLCloseTest
             data = data + data + data + data;
             byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
 
+            Callback callback = request.setHandling();
             response.write(false,
-                Callback.from(() -> response.write(true, request, BufferUtil.toBuffer(bytes)), request::failed),
+                Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer(bytes)), callback::failed),
                 BufferUtil.toBuffer(bytes));
-            return true;
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLCloseTest.java
@@ -93,7 +93,7 @@ public class SSLCloseTest
             data = data + data + data + data;
             byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
 
-            Callback callback = request.setHandling();
+            Callback callback = request.accept();
             response.write(false,
                 Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer(bytes)), callback::failed),
                 BufferUtil.toBuffer(bytes));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
@@ -355,7 +355,7 @@ public class SSLEngineTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             // System.err.println("HANDLE "+request.getRequestURI());
             SecureRequestCustomizer.SslSessionData sslData = (SecureRequestCustomizer.SslSessionData)
@@ -372,13 +372,12 @@ public class SSLEngineTest
                 {
                     buf[i] = (byte)('0' + (i % 10));
                 }
-                response.write(true, request, BufferUtil.toBuffer(buf));
+                response.write(true, request.setHandling(), BufferUtil.toBuffer(buf));
             }
             else
             {
-                response.write(true, request, BufferUtil.toBuffer(HELLO_WORLD));
+                response.write(true, request.setHandling(), BufferUtil.toBuffer(HELLO_WORLD));
             }
-            return true;
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
@@ -372,11 +372,11 @@ public class SSLEngineTest
                 {
                     buf[i] = (byte)('0' + (i % 10));
                 }
-                response.write(true, request.setHandling(), BufferUtil.toBuffer(buf));
+                response.write(true, request.accept(), BufferUtil.toBuffer(buf));
             }
             else
             {
-                response.write(true, request.setHandling(), BufferUtil.toBuffer(HELLO_WORLD));
+                response.write(true, request.accept(), BufferUtil.toBuffer(HELLO_WORLD));
             }
         }
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLEngineTest.java
@@ -355,8 +355,9 @@ public class SSLEngineTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             // System.err.println("HANDLE "+request.getRequestURI());
             SecureRequestCustomizer.SslSessionData sslData = (SecureRequestCustomizer.SslSessionData)
                 request.getAttribute("org.eclipse.jetty.servlet.request.ssl_session_data");
@@ -372,11 +373,11 @@ public class SSLEngineTest
                 {
                     buf[i] = (byte)('0' + (i % 10));
                 }
-                response.write(true, request.accept(), BufferUtil.toBuffer(buf));
+                response.write(true, response.getCallback(), BufferUtil.toBuffer(buf));
             }
             else
             {
-                response.write(true, request.accept(), BufferUtil.toBuffer(HELLO_WORLD));
+                response.write(true, response.getCallback(), BufferUtil.toBuffer(HELLO_WORLD));
             }
         }
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
@@ -76,7 +76,7 @@ public class SSLReadEOFAfterResponseTest
                         c.release();
                     }
                     if (c == Content.EOF)
-                        request.setHandling().failed(new IllegalStateException());
+                        request.accept().failed(new IllegalStateException());
                 }
 
                 // Second: write the response.
@@ -93,7 +93,7 @@ public class SSLReadEOFAfterResponseTest
                 Content content = request.readContent();
                 if (!content.isLast())
                     throw new IllegalStateException();
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
@@ -54,7 +54,7 @@ public class SSLReadEOFAfterResponseTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 // First: read the whole content exactly
                 int length = bytes.length;
@@ -76,7 +76,7 @@ public class SSLReadEOFAfterResponseTest
                         c.release();
                     }
                     if (c == Content.EOF)
-                        request.failed(new IllegalStateException());
+                        request.setHandling().failed(new IllegalStateException());
                 }
 
                 // Second: write the response.
@@ -93,8 +93,7 @@ public class SSLReadEOFAfterResponseTest
                 Content content = request.readContent();
                 if (!content.isLast())
                     throw new IllegalStateException();
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLReadEOFAfterResponseTest.java
@@ -54,8 +54,9 @@ public class SSLReadEOFAfterResponseTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 // First: read the whole content exactly
                 int length = bytes.length;
                 while (length > 0)
@@ -76,7 +77,7 @@ public class SSLReadEOFAfterResponseTest
                         c.release();
                     }
                     if (c == Content.EOF)
-                        request.accept().failed(new IllegalStateException());
+                        response.getCallback().failed(new IllegalStateException());
                 }
 
                 // Second: write the response.
@@ -93,7 +94,7 @@ public class SSLReadEOFAfterResponseTest
                 Content content = request.readContent();
                 if (!content.isLast())
                     throw new IllegalStateException();
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
@@ -322,10 +322,11 @@ public class SSLSelectChannelConnectorLoadTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request.accept(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
+            response.write(true, response.getCallback(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
@@ -325,7 +325,7 @@ public class SSLSelectChannelConnectorLoadTest
         public void handle(Request request, Response response) throws Exception
         {
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request.setHandling(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
+            response.write(true, request.accept(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SSLSelectChannelConnectorLoadTest.java
@@ -322,11 +322,10 @@ public class SSLSelectChannelConnectorLoadTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request, BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
-            return true;
+            response.write(true, request.setHandling(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
@@ -44,9 +44,10 @@ public class ServerConnectorAcceptTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
-                request.accept().succeeded();
+                Response response = request.accept();
+                response.getCallback().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
@@ -44,10 +44,9 @@ public class ServerConnectorAcceptTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response)
             {
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorAcceptTest.java
@@ -46,7 +46,7 @@ public class ServerConnectorAcceptTest
             @Override
             public void handle(Request request, Response response)
             {
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
         server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
@@ -242,7 +242,7 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
             out.append("key_size='").append(data == null ? "" : data.getKeySize()).append("'").append('\n');
             out.append("ssl_session_id='").append(data == null ? "" : data.getId()).append("'").append('\n');
             out.append("ssl_session='").append(session).append("'").append('\n');
-            response.write(true, request.setHandling(), out.toString());
+            response.write(true, request.accept(), out.toString());
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
@@ -226,8 +226,9 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
     public static class SecureRequestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setStatus(200);
             StringBuilder out = new StringBuilder();
             SSLSession session = (SSLSession)request.getAttribute("SSL_SESSION");
@@ -242,7 +243,7 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
             out.append("key_size='").append(data == null ? "" : data.getKeySize()).append("'").append('\n');
             out.append("ssl_session_id='").append(data == null ? "" : data.getId()).append("'").append('\n');
             out.append("ssl_session='").append(session).append("'").append('\n');
-            response.write(true, request.accept(), out.toString());
+            response.write(true, response.getCallback(), out.toString());
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorSslServerTest.java
@@ -226,7 +226,7 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
     public static class SecureRequestHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             response.setStatus(200);
             StringBuilder out = new StringBuilder();
@@ -242,8 +242,7 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
             out.append("key_size='").append(data == null ? "" : data.getKeySize()).append("'").append('\n');
             out.append("ssl_session_id='").append(data == null ? "" : data.getId()).append("'").append('\n');
             out.append("ssl_session='").append(session).append("'").append('\n');
-            response.write(true, request, out.toString());
-            return true;
+            response.write(true, request.setHandling(), out.toString());
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
@@ -64,7 +64,7 @@ public class ServerConnectorTest
     public static class ReuseInfoHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             response.setContentType("text/plain");
 
@@ -92,8 +92,7 @@ public class ServerConnectorTest
             }
             out.printf("socket.getReuseAddress() = %b%n", socket.getReuseAddress());
             out.flush();
-            response.write(true, request, BufferUtil.toBuffer(buffer.toByteArray()));
-            return true;
+            response.write(true, request.setHandling(), BufferUtil.toBuffer(buffer.toByteArray()));
         }
     }
 
@@ -242,10 +241,9 @@ public class ServerConnectorTest
             server.setHandler(new Handler.Abstract()
             {
                 @Override
-                public boolean handle(Request request, Response response) throws Exception
+                public void handle(Request request, Response response)
                 {
-                    request.succeeded();
-                    return true;
+                    request.setHandling().succeeded();
                 }
             });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
@@ -92,7 +92,7 @@ public class ServerConnectorTest
             }
             out.printf("socket.getReuseAddress() = %b%n", socket.getReuseAddress());
             out.flush();
-            response.write(true, request.setHandling(), BufferUtil.toBuffer(buffer.toByteArray()));
+            response.write(true, request.accept(), BufferUtil.toBuffer(buffer.toByteArray()));
         }
     }
 
@@ -243,7 +243,7 @@ public class ServerConnectorTest
                 @Override
                 public void handle(Request request, Response response)
                 {
-                    request.setHandling().succeeded();
+                    request.accept().succeeded();
                 }
             });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ServerConnectorTest.java
@@ -64,8 +64,9 @@ public class ServerConnectorTest
     public static class ReuseInfoHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             response.setContentType("text/plain");
 
             EndPoint endPoint = request.getConnectionMetaData().getConnection().getEndPoint();
@@ -92,7 +93,7 @@ public class ServerConnectorTest
             }
             out.printf("socket.getReuseAddress() = %b%n", socket.getReuseAddress());
             out.flush();
-            response.write(true, request.accept(), BufferUtil.toBuffer(buffer.toByteArray()));
+            response.write(true, response.getCallback(), BufferUtil.toBuffer(buffer.toByteArray()));
         }
     }
 
@@ -241,9 +242,10 @@ public class ServerConnectorTest
             server.setHandler(new Handler.Abstract()
             {
                 @Override
-                public void handle(Request request, Response response)
+                public void handle(Request request)
                 {
-                    request.accept().succeeded();
+                    Response response = request.accept();
+                    response.getCallback().succeeded();
                 }
             });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
@@ -68,11 +68,12 @@ public class SlowClientsTest
             server.setHandler(new Handler.Abstract()
             {
                 @Override
-                public void handle(Request request, Response response) throws Exception
+                public void handle(Request request) throws Exception
                 {
                     LOG.info("SERVING {}", request);
                     // Write some big content.
-                    Callback callback = request.accept();
+                    Response response = request.accept();
+                    Callback callback = response.getCallback();
                     response.write(true, new Callback()
                         {
                             @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
@@ -68,27 +68,27 @@ public class SlowClientsTest
             server.setHandler(new Handler.Abstract()
             {
                 @Override
-                public boolean handle(Request request, Response response) throws Exception
+                public void handle(Request request, Response response) throws Exception
                 {
                     LOG.info("SERVING {}", request);
                     // Write some big content.
+                    Callback callback = request.setHandling();
                     response.write(true, new Callback()
                         {
                             @Override
                             public void succeeded()
                             {
-                                request.succeeded();
+                                callback.succeeded();
                                 LOG.info("SERVED {}", request);
                             }
 
                             @Override
                             public void failed(Throwable x)
                             {
-                                request.failed(x);
+                                callback.failed(x);
                             }
                         },
                         BufferUtil.toBuffer(new byte[contentLength]));
-                    return true;
                 }
             });
             server.start();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SlowClientsTest.java
@@ -72,7 +72,7 @@ public class SlowClientsTest
                 {
                     LOG.info("SERVING {}", request);
                     // Write some big content.
-                    Callback callback = request.setHandling();
+                    Callback callback = request.accept();
                     response.write(true, new Callback()
                         {
                             @Override

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
@@ -115,12 +115,12 @@ public class SniSslConnectionFactoryTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response)
             {
                 response.setStatus(200);
                 response.setHeader("X-URL", request.getHttpURI().toString());
                 response.setHeader("X-HOST", request.getServerName());
-                return true;
+                request.setHandling().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
@@ -120,7 +120,7 @@ public class SniSslConnectionFactoryTest
                 response.setStatus(200);
                 response.setHeader("X-URL", request.getHttpURI().toString());
                 response.setHeader("X-HOST", request.getServerName());
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SniSslConnectionFactoryTest.java
@@ -115,12 +115,13 @@ public class SniSslConnectionFactoryTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response)
+            public void handle(Request request)
             {
+                Response response = request.accept();
                 response.setStatus(200);
                 response.setHeader("X-URL", request.getHttpURI().toString());
                 response.setHeader("X-HOST", request.getServerName());
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
@@ -84,11 +84,10 @@ public class SslConnectionFactoryTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 response.setStatus(200);
-                response.write(true, request, BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
-                return true;
+                response.write(true, request.setHandling(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
@@ -87,7 +87,7 @@ public class SslConnectionFactoryTest
             public void handle(Request request, Response response) throws Exception
             {
                 response.setStatus(200);
-                response.write(true, request.setHandling(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
+                response.write(true, request.accept(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslConnectionFactoryTest.java
@@ -84,10 +84,11 @@ public class SslConnectionFactoryTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
+                Response response = request.accept();
                 response.setStatus(200);
-                response.write(true, request.accept(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
+                response.write(true, response.getCallback(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
             }
         });
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
@@ -244,7 +244,7 @@ public class SslContextFactoryReloadTest
             else
             {
                 response.setContentLength(0);
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         }
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
@@ -237,14 +237,15 @@ public class SslContextFactoryReloadTest
     private static class TestHandler extends EchoHandler
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
             if (HttpMethod.POST.is(request.getMethod()))
-                super.handle(request, response);
+                super.handle(request);
             else
             {
+                Response response = request.accept();
                 response.setContentLength(0);
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         }
     }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslContextFactoryReloadTest.java
@@ -237,13 +237,15 @@ public class SslContextFactoryReloadTest
     private static class TestHandler extends EchoHandler
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             if (HttpMethod.POST.is(request.getMethod()))
-                return super.handle(request, response);
-            response.setContentLength(0);
-            request.succeeded();
-            return true;
+                super.handle(request, response);
+            else
+            {
+                response.setContentLength(0);
+                request.setHandling().succeeded();
+            }
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
@@ -142,7 +142,7 @@ public class SslUploadTest
         public void handle(Request request, Response response) throws Exception
         {
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request.setHandling(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
+            response.write(true, request.accept(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
@@ -139,10 +139,11 @@ public class SslUploadTest
     private static class EmptyHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request, Response response) throws Exception
+        public void handle(Request request) throws Exception
         {
+            Response response = request.accept();
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request.accept(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
+            response.write(true, response.getCallback(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/SslUploadTest.java
@@ -139,11 +139,10 @@ public class SslUploadTest
     private static class EmptyHandler extends Handler.Abstract
     {
         @Override
-        public boolean handle(Request request, Response response) throws Exception
+        public void handle(Request request, Response response) throws Exception
         {
             ByteBuffer input = Content.readBytes(request);
-            response.write(true, request, BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
-            return true;
+            response.write(true, request.setHandling(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -160,7 +160,7 @@ public class ContextHandlerTest
             {
                 assertInContext(request);
                 response.setStatus(200);
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         };
         _contextHandler.setHandler(handler);
@@ -191,7 +191,7 @@ public class ContextHandlerTest
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
 
-                Callback callback = request.setHandling();
+                Callback callback = request.accept();
                 request.demandContent(() ->
                 {
                     assertInContext(request);
@@ -274,7 +274,7 @@ public class ContextHandlerTest
                 assertTrue(content.isLast());
                 content.release();
                 response.setStatus(200);
-                request.setHandling().succeeded();
+                request.accept().succeeded();
             }
         };
         _contextHandler.setHandler(handler);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -160,11 +160,12 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
                 assertInContext(request);
+                Response response = request.accept();
                 response.setStatus(200);
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         };
         _contextHandler.setHandler(handler);
@@ -191,11 +192,11 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request)
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
-
-                Callback callback = request.accept();
+                Response response = request.accept();
+                Callback callback = response.getCallback();
                 request.demandContent(() ->
                 {
                     assertInContext(request);
@@ -259,9 +260,11 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
+
+                Response response = request.accept();
 
                 CountDownLatch latch = new CountDownLatch(1);
                 request.demandContent(() ->
@@ -278,7 +281,7 @@ public class ContextHandlerTest
                 assertTrue(content.isLast());
                 content.release();
                 response.setStatus(200);
-                request.accept().succeeded();
+                response.getCallback().succeeded();
             }
         };
         _contextHandler.setHandler(handler);
@@ -375,7 +378,7 @@ public class ContextHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request, Response response) throws Exception
+            public void handle(Request request) throws Exception
             {
                 request.accept();
                 throw new RuntimeException("Testing");

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -156,12 +156,11 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 assertInContext(request);
                 response.setStatus(200);
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         };
         _contextHandler.setHandler(handler);
@@ -188,10 +187,11 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
 
+                Callback callback = request.setHandling();
                 request.demandContent(() ->
                 {
                     assertInContext(request);
@@ -204,14 +204,13 @@ public class ContextHandlerTest
                         {
                             content.release();
                             assertInContext(request);
-                            request.succeeded();
+                            callback.succeeded();
                         },
                         t ->
                         {
                             throw new IllegalStateException();
                         }), content.getByteBuffer());
                 });
-                return true;
             }
         };
         _contextHandler.setHandler(handler);
@@ -256,7 +255,7 @@ public class ContextHandlerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response) throws Exception
+            public void handle(Request request, Response response) throws Exception
             {
                 request.addCompletionListener(Callback.from(() -> assertInContext(request)));
 
@@ -275,8 +274,7 @@ public class ContextHandlerTest
                 assertTrue(content.isLast());
                 content.release();
                 response.setStatus(200);
-                request.succeeded();
-                return true;
+                request.setHandling().succeeded();
             }
         };
         _contextHandler.setHandler(handler);

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
@@ -71,7 +71,7 @@ public class DumpHandler extends Handler.Abstract
         if (Boolean.parseBoolean(params.getValue("empty")))
         {
             response.setStatus(200);
-            request.setHandling().succeeded();
+            request.accept().succeeded();
             return;
         }
 
@@ -101,7 +101,7 @@ public class DumpHandler extends Handler.Abstract
 
                 if (content instanceof Content.Error)
                 {
-                    request.setHandling().failed(((Content.Error)content).getCause());
+                    request.accept().failed(((Content.Error)content).getCause());
                     return;
                 }
 
@@ -132,7 +132,7 @@ public class DumpHandler extends Handler.Abstract
         if (params.getValue("error") != null)
         {
             response.setStatus(Integer.parseInt(params.getValue("error")));
-            request.setHandling().succeeded();
+            request.accept().succeeded();
             return;
         }
 
@@ -201,6 +201,6 @@ public class DumpHandler extends Handler.Abstract
             response.write(true, blocker, BufferUtil.toBuffer(padding.getBytes(StandardCharsets.ISO_8859_1)));
         }
 
-        request.setHandling().succeeded();
+        request.accept().succeeded();
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
@@ -51,8 +51,9 @@ public class DumpHandler extends Handler.Abstract
     }
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
+        Response response = request.accept();
         if (LOG.isDebugEnabled())
             LOG.debug("dump {}", request);
         HttpURI httpURI = request.getHttpURI();
@@ -71,7 +72,7 @@ public class DumpHandler extends Handler.Abstract
         if (Boolean.parseBoolean(params.getValue("empty")))
         {
             response.setStatus(200);
-            request.accept().succeeded();
+            response.getCallback().succeeded();
             return;
         }
 
@@ -101,7 +102,7 @@ public class DumpHandler extends Handler.Abstract
 
                 if (content instanceof Content.Error)
                 {
-                    request.accept().failed(((Content.Error)content).getCause());
+                    response.getCallback().failed(((Content.Error)content).getCause());
                     return;
                 }
 
@@ -132,7 +133,7 @@ public class DumpHandler extends Handler.Abstract
         if (params.getValue("error") != null)
         {
             response.setStatus(Integer.parseInt(params.getValue("error")));
-            request.accept().succeeded();
+            response.getCallback().succeeded();
             return;
         }
 
@@ -201,6 +202,6 @@ public class DumpHandler extends Handler.Abstract
             response.write(true, blocker, BufferUtil.toBuffer(padding.getBytes(StandardCharsets.ISO_8859_1)));
         }
 
-        request.accept().succeeded();
+        response.getCallback().succeeded();
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
@@ -41,7 +41,7 @@ public class EchoHandler extends Handler.Abstract
             response.setContentLength(contentLength);
         if (request.getHeaders().contains(HttpHeader.TRAILER))
             response.getTrailers();
-        new Echo(request, response, request.setHandling()).iterate();
+        new Echo(request, response, request.accept()).iterate();
     }
 
     static class Echo extends IteratingCallback

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
@@ -30,7 +30,7 @@ import org.eclipse.jetty.util.StringUtil;
 public class EchoHandler extends Handler.Abstract
 {
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         response.setStatus(200);
         String contentType = request.getHeaders().get(HttpHeader.CONTENT_TYPE);
@@ -41,19 +41,20 @@ public class EchoHandler extends Handler.Abstract
             response.setContentLength(contentLength);
         if (request.getHeaders().contains(HttpHeader.TRAILER))
             response.getTrailers();
-        new Echo(request, response).iterate();
-        return true;
+        new Echo(request, response, request.setHandling()).iterate();
     }
 
     static class Echo extends IteratingCallback
     {
         private final Request _request;
         private final Response _response;
+        private final Callback _callback;
 
-        Echo(Request request, Response response)
+        Echo(Request request, Response response, Callback callback)
         {
             _request = request;
             _response = response;
+            _callback = callback;
         }
 
         @Override
@@ -89,13 +90,13 @@ public class EchoHandler extends Handler.Abstract
         @Override
         protected void onCompleteSuccess()
         {
-            _request.succeeded();
+            _callback.succeeded();
         }
 
         @Override
         protected void onCompleteFailure(Throwable cause)
         {
-            _request.failed(cause);
+            _callback.failed(cause);
         }
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
@@ -30,8 +30,9 @@ import org.eclipse.jetty.util.StringUtil;
 public class EchoHandler extends Handler.Abstract
 {
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
+        Response response = request.accept();
         response.setStatus(200);
         String contentType = request.getHeaders().get(HttpHeader.CONTENT_TYPE);
         if (StringUtil.isNotBlank(contentType))
@@ -41,7 +42,7 @@ public class EchoHandler extends Handler.Abstract
             response.setContentLength(contentLength);
         if (request.getHeaders().contains(HttpHeader.TRAILER))
             response.getTrailers();
-        new Echo(request, response, request.accept()).iterate();
+        new Echo(request, response, response.getCallback()).iterate();
     }
 
     static class Echo extends IteratingCallback

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
@@ -52,12 +52,11 @@ public class HelloHandler extends Handler.Abstract
     }
 
     @Override
-    public boolean handle(Request request, Response response) throws Exception
+    public void handle(Request request, Response response) throws Exception
     {
         response.setStatus(200);
         response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
         response.setContentLength(_byteBuffer.remaining());
-        response.write(true, request, _byteBuffer.slice());
-        return true;
+        response.write(true, request.setHandling(), _byteBuffer.slice());
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
@@ -57,6 +57,6 @@ public class HelloHandler extends Handler.Abstract
         response.setStatus(200);
         response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
         response.setContentLength(_byteBuffer.remaining());
-        response.write(true, request.setHandling(), _byteBuffer.slice());
+        response.write(true, request.accept(), _byteBuffer.slice());
     }
 }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HelloHandler.java
@@ -52,11 +52,12 @@ public class HelloHandler extends Handler.Abstract
     }
 
     @Override
-    public void handle(Request request, Response response) throws Exception
+    public void handle(Request request) throws Exception
     {
+        Response response = request.accept();
         response.setStatus(200);
         response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
         response.setContentLength(_byteBuffer.remaining());
-        response.write(true, request.accept(), _byteBuffer.slice());
+        response.write(true, response.getCallback(), _byteBuffer.slice());
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
@@ -147,6 +147,7 @@ public class SerializedInvoker
                 }
                 catch (Throwable t)
                 {
+                    t.printStackTrace();
                     onError(link._task, t);
                 }
                 link = link.next();


### PR DESCRIPTION
This is another alternative fix for #7424 that extends #7437 so that if the request is not accepted then:
 + request content cannot be read
 + the response can't be seen (and even if it could be, then content could not be written)
 + the callback cannot be seen and thus not succeeded nor failed.

A request can only be accepted once, so that if two handlers try to accept only 1 will succeed.  Furthermore, as the response is not available until the request is accepted, this prevents concurrent threads writing to the response, as only one will succeed in accepting the request.   Whilst on its own, it does not fully support async acceptance, there is a path to fully async acceptance if that proves necessary. This gives very safe handler usage, as bad states are simply prevented, by hiding the response and callback until the request is accepted.

The main changes can be summarized as:
```java
public interface Request 
{
    /**
     * @return The response instance or null if the request has already been accepted.
     */
    Response accept();
    // ...
}

public interface Handler
{
    void handle(Request request) throws Exception;
    // ...
}
```

This allows for simple handlers like:
```java
public class HelloHandler extends Handler.Abstract
{
    @Override
    public void handle(Request request) throws Exception
    {
        Response response = request.accept();
        response.setStatus(200);
        response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
        response.write(true, response.getCallback(), BufferUtil.toBuffer("Hello World!"));
    }
}
```
Handlers can wrap requests as they always have done.  If they wish to wrap the response, they need to wrap the request and intercept the accept method.  However, this gives the benefit that the response is only wrapped if some nested handler accepts:
```java

public class GzipHandler extends Handler.Wrapper
{
    @Override
    public void handle(Request request) throws Exception
    {
        if (!request.getHeaders().contains(ACCEPT_GZIP))
        {
            super.handle(request);
            return;
        }

        HttpFields updated = HttpFields.from(request.getHeaders(), f ->
        {
            if (f.getHeader() != null)
            {
                if (CONTENT_ENCODING_GZIP.equals(f) || f.getHeader().equals(HttpHeader.CONTENT_LENGTH))
                    return null;
            }
            return f;
        });

        // wrap and handle request
        super.handle(
            new Request.Wrapper(request)
            {
                @Override
                public HttpFields getHeaders()
                {
                    return updated;
                }

                @Override
                public long getContentLength()
                {
                    return -1;
                }

                @Override
                public Content readContent()
                {
                    // TODO inflate data
                    return super.readContent();
                }

                @Override
                public Response accept()
                {
                    Response response = super.accept();
                    if (response != null)
                    {
                        return new Response.Wrapper(request, request.accept())
                        {
                            @Override
                            public void write(boolean last, Callback callback, ByteBuffer... content)
                            {
                                // TODO deflate data
                                super.write(last, callback, content);
                            }
                        };
                    }
                    return null;
                }
            }
        );
    }
}
```

This also allows atomic handling of exceptions that switch on if the request has been accepted or not, so rather than the anti pattern:
```java
      if (!request.isAccepted())
      {
          Response response = request.accept();
          response.setStatus(404);
          // ...
      }
```
We can do the atomic:
```java
      Response response = request.accept();
      if (response != null)
      {
          response.setStatus(404);
          // ...
      }
```


Finally, this is not fully asynchronous, but even in this form, you could concurrently call multiple handlers and only the first to accept it would be able to generate a response and complete the callback.  However, there is currently no mechanism to be notified of rejection, so it is not possible to know how long to wait before issuing a 404.   However, if we ever needed to go fully async, we could add the following method:

```java
public interface Request 
{
    Function<Boolean, Response> getAcceptor();
    // ...
}
```
A handler that has called `getAcceptor()` has indicated that it will eventually call the returned function with true/false to accept/reject the request.  If it passes true and no other handler has already accepted, then it gets the response to proceed with.  This could work in parallel with other simple handlers just calling the `accept()` method, and only a few classes would need to be modified to know if there were any outstanding Acceptors and thus to wait for a accept/reject before proceeding.








