### PR TITLE
Work in progress for alternate AcceptorProcessorExchange

### DIFF
--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/Request.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/Request.java
@@ -17,7 +17,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -32,35 +31,8 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 // TODO lots of javadoc
-public interface Request extends Attributes, Executor, Content.Provider
+public interface Request extends Attributes
 {
-    /**
-     * Accept the request for handling and provide the {@link Response} instance.
-     * @return The response instance or null if the request has already been accepted.
-     */
-    Response accept();
-
-    /**
-     * Test if the request has been accepted.
-     * <p>This should not be used if the caller intends to accept the request.  Specifically
-     * the following is an anti-pattern: <pre>
-     *     if (!request.isAccepted())
-     *     {
-     *         Response response = request.accept();
-     *         // ...
-     *     }
-     * </pre>
-     * Instead, the {@link #accept()} method should be used and tested for a null result: <pre>
-     *     Response response = request.accept();
-     *     if (response != null)
-     *     {
-     *         // ...
-     *     }
-     * </pre>
-     *
-     * @return true if the request has been accepted, else null
-     * @see #accept()
-     */
     boolean isAccepted();
 
     String getId();
@@ -86,20 +58,9 @@ public interface Request extends Attributes, Executor, Content.Provider
 
     long getContentLength();
 
-    @Override
-    Content readContent();
-
-    @Override
-    void demandContent(Runnable onContentAvailable);
-
     void addErrorListener(Consumer<Throwable> onError);
 
     void addCompletionListener(Callback onComplete);
-
-    /**
-     * @return The response instance iff this request has been excepted, else null
-     */
-    Response getResponse();
 
     default Request getWrapped()
     {
@@ -249,12 +210,6 @@ public interface Request extends Attributes, Executor, Content.Provider
         }
 
         @Override
-        public void execute(Runnable task)
-        {
-            _wrapped.execute(task);
-        }
-
-        @Override
         public boolean isComplete()
         {
             return _wrapped.isComplete();
@@ -309,18 +264,6 @@ public interface Request extends Attributes, Executor, Content.Provider
         }
 
         @Override
-        public Content readContent()
-        {
-            return _wrapped.readContent();
-        }
-
-        @Override
-        public void demandContent(Runnable onContentAvailable)
-        {
-            _wrapped.demandContent(onContentAvailable);
-        }
-
-        @Override
         public void addErrorListener(Consumer<Throwable> onError)
         {
             _wrapped.addErrorListener(onError);
@@ -333,21 +276,9 @@ public interface Request extends Attributes, Executor, Content.Provider
         }
 
         @Override
-        public Response getResponse()
-        {
-            return _wrapped.getResponse();
-        }
-
-        @Override
         public Request getWrapped()
         {
             return _wrapped;
-        }
-
-        @Override
-        public Response accept()
-        {
-            return _wrapped.accept();
         }
 
         @Override

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextHandlerCollection.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextHandlerCollection.java
@@ -122,7 +122,7 @@ public class ContextHandlerCollection extends Handler.Collection
     }
 
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request request, Acceptor acceptor) throws Exception
     {
         List<Handler> handlers = getHandlers();
 
@@ -132,7 +132,7 @@ public class ContextHandlerCollection extends Handler.Collection
 
         if (!(handlers instanceof Mapping))
         {
-            super.handle(request);
+            super.offer(request, acceptor);
             return;
         }
 
@@ -141,7 +141,7 @@ public class ContextHandlerCollection extends Handler.Collection
         // handle only a single context.
         if (handlers.size() == 1)
         {
-            handlers.get(0).handle(request);
+            handlers.get(0).offer(request, acceptor);
             return;
         }
 
@@ -153,7 +153,7 @@ public class ContextHandlerCollection extends Handler.Collection
         String path = request.getPath();
         if (!path.startsWith("/"))
         {
-            super.handle(request);
+            super.offer(request, acceptor);
             return;
         }
 
@@ -174,7 +174,7 @@ public class ContextHandlerCollection extends Handler.Collection
                 {
                     try
                     {
-                        branch.getHandler().handle(request);
+                        branch.getHandler().offer(request, acceptor);
                     }
                     catch (Throwable t)
                     {

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextRequest.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextRequest.java
@@ -38,7 +38,7 @@ public class ContextRequest extends Request.Wrapper
     @Override
     public void addErrorListener(Consumer<Throwable> onError)
     {
-        super.addErrorListener(t -> _contextHandler.getContext().accept(onError, t));
+        super.addErrorListener(t -> _contextHandler.getContext().consumeThrowableInContext(onError, t));
     }
 
     @Override
@@ -55,7 +55,7 @@ public class ContextRequest extends Request.Wrapper
             @Override
             public void failed(Throwable t)
             {
-                _contextHandler.getContext().accept(onComplete::failed, t);
+                _contextHandler.getContext().consumeThrowableInContext(onComplete::failed, t);
             }
         });
     }

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextResponse.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ContextResponse.java
@@ -42,7 +42,7 @@ class ContextResponse extends Response.Wrapper
             @Override
             public void failed(Throwable t)
             {
-                _contextHandler.getContext().accept(callback::failed, t);
+                _contextHandler.getContext().consumeThrowableInContext(callback::failed, t);
             }
         };
         super.write(last, contextCallback, content);

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ProxiedRequestHandler.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/ProxiedRequestHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.jetty.util.HostPort;
 public class ProxiedRequestHandler extends Handler.Wrapper
 {
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request request, Acceptor acceptor) throws Exception
     {
         ConnectionMetaData proxiedFor = new ConnectionMetaData.Wrapper(request.getConnectionMetaData())
         {
@@ -57,7 +57,7 @@ public class ProxiedRequestHandler extends Handler.Wrapper
             }
         };
 
-        super.handle(new Request.Wrapper(request)
+        super.offer(new Request.Wrapper(request)
         {
             @Override
             public HttpURI getHttpURI()
@@ -71,6 +71,6 @@ public class ProxiedRequestHandler extends Handler.Wrapper
             {
                 return proxiedFor;
             }
-        });
+        }, acceptor);
     }
 }

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/RequestStatsHandler.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/RequestStatsHandler.java
@@ -35,7 +35,7 @@ public class RequestStatsHandler extends Handler.Wrapper
     private final SampleStatistic _handleTimeStats = new SampleStatistic();
 
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request request, Acceptor acceptor) throws Exception
     {
         Object connectionStats = _connectionStats.computeIfAbsent(request.getConnectionMetaData().getId(), id ->
         {
@@ -96,7 +96,7 @@ public class RequestStatsHandler extends Handler.Wrapper
 
         try
         {
-            super.handle(new Request.Wrapper(request)
+            super.offer(new Request.Wrapper(request)
             {
                 // TODO make this wrapper optional. Only needed if requestLog asks for these attributes.
                 @Override
@@ -113,7 +113,7 @@ public class RequestStatsHandler extends Handler.Wrapper
                             return super.getAttribute(name);
                     }
                 }
-            });
+            }, acceptor);
         }
         finally
         {

--- a/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/RewriteHandler.java
+++ b/jetty-core/jetty-core-server/src/main/java/org/eclipse/jetty/core/server/handler/RewriteHandler.java
@@ -21,12 +21,12 @@ import org.eclipse.jetty.http.HttpURI;
 public class RewriteHandler extends Handler.Wrapper
 {
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request request, Acceptor acceptor) throws Exception
     {
         Request rewritten = rewrite(request);
         if (request.isAccepted())
             return;
-        super.handle(request);
+        super.offer(request, acceptor);
     }
 
     protected Request rewrite(Request request)

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ExtendedServerTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ExtendedServerTest.java
@@ -141,11 +141,14 @@ public class ExtendedServerTest extends HttpServerTestBase
     protected static class DispatchedAtHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            response.setStatus(200);
-            response.write(true, response.getCallback(), BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                response.setStatus(200);
+                response.write(true, exchange, BufferUtil.toBuffer("DispatchedAt=" + request.getAttribute("DispatchedAt") + "\r\n"));
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/HandlerTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/HandlerTest.java
@@ -262,7 +262,7 @@ public class HandlerTest
         c.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor)
             {
             }
         });

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/HttpChannelTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/HttpChannelTest.java
@@ -326,7 +326,7 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor)
             {
             }
         };
@@ -356,7 +356,7 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor)
             {
                 throw new UnsupportedOperationException("testing");
             }
@@ -390,15 +390,18 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setStatus(200);
-                response.setContentLength(10);
-                response.write(false, Callback.from(response.getCallback(), () ->
+                acceptor.accept(request, exchange ->
                 {
-                    throw new Error("testing");
-                }));
+                    Response response = exchange.getResponse();
+                    response.setStatus(200);
+                    response.setContentLength(10);
+                    response.write(false, Callback.from(exchange, () ->
+                    {
+                        throw new Error("testing");
+                    }));
+                });
             }
         };
         _server.setHandler(handler);
@@ -428,10 +431,13 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.write(true, response.getCallback(), BufferUtil.toBuffer("12345"));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.write(true, exchange, BufferUtil.toBuffer("12345"));
+                });
             }
         };
         _server.setHandler(handler);
@@ -460,11 +466,14 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setContentLength(10);
-                response.write(true, response.getCallback(), BufferUtil.toBuffer("12345"));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setContentLength(10);
+                    response.write(true, exchange, BufferUtil.toBuffer("12345"));
+                });
             }
         };
         _server.setHandler(handler);
@@ -493,12 +502,14 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setContentLength(10);
-                Callback callback = response.getCallback();
-                response.write(false, Callback.from(() -> response.write(true, callback)), BufferUtil.toBuffer("12345"));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setContentLength(10);
+                    response.write(false, Callback.from(() -> response.write(true, exchange)), BufferUtil.toBuffer("12345"));
+                });
             }
         };
         _server.setHandler(handler);
@@ -526,11 +537,14 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setContentLength(5);
-                response.write(true, response.getCallback(), BufferUtil.toBuffer("1234567890"));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setContentLength(5);
+                    response.write(true, exchange, BufferUtil.toBuffer("1234567890"));
+                });
             }
         };
         _server.setHandler(handler);
@@ -559,12 +573,14 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setContentLength(5);
-                Callback callback = response.getCallback();
-                response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("567890"))), BufferUtil.toBuffer("1234"));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setContentLength(5);
+                    response.write(false, Callback.from(() -> response.write(true, exchange, BufferUtil.toBuffer("567890"))), BufferUtil.toBuffer("1234"));
+                });
             }
         };
         _server.setHandler(handler);
@@ -626,14 +642,16 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setStatus(200);
-                response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
-                response.setContentLength(5);
-                Callback callback = response.getCallback();
-                response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("12345"))));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setStatus(200);
+                    response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
+                    response.setContentLength(5);
+                    response.write(false, Callback.from(() -> response.write(true, exchange, BufferUtil.toBuffer("12345"))));
+                });
             }
         };
         _server.setHandler(handler);
@@ -670,15 +688,17 @@ public class HttpChannelTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setStatus(200);
-                response.addHeader(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString());
-                response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
-                response.setContentLength(5);
-                Callback callback = response.getCallback();
-                response.write(false, Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer("12345"))));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setStatus(200);
+                    response.addHeader(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString());
+                    response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
+                    response.setContentLength(5);
+                    response.write(false, Callback.from(() -> response.write(true, exchange, BufferUtil.toBuffer("12345"))));
+                });
             }
         };
         _server.setHandler(handler);
@@ -968,36 +988,38 @@ public class HttpChannelTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                LongAdder contentSize = new LongAdder();
-                CountDownLatch latch = new CountDownLatch(1);
-                Runnable onContentAvailable = new Runnable()
+                acceptor.accept(request, exchange ->
                 {
-                    @Override
-                    public void run()
+                    Response response = exchange.getResponse();
+                    LongAdder contentSize = new LongAdder();
+                    CountDownLatch latch = new CountDownLatch(1);
+                    Runnable onContentAvailable = new Runnable()
                     {
-                        Content content = request.readContent();
-                        contentSize.add(content.remaining());
-                        content.release();
-                        if (content.isLast())
-                            latch.countDown();
-                        else
-                            request.demandContent(this);
+                        @Override
+                        public void run()
+                        {
+                            Content content = exchange.readContent();
+                            contentSize.add(content.remaining());
+                            content.release();
+                            if (content.isLast())
+                                latch.countDown();
+                            else
+                                exchange.demandContent(this);
+                        }
+                    };
+                    exchange.demandContent(onContentAvailable);
+                    if (latch.await(30, TimeUnit.SECONDS))
+                    {
+                        response.setStatus(200);
+                        response.write(true, exchange, BufferUtil.toBuffer("contentSize=" + contentSize.longValue()));
                     }
-                };
-                request.demandContent(onContentAvailable);
-                Callback callback = response.getCallback();
-                if (latch.await(30, TimeUnit.SECONDS))
-                {
-                    response.setStatus(200);
-                    response.write(true, callback, BufferUtil.toBuffer("contentSize=" + contentSize.longValue()));
-                }
-                else
-                {
-                    callback.failed(new IOException());
-                }
+                    else
+                    {
+                        exchange.failed(new IOException());
+                    }
+                });
             }
         });
         _server.start();
@@ -1045,18 +1067,20 @@ public class HttpChannelTest
     @Test
     public void testOnError() throws Exception
     {
-        AtomicReference<Request> handling = new AtomicReference<>();
+        AtomicReference<Handler.Exchange> handling = new AtomicReference<>();
         AtomicReference<Throwable> error = new AtomicReference<>();
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                request.accept();
-                handling.set(request);
-                request.addErrorListener(t -> {});
-                request.addErrorListener(error::set);
-                request.addErrorListener(t -> {});
+                acceptor.accept(request, exchange ->
+                {
+                    handling.set(exchange);
+                    request.addErrorListener(t -> {});
+                    request.addErrorListener(error::set);
+                    request.addErrorListener(t -> {});
+                });
             }
         };
         _server.setHandler(handler);
@@ -1073,7 +1097,7 @@ public class HttpChannelTest
 
         // check we are handling
         assertNotNull(handling.get());
-        assertTrue(handling.get().isAccepted());
+        assertTrue(handling.get().getRequest().isAccepted());
         assertThat(stream.isComplete(), is(false));
         assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), nullValue());
@@ -1087,7 +1111,7 @@ public class HttpChannelTest
         assertThat(error.get(), nullValue());
 
         // request still handling
-        assertFalse(handling.get().isComplete());
+        assertFalse(handling.get().getRequest().isComplete());
         assertFalse(stream.isComplete());
 
         // but now we cannot read, demand nor write
@@ -1104,7 +1128,7 @@ public class HttpChannelTest
 
         FuturePromise<Throwable> callback = new FuturePromise<>();
         // Callback serialized until after onError task
-        handling.get().getHttpChannel().getResponse().write(false, Callback.from(() -> {}, callback::succeeded));
+        handling.get().getRequest().getHttpChannel().getResponse().write(false, Callback.from(() -> {}, callback::succeeded));
         assertFalse(callback.isDone());
 
         // process error callback
@@ -1118,7 +1142,7 @@ public class HttpChannelTest
         assertThat(callback.get(5, TimeUnit.SECONDS), sameInstance(failure));
 
         // request completed handling
-        assertTrue(handling.get().isComplete());
+        assertTrue(handling.get().getRequest().isComplete());
         assertTrue(stream.isComplete());
     }
 
@@ -1130,10 +1154,10 @@ public class HttpChannelTest
         EchoHandler echoHandler = new EchoHandler()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
                 request.addCompletionListener(Callback.from(completed::countDown));
-                super.handle(request);
+                super.offer(request, acceptor);
             }
         };
         _server.setHandler(echoHandler);

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ProxyCustomizerTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ProxyCustomizerTest.java
@@ -82,24 +82,27 @@ public class ProxyCustomizerTest
         Handler handler = new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.addHeader("preexisting.attribute", request.getAttribute("some.attribute").toString());
-                ArrayList<String> attributeNames = new ArrayList<>(request.getAttributeNamesSet());
-                Collections.sort(attributeNames);
-                response.addHeader("attributeNames", String.join(",", attributeNames));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.addHeader("preexisting.attribute", request.getAttribute("some.attribute").toString());
+                    ArrayList<String> attributeNames = new ArrayList<>(request.getAttributeNamesSet());
+                    Collections.sort(attributeNames);
+                    response.addHeader("attributeNames", String.join(",", attributeNames));
 
-                response.addHeader("localAddress", request.getConnectionMetaData().getLocalAddress().toString());
-                response.addHeader("remoteAddress", request.getConnectionMetaData().getRemoteAddress().toString());
-                Object localAddress = request.getAttribute(ProxyCustomizer.LOCAL_ADDRESS_ATTRIBUTE_NAME);
-                if (localAddress != null)
-                    response.addHeader("proxyLocalAddress", localAddress + ":" + request.getAttribute(ProxyCustomizer.LOCAL_PORT_ATTRIBUTE_NAME));
-                Object remoteAddress = request.getAttribute(ProxyCustomizer.REMOTE_ADDRESS_ATTRIBUTE_NAME);
-                if (remoteAddress != null)
-                    response.addHeader("proxyRemoteAddress", remoteAddress + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
+                    response.addHeader("localAddress", request.getConnectionMetaData().getLocalAddress().toString());
+                    response.addHeader("remoteAddress", request.getConnectionMetaData().getRemoteAddress().toString());
+                    Object localAddress = request.getAttribute(ProxyCustomizer.LOCAL_ADDRESS_ATTRIBUTE_NAME);
+                    if (localAddress != null)
+                        response.addHeader("proxyLocalAddress", localAddress + ":" + request.getAttribute(ProxyCustomizer.LOCAL_PORT_ATTRIBUTE_NAME));
+                    Object remoteAddress = request.getAttribute(ProxyCustomizer.REMOTE_ADDRESS_ATTRIBUTE_NAME);
+                    if (remoteAddress != null)
+                        response.addHeader("proxyRemoteAddress", remoteAddress + ":" + request.getAttribute(ProxyCustomizer.REMOTE_PORT_ATTRIBUTE_NAME));
 
-                response.getCallback().succeeded();
+                    exchange.succeeded();
+                });
             }
         };
 

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLCloseTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLCloseTest.java
@@ -80,24 +80,27 @@ public class SSLCloseTest
     private static class WriteHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            response.setStatus(200);
-            response.setHeader("test", "value");
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                response.setStatus(200);
+                response.setHeader("test", "value");
 
-            String data = "Now is the time for all good men to come to the aid of the party.\n";
-            data += "How now brown cow.\n";
-            data += "The quick brown fox jumped over the lazy dog.\n";
-            // data=data+data+data+data+data+data+data+data+data+data+data+data+data;
-            // data=data+data+data+data+data+data+data+data+data+data+data+data+data;
-            data = data + data + data + data;
-            byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+                String data = "Now is the time for all good men to come to the aid of the party.\n";
+                data += "How now brown cow.\n";
+                data += "The quick brown fox jumped over the lazy dog.\n";
+                // data=data+data+data+data+data+data+data+data+data+data+data+data+data;
+                // data=data+data+data+data+data+data+data+data+data+data+data+data+data;
+                data = data + data + data + data;
+                byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
 
-            Callback callback = response.getCallback();
-            response.write(false,
-                Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer(bytes)), callback::failed),
-                BufferUtil.toBuffer(bytes));
+                Callback callback = exchange;
+                response.write(false,
+                    Callback.from(() -> response.write(true, callback, BufferUtil.toBuffer(bytes)), callback::failed),
+                    BufferUtil.toBuffer(bytes));
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLEngineTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLEngineTest.java
@@ -355,30 +355,33 @@ public class SSLEngineTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            // System.err.println("HANDLE "+request.getRequestURI());
-            SecureRequestCustomizer.SslSessionData sslData = (SecureRequestCustomizer.SslSessionData)
-                request.getAttribute("org.eclipse.jetty.servlet.request.ssl_session_data");
-            String sslId = sslData.getId();
-            assertNotNull(sslId);
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                // System.err.println("HANDLE "+request.getRequestURI());
+                SecureRequestCustomizer.SslSessionData sslData = (SecureRequestCustomizer.SslSessionData)
+                    request.getAttribute("org.eclipse.jetty.servlet.request.ssl_session_data");
+                String sslId = sslData.getId();
+                assertNotNull(sslId);
 
-            MultiMap<String> params = request.extractQueryParameters();
-            if (params.get("dump") != null)
-            {
-                byte[] buf = new byte[Integer.parseInt(params.getValue("dump"))];
-                // System.err.println("DUMP "+buf.length);
-                for (int i = 0; i < buf.length; i++)
+                MultiMap<String> params = request.extractQueryParameters();
+                if (params.get("dump") != null)
                 {
-                    buf[i] = (byte)('0' + (i % 10));
+                    byte[] buf = new byte[Integer.parseInt(params.getValue("dump"))];
+                    // System.err.println("DUMP "+buf.length);
+                    for (int i = 0; i < buf.length; i++)
+                    {
+                        buf[i] = (byte)('0' + (i % 10));
+                    }
+                    response.write(true, exchange, BufferUtil.toBuffer(buf));
                 }
-                response.write(true, response.getCallback(), BufferUtil.toBuffer(buf));
-            }
-            else
-            {
-                response.write(true, response.getCallback(), BufferUtil.toBuffer(HELLO_WORLD));
-            }
+                else
+                {
+                    response.write(true, exchange, BufferUtil.toBuffer(HELLO_WORLD));
+                }
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLSelectChannelConnectorLoadTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SSLSelectChannelConnectorLoadTest.java
@@ -322,11 +322,14 @@ public class SSLSelectChannelConnectorLoadTest
     private static class TestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            ByteBuffer input = Content.readBytes(request);
-            response.write(true, response.getCallback(), BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                ByteBuffer input = Content.readBytes(exchange);
+                response.write(true, exchange, BufferUtil.toBuffer(String.valueOf(input.remaining()).getBytes()));
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ServerConnectorAcceptTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ServerConnectorAcceptTest.java
@@ -25,6 +25,7 @@ import java.util.stream.IntStream;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.io.ManagedSelector;
+import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -44,10 +45,9 @@ public class ServerConnectorAcceptTest
         server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request)
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.getCallback().succeeded();
+                acceptor.accept(request, Callback::succeeded);
             }
         });
         server.start();

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ServerConnectorSslServerTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/ServerConnectorSslServerTest.java
@@ -226,24 +226,27 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
     public static class SecureRequestHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            response.setStatus(200);
-            StringBuilder out = new StringBuilder();
-            SSLSession session = (SSLSession)request.getAttribute("SSL_SESSION");
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                response.setStatus(200);
+                StringBuilder out = new StringBuilder();
+                SSLSession session = (SSLSession)request.getAttribute("SSL_SESSION");
 
-            SecureRequestCustomizer.SslSessionData data = (SecureRequestCustomizer.SslSessionData)request.getAttribute("SSL_SESSION_data");
+                SecureRequestCustomizer.SslSessionData data = (SecureRequestCustomizer.SslSessionData)request.getAttribute("SSL_SESSION_data");
 
-            out.append("Hello world").append('\n');
-            out.append("scheme='").append(request.getHttpURI().getScheme()).append("'").append('\n');
-            out.append("isSecure='").append(request.isSecure()).append("'").append('\n');
-            out.append("X509Certificate='").append(data == null ? "" : data.getX509Certificates()).append("'").append('\n');
-            out.append("cipher_suite='").append(session == null ? "" : session.getCipherSuite()).append("'").append('\n');
-            out.append("key_size='").append(data == null ? "" : data.getKeySize()).append("'").append('\n');
-            out.append("ssl_session_id='").append(data == null ? "" : data.getId()).append("'").append('\n');
-            out.append("ssl_session='").append(session).append("'").append('\n');
-            response.write(true, response.getCallback(), out.toString());
+                out.append("Hello world").append('\n');
+                out.append("scheme='").append(request.getHttpURI().getScheme()).append("'").append('\n');
+                out.append("isSecure='").append(request.isSecure()).append("'").append('\n');
+                out.append("X509Certificate='").append(data == null ? "" : data.getX509Certificates()).append("'").append('\n');
+                out.append("cipher_suite='").append(session == null ? "" : session.getCipherSuite()).append("'").append('\n');
+                out.append("key_size='").append(data == null ? "" : data.getKeySize()).append("'").append('\n');
+                out.append("ssl_session_id='").append(data == null ? "" : data.getId()).append("'").append('\n');
+                out.append("ssl_session='").append(session).append("'").append('\n');
+                response.write(true, exchange, out.toString());
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SlowClientsTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SlowClientsTest.java
@@ -68,28 +68,31 @@ public class SlowClientsTest
             server.setHandler(new Handler.Abstract()
             {
                 @Override
-                public void handle(Request request) throws Exception
+                public void offer(Request request, Acceptor acceptor) throws Exception
                 {
-                    LOG.info("SERVING {}", request);
-                    // Write some big content.
-                    Response response = request.accept();
-                    Callback callback = response.getCallback();
-                    response.write(true, new Callback()
-                        {
-                            @Override
-                            public void succeeded()
+                    acceptor.accept(request, exchange ->
+                    {
+                        Response response = exchange.getResponse();
+                        LOG.info("SERVING {}", request);
+                        // Write some big content.
+                        Callback callback = exchange;
+                        response.write(true, new Callback()
                             {
-                                callback.succeeded();
-                                LOG.info("SERVED {}", request);
-                            }
+                                @Override
+                                public void succeeded()
+                                {
+                                    callback.succeeded();
+                                    LOG.info("SERVED {}", request);
+                                }
 
-                            @Override
-                            public void failed(Throwable x)
-                            {
-                                callback.failed(x);
-                            }
-                        },
-                        BufferUtil.toBuffer(new byte[contentLength]));
+                                @Override
+                                public void failed(Throwable x)
+                                {
+                                    callback.failed(x);
+                                }
+                            },
+                            BufferUtil.toBuffer(new byte[contentLength]));
+                    });
                 }
             });
             server.start();

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslConnectionFactoryTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslConnectionFactoryTest.java
@@ -84,11 +84,14 @@ public class SslConnectionFactoryTest
         _server.setHandler(new Handler.Abstract()
         {
             @Override
-            public void handle(Request request) throws Exception
+            public void offer(Request request, Acceptor acceptor) throws Exception
             {
-                Response response = request.accept();
-                response.setStatus(200);
-                response.write(true, response.getCallback(), BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setStatus(200);
+                    response.write(true, exchange, BufferUtil.toBuffer("url=" + request.getHttpURI() + "\nhost=" + request.getServerName()));
+                });
             }
         });
 

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslContextFactoryReloadTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslContextFactoryReloadTest.java
@@ -237,15 +237,18 @@ public class SslContextFactoryReloadTest
     private static class TestHandler extends EchoHandler
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
             if (HttpMethod.POST.is(request.getMethod()))
-                super.handle(request);
+                super.offer(request, acceptor);
             else
             {
-                Response response = request.accept();
-                response.setContentLength(0);
-                response.getCallback().succeeded();
+                acceptor.accept(request, exchange ->
+                {
+                    Response response = exchange.getResponse();
+                    response.setContentLength(0);
+                    exchange.succeeded();
+                });
             }
         }
     }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslUploadTest.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/SslUploadTest.java
@@ -139,11 +139,14 @@ public class SslUploadTest
     private static class EmptyHandler extends Handler.Abstract
     {
         @Override
-        public void handle(Request request) throws Exception
+        public void offer(Request request, Acceptor acceptor) throws Exception
         {
-            Response response = request.accept();
-            ByteBuffer input = Content.readBytes(request);
-            response.write(true, response.getCallback(), BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
+            acceptor.accept(request, exchange ->
+            {
+                Response response = exchange.getResponse();
+                ByteBuffer input = Content.readBytes(exchange);
+                response.write(true, exchange, BufferUtil.toBuffer(("Read " + input.remaining()).getBytes()));
+            });
         }
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/handler/DumpHandler.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/handler/DumpHandler.java
@@ -51,157 +51,159 @@ public class DumpHandler extends Handler.Abstract
     }
 
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request request, Acceptor acceptor) throws Exception
     {
-        Response response = request.accept();
-        if (LOG.isDebugEnabled())
-            LOG.debug("dump {}", request);
-        HttpURI httpURI = request.getHttpURI();
-
-        MultiMap<String> params = UrlEncoded.decodeQuery(httpURI.getQuery());
-
-        if (Boolean.parseBoolean(params.getValue("flush")))
+        acceptor.accept(request, exchange ->
         {
-            try (Blocking.Callback blocker = _blocker.callback())
+            Response response = exchange.getResponse();
+            if (LOG.isDebugEnabled())
+                LOG.debug("dump {}", request);
+            HttpURI httpURI = request.getHttpURI();
+
+            MultiMap<String> params = UrlEncoded.decodeQuery(httpURI.getQuery());
+
+            if (Boolean.parseBoolean(params.getValue("flush")))
             {
-                response.write(false, blocker);
-                blocker.block();
-            }
-        }
-
-        if (Boolean.parseBoolean(params.getValue("empty")))
-        {
-            response.setStatus(200);
-            response.getCallback().succeeded();
-            return;
-        }
-
-        Utf8StringBuilder read = null;
-        if (params.getValue("read") != null)
-        {
-            read = new Utf8StringBuilder();
-            int len = Integer.parseInt(params.getValue("read"));
-            byte[] buffer = new byte[8192];
-
-            Content content = null;
-            while (len > 0)
-            {
-                if (content == null)
+                try (Blocking.Callback blocker = _blocker.callback())
                 {
-                    content = request.readContent();
+                    response.write(false, blocker);
+                    blocker.block();
+                }
+            }
+
+            if (Boolean.parseBoolean(params.getValue("empty")))
+            {
+                response.setStatus(200);
+                exchange.succeeded();
+                return;
+            }
+
+            Utf8StringBuilder read = null;
+            if (params.getValue("read") != null)
+            {
+                read = new Utf8StringBuilder();
+                int len = Integer.parseInt(params.getValue("read"));
+                byte[] buffer = new byte[8192];
+
+                Content content = null;
+                while (len > 0)
+                {
                     if (content == null)
                     {
-                        try (Blocking.Runnable blocker = _blocker.runnable())
+                        content = exchange.readContent();
+                        if (content == null)
                         {
-                            request.demandContent(blocker);
-                            blocker.block();
+                            try (Blocking.Runnable blocker = _blocker.runnable())
+                            {
+                                exchange.demandContent(blocker);
+                                blocker.block();
+                            }
+                            continue;
                         }
-                        continue;
+                    }
+
+                    if (content instanceof Content.Error)
+                    {
+                        exchange.failed(((Content.Error)content).getCause());
+                        return;
+                    }
+
+                    int l = Math.min(buffer.length, Math.min(len, content.remaining()));
+                    content.fill(buffer, 0, l);
+                    read.append(buffer, 0, l);
+                    len -= l;
+
+                    if (content.isEmpty())
+                    {
+                        content.release();
+                        if (content.isLast())
+                            break;
+                        if (!content.isSpecial())
+                            content = null;
                     }
                 }
-
-                if (content instanceof Content.Error)
-                {
-                    response.getCallback().failed(((Content.Error)content).getCause());
-                    return;
-                }
-
-                int l = Math.min(buffer.length, Math.min(len, content.remaining()));
-                content.fill(buffer, 0, l);
-                read.append(buffer, 0, l);
-                len -= l;
-
-                if (content.isEmpty())
-                {
+                if (content != null)
                     content.release();
-                    if (content.isLast())
-                        break;
-                    if (!content.isSpecial())
-                        content = null;
-                }
             }
-            if (content != null)
-                content.release();
-        }
 
-        if (params.getValue("date") != null)
-            response.getHeaders().put("Date", params.getValue("date"));
+            if (params.getValue("date") != null)
+                response.getHeaders().put("Date", params.getValue("date"));
 
-        if (params.getValue("ISE") != null)
-            throw new IllegalStateException("Testing ISE");
+            if (params.getValue("ISE") != null)
+                throw new IllegalStateException("Testing ISE");
 
-        if (params.getValue("error") != null)
-        {
-            response.setStatus(Integer.parseInt(params.getValue("error")));
-            response.getCallback().succeeded();
-            return;
-        }
+            if (params.getValue("error") != null)
+            {
+                response.setStatus(Integer.parseInt(params.getValue("error")));
+                exchange.succeeded();
+                return;
+            }
 
-        response.setContentType(MimeTypes.Type.TEXT_HTML.asString());
+            response.setContentType(MimeTypes.Type.TEXT_HTML.asString());
 
-        ByteArrayOutputStream buf = new ByteArrayOutputStream(2048);
-        Writer writer = new OutputStreamWriter(buf, StandardCharsets.ISO_8859_1);
-        writer.write("<html><h1>" + _label + "</h1>\n");
-        writer.write("<pre>httpURI=" + httpURI + "</pre><br/>\n");
-        writer.write("<pre>path=" + request.getPath() + "</pre><br/>\n");
-        writer.write("<pre>contentType=" + request.getHeaders().get(HttpHeader.CONTENT_TYPE) + "</pre><br/>\n");
-        writer.write("<pre>servername=" + request.getServerName() + "</pre><br/>\n");
-        writer.write("<pre>local=" + request.getLocalAddr() + ":" + request.getLocalPort() + "</pre><br/>\n");
-        writer.write("<pre>remote=" + request.getRemoteAddr() + ":" + request.getRemotePort() + "</pre><br/>\n");
-        writer.write("<h3>Header:</h3><pre>");
-        writer.write(String.format("%4s %s %s\n", request.getMethod(), httpURI.getPathQuery(), request.getConnectionMetaData().getProtocol()));
-        for (HttpField field : request.getHeaders())
-        {
-            String name = field.getName();
-            writer.write(name);
-            writer.write(": ");
-            String value = field.getValue();
-            writer.write(value == null ? "" : value);
-            writer.write("\n");
-        }
+            ByteArrayOutputStream buf = new ByteArrayOutputStream(2048);
+            Writer writer = new OutputStreamWriter(buf, StandardCharsets.ISO_8859_1);
+            writer.write("<html><h1>" + _label + "</h1>\n");
+            writer.write("<pre>httpURI=" + httpURI + "</pre><br/>\n");
+            writer.write("<pre>path=" + request.getPath() + "</pre><br/>\n");
+            writer.write("<pre>contentType=" + request.getHeaders().get(HttpHeader.CONTENT_TYPE) + "</pre><br/>\n");
+            writer.write("<pre>servername=" + request.getServerName() + "</pre><br/>\n");
+            writer.write("<pre>local=" + request.getLocalAddr() + ":" + request.getLocalPort() + "</pre><br/>\n");
+            writer.write("<pre>remote=" + request.getRemoteAddr() + ":" + request.getRemotePort() + "</pre><br/>\n");
+            writer.write("<h3>Header:</h3><pre>");
+            writer.write(String.format("%4s %s %s\n", request.getMethod(), httpURI.getPathQuery(), request.getConnectionMetaData().getProtocol()));
+            for (HttpField field : request.getHeaders())
+            {
+                String name = field.getName();
+                writer.write(name);
+                writer.write(": ");
+                String value = field.getValue();
+                writer.write(value == null ? "" : value);
+                writer.write("\n");
+            }
 
-        writer.write("</pre>\n<h3>Attributes:</h3>\n<pre>");
-        for (String attr : request.getAttributeNamesSet())
-        {
-            writer.write(attr);
-            writer.write("=");
-            writer.write(request.getAttribute(attr).toString());
-            writer.write("\n");
-        }
+            writer.write("</pre>\n<h3>Attributes:</h3>\n<pre>");
+            for (String attr : request.getAttributeNamesSet())
+            {
+                writer.write(attr);
+                writer.write("=");
+                writer.write(request.getAttribute(attr).toString());
+                writer.write("\n");
+            }
 
-        writer.write("</pre>\n<h3>Content:</h3>\n<pre>");
-        if (read != null)
-            writer.write(read.toString());
-        else
-            writer.write(Content.readUtf8String(request));
+            writer.write("</pre>\n<h3>Content:</h3>\n<pre>");
+            if (read != null)
+                writer.write(read.toString());
+            else
+                writer.write(Content.readUtf8String(exchange));
 
-        writer.write("</pre>\n");
-        writer.write("</html>\n");
-        writer.flush();
+            writer.write("</pre>\n");
+            writer.write("</html>\n");
+            writer.flush();
 
-        // commit now
-        if (!Boolean.parseBoolean(params.getValue("no-content-length")))
-            response.setContentLength(buf.size() + 1000);
+            // commit now
+            if (!Boolean.parseBoolean(params.getValue("no-content-length")))
+                response.setContentLength(buf.size() + 1000);
 
-        response.getHeaders().add("Before-Flush", response.isCommitted() ? "Committed???" : "Not Committed");
+            response.getHeaders().add("Before-Flush", response.isCommitted() ? "Committed???" : "Not Committed");
 
+            try (Blocking.Callback blocker = _blocker.callback())
+            {
+                response.write(false, blocker, BufferUtil.toBuffer(buf.toByteArray()));
+                blocker.block();
+            }
+            response.addHeader("After-Flush", "These headers should not be seen in the response!!!");
+            response.addHeader("After-Flush", response.isCommitted() ? "Committed" : "Not Committed?");
 
-        try (Blocking.Callback blocker = _blocker.callback())
-        {
-            response.write(false, blocker, BufferUtil.toBuffer(buf.toByteArray()));
-            blocker.block();
-        }
-        response.addHeader("After-Flush", "These headers should not be seen in the response!!!");
-        response.addHeader("After-Flush", response.isCommitted() ? "Committed" : "Not Committed?");
+            // write remaining content after commit
+            String padding = "ABCDEFGHIJ".repeat(99) + "ABCDEFGH\r\n";
 
-        // write remaining content after commit
-        String padding = "ABCDEFGHIJ".repeat(99) + "ABCDEFGH\r\n";
+            try (Blocking.Callback blocker = _blocker.callback())
+            {
+                response.write(true, blocker, BufferUtil.toBuffer(padding.getBytes(StandardCharsets.ISO_8859_1)));
+            }
 
-        try (Blocking.Callback blocker = _blocker.callback())
-        {
-            response.write(true, blocker, BufferUtil.toBuffer(padding.getBytes(StandardCharsets.ISO_8859_1)));
-        }
-
-        response.getCallback().succeeded();
+            exchange.succeeded();
+        });
     }
 }

--- a/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/handler/HelloHandler.java
+++ b/jetty-core/jetty-core-server/src/test/java/org/eclipse/jetty/core/server/handler/HelloHandler.java
@@ -52,12 +52,15 @@ public class HelloHandler extends Handler.Abstract
     }
 
     @Override
-    public void handle(Request request) throws Exception
+    public void offer(Request originalRequest, Acceptor acceptor) throws Exception
     {
-        Response response = request.accept();
-        response.setStatus(200);
-        response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
-        response.setContentLength(_byteBuffer.remaining());
-        response.write(true, response.getCallback(), _byteBuffer.slice());
+        acceptor.accept(originalRequest, exchange ->
+        {
+            Response response = exchange.getResponse();
+            response.setStatus(200);
+            response.setContentType(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString());
+            response.setContentLength(_byteBuffer.remaining());
+            response.write(true, exchange, _byteBuffer.slice());
+        });
     }
 }


### PR DESCRIPTION
This is an attempt at introducing the `Acceptor`, `Processor & `Exchange` concepts to the handling.  It is essentially @sbordet method from jetty-12-ng-sbordet, but with an Acceptor separated out that takes the request, so request wrappers are not lost (see discussion in #7424):

 + `Handler`s are offerred an immutable `Request` along with an `Acceptor`.  There is no content API on request.
 + A `Handler` can accept the offered request by calling `Acceptor.accept(Request, Processor)` passing in the request that may have been wrapped by this or a previous `Handler`. 
 + Once accepted, the `Processor.process(Exchange)` method will subsequently be called to actually process the request and generate the response. The `process` call may happen within the scope of `accept` or it may be deferred waiting for content, or QoS issues etc.
 + The `Exchange` passed to `process` contains the `Request` and `Response` instances, it also is-a `Content.Provider` (to get the request body) and a `Callback` to signal success or failure of the exchange.


It is mostly working (8 tests failing) and those should be able to be fixed easily enough......

However, I don't like it.  I almost REALLY don't like it.  I'm close to hating it... but there is enough goodness to make me keep trying a bit more.

It is very technically correct and the concepts of `Acceptor`, `Processor` and `Exchange` feel real and not contrived.     But geeze it is hard to work with and makes many simple cases a lot more complex.   Several times I found myself wrapping an acceptor to wrap the processor so that the exchange could be wrapped to return a wrapped Content.Producer!    That's 4 wrappers instead of something that could have been done with 1.

I think it is going to produce a lot more garbage, have a lot deeper stacks, be a whole bunch hard to debug and the basic handler code will be harder to write correctly.

BUT  I really do like how well it allows deferred call to a Processor (waiting for content, or perhaps a QoS filter etc.)   

BUT I'm wondering if we are messing up the 99% case to make the 1% case work well?

I'll make a few more inline comments to illustrate some of my issues.... and then I'll keep working on it at least until it is green build and we (@lorban) can benchmark it.  Perhaps if it doesn't suck noticeably badly in benchmarks, then I might like it more.





