### PR TITLE
 #7529 upgrade quiche native lib to version 0.11.0.1 to work on less recent linux libc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jboss-threads.version>3.1.0.Final</jboss-threads.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
-    <jetty-quiche-native.version>0.11.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.11.0b</jetty-quiche-native.version>
     <jetty.servlet.api.version>4.0.6</jetty.servlet.api.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty.test.version>5.9</jetty.test.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jboss-threads.version>3.1.0.Final</jboss-threads.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
-    <jetty-quiche-native.version>0.11.0b</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.11.0.1</jetty-quiche-native.version>
     <jetty.servlet.api.version>4.0.6</jetty.servlet.api.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty.test.version>5.9</jetty.test.version>


### PR DESCRIPTION
The previous Linux native build was made against a too recent version of libc which fails to load on less recent systems.