### PR TITLE
Fixing Jetty 10 release - must use Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,12 +7,12 @@ pipeline {
   stages {
     stage("Parallel Stage") {
       parallel {
-        stage("Build / Test - JDK11") {
+        stage("Build / Test - JDK17") {
           agent { node { label 'linux' } }
           steps {
             container('jetty-build') {
               timeout( time: 120, unit: 'MINUTES' ) {
-                mavenBuild( "jdk11", "clean install -Perrorprone", "maven3")
+                mavenBuild( "jdk17", "clean install -Perrorprone", "maven3")
                 // Collect up the jacoco execution results (only on main build)
                 jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
@@ -37,13 +37,13 @@ pipeline {
           }
         }
 
-        stage("Build / Test - JDK17") {
+        stage("Build / Test - JDK11") {
           agent { node { label 'linux' } }
           steps {
             container( 'jetty-build' ) {
               timeout( time: 120, unit: 'MINUTES' ) {
-                mavenBuild( "jdk17", "clean install -Dspotbugs.skip=true -Djacoco.skip=true", "maven3")
-                recordIssues id: "jdk17", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
+                mavenBuild( "jdk11", "clean install -Dspotbugs.skip=true -Djacoco.skip=true", "maven3")
+                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
           steps {
             container('jetty-build') {
               timeout( time: 120, unit: 'MINUTES' ) {
-                mavenBuild( "jdk17", "clean install -Perrorprone", "maven3")
+                mavenBuild( "jdk17", "clean install", "maven3")
                 // Collect up the jacoco execution results (only on main build)
                 jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
@@ -42,7 +42,7 @@ pipeline {
           steps {
             container( 'jetty-build' ) {
               timeout( time: 120, unit: 'MINUTES' ) {
-                mavenBuild( "jdk11", "clean install -Dspotbugs.skip=true -Djacoco.skip=true", "maven3")
+                mavenBuild( "jdk11", "clean install -Dspotbugs.skip=true -Djacoco.skip=true -Perrorprone", "maven3")
                 recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                        execPattern: '**/target/jacoco.exec',
                        classPattern: '**/target/classes',
                        sourcePattern: '**/src/main/java'
-                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]
+                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), pmdParser()]
               }
             }
           }
@@ -43,7 +43,7 @@ pipeline {
             container( 'jetty-build' ) {
               timeout( time: 120, unit: 'MINUTES' ) {
                 mavenBuild( "jdk11", "clean install -Dspotbugs.skip=true -Djacoco.skip=true -Perrorprone", "maven3")
-                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser()]
+                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), errorProne(), pmdParser()]
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                        execPattern: '**/target/jacoco.exec',
                        classPattern: '**/target/classes',
                        sourcePattern: '**/src/main/java'
-                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), pmdParser()]
+                recordIssues id: "jdk17", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle()]
               }
             }
           }
@@ -43,7 +43,7 @@ pipeline {
             container( 'jetty-build' ) {
               timeout( time: 120, unit: 'MINUTES' ) {
                 mavenBuild( "jdk11", "clean install -Dspotbugs.skip=true -Djacoco.skip=true -Perrorprone", "maven3")
-                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), errorProne(), pmdParser()]
+                recordIssues id: "jdk11", name: "Static Analysis jdk11", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), errorProne()]
               }
             }
           }

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -109,6 +109,10 @@
                 infinispan-remote,
                 jetty-test-helper,
                 alpn-api,
+                quic-quiche,
+                quic-quiche-common,
+                quic-quiche-foreign-incubator,
+                quic-quiche-jna,
                 javax.servlet,
                 javax.websocket,
                 jetty-servlet-api,
@@ -148,25 +152,11 @@
                 org.eclipse.jetty.http3.qpack.internal.*;
                 org.eclipse.jetty.http3.server.internal;
                 org.eclipse.jetty.quic.common.internal;
-                org.eclipse.jetty.quic.quiche;
-                org.eclipse.jetty.quic.quiche.*;
                 org.eclipse.jetty.quic.server.internal;
               </excludePackageNames>
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-          <release>17</release>
-          <compilerArgs>
-            <arg>--add-modules</arg>
-            <arg>jdk.incubator.foreign</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <sources-directory>${project.build.directory}/jetty-sources</sources-directory>
     <sonar.skip>true</sonar.skip>
-    <pmd.skip>true</pmd.skip>
     <spotbugs.skip>true</spotbugs.skip>
     <checkstyle.skip>true</checkstyle.skip>
   </properties>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -156,6 +156,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+          <release>17</release>
+          <compilerArgs>
+            <arg>--add-modules</arg>
+            <arg>jdk.incubator.foreign</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
     <maven.invoker.plugin.version>3.2.2</maven.invoker.plugin.version>
     <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
+    <maven.javadoc.plugin.version>3.3.2</maven.javadoc.plugin.version>
     <maven.jxr.plugin.version>3.1.1</maven.jxr.plugin.version>
     <maven.plugin-tools.version>3.6.4</maven.plugin-tools.version>
     <maven-plugin.plugin.version>3.6.4</maven-plugin.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2353,7 +2353,6 @@
       <properties>
         <!-- disable plugins known not to work with JDK 17 (yet) -->
         <spotbugs.skip>true</spotbugs.skip>
-        <jacoco.skip>true</jacoco.skip>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2237,8 +2237,8 @@
                 <configuration>
                   <rules>
                     <requireJavaVersion>
-                      <version>[11,)</version>
-                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 11 or newer</message>
+                      <version>[17,)</version>
+                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 17 or newer</message>
                     </requireJavaVersion>
                   </rules>
                 </configuration>


### PR DESCRIPTION
+ `/javadoc/` (aggregate) module now has missing `jdk.incubator.foreign` 
+ the `-Peclipse-release` profile now enforces Java 17 minimum version.