### PR TITLE
Disable PGP signature propagation for now

### DIFF
--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -26,7 +26,9 @@
               <categoryName>Jetty Bundles</categoryName>
               <includeReactor>true</includeReactor>
               <includeDependencies>false</includeDependencies>
-              <includePGPSignature>true</includePGPSignature>
+              <!-- due to a bug in tycho PGP signatures should be disabled until it is resolved -->
+              <!-- https://github.com/eclipse/tycho/issues/808 -->
+              <includePGPSignature>false</includePGPSignature>
             </configuration>
             <id>maven-p2-site</id>
             <phase>prepare-package</phase>


### PR DESCRIPTION
Due to a bug in Tycho invalid PGP signatures are generated. PGP signature propagation should therefore be disabled until fix in Tycho 3.0.0 is available.

See also:

- https://github.com/eclipse/tycho/discussions/803
- https://github.com/eclipse/tycho/issues/808
- https://github.com/eclipse-equinox/p2/issues/16

