### PR TITLE
Issue #7855 - maven compiler plugin should not generate package-info.class files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <!-- build -->
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
     <jetty.url>https://eclipse.org/jetty</jetty.url>
     <jmhjar.name>benchmarks</jmhjar.name>
     <jpms-module-name>${bundle-symbolic-name}</jpms-module-name>


### PR DESCRIPTION
This behavior change in `maven-compiler-plugin` 3.10.0 comes from.

* https://issues.apache.org/jira/browse/MCOMPILER-205
* https://github.com/apache/maven-compiler-plugin/pull/88

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>