### PR TITLE
Honor parameters order when parsing query and form parameters (#7599)

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/MultiMap.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +27,7 @@ import java.util.Map;
  * @param <V> the entry type for multimap values
  */
 @SuppressWarnings("serial")
-public class MultiMap<V> extends HashMap<String, List<V>>
+public class MultiMap<V> extends LinkedHashMap<String, List<V>>
 {
     public MultiMap()
     {
@@ -316,13 +317,13 @@ public class MultiMap<V> extends HashMap<String, List<V>>
     @Override
     public String toString()
     {
-        Iterator<Entry<String, List<V>>> iter = entrySet().iterator();
+        Iterator<Map.Entry<String, List<V>>> iter = entrySet().iterator();
         StringBuilder sb = new StringBuilder();
         sb.append('{');
         boolean delim = false;
         while (iter.hasNext())
         {
-            Entry<String, List<V>> e = iter.next();
+            Map.Entry<String, List<V>> e = iter.next();
             if (delim)
             {
                 sb.append(", ");
@@ -350,7 +351,7 @@ public class MultiMap<V> extends HashMap<String, List<V>>
      */
     public Map<String, String[]> toStringArrayMap()
     {
-        HashMap<String, String[]> map = new HashMap<String, String[]>(size() * 3 / 2)
+        Map<String, String[]> map = new LinkedHashMap<String, String[]>(size() * 3 / 2)
         {
             @Override
             public String toString()


### PR DESCRIPTION
Cherry-pick of changes from PR #7599

* Honor parameters order when parsing query and form parameters

When parsing the query or form parameters in Request, the values are stored in a MultiMap. This class extends HashMap which does not preserve the order of insertion so a request with parameters "first=1&second=2" might end up in a map where "second" will come first when iterating on the entry set. 

The order is necessary in some case where the request is signed off the body and/or the query parameters. When the order is not preserved, it is impossible to reconstruct the original request sent, unless using the Request::getInputStream which consumes the stream and makes subsequent calls to Request::getParameters to don't return the form parameters which can be misleading. The same behavior applied to query parameters, by using Request::getQueryString, you get the correct order but Request::getParameters will not.

Moreoever, if the application is behind a reverse proxy using Jetty that is proxying using Request::getParameters which consume the request InputStream, it will be completely impossible to reconstruct the original request.

* Added a test with parameter merging