### PR TITLE
Fix #7918 Root path spec

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -199,12 +199,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
 
     public static PathSpec asPathSpec(String pathSpecString)
     {
-        if ((pathSpecString == null) || (pathSpecString.length() < 1))
-        {
-            if (pathSpecString != null)
-                return new ServletPathSpec("");
+        if (pathSpecString == null)
             throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
-        }
+
+        if (pathSpecString.length() == 0)
+            return new ServletPathSpec("");
+
         return pathSpecString.charAt(0) == '^' ? new RegexPathSpec(pathSpecString) : new ServletPathSpec(pathSpecString);
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -201,6 +201,8 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     {
         if ((pathSpecString == null) || (pathSpecString.length() < 1))
         {
+            if (pathSpecString != null)
+                return new ServletPathSpec("");
             throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
         }
         return pathSpecString.charAt(0) == '^' ? new RegexPathSpec(pathSpecString) : new ServletPathSpec(pathSpecString);

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -460,5 +461,19 @@ public class PathMappingsTest
         assertThat(p.remove(new ServletPathSpec("/a/b/d")), is(false));
         assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(true));
         assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(false));
+    }
+
+    @Test
+    public void testAsPathSpec()
+    {
+        assertThat(PathMappings.asPathSpec(""), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/foo/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("*.jsp"), instanceOf(ServletPathSpec.class));
+
+        assertThat(PathMappings.asPathSpec("^$"), instanceOf(RegexPathSpec.class));
+        assertThat(PathMappings.asPathSpec("^.*"), instanceOf(RegexPathSpec.class));
+        assertThat(PathMappings.asPathSpec("^/"), instanceOf(RegexPathSpec.class));
     }
 }

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
@@ -1864,6 +1864,44 @@ public class ConstraintTest
         assertThat(response, startsWith("HTTP/1.1 403 "));
     }
 
+    @Test
+    public void testDefaultConstraint() throws Exception
+    {
+        _security.setAuthenticator(new BasicAuthenticator());
+
+        ConstraintMapping forbidDefault = new ConstraintMapping();
+        forbidDefault.setPathSpec("/");
+        forbidDefault.setConstraint(_forbidConstraint);
+        _security.addConstraintMapping(forbidDefault);
+
+        ConstraintMapping allowRoot = new ConstraintMapping();
+        allowRoot.setPathSpec("");
+        allowRoot.setConstraint(_relaxConstraint);
+        _security.addConstraintMapping(allowRoot);
+
+        _server.start();
+        String response;
+
+        response = _connector.getResponse("GET /ctx/ HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 200 OK"));
+
+        response = _connector.getResponse("GET /ctx/anything HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/noauth/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/forbid/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
+        assertThat(response, containsString("WWW-Authenticate: basic realm=\"TestRealm\""));
+
+        response = _connector.getResponse("GET /ctx/admin/relax/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 200 OK"));
+    }
+
     private static String authBase64(String authorization)
     {
         byte[] raw = authorization.getBytes(ISO_8859_1);


### PR DESCRIPTION
Handle root pathspec in PathMappings.asPathSpec

Not used in jetty-9, but will be ported forward to where it is used in 10,11 & 12

Signed-off-by: Greg Wilkins <gregw@webtide.com>