### PR TITLE
Issue #7615 HttpServletResponse.encodeURL() should support relative paths

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -1520,7 +1520,7 @@ public class ResponseTest
     }
 
     @Test
-    public void testEncodeRedirect()
+    public void testEncodeURLs()
         throws Exception
     {
         Response response = getResponse();
@@ -1570,6 +1570,7 @@ public class ResponseTest
         assertEquals("/;jsessionid=12345", response.encodeURL("/"));
         assertEquals("/foo.html;jsessionid=12345#target", response.encodeURL("/foo.html#target"));
         assertEquals(";jsessionid=12345", response.encodeURL(""));
+        assertEquals("../foo/bar.jsp;jsessionid=12345", response.encodeURL("../foo/bar.jsp"));
     }
 
     @Test


### PR DESCRIPTION
Fixing `Response.encodeURL(String)` to work with relative paths like `encodeURL("../foo/bar.txt")`