### PR TITLE
Honor parameters order when parsing query and form parameters

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -32,13 +32,16 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.servlet.DispatcherType;
 import javax.servlet.MultipartConfigElement;
@@ -190,6 +193,33 @@ public class RequestTest
 
         String responses = _connector.getResponse(request);
         assertTrue(responses.startsWith("HTTP/1.1 200"));
+    }
+
+    @Test
+    public void testParameterExtractionKeepOrderingIntact() throws Exception
+    {
+        AtomicReference<Map<String, String[]>> reference = new AtomicReference<>();
+        _handler._checker = new RequestTester()
+        {
+            @Override
+            public boolean check(HttpServletRequest request, HttpServletResponse response)
+            {
+                reference.set(request.getParameterMap());
+                return true;
+            }
+        };
+
+        String request = "POST /?first=1&second=2&third=3&fourth=4 HTTP/1.1\r\n" +
+            "Host: whatever\r\n" +
+            "Content-Type: application/x-www-form-urlencoded\n" +
+            "Connection: close\n" +
+            "Content-Length: 34\n" +
+            "\n" +
+            "fifth=5&sixth=6&seventh=7&eighth=8";;
+
+        String responses = _connector.getResponse(request);
+        assertTrue(responses.startsWith("HTTP/1.1 200"));
+        assertThat(new ArrayList<>(reference.get().keySet()), is(Arrays.asList("first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth")));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -32,7 +32,6 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -215,7 +214,7 @@ public class RequestTest
             "Connection: close\n" +
             "Content-Length: 34\n" +
             "\n" +
-            "fifth=5&sixth=6&seventh=7&eighth=8";;
+            "fifth=5&sixth=6&seventh=7&eighth=8";
 
         String responses = _connector.getResponse(request);
         assertTrue(responses.startsWith("HTTP/1.1 200"));

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ import java.util.Map;
  * @param <V> the entry type for multimap values
  */
 @SuppressWarnings("serial")
-public class MultiMap<V> extends HashMap<String, List<V>>
+public class MultiMap<V> extends LinkedHashMap<String, List<V>>
 {
     public MultiMap()
     {
@@ -321,13 +322,13 @@ public class MultiMap<V> extends HashMap<String, List<V>>
     @Override
     public String toString()
     {
-        Iterator<Entry<String, List<V>>> iter = entrySet().iterator();
+        Iterator<Map.Entry<String, List<V>>> iter = entrySet().iterator();
         StringBuilder sb = new StringBuilder();
         sb.append('{');
         boolean delim = false;
         while (iter.hasNext())
         {
-            Entry<String, List<V>> e = iter.next();
+            Map.Entry<String, List<V>> e = iter.next();
             if (delim)
             {
                 sb.append(", ");
@@ -355,7 +356,7 @@ public class MultiMap<V> extends HashMap<String, List<V>>
      */
     public Map<String, String[]> toStringArrayMap()
     {
-        HashMap<String, String[]> map = new HashMap<String, String[]>(size() * 3 / 2)
+        Map<String, String[]> map = new LinkedHashMap<String, String[]>(size() * 3 / 2)
         {
             @Override
             public String toString()


### PR DESCRIPTION
When parsing the query or form parameters in `Request`, the values are stored in a `MultiMap`. This class extends `HashMap` which does not preserve the order of insertion so a request with parameters `first=1&second=2` might end up in a map where `second` will come first when iterating on the entry set. 

The order is necessary in some case where the request is signed off the body and/or the query parameters. When the order is not preserved, it is impossible to reconstruct the original request sent to form a digest, unless using the `Request::getInputStream` which consumes the stream and makes subsequent calls to `Request::getParameters` to don't return the form parameters which can be misleading. The same behavior applied to query parameters, by using `Request::getQueryString`, you get the correct order but `Request::getParameters` will not.

Moreoever, if the application is behind a reverse proxy using Jetty that is proxying using `Request::getParameters` which consume the request InputStream, it will be completely impossible to reconstruct the original request.

I believe changing `MultiMap` to extends `LinkedHashMap` should have no performance impact and a minimal additional memory footprint. I'm of course open to alternatives if you have any.

I've based off this PR against the 9.4 branch which is still widely used by Spring Boot notably. I believe it can also be easily merged in other branch since changes are quite trivial.

Thanks!