### PR TITLE
Fixed flaky ssl fullMethod test

### DIFF
--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -217,7 +217,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             catch (Exception e)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.warn("write exception", e);
+                    LOG.debug("write exception", e);
             }
 
             // Read the response.

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -209,8 +209,16 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             byte[] buffer = new byte[64 * 1024];
             Arrays.fill(buffer, (byte)'A');
 
-            os.write(buffer);
-            os.flush();
+            try
+            {
+                os.write(buffer);
+                os.flush();
+            }
+            catch (Exception e)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.warn("write exception", e);
+            }
 
             // Read the response.
             String response = readResponse(client);


### PR DESCRIPTION
The write of the test request was sometimes failing before the write was complete.  A good response was produced.
In the case of too large messages, we should fail before reading them all.

Signed-off-by: Greg Wilkins <gregw@webtide.com>