### PR TITLE
Issue #7567 - don't compare params when checking MIME type for GzipHandler (9.4)

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -727,7 +727,7 @@ public class GzipHandler extends HandlerWrapper implements GzipFactory
         String mimeType = context == null ? MimeTypes.getDefaultMimeByExtension(path) : context.getMimeType(path);
         if (mimeType != null)
         {
-            mimeType = MimeTypes.getContentTypeWithoutCharset(mimeType);
+            mimeType = HttpFields.valueParameters(mimeType, null);
             if (!isMimeTypeGzipable(mimeType))
             {
                 LOG.debug("{} excluded by path suffix mime type {}", this, request);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpOutput;
@@ -36,7 +35,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingNestedCallback;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 
@@ -171,8 +169,8 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
         String ct = response.getContentType();
         if (ct != null)
         {
-            ct = MimeTypes.getContentTypeWithoutCharset(ct);
-            if (!_factory.isMimeTypeGzipable(StringUtil.asciiToLowerCase(ct)))
+            String baseType = HttpFields.valueParameters(ct, null);
+            if (!_factory.isMimeTypeGzipable(baseType))
             {
                 LOG.debug("{} exclude by mimeType {}", this, ct);
                 noCompression();


### PR DESCRIPTION
backport of PR #7576 to 9.4.x for issue #7567.