### PR TITLE
Fix #7929 requestlog format string commented default

### DIFF
--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -19,7 +19,7 @@ logs/
 [ini-template]
 # tag::documentation[]
 ## Request log line format string.
-# jetty.requestlog.formatString=%a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %B "%{Referer}i" "%{User-Agent}i" "%C"
+#jetty.requestlog.formatString=%{client}a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %O "%{Referer}i" "%{User-Agent}i"
 
 ## The logging directory (relative to $JETTY_BASE).
 # jetty.requestlog.dir=logs


### PR DESCRIPTION
Signed-off-by: Padraic Renaghan <padraic@renaghan.com>

Change the commented default `jetty.requestlog.formatString` in `requestlog.ini` to match what the `CustomRequestLog` code actually does.
Also the current comment mentions `%B` which is not listed as valid in the documentation - which confused me for a while.
And the `%a` is missing the format parameter used in the code.

This aligns the comment with the default value, which seems to be the pattern of the values in module default `.ini` files. Also aligns said comment with format specifiers listed in the online documentation. All of which goes to avoid confusion and questions by folks configuring Jetty requestlog module.
