### PR TITLE
upgrade maven-shade-plugin 3.3.0 working with Maven 3.8.5 (skip this dependency-reduced pom generation as we do not use and it causes issues)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.remote-resources.plugin.version>1.7.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-    <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
+    <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
     <maven.site.plugin.version>3.11.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
@@ -681,6 +681,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven.shade.plugin.version}</version>
+          <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- shade plugin 3.3.0
- avoid a lot of potential problems due to this "feature" we do not need here
