### PR TITLE
Issue #7531 Reinstate ClassLoaderServlet test class

### DIFF
--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/pom.xml
@@ -210,6 +210,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>9.3.0.RC0</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.tests</groupId>
       <artifactId>test-web-fragment</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Re-instates the ClassLoaderSerlvet test class from `test-spec-webapp`, which had been throwing exceptions. The intention is for the ClassLoaderServlet class to be able to load a class from `jetty-util` at a _different_ version level than the server.