### PR TITLE
Issue #7531 Reinstate ClassLoaderServlet demo class

### DIFF
--- a/demos/demo-spec/demo-spec-webapp/pom.xml
+++ b/demos/demo-spec/demo-spec-webapp/pom.xml
@@ -65,9 +65,9 @@
           </supportedProjectTypes>
           <instructions>
             <Bundle-Description>Test Webapp for Servlet 4.0 Features</Bundle-Description>
-            <!-- TODO Add 'org.eclipse.jetty.util;version="[9.4.19,9.4.20)",' below, once 9.4.19 is released with a fix for #3726 -->
+            <!-- Specifically import an old jar to test webapp isolated classloading -->
             <Import-Package>
-              javax.transaction*;version="[1.1,2.0)", javax.servlet*;version="[2.6,4.1)", org.eclipse.jetty*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))", org.eclipse.jetty.webapp;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))";resolution:="optional", org.eclipse.jetty.plus.jndi;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))";resolution:="optional", com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}", *
+                javax.transaction*;version="[1.1,2.0)", javax.servlet*;version="[2.6,4.1)", org.eclipse.jetty.webapp;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))";resolution:="optional", org.eclipse.jetty.plus.jndi;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))";resolution:="optional", com.acme;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}", org.eclipse.jetty.monitor.thread;version="(9.3.29, 9.3.30]", *
             </Import-Package>
             <_nouses />
             <Export-Package>com.acme.test;version="${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}";-noimport:=true</Export-Package>

--- a/demos/demo-spec/demo-spec-webapp/pom.xml
+++ b/demos/demo-spec/demo-spec-webapp/pom.xml
@@ -177,6 +177,12 @@
               <artifactId>demo-mock-resources</artifactId>
               <version>${project.version}</version>
             </dependency>
+            <!-- deliberately newer version to test with -->
+            <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-monitor</artifactId>
+              <version>${monitor.version}</version>
+            </dependency>
           </dependencies>
         </plugin>
       </plugins>
@@ -211,12 +217,28 @@
     <!-- deliberately old version to test classloading -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>9.4.45.v20220203</version>
+      <artifactId>jetty-monitor</artifactId>
+      <version>${monitor.old.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>javax.servlet-api</artifactId>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-xml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/demos/demo-spec/demo-spec-webapp/pom.xml
+++ b/demos/demo-spec/demo-spec-webapp/pom.xml
@@ -209,11 +209,10 @@
     </dependency>
 
     <!-- deliberately old version to test classloading -->
-    <!-- TODO uncomment and update the following once 9.4.19 is released with a fix for #3726
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.4.19.vXXXXXXXX</version>
+      <version>9.4.45.v20220203</version>
       <exclusions>
         <exclusion>
           <groupId>javax.servlet</groupId>
@@ -221,6 +220,5 @@
         </exclusion>
       </exclusions>
     </dependency>
- -->
   </dependencies>
 </project>

--- a/demos/demo-spec/demo-spec-webapp/src/main/config/modules/demo-spec.mod
+++ b/demos/demo-spec/demo-spec-webapp/src/main/config/modules/demo-spec.mod
@@ -19,3 +19,4 @@ demo-mock-resources
 [files]
 basehome:modules/demo.d/demo-spec.xml|webapps/demo-spec.xml
 maven://org.eclipse.jetty.demos/demo-spec-webapp/${jetty.version}/war|webapps/demo-spec.war
+maven://org.eclipse.jetty/jetty-monitor/@monitor.version@/jar|lib/ext/jetty-monitor-@monitor.version@.jar

--- a/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
+++ b/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
@@ -25,8 +25,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.monitor.thread.ThreadMonitorInfo;
-
 @WebServlet(urlPatterns = "/classloader")
 public class ClassLoaderServlet extends HttpServlet
 {
@@ -41,7 +39,7 @@ public class ClassLoaderServlet extends HttpServlet
             writer.println("<body>");
             writer.println("<h1>ClassLoader Isolation Test</h1>");
 
-            Class<?> webappClass = ThreadMonitorInfo.class;
+            Class<?> webappClass = Thread.currentThread().getContextClassLoader().loadClass("org.eclipse.jetty.monitor.thread.ThreadMonitorInfo");
             URI webappURI = getLocationOfClass(webappClass);
             String webappVersion = webappClass.getPackage().getImplementationVersion();
             Class<?> serverClass = req.getServletContext().getClass().getClassLoader().loadClass("org.eclipse.jetty.monitor.thread.ThreadMonitorInfo");

--- a/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
+++ b/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.monitor.thread.ThreadMonitorInfo;
 
 @WebServlet(urlPatterns = "/classloader")
 public class ClassLoaderServlet extends HttpServlet
@@ -41,15 +41,14 @@ public class ClassLoaderServlet extends HttpServlet
             writer.println("<body>");
             writer.println("<h1>ClassLoader Isolation Test</h1>");
 
-            Class<?> webappIO = IO.class;
-            URI webappURI = getLocationOfClass(webappIO);
-            String webappVersion = webappIO.getPackage().getImplementationVersion();
-            Class<?> serverIO = req.getServletContext().getClass().getClassLoader().loadClass("org.eclipse.jetty.util.IO");
-            URI serverURI = getLocationOfClass(serverIO);
-            String serverVersion = serverIO.getPackage().getImplementationVersion();
-
-            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", webappVersion, webappURI);
-            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", serverVersion, serverURI);
+            Class<?> webappClass = ThreadMonitorInfo.class;
+            URI webappURI = getLocationOfClass(webappClass);
+            String webappVersion = webappClass.getPackage().getImplementationVersion();
+            Class<?> serverClass = req.getServletContext().getClass().getClassLoader().loadClass("org.eclipse.jetty.monitor.thread.ThreadMonitorInfo");
+            URI serverURI = getLocationOfClass(serverClass);
+            String serverVersion = serverClass.getPackage().getImplementationVersion();
+            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.monitor.thread.ThreadMonitorInfo</code>(%s) from %s%n", webappVersion, webappURI);
+            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.monitor.thread.ThreadMonitorInfo</code>(%s) from %s%n", serverVersion, serverURI);
             if (webappVersion.equals(serverVersion))
                 writer.println("<br/><b>Version Result: <span class=\"fail\">FAIL</span></b>");
             else

--- a/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
+++ b/demos/demo-spec/demo-spec-webapp/src/main/java/com/acme/test/ClassLoaderServlet.java
@@ -25,6 +25,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.util.IO;
+
 @WebServlet(urlPatterns = "/classloader")
 public class ClassLoaderServlet extends HttpServlet
 {
@@ -39,8 +41,6 @@ public class ClassLoaderServlet extends HttpServlet
             writer.println("<body>");
             writer.println("<h1>ClassLoader Isolation Test</h1>");
 
-            // TODO uncomment the following once 9.4.19 is released with a fix for #3726
-            /*
             Class<?> webappIO = IO.class;
             URI webappURI = getLocationOfClass(webappIO);
             String webappVersion = webappIO.getPackage().getImplementationVersion();
@@ -48,8 +48,8 @@ public class ClassLoaderServlet extends HttpServlet
             URI serverURI = getLocationOfClass(serverIO);
             String serverVersion = serverIO.getPackage().getImplementationVersion();
 
-            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n",webappVersion,webappURI);
-            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n",serverVersion, serverURI);
+            writer.printf("<p>Webapp loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", webappVersion, webappURI);
+            writer.printf("<br/>Server loaded <code>org.eclipse.jetty.util.IO</code>(%s) from %s%n", serverVersion, serverURI);
             if (webappVersion.equals(serverVersion))
                 writer.println("<br/><b>Version Result: <span class=\"fail\">FAIL</span></b>");
             else
@@ -58,7 +58,6 @@ public class ClassLoaderServlet extends HttpServlet
                 writer.println("<br/><b>URI Result: <span class=\"fail\">FAIL</span></b></p>");
             else
                 writer.println("<br/><b>URI Result: <span class=\"pass\">PASS</span></b></p>");
-            */
 
             writer.println("</body>");
             writer.println("</html>");

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -133,7 +133,7 @@
                 org.eclipse.jetty.demo,org.eclipse.jetty.orbit,org.eclipse.jetty.http2,org.eclipse.jetty.http3,org.eclipse.jetty.quic,org.eclipse.jetty.websocket,org.eclipse.jetty.fcgi,org.eclipse.jetty.toolchain,org.apache.taglibs
               </excludeGroupIds>
               <excludeArtifactIds>
-                apache-jsp,apache-jstl,jetty-start,jetty-slf4j-impl
+                apache-jsp,apache-jstl,jetty-start,jetty-slf4j-impl,jetty-monitor
               </excludeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib</outputDirectory>
@@ -151,7 +151,7 @@
                 org.eclipse.jetty.orbit,org.eclipse.jetty.http2,org.eclipse.jetty.http3,org.eclipse.jetty.quic,org.eclipse.jetty.websocket,org.eclipse.jetty.fcgi,org.eclipse.jetty.toolchain,org.apache.taglibs
               </excludeGroupIds>
               <excludeArtifactIds>
-                apache-jsp,apache-jstl,jetty-start
+                apache-jsp,apache-jstl,jetty-start,jetty-monitor
               </excludeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
@@ -474,7 +474,7 @@
               <includeGroupIds>
                 org.eclipse.jetty, org.eclipse.jetty.websocket, org.eclipse.jetty.demos
               </includeGroupIds>
-              <excludeArtifactIds>infinispan-embedded,infinispan-remote,jetty-test-helper,alpn-api,javax.security.auth.message,javax.activation</excludeArtifactIds>
+              <excludeArtifactIds>infinispan-embedded,infinispan-remote,jetty-test-helper,alpn-api,javax.security.auth.message,javax.activation,jetty-monitor</excludeArtifactIds>
               <classifier>config</classifier>
               <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
               <excludes>META-INF/**,webapps/**,start.d/**,start.ini</excludes>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -521,6 +521,8 @@
             <systemPropertyVariables>
               <mavenRepoPath>${settings.localRepository}</mavenRepoPath>
               <settingsFilePath>${env.GLOBAL_MVN_SETTINGS}</settingsFilePath>
+              <monitor.version>${monitor.version}</monitor.version>
+              <monitor.old.version>${monitor.old.version}</monitor.old.version>
             </systemPropertyVariables>
             <argLine>-Dconscrypt-version=${conscrypt.version}</argLine>
           </configuration>

--- a/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithAnnotations.java
+++ b/jetty-osgi/test-jetty-osgi/src/test/java/org/eclipse/jetty/osgi/test/TestJettyOSGiBootWithAnnotations.java
@@ -78,6 +78,21 @@ public class TestJettyOSGiBootWithAnnotations
         res.add(mavenBundle().groupId("org.eclipse.jetty.orbit").artifactId("javax.mail.glassfish").version("1.4.1.v201005082020").noStart());
         res.add(mavenBundle().groupId("org.eclipse.jetty.demos").artifactId("demo-container-initializer").versionAsInProject());
         res.add(mavenBundle().groupId("org.eclipse.jetty.demos").artifactId("demo-mock-resources").versionAsInProject());
+        // Deploy 2 versions of a jar (and dependencies): one will be on the server classpath and the other on the webapp classpath.
+        // Tests webapp isolated classloading.
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-monitor").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-client").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-io").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-xml").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-http").version(System.getProperty("monitor.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-monitor").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-client").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-io").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-xml").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-http").version(System.getProperty("monitor.old.version")).noStart());
+        res.add(mavenBundle().groupId("javax.servlet").artifactId("javax.servlet-api").version("3.1.0").noStart());
         //test webapp bundle
         res.add(mavenBundle().groupId("org.eclipse.jetty.demos").artifactId("demo-spec-webapp").classifier("webbundle").versionAsInProject());
         return res;

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,8 @@
     <maven.resolver.version>1.7.3</maven.resolver.version>
     <maven.version>3.8.4</maven.version>
     <mongodb.version>3.2.2</mongodb.version>
+    <monitor.version>9.3.30.v20211001</monitor.version>
+    <monitor.old.version>9.3.29.v20201019</monitor.old.version>
     <openpojo.version>0.9.1</openpojo.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>


### PR DESCRIPTION
Re-instated the ClassLoaderServlet class in the demo-spec-webapp. The stated purpose of the test is to show that the `jetty-util` jar can be included in a webapp's `WEB-INF/lib` at a _different_ version level to that of the server and have the webapp use that.