### PR TITLE
Fixes #7524 - Missing package in JmxConfiguration

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/JmxConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/JmxConfiguration.java
@@ -32,7 +32,7 @@ public class JmxConfiguration extends AbstractConfiguration
     public JmxConfiguration()
     {
         addDependents(WebXmlConfiguration.class, MetaInfConfiguration.class, WebInfConfiguration.class);
-        protectAndExpose("org.eclipse.jetty.jmx.");
+        protectAndExpose("org.eclipse.jetty.util.annotation", "org.eclipse.jetty.jmx.");
     }
 
     @Override


### PR DESCRIPTION
Also protectAndExpose "org.eclipse.jetty.util.annotation" to make JMX annotations loaded by the server available to web applications.
This allows the server JMX mechanism (MBeanContainer) to work on web application classes too.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>