### PR TITLE
Issue #7513 Move jmx annotation to PropertiesConfigurationManager.getFile

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/PropertiesConfigurationManager.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/PropertiesConfigurationManager.java
@@ -57,7 +57,6 @@ public class PropertiesConfigurationManager implements ConfigurationManager, Dum
         this(null);
     }
 
-    @ManagedAttribute("A file or URL of properties")
     public void setFile(String resource) throws IOException
     {
         _properties = resource;
@@ -65,6 +64,7 @@ public class PropertiesConfigurationManager implements ConfigurationManager, Dum
         loadProperties(_properties);
     }
 
+    @ManagedAttribute("A file or URL of properties")
     public String getFile()
     {
         return _properties;


### PR DESCRIPTION
Closes #7513

The `PropertiesConfigurationManager` class had a jmx attribute annotation on `setFile` method instead of `getFile` method.