### PR TITLE
Fixes #7548 - Interrupt flag is not always cleared in between request…

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java
@@ -412,6 +412,11 @@ public class ReservedThreadExecutor extends AbstractLifeCycle implements TryExec
                     {
                         LOG.warn("Unable to run task", e);
                     }
+                    finally
+                    {
+                        // Clear any interrupted status.
+                        Thread.interrupted();
+                    }
                 }
             }
             finally


### PR DESCRIPTION
…s. (#7563)

Now clearing the interrupt flag.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>
(cherry picked from commit 7b648f6d5caf118c654ef6a7f83473f7912c404c)