### PR TITLE
Issue #7569 - better error message if headerCacheSize is too large

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.util.ArrayTernaryTrie;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.TreeTrie;
@@ -434,6 +435,10 @@ public class HttpConfiguration implements Dumpable
      */
     public void setHeaderCacheSize(int headerCacheSize)
     {
+        if (headerCacheSize > ArrayTernaryTrie.MAX_CAPACITY)
+        {
+            throw new IllegalArgumentException("headerCacheSize " + headerCacheSize + " exceeds maximum value of " + ArrayTernaryTrie.MAX_CAPACITY);
+        }
         _headerCacheSize = headerCacheSize;
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
@@ -74,7 +74,7 @@ public class ArrayTernaryTrie<V> extends AbstractTrie<V>
      * the 16 bit indexes can overflow and the trie
      * cannot find existing entries anymore.
      */
-    private static final int MAX_CAPACITY = Character.MAX_VALUE - 1;
+    public static final int MAX_CAPACITY = Character.MAX_VALUE - 1;
 
     /**
      * The Trie rows in a single array which allows a lookup of row,character


### PR DESCRIPTION
Fixes #7569 