### PR TITLE
#7880 retain resource service configuration

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.servlet;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -170,7 +171,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
         _resourceService.setAcceptRanges(getInitBoolean("acceptRanges", _resourceService.isAcceptRanges()));
         _resourceService.setDirAllowed(getInitBoolean("dirAllowed", _resourceService.isDirAllowed()));
         _resourceService.setRedirectWelcome(getInitBoolean("redirectWelcome", _resourceService.isRedirectWelcome()));
-        _resourceService.setPrecompressedFormats(parsePrecompressedFormats(getInitParameter("precompressed"), getInitBoolean("gzip", false)));
+        _resourceService.setPrecompressedFormats(parsePrecompressedFormats(getInitParameter("precompressed"), getInitBoolean("gzip"), _resourceService.getPrecompressedFormats()));
         _resourceService.setPathInfoOnly(getInitBoolean("pathInfoOnly", _resourceService.isPathInfoOnly()));
         _resourceService.setEtags(getInitBoolean("etags", _resourceService.isEtags()));
 
@@ -303,8 +304,11 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             LOG.debug("resource base = {}", _resourceBase);
     }
 
-    private CompressedContentFormat[] parsePrecompressedFormats(String precompressed, boolean gzip)
+    private CompressedContentFormat[] parsePrecompressedFormats(String precompressed, Boolean gzip, CompressedContentFormat[] dft)
     {
+        if (precompressed == null && gzip == null) {
+            return dft;
+        }
         List<CompressedContentFormat> ret = new ArrayList<>();
         if (precompressed != null && precompressed.indexOf('=') > 0)
         {
@@ -367,16 +371,21 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
         return value;
     }
 
-    private boolean getInitBoolean(String name, boolean dft)
+    private Boolean getInitBoolean(String name)
     {
         String value = getInitParameter(name);
         if (value == null || value.length() == 0)
-            return dft;
+            return null;
         return (value.startsWith("t") ||
             value.startsWith("T") ||
             value.startsWith("y") ||
             value.startsWith("Y") ||
             value.startsWith("1"));
+    }
+
+    private boolean getInitBoolean(String name, boolean dft)
+    {
+        return Optional.ofNullable(getInitBoolean(name)).orElse(dft);
     }
 
     private int getInitInt(String name, int dft)

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -319,7 +319,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
                 String encoding = setting[0].trim();
                 String extension = setting[1].trim();
                 ret.add(new CompressedContentFormat(encoding, extension));
-                if (gzip && !ret.contains(CompressedContentFormat.GZIP))
+                if (gzip == Boolean.TRUE && !ret.contains(CompressedContentFormat.GZIP))
                     ret.add(CompressedContentFormat.GZIP);
             }
         }
@@ -331,7 +331,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
                 ret.add(CompressedContentFormat.GZIP);
             }
         }
-        else if (gzip)
+        else if (gzip == Boolean.TRUE)
         {
             // gzip handling is for backwards compatibility with older Jetty
             ret.add(CompressedContentFormat.GZIP);

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/DefaultServlet.java
@@ -306,7 +306,8 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
 
     private CompressedContentFormat[] parsePrecompressedFormats(String precompressed, Boolean gzip, CompressedContentFormat[] dft)
     {
-        if (precompressed == null && gzip == null) {
+        if (precompressed == null && gzip == null)
+        {
             return dft;
         }
         List<CompressedContentFormat> ret = new ArrayList<>();

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -40,7 +40,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.*;
+import org.eclipse.jetty.http.CompressedContentFormat;
+import org.eclipse.jetty.http.DateGenerator;
+import org.eclipse.jetty.http.HttpContent;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.HttpConfiguration;


### PR DESCRIPTION
Added method for getting `Boolean` init parameters that returns `null` if not set.
Rewrote method for getting `boolean` or default init parameters to use `Boolean` init parameters method.
Used `Boolean` init parameter to identify when neither `precompressed` nor `gzip` init parameters have been set, and fall back to existing precompression formats from `_resourceService`.