### PR TITLE
Issue #7855 - maven compiler plugin should not generate package-info.class files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <compiler.source>11</compiler.source>
     <compiler.target>11</compiler.target>
     <compiler.release>11</compiler.release>
+    <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
     <jetty.url>https://www.eclipse.org/jetty/</jetty.url>
     <jmhjar.name>benchmarks</jmhjar.name>
     <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.slf4j.import.packages>


### PR DESCRIPTION
Cherry-pick of commit 1678a21b8282e304414e4b17acea53fe89bd0ee5

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>