### PR TITLE
Turn off peer certificate verification for quic-server by default

### DIFF
--- a/jetty-quic/quic-server/src/main/java/org/eclipse/jetty/quic/server/QuicServerConnector.java
+++ b/jetty-quic/quic-server/src/main/java/org/eclipse/jetty/quic/server/QuicServerConnector.java
@@ -89,7 +89,7 @@ public class QuicServerConnector extends AbstractNetworkConnector
         // One bidirectional stream to simulate the TCP stream, and no unidirectional streams.
         quicConfiguration.setMaxBidirectionalRemoteStreams(1);
         quicConfiguration.setMaxUnidirectionalRemoteStreams(0);
-        quicConfiguration.setVerifyPeerCertificates(true);
+        quicConfiguration.setVerifyPeerCertificates(false);
     }
 
     public QuicConfiguration getQuicConfiguration()


### PR DESCRIPTION
Current version of quic-server is configured to verify peer certificate (aka mutual tls) by default. I think this is accidentally set to `true` and should be changed to `false` in order to get examples working.

Signed-off-by: Ning Sun <sunng@protonmail.com>