### PR TITLE
Jetty 10 7918 root pathspec

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -199,12 +199,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
 
     public static PathSpec asPathSpec(String pathSpecString)
     {
-        if ((pathSpecString == null) || (pathSpecString.length() < 1))
-        {
-            if (pathSpecString != null)
-                return new ServletPathSpec("");
+        if (pathSpecString == null)
             throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
-        }
+
+        if (pathSpecString.length() == 0)
+            return new ServletPathSpec("");
+
         return pathSpecString.charAt(0) == '^' ? new RegexPathSpec(pathSpecString) : new ServletPathSpec(pathSpecString);
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -210,14 +209,10 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
 
     public E get(PathSpec spec)
     {
-        Optional<E> optionalResource = _mappings.stream()
+        return _mappings.stream()
             .filter(mappedResource -> mappedResource.getPathSpec().equals(spec))
-            .map(mappedResource -> mappedResource.getResource())
-            .findFirst();
-        if (!optionalResource.isPresent())
-            return null;
-
-        return optionalResource.get();
+            .map(MappedResource::getResource)
+            .findFirst().orElse(null);
     }
 
     public boolean put(String pathSpecString, E resource)

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -201,6 +201,8 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     {
         if ((pathSpecString == null) || (pathSpecString.length() < 1))
         {
+            if (pathSpecString != null)
+                return new ServletPathSpec("");
             throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
         }
         return pathSpecString.charAt(0) == '^' ? new RegexPathSpec(pathSpecString) : new ServletPathSpec(pathSpecString);

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -455,5 +456,19 @@ public class PathMappingsTest
         assertThat(p.remove(new ServletPathSpec("/a/b/d")), is(false));
         assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(true));
         assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(false));
+    }
+
+    @Test
+    public void testAsPathSpec()
+    {
+        assertThat(PathMappings.asPathSpec(""), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("/foo/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathMappings.asPathSpec("*.jsp"), instanceOf(ServletPathSpec.class));
+
+        assertThat(PathMappings.asPathSpec("^$"), instanceOf(RegexPathSpec.class));
+        assertThat(PathMappings.asPathSpec("^.*"), instanceOf(RegexPathSpec.class));
+        assertThat(PathMappings.asPathSpec("^/"), instanceOf(RegexPathSpec.class));
     }
 }

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/ConstraintSecurityHandler.java
@@ -35,6 +35,7 @@ import javax.servlet.annotation.ServletSecurity.TransportGuarantee;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
+import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -422,7 +423,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     protected void processConstraintMapping(ConstraintMapping mapping)
     {
-        Map<String, RoleInfo> mappings = _constraintRoles.get(PathMappings.asPathSpec(mapping.getPathSpec()));
+        Map<String, RoleInfo> mappings = _constraintRoles.get(asPathSpec(mapping));
         if (mappings == null)
         {
             mappings = new HashMap<>();
@@ -465,6 +466,13 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 mappings.put(ALL_METHODS, roleInfo);
             }
         }
+    }
+
+    protected PathSpec asPathSpec(ConstraintMapping mapping)
+    {
+        // As currently written, this allows regex patterns to be used.
+        // This may not be supported by default in future releases.
+        return PathMappings.asPathSpec(mapping.getPathSpec());
     }
 
     /**

--- a/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
+++ b/jetty-security/src/test/java/org/eclipse/jetty/security/ConstraintTest.java
@@ -1869,6 +1869,44 @@ public class ConstraintTest
         assertThat(response, startsWith("HTTP/1.1 403 "));
     }
 
+    @Test
+    public void testDefaultConstraint() throws Exception
+    {
+        _security.setAuthenticator(new BasicAuthenticator());
+
+        ConstraintMapping forbidDefault = new ConstraintMapping();
+        forbidDefault.setPathSpec("/");
+        forbidDefault.setConstraint(_forbidConstraint);
+        _security.addConstraintMapping(forbidDefault);
+
+        ConstraintMapping allowRoot = new ConstraintMapping();
+        allowRoot.setPathSpec("");
+        allowRoot.setConstraint(_relaxConstraint);
+        _security.addConstraintMapping(allowRoot);
+
+        _server.start();
+        String response;
+
+        response = _connector.getResponse("GET /ctx/ HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 200 OK"));
+
+        response = _connector.getResponse("GET /ctx/anything HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/noauth/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/forbid/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
+
+        response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
+        assertThat(response, containsString("WWW-Authenticate: basic realm=\"TestRealm\""));
+
+        response = _connector.getResponse("GET /ctx/admin/relax/info HTTP/1.0\r\n\r\n");
+        assertThat(response, startsWith("HTTP/1.1 200 OK"));
+    }
+
     private static String authBase64(String authorization)
     {
         byte[] raw = authorization.getBytes(ISO_8859_1);


### PR DESCRIPTION
In addition to cherry-picking asPathSpec fix from 9, this PR makes asPathSpec extensible in ConstraintSecurityHandler in the same way it is now extensible in ServletHandler