### PR TITLE
Fixes #7523 - Typo in AnnotationConfiguration

### DIFF
--- a/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
+++ b/jetty-annotations/src/main/java/org/eclipse/jetty/annotations/AnnotationConfiguration.java
@@ -97,7 +97,6 @@ public class AnnotationConfiguration extends AbstractConfiguration
     {
         addDependencies(WebXmlConfiguration.class, MetaInfConfiguration.class, FragmentConfiguration.class, PlusConfiguration.class);
         addDependents(JettyWebXmlConfiguration.class);
-        protectAndExpose("org.eclipse.jetty.util.annotations.");
         hide("org.objectweb.asm.");
     }
 


### PR DESCRIPTION
Removed protectAndExpose() call because org.eclipse.jetty.util.annotation has been moved to JmxConfiguration,
and there is no need to expose org.eclipse.jetty.annotations.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>