### PR TITLE
Issue #7344 - Fix stop in process

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyStopMojo.java
@@ -129,13 +129,14 @@ public class JettyStopMojo extends AbstractWebAppMojo
                 //wait for pid to stop
                 getLog().info("Waiting " + stopWait + " seconds for jetty " + pid + " to stop");
                 Optional<ProcessHandle> optional = ProcessHandle.of(pid);
+                final long remotePid = pid.longValue();
                 optional.ifPresentOrElse(p -> 
                 {
                     try
                     {
                         //if running in the same process, just send the stop
                         //command and wait for the response
-                        if (DeploymentMode.EMBED.equals(deployMode))
+                        if (ProcessHandle.current().pid() == remotePid)
                         {
                             send(stopKey + "\r\n" + command + "\r\n", stopWait);
                         }


### PR DESCRIPTION
The previous fix for #7344 works when jetty has been forked, but _doesn't_ work if jetty is executing in the same process as maven because it calls the `Process.onExit()` method, which throws ISE when called within the same process. This PR addresses that, and adds a unit test for it.