### PR TITLE
Bump slf4j to 2.0.0-alpha6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>3.4.1</plexus-utils.version>
-    <slf4j.version>2.0.0-alpha5</slf4j.version>
+    <slf4j.version>2.0.0-alpha6</slf4j.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>


### PR DESCRIPTION
> SLF4J 2.0.x series requires Java 8. It builds upon the 1.8.x series and adds a backward-compatible fluent logging api. By backward-compatible, we mean that existing logging frameworks do not have to be changed for the user to benefit from the [fluent logging API](https://www.slf4j.org/manual.html#fluent). However, existing frameworks must migrate to the `ServiceLoader` mechanism. The resulting internal changes are [detailed](https://www.slf4j.org/faq.html#changesInVersion200) in the FAQ page.
>
> - SLF4J now ships with the slf4j-reload4j module delegating to the reload4j backend. Reload4j is a drop-in replacement for log4j version 1.2.17.
> - `SimpleLogger` now prints the thread Id if instructed to do so. This fixes [SLF4J-499](https://jira.qos.ch/browse/SLF4J-499) requested by Michael Osipov

Signed-off-by: Jochen Schalanda <jochen@schalanda.name>