### PR TITLE
Fixes #7548 - Interrupt flag is not always cleared in between requests.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -410,6 +410,11 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
                     {
                         LOG.warn("Unable to run task", e);
                     }
+                    finally
+                    {
+                        // Clear any interrupted status.
+                        Thread.interrupted();
+                    }
                 }
             }
             finally


### PR DESCRIPTION
Now clearing the interrupt flag.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>