### PR TITLE
Issue #5859 - Use JVM PrivilegedThreadFactory instead.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.util.thread;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 /**
@@ -32,7 +33,10 @@ import java.util.function.Supplier;
  * calling context - which contains ProtectionDomains that may
  * reference the context classloader - and remembers it for the
  * lifetime of the Thread.
+ *
+ * @deprecated use {@link Executors#privilegedThreadFactory()} instead.
  */
+@Deprecated
 class PrivilegedThreadFactory
 {
     /**
@@ -51,6 +55,6 @@ class PrivilegedThreadFactory
             {
                 return newThreadSupplier.get();
             }
-        });
+        }, AccessController.getContext());
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -103,6 +104,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     private final BlockingQueue<Runnable> _jobs;
     private final ThreadGroup _threadGroup;
     private final ThreadFactory _threadFactory;
+    private final ThreadFactory _privilegedThreadFactory = Executors.privilegedThreadFactory();
     private String _name = "qtp" + hashCode();
     private int _idleTimeout;
     private int _maxThreads;
@@ -813,14 +815,13 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     @Override
     public Thread newThread(Runnable runnable)
     {
-        return PrivilegedThreadFactory.newThread(() ->
+        return _privilegedThreadFactory.newThread(() ->
         {
             Thread thread = new Thread(_threadGroup, runnable);
             thread.setDaemon(isDaemon());
             thread.setPriority(getThreadsPriority());
             thread.setName(_name + "-" + thread.getId());
             thread.setContextClassLoader(getClass().getClassLoader());
-            return thread;
         });
     }
 


### PR DESCRIPTION
* Deprecate our internal `PrivilegedThreadFactory`
* Use JVM provided `Executors.privilegedThreadFactory()` instead in QTP.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>