### PR TITLE
#7863 Include value of first accept-encoding header where multiple accept-encoding headers are given

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -327,6 +327,7 @@ public class ResourceService
         if (headers.hasMoreElements())
         {
             StringBuilder sb = new StringBuilder(key.length() * 2);
+            sb.append(key);
             do
             {
                 sb.append(',').append(headers.nextElement());

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -1932,6 +1932,16 @@ public class DefaultServletTest
         assertThat(response, containsHeaderValue(HttpHeader.CONTENT_ENCODING, "gzip"));
         body = response.getContent();
         assertThat(body, containsString("fake gzip"));
+
+        rawResponse = connector.getResponse("GET /context/data0.txt HTTP/1.0\r\nHost:localhost:8080\r\nAccept-Encoding:br\r\nAccept-Encoding:gzip, compress\r\n\r\n");
+        response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response, containsHeaderValue(HttpHeader.CONTENT_LENGTH, "11"));
+        assertThat(response, containsHeaderValue(HttpHeader.CONTENT_TYPE, "text/plain"));
+        assertThat(response, containsHeaderValue(HttpHeader.VARY, "Accept-Encoding"));
+        assertThat(response, containsHeaderValue(HttpHeader.CONTENT_ENCODING, "br"));
+        body = response.getContent();
+        assertThat(body, containsString("fake brotli"));
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of commit 8bcb842fbbd2e4c9f57bfa7718b038786edc0aa0 for `jetty-9.4.x`
