### PR TITLE
Fixes #6756 - Deprecate `jetty-spring` sub-project

### DIFF
--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -9,7 +9,7 @@
   <name>Example :: Jetty Spring</name>
 
   <properties>
-    <spring-version>3.2.18.RELEASE</spring-version>
+    <spring-version>5.3.17</spring-version>
     <dependencies>target/dependencies</dependencies>
     <bundle-symbolic-name>${project.groupId}.spring</bundle-symbolic-name>
     <jacoco.skip>true</jacoco.skip>

--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -9,7 +9,7 @@
   <name>Example :: Jetty Spring</name>
 
   <properties>
-    <spring-version>5.3.17</spring-version>
+    <spring-version>5.3.18</spring-version>
     <dependencies>target/dependencies</dependencies>
     <bundle-symbolic-name>${project.groupId}.spring</bundle-symbolic-name>
     <jacoco.skip>true</jacoco.skip>

--- a/jetty-spring/src/main/java/org/eclipse/jetty/spring/Main.java
+++ b/jetty-spring/src/main/java/org/eclipse/jetty/spring/Main.java
@@ -23,11 +23,14 @@ import org.eclipse.jetty.xml.XmlConfiguration;
 
 /**
  * Runs Jetty from a Spring configuration file passed as argument.
+ * @deprecated Has been removed in Jetty 10+
  */
+@Deprecated
 public class Main
 {
     public static void main(String[] args) throws Exception
     {
+        System.err.println("DEPRECATION WARNING - The `jetty-spring` project will see no further updates, and has been fully removed from Jetty 10 onwards");
         Resource config = Resource.newResource(args.length == 1 ? args[0] : "etc/jetty-spring.xml");
         XmlConfiguration.main(config.getFile().getAbsolutePath());
     }

--- a/jetty-spring/src/main/java/org/eclipse/jetty/spring/SpringConfigurationProcessor.java
+++ b/jetty-spring/src/main/java/org/eclipse/jetty/spring/SpringConfigurationProcessor.java
@@ -58,7 +58,9 @@ import org.springframework.core.io.UrlResource;
  * <p>
  * This processor is returned by the {@link SpringConfigurationProcessorFactory} for any XML document whos first
  * element is "beans". The factory is discovered by a {@link ServiceLoader} for {@link ConfigurationProcessorFactory}.
+ * @deprecated Has been removed in Jetty 10+
  */
+@Deprecated
 public class SpringConfigurationProcessor implements ConfigurationProcessor
 {
     private static final Logger LOG = Log.getLogger(SpringConfigurationProcessor.class);
@@ -66,6 +68,11 @@ public class SpringConfigurationProcessor implements ConfigurationProcessor
     private XmlConfiguration _configuration;
     private DefaultListableBeanFactory _beanFactory;
     private String _main;
+
+    public SpringConfigurationProcessor()
+    {
+        LOG.warn("DEPRECATION WARNING - The `jetty-spring` project will see no further updates, and has been fully removed from Jetty 10 onwards");
+    }
 
     @Override
     public void init(URL url, XmlParser.Node root, XmlConfiguration configuration)
@@ -141,7 +148,7 @@ public class SpringConfigurationProcessor implements ConfigurationProcessor
         {
             LOG.debug("{} - {}", bean, Arrays.asList(_beanFactory.getAliases(bean)));
             String[] aliases = _beanFactory.getAliases(bean);
-            if ("Main".equals(bean) || aliases != null && Arrays.asList(aliases).contains("Main"))
+            if ("Main".equals(bean) || Arrays.asList(aliases).contains("Main"))
             {
                 _main = bean;
                 break;

--- a/jetty-spring/src/main/java/org/eclipse/jetty/spring/SpringConfigurationProcessorFactory.java
+++ b/jetty-spring/src/main/java/org/eclipse/jetty/spring/SpringConfigurationProcessorFactory.java
@@ -30,7 +30,9 @@ import org.eclipse.jetty.xml.XmlConfiguration;
  *
  * @see SpringConfigurationProcessor
  * @see XmlConfiguration
+ * @deprecated Has been removed in Jetty 10+
  */
+@Deprecated
 public class SpringConfigurationProcessorFactory implements ConfigurationProcessorFactory
 {
     @Override

--- a/jetty-spring/src/main/java/org/eclipse/jetty/spring/package-info.java
+++ b/jetty-spring/src/main/java/org/eclipse/jetty/spring/package-info.java
@@ -17,7 +17,8 @@
 //
 
 /**
- * Jetty Spring : Spring IoC Configuration for Jetty
+ * Jetty Spring : (Deprecated) Spring IoC Configuration for Jetty
+ * @deprecated
  */
 package org.eclipse.jetty.spring;
 

--- a/jetty-spring/src/test/resources/org/eclipse/jetty/spring/configure.xml
+++ b/jetty-spring/src/test/resources/org/eclipse/jetty/spring/configure.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
   <!-- define the singleton properties Map, filled in with XmlConfiguration.getProperties() -->
   <bean id="properties" class="java.util.Map"/>
 
   <!-- extract a value from the property map -->
   <bean id="testProperty" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-    <property name="targetObject"><ref local="properties" /></property>
+    <property name="targetObject" ref="properties" />
     <property name="targetMethod" value="get" />
     <property name="arguments"><list><value>test</value></list></property>
   </bean>


### PR DESCRIPTION
Updating version of spring-beans to 5.3.17, and deprecating everything in the sub-project.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>