### PR TITLE
Issue #7818 - HttpChannel.Listener.onResponseBegin() Test 

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelEventTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelEventTest.java
@@ -178,7 +178,7 @@ public class HttpChannelEventTest
         start(new TestHandler()
         {
             @Override
-            protected void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            protected void handle(HttpServletRequest request, HttpServletResponse response)
             {
                 response.setCharacterEncoding("utf-8");
                 response.setContentType("text/plain");

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelEventTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelEventTest.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.server;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -28,8 +29,10 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.hamcrest.Matchers;
@@ -37,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -166,6 +170,54 @@ public class HttpChannelEventTest
 
         assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
         assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testResponseBeginModifyHeaders() throws Exception
+    {
+        start(new TestHandler()
+        {
+            @Override
+            protected void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            {
+                response.setCharacterEncoding("utf-8");
+                response.setContentType("text/plain");
+                // Intentionally add two values for a header
+                response.addHeader("X-Header", "foo");
+                response.addHeader("X-Header", "bar");
+            }
+        });
+
+        CountDownLatch latch = new CountDownLatch(1);
+        connector.addBean(new HttpChannel.Listener()
+        {
+            @Override
+            public void onResponseBegin(Request request)
+            {
+                Response response = request.getResponse();
+                // Eliminate all "X-Header" values from Handler, and force it to be the one value "zed"
+                response.getHttpFields().computeField("X-Header", (n, f) -> new HttpField(n, "zed"));
+            }
+
+            @Override
+            public void onComplete(Request request)
+            {
+                latch.countDown();
+            }
+        });
+
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "localhost");
+        request.setHeader("Connection", "close");
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request.toString(), 5, TimeUnit.SECONDS));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        List<HttpField> xheaders = response.getFields("X-Header");
+        assertThat("X-Header count", xheaders.size(), is(1));
+        assertThat("X-Header[0].value", xheaders.get(0).getValue(), is("zed"));
     }
 
     @Test


### PR DESCRIPTION
Confirming behavior in Jetty 9.4.x

This is a test case only, no mainline code changes.