### PR TITLE
#7461 Fix flakey ConnectionPoolTest.testQueuedRequestsDontOpenTooManyConnections: 

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -77,11 +77,6 @@ public class ConnectionPoolTest
         return Stream.of(DUPLEX, MULTIPLEX, RANDOM, DUPLEX_MAX_DURATION, ROUND_ROBIN);
     }
 
-    public static Stream<ConnectionPoolFactory> poolsNoMaxDuration()
-    {
-        return Stream.of(DUPLEX, MULTIPLEX, RANDOM, ROUND_ROBIN);
-    }
-
     public static Stream<ConnectionPoolFactory> poolsNoRoundRobin()
     {
         return Stream.of(DUPLEX, MULTIPLEX, RANDOM, DUPLEX_MAX_DURATION);
@@ -381,8 +376,7 @@ public class ConnectionPoolTest
     }
 
     @ParameterizedTest
-    // Connection pool aggressively closes expired connections upon release, which interferes with this test's assertion.
-    @MethodSource("poolsNoMaxDuration")
+    @MethodSource("pools")
     public void testConcurrentRequestsAllBlockedOnServerWithLargeConnectionPool(ConnectionPoolFactory factory) throws Exception
     {
         int count = 50;
@@ -390,8 +384,7 @@ public class ConnectionPoolTest
     }
 
     @ParameterizedTest
-    // Connection pool aggressively closes expired connections upon release, which interferes with this test's assertion.
-    @MethodSource("poolsNoMaxDuration")
+    @MethodSource("pools")
     public void testConcurrentRequestsAllBlockedOnServerWithExactConnectionPool(ConnectionPoolFactory factory) throws Exception
     {
         int count = 50;
@@ -454,9 +447,13 @@ public class ConnectionPoolTest
         assertTrue(latch.await(5, TimeUnit.SECONDS), "server requests " + barrier.getNumberWaiting() + "<" + count + " - client: " + client.dump());
         List<Destination> destinations = client.getDestinations();
         assertEquals(1, destinations.size());
-        HttpDestination destination = (HttpDestination)destinations.get(0);
-        AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
-        assertThat(connectionPool.getConnectionCount(), Matchers.greaterThanOrEqualTo(count));
+        // The max duration connection pool aggressively closes expired connections upon release, which interferes with this assertion.
+        if (DUPLEX_MAX_DURATION != factory)
+        {
+            HttpDestination destination = (HttpDestination)destinations.get(0);
+            AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
+            assertThat(connectionPool.getConnectionCount(), Matchers.greaterThanOrEqualTo(count));
+        }
     }
 
     @Test
@@ -593,8 +590,17 @@ public class ConnectionPoolTest
         AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
 
         assertEquals(0, connectionPool.getActiveConnectionCount());
-        assertEquals(1, connectionPool.getIdleConnectionCount());
-        assertEquals(1, connectionPool.getConnectionCount());
+        if (DUPLEX_MAX_DURATION == factory)
+        {
+            // The connections can expire upon release.
+            assertThat(connectionPool.getIdleConnectionCount(), lessThanOrEqualTo(1));
+            assertThat(connectionPool.getConnectionCount(), lessThanOrEqualTo(1));
+        }
+        else
+        {
+            assertThat(connectionPool.getIdleConnectionCount(), is(1));
+            assertThat(connectionPool.getConnectionCount(), is(1));
+        }
 
         // Send second request, max usage count will be reached,
         // the only connection must be closed.
@@ -630,7 +636,10 @@ public class ConnectionPoolTest
         // Trigger the creation of a destination, that will create the connection pool.
         HttpDestination destination = client.resolveDestination(new Origin("http", "localhost", connector.getLocalPort()));
         AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
-        assertEquals(1, connectionPool.getConnectionCount());
+        if (DUPLEX_MAX_DURATION == factory)
+            assertThat(connectionPool.getConnectionCount(), lessThanOrEqualTo(1)); // The connections can expire upon release.
+        else
+            assertThat(connectionPool.getConnectionCount(), is(1));
 
         // Wait for the pre-created connections to idle timeout.
         Thread.sleep(idleTimeout + idleTimeout / 2);

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -54,6 +54,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -316,7 +318,10 @@ public class ConnectionPoolTest
         assertEquals(1, destinations.size());
         HttpDestination destination = (HttpDestination)destinations.get(0);
         AbstractConnectionPool connectionPool = (AbstractConnectionPool)destination.getConnectionPool();
-        assertEquals(2, connectionPool.getConnectionCount());
+        if (DUPLEX_MAX_DURATION == factory)
+            assertThat(connectionPool.getConnectionCount(), lessThanOrEqualTo(2)); // The connections can expire upon release.
+        else
+            assertThat(connectionPool.getConnectionCount(), is(2));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Use less strict assertion for expiring pool to account for potential expirations. Since an expiration check is done by the pool every time a connection is released, it is entirely possible (and legal) that a bad scheduling would close some connections; hence the assertion must be relaxed to account for this in the expiring pool case.

Fixes #7461.