### PR TITLE
Improved PathSpec handling for servletName & pathInfo

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/AbstractPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/AbstractPathSpec.java
@@ -36,7 +36,12 @@ public abstract class AbstractPathSpec implements PathSpec
             return diff;
 
         // Path Spec Name (alphabetical)
-        return getDeclaration().compareTo(other.getDeclaration());
+        diff = getDeclaration().compareTo(other.getDeclaration());
+        if (diff != 0)
+            return diff;
+
+        // Path Implementation
+        return getClass().getName().compareTo(other.getClass().getName());
     }
 
     @Override
@@ -55,7 +60,7 @@ public abstract class AbstractPathSpec implements PathSpec
     @Override
     public final int hashCode()
     {
-        return Objects.hash(getDeclaration());
+        return Objects.hash(this.getClass().getSimpleName() + ":" + getDeclaration());
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/AbstractPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/AbstractPathSpec.java
@@ -60,7 +60,7 @@ public abstract class AbstractPathSpec implements PathSpec
     @Override
     public final int hashCode()
     {
-        return Objects.hash(this.getClass().getSimpleName() + ":" + getDeclaration());
+        return Objects.hash(getGroup().ordinal(), getSpecLength(), getDeclaration(), getClass().getName());
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
@@ -37,7 +37,7 @@ public interface MatchedPath
         @Override
         public String toString()
         {
-            return "MatchedPath.EMPTY";
+            return MatchedPath.class.getSimpleName() + ".EMPTY";
         }
     };
 
@@ -60,7 +60,7 @@ public interface MatchedPath
             @Override
             public String toString()
             {
-                return "MatchedPath.from[pathMatch=" + pathMatch + ", pathInfo=" + pathInfo + "]";
+                return MatchedPath.class.getSimpleName() + "[pathMatch=" + pathMatch + ", pathInfo=" + pathInfo + "]";
             }
         };
     }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
@@ -1,0 +1,41 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.http.pathmap;
+
+public interface MatchedPath
+{
+    /**
+     * @return the raw input path as provided.
+     */
+    String getPath();
+
+    /**
+     * Return the portion of the path that matches a path spec.
+     *
+     * @return the path name portion of the match.
+     */
+    String getPathMatch();
+
+    /**
+     * Return the portion of the path that is after the path spec.
+     *
+     * @return the path info portion of the match, or null if there is no portion after the {@link #getPathMatch()}
+     */
+    String getPathInfo();
+}

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedPath.java
@@ -33,7 +33,37 @@ public interface MatchedPath
         {
             return null;
         }
+
+        @Override
+        public String toString()
+        {
+            return "MatchedPath.EMPTY";
+        }
     };
+
+    static MatchedPath from(String pathMatch, String pathInfo)
+    {
+        return new MatchedPath()
+        {
+            @Override
+            public String getPathMatch()
+            {
+                return pathMatch;
+            }
+
+            @Override
+            public String getPathInfo()
+            {
+                return pathInfo;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "MatchedPath.from[pathMatch=" + pathMatch + ", pathInfo=" + pathInfo + "]";
+            }
+        };
+    }
 
     /**
      * Return the portion of the path that matches a path spec.

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
@@ -20,6 +20,12 @@ package org.eclipse.jetty.http.pathmap;
 
 import java.util.Map;
 
+/**
+ * The match details when using {@link PathMappings#getMatched(String)}, used to minimize return to the PathSpec or PathMappings for subsequent details
+ * that are now provided by the {@link MatchedPath} instance.
+ *
+ * @param <E> the type of resource (IncludeExclude uses boolean, WebSocket uses endpoint/endpoint config, servlet uses ServletHolder, etc)
+ */
 public class MatchedResource<E>
 {
     private final E resource;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
@@ -18,34 +18,34 @@
 
 package org.eclipse.jetty.http.pathmap;
 
-public interface MatchedPath
+public class MatchedResource<E>
 {
-    MatchedPath EMPTY = new MatchedPath()
+    private final MappedResource<E> mappedResource;
+    private final MatchedPath matchedPath;
+
+    public MatchedResource(MappedResource<E> resource, MatchedPath matchedPath)
     {
-        @Override
-        public String getPathMatch()
-        {
-            return null;
-        }
+        this.mappedResource = resource;
+        this.matchedPath = matchedPath;
+    }
 
-        @Override
-        public String getPathInfo()
-        {
-            return null;
-        }
-    };
+    public MappedResource<E> getMappedResource()
+    {
+        return this.mappedResource;
+    }
 
-    /**
-     * Return the portion of the path that matches a path spec.
-     *
-     * @return the path name portion of the match.
-     */
-    String getPathMatch();
+    public PathSpec getPathSpec()
+    {
+        return mappedResource.getPathSpec();
+    }
 
-    /**
-     * Return the portion of the path that is after the path spec.
-     *
-     * @return the path info portion of the match, or null if there is no portion after the {@link #getPathMatch()}
-     */
-    String getPathInfo();
+    public E getResource()
+    {
+        return mappedResource.getResource();
+    }
+
+    public MatchedPath getMatchedPath()
+    {
+        return matchedPath;
+    }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MatchedResource.java
@@ -18,34 +18,53 @@
 
 package org.eclipse.jetty.http.pathmap;
 
+import java.util.Map;
+
 public class MatchedResource<E>
 {
-    private final MappedResource<E> mappedResource;
+    private final E resource;
+    private final PathSpec pathSpec;
     private final MatchedPath matchedPath;
 
-    public MatchedResource(MappedResource<E> resource, MatchedPath matchedPath)
+    public MatchedResource(E resource, PathSpec pathSpec, MatchedPath matchedPath)
     {
-        this.mappedResource = resource;
+        this.resource = resource;
+        this.pathSpec = pathSpec;
         this.matchedPath = matchedPath;
     }
 
-    public MappedResource<E> getMappedResource()
+    public static <E> MatchedResource<E> of(Map.Entry<PathSpec, E> mapping, MatchedPath matchedPath)
     {
-        return this.mappedResource;
+        return new MatchedResource<>(mapping.getValue(), mapping.getKey(), matchedPath);
     }
 
     public PathSpec getPathSpec()
     {
-        return mappedResource.getPathSpec();
+        return this.pathSpec;
     }
 
     public E getResource()
     {
-        return mappedResource.getResource();
+        return this.resource;
     }
 
-    public MatchedPath getMatchedPath()
+    /**
+     * Return the portion of the path that matches a path spec.
+     *
+     * @return the path name portion of the match.
+     */
+    public String getPathMatch()
     {
-        return matchedPath;
+        return matchedPath.getPathMatch();
+    }
+
+    /**
+     * Return the portion of the path that is after the path spec.
+     *
+     * @return the path info portion of the match, or null if there is no portion after the {@link #getPathMatch()}
+     */
+    public String getPathInfo()
+    {
+        return matchedPath.getPathInfo();
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -160,6 +160,9 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
             // Run servlet spec optimizations on first hit of specific groups
             if (group != lastGroup)
             {
+                // New group, reset skip logic
+                skipRestOfGroup = false;
+
                 // New group in list, so let's look for an optimization
                 switch (group)
                 {

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -392,9 +392,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         _exactMap.remove(exact);
                         // Recalculate _optimizeExact
-                        _optimizedExact = _mappings.stream()
-                            .filter((mapping) -> mapping.getPathSpec().getGroup() == PathSpecGroup.EXACT)
-                            .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
+                        _optimizedExact = canBeOptimized(PathSpecGroup.EXACT);
                     }
                     break;
                 case PREFIX_GLOB:
@@ -403,9 +401,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         _prefixMap.remove(prefix);
                         // Recalculate _optimizePrefix
-                        _optimizedPrefix = _mappings.stream()
-                            .filter((mapping) -> mapping.getPathSpec().getGroup() == PathSpecGroup.PREFIX_GLOB)
-                            .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
+                        _optimizedPrefix = canBeOptimized(PathSpecGroup.PREFIX_GLOB);
                     }
                     break;
                 case SUFFIX_GLOB:
@@ -414,15 +410,20 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         _suffixMap.remove(suffix);
                         // Recalculate _optimizeSuffix
-                        _optimizedSuffix = _mappings.stream()
-                            .filter((mapping) -> mapping.getPathSpec().getGroup() == PathSpecGroup.SUFFIX_GLOB)
-                            .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
+                        _optimizedSuffix = canBeOptimized(PathSpecGroup.SUFFIX_GLOB);
                     }
                     break;
             }
         }
 
         return removed;
+    }
+
+    private boolean canBeOptimized(PathSpecGroup suffixGlob)
+    {
+        return _mappings.stream()
+            .filter((mapping) -> mapping.getPathSpec().getGroup() == suffixGlob)
+            .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -120,8 +120,9 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         return ret;
     }
 
-    public MappedResource<E> getMatch(String path)
+    public MatchedResource<E> getMatched(String path)
     {
+        MatchedPath matchedPath = null;
         PathSpecGroup lastGroup = null;
 
         // Search all the mappings
@@ -142,8 +143,10 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                             MappedResource<E> candidate = exact_map.getBest(path, 0, i);
                             if (candidate == null)
                                 break;
-                            if (candidate.getPathSpec().matches(path))
-                                return candidate;
+
+                            matchedPath = candidate.getPathSpec().matched(path);
+                            if (matchedPath != null)
+                                return new MatchedResource<>(candidate, matchedPath);
                             i = candidate.getPathSpec().getPrefix().length() - 1;
                         }
                         break;
@@ -158,8 +161,10 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                             MappedResource<E> candidate = prefix_map.getBest(path, 0, i);
                             if (candidate == null)
                                 break;
-                            if (candidate.getPathSpec().matches(path))
-                                return candidate;
+
+                            matchedPath = candidate.getPathSpec().matched(path);
+                            if (matchedPath != null)
+                                return new MatchedResource<>(candidate, matchedPath);
                             i = candidate.getPathSpec().getPrefix().length() - 1;
                         }
                         break;
@@ -172,8 +177,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         while ((i = path.indexOf('.', i + 1)) > 0)
                         {
                             MappedResource<E> candidate = suffix_map.get(path, i + 1, path.length() - i - 1);
-                            if (candidate != null && candidate.getPathSpec().matches(path))
-                                return candidate;
+                            if (candidate == null)
+                                break;
+
+                            matchedPath = candidate.getPathSpec().matched(path);
+                            if (matchedPath != null)
+                                return new MatchedResource<>(candidate, matchedPath);
                         }
                         break;
                     }
@@ -182,13 +191,23 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                 }
             }
 
-            if (mr.getPathSpec().matches(path))
-                return mr;
+            matchedPath = mr.getPathSpec().matched(path);
+            if (matchedPath != null)
+                return new MatchedResource<>(mr, matchedPath);
 
             lastGroup = group;
         }
 
         return null;
+    }
+
+    /**
+     * @deprecated use {@link #getMatched(String)} instead
+     */
+    @Deprecated
+    public MappedResource<E> getMatch(String path)
+    {
+        return getMatched(path).getMappedResource();
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.http.pathmap;
 
+import java.util.Objects;
+
 /**
  * A path specification is a URI path template that can be matched against.
  * <p>
@@ -27,8 +29,7 @@ public interface PathSpec extends Comparable<PathSpec>
 {
     static PathSpec from(String pathSpecString)
     {
-        if (pathSpecString == null)
-            throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
+        Objects.requireNonNull(pathSpecString, "null PathSpec not supported");
 
         if (pathSpecString.length() == 0)
             return new ServletPathSpec("");

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
@@ -53,7 +53,9 @@ public interface PathSpec extends Comparable<PathSpec>
      *
      * @param path the path to match against
      * @return the path info portion of the string
+     * @deprecated use {@link #matched(String)} instead
      */
+    @Deprecated
     String getPathInfo(String path);
 
     /**
@@ -61,7 +63,9 @@ public interface PathSpec extends Comparable<PathSpec>
      *
      * @param path the path to match against
      * @return the match, or null if no match at all
+     * @deprecated use {@link #matched(String)} instead
      */
+    @Deprecated
     String getPathMatch(String path);
 
     /**
@@ -90,6 +94,15 @@ public interface PathSpec extends Comparable<PathSpec>
      *
      * @param path the path to test
      * @return true if the path matches this path spec, false otherwise
+     * @deprecated use {@link #matched(String)} instead
      */
+    @Deprecated
     boolean matches(String path);
+
+    /**
+     * Get the complete matched details of the provided path.
+     * @param path the path to test
+     * @return the matched details, if a match was possible, or null if not able to be matched.
+     */
+    MatchedPath matched(String path);
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpec.java
@@ -25,6 +25,17 @@ package org.eclipse.jetty.http.pathmap;
  */
 public interface PathSpec extends Comparable<PathSpec>
 {
+    static PathSpec from(String pathSpecString)
+    {
+        if (pathSpecString == null)
+            throw new RuntimeException("Path Spec String must start with '^', '/', or '*.': got [" + pathSpecString + "]");
+
+        if (pathSpecString.length() == 0)
+            return new ServletPathSpec("");
+
+        return pathSpecString.charAt(0) == '^' ? new RegexPathSpec(pathSpecString) : new ServletPathSpec(pathSpecString);
+    }
+
     /**
      * The length of the spec.
      *
@@ -101,6 +112,7 @@ public interface PathSpec extends Comparable<PathSpec>
 
     /**
      * Get the complete matched details of the provided path.
+     *
      * @param path the path to test
      * @return the matched details, if a match was possible, or null if not able to be matched.
      */

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
@@ -55,13 +55,13 @@ public class PathSpecSet extends AbstractSet<String> implements Predicate<String
             return (PathSpec)o;
         }
 
-        return PathMappings.asPathSpec(Objects.toString(o));
+        return PathSpec.from(Objects.toString(o));
     }
 
     @Override
     public boolean add(String s)
     {
-        return specs.put(PathMappings.asPathSpec(s), Boolean.TRUE);
+        return specs.put(PathSpec.from(s), Boolean.TRUE);
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
@@ -35,7 +35,7 @@ public class PathSpecSet extends AbstractSet<String> implements Predicate<String
     @Override
     public boolean test(String s)
     {
-        return specs.getMatches(s) != null;
+        return specs.getMatched(s) != null;
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.http.pathmap;
 
 import java.util.AbstractSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -34,7 +35,7 @@ public class PathSpecSet extends AbstractSet<String> implements Predicate<String
     @Override
     public boolean test(String s)
     {
-        return specs.getMatch(s) != null;
+        return specs.getMatches(s) != null;
     }
 
     @Override
@@ -53,11 +54,8 @@ public class PathSpecSet extends AbstractSet<String> implements Predicate<String
         {
             return (PathSpec)o;
         }
-        if (o instanceof String)
-        {
-            return PathMappings.asPathSpec((String)o);
-        }
-        return PathMappings.asPathSpec(o.toString());
+
+        return PathMappings.asPathSpec(Objects.toString(o));
     }
 
     @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
@@ -73,6 +73,8 @@ public class RegexPathSpec extends AbstractPathSpec
                 case '^': // ignore anchors
                 case '$': // ignore anchors
                 case '\'': // ignore escaping
+                case '(': // ignore grouping
+                case ')': // ignore grouping
                     break;
                 case '+': // single char quantifier
                 case '?': // single char quantifier
@@ -107,7 +109,7 @@ public class RegexPathSpec extends AbstractPathSpec
                             if (forbiddenReason != null)
                             {
                                 throw new IllegalArgumentException(String.format("%s does not support \\%c (%s) for \"%s\"",
-                                    this.getClass().getSimpleName(), c, forbiddenReason));
+                                    this.getClass().getSimpleName(), c, forbiddenReason, declaration));
                             }
                             switch (c)
                             {
@@ -123,7 +125,7 @@ public class RegexPathSpec extends AbstractPathSpec
                                     break;
                             }
                         }
-                        else
+                        else // not escaped
                         {
                             signature.append('l'); // literal (exact)
                         }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
@@ -278,7 +278,7 @@ public class RegexPathSpec extends AbstractPathSpec
         return null;
     }
 
-    public class RegexMatchedPath implements MatchedPath
+    private class RegexMatchedPath implements MatchedPath
     {
         private final RegexPathSpec pathSpec;
         private final String path;
@@ -341,7 +341,7 @@ public class RegexPathSpec extends AbstractPathSpec
         @Override
         public String toString()
         {
-            return "RegexMatchedPath[" +
+            return getClass().getSimpleName() + "[" +
                 "pathSpec=" + pathSpec +
                 ", path=\"" + path + "\"" +
                 ", matcher=" + matcher +

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
@@ -230,12 +230,6 @@ public class RegexPathSpec extends AbstractPathSpec
         }
 
         @Override
-        public String getPath()
-        {
-            return this.path;
-        }
-
-        @Override
         public String getPathMatch()
         {
             String p = matcher.group("name");

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
@@ -337,5 +337,15 @@ public class RegexPathSpec extends AbstractPathSpec
             // default is null
             return null;
         }
+
+        @Override
+        public String toString()
+        {
+            return "RegexMatchedPath[" +
+                "pathSpec=" + pathSpec +
+                ", path=\"" + path + "\"" +
+                ", matcher=" + matcher +
+                ']';
+        }
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -288,9 +288,8 @@ public class ServletPathSpec extends AbstractPathSpec
     private boolean isWildcardMatch(String path)
     {
         // For a spec of "/foo/*" match "/foo" , "/foo/..." but not "/foobar"
-        int cpl = _matchLength;
-        if ((_group == PathSpecGroup.PREFIX_GLOB) && (path.regionMatches(0, _declaration, 0, cpl)))
-            return (path.length() == cpl) || ('/' == path.charAt(cpl));
+        if (_group == PathSpecGroup.PREFIX_GLOB && path.length() >= _matchLength && path.regionMatches(0, _declaration, 0, _matchLength))
+            return path.length() == _matchLength || path.charAt(_matchLength) == '/';
         return false;
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -89,6 +89,7 @@ public class ServletPathSpec extends AbstractPathSpec
         PathSpecGroup group;
         String prefix;
         String suffix;
+        MatchedPath preMatchedPath;
 
         // prefix based
         if (servletPathSpec.charAt(0) == '/' && servletPathSpec.endsWith("/*"))
@@ -96,7 +97,7 @@ public class ServletPathSpec extends AbstractPathSpec
             group = PathSpecGroup.PREFIX_GLOB;
             prefix = servletPathSpec.substring(0, specLength - 2);
             suffix = null;
-            _preMatchedPath = MatchedPath.from(prefix, null);
+            preMatchedPath = MatchedPath.from(prefix, null);
         }
         // suffix based
         else if (servletPathSpec.charAt(0) == '*' && servletPathSpec.length() > 1)
@@ -104,7 +105,7 @@ public class ServletPathSpec extends AbstractPathSpec
             group = PathSpecGroup.SUFFIX_GLOB;
             prefix = null;
             suffix = servletPathSpec.substring(2, specLength);
-            _preMatchedPath = null;
+            preMatchedPath = null;
         }
         else
         {
@@ -116,16 +117,15 @@ public class ServletPathSpec extends AbstractPathSpec
                 LOG.warn("Suspicious URL pattern: '{}'; see sections 12.1 and 12.2 of the Servlet specification",
                         servletPathSpec);
             }
-            _preMatchedPath = MatchedPath.from(servletPathSpec, null);
+            preMatchedPath = MatchedPath.from(servletPathSpec, null);
         }
 
         int pathDepth = 0;
         for (int i = 0; i < specLength; i++)
         {
-            int cp = servletPathSpec.codePointAt(i);
-            if (cp < 128)
+            char c = servletPathSpec.charAt(i);
+            if (c < 128)
             {
-                char c = (char)cp;
                 if (c == '/')
                     pathDepth++;
             }
@@ -138,10 +138,12 @@ public class ServletPathSpec extends AbstractPathSpec
         _matchLength = prefix == null ? 0 : prefix.length();
         _prefix = prefix;
         _suffix = suffix;
+        _preMatchedPath = preMatchedPath;
 
         if (LOG.isDebugEnabled())
         {
-            LOG.debug("Creating ServletPathSpec[{}] (group: {}, prefix: \"{}\", suffix: \"{}\")",
+            LOG.debug("Creating {}[{}] (group: {}, prefix: \"{}\", suffix: \"{}\")",
+                getClass().getSimpleName(),
                 _declaration, _group, _prefix, _suffix);
         }
     }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -291,7 +291,7 @@ public class ServletPathSpec extends AbstractPathSpec
         {
             case EXACT:
                 if (_declaration.equals(path))
-                    return new ServletMatchedPath(path, path, null);
+                    return new ServletMatchedPath(path, null); // TODO: return final matchedpath
                 break;
             case PREFIX_GLOB:
                 if (isWildcardMatch(path))
@@ -303,21 +303,21 @@ public class ServletPathSpec extends AbstractPathSpec
                         pathMatch = path.substring(0, _specLength - 2);
                         pathInfo = path.substring(_specLength - 2);
                     }
-                    return new ServletMatchedPath(path, pathMatch, pathInfo);
+                    return new ServletMatchedPath(pathMatch, pathInfo);
                 }
                 break;
             case SUFFIX_GLOB:
                 if (path.regionMatches((path.length() - _specLength) + 1, _declaration, 1, _specLength - 1))
-                    return new ServletMatchedPath(path, path, null);
+                    return new ServletMatchedPath(path, null);
                 break;
             case ROOT:
                 // Only "/" matches
                 if ("/".equals(path))
-                    return new ServletMatchedPath(path, "", path);
+                    return new ServletMatchedPath("", path); // TODO: review this
                 break;
             case DEFAULT:
                 // If we reached this point, then everything matches
-                return new ServletMatchedPath(path, path, null);
+                return new ServletMatchedPath(path, null);
         }
         return null;
     }
@@ -346,21 +346,13 @@ public class ServletPathSpec extends AbstractPathSpec
 
     public static class ServletMatchedPath implements MatchedPath
     {
-        private final String path;
         private final String servletName;
         private final String pathInfo;
 
-        public ServletMatchedPath(String inputPath, String servletName, String pathInfo)
+        public ServletMatchedPath(String servletName, String pathInfo)
         {
-            this.path = inputPath;
             this.servletName = servletName;
             this.pathInfo = pathInfo;
-        }
-
-        @Override
-        public String getPath()
-        {
-            return this.path;
         }
 
         @Override

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java
@@ -291,7 +291,7 @@ public class ServletPathSpec extends AbstractPathSpec
         {
             case EXACT:
                 if (_declaration.equals(path))
-                    return new ServletMatchedPath(path, null); // TODO: return final matchedpath
+                    return MatchedPath.from(path, null);
                 break;
             case PREFIX_GLOB:
                 if (isWildcardMatch(path))
@@ -303,21 +303,21 @@ public class ServletPathSpec extends AbstractPathSpec
                         pathMatch = path.substring(0, _specLength - 2);
                         pathInfo = path.substring(_specLength - 2);
                     }
-                    return new ServletMatchedPath(pathMatch, pathInfo);
+                    return MatchedPath.from(pathMatch, pathInfo);
                 }
                 break;
             case SUFFIX_GLOB:
                 if (path.regionMatches((path.length() - _specLength) + 1, _declaration, 1, _specLength - 1))
-                    return new ServletMatchedPath(path, null);
+                    return MatchedPath.from(path, null);
                 break;
             case ROOT:
                 // Only "/" matches
                 if ("/".equals(path))
-                    return new ServletMatchedPath("", path); // TODO: review this
+                    return MatchedPath.from("", path);
                 break;
             case DEFAULT:
                 // If we reached this point, then everything matches
-                return new ServletMatchedPath(path, null);
+                return MatchedPath.from(path, null);
         }
         return null;
     }
@@ -341,30 +341,6 @@ public class ServletPathSpec extends AbstractPathSpec
                 return true;
             default:
                 return false;
-        }
-    }
-
-    public static class ServletMatchedPath implements MatchedPath
-    {
-        private final String servletName;
-        private final String pathInfo;
-
-        public ServletMatchedPath(String servletName, String pathInfo)
-        {
-            this.servletName = servletName;
-            this.pathInfo = pathInfo;
-        }
-
-        @Override
-        public String getPathMatch()
-        {
-            return this.servletName;
-        }
-
-        @Override
-        public String getPathInfo()
-        {
-            return this.pathInfo;
         }
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
@@ -487,5 +487,15 @@ public class UriTemplatePathSpec extends AbstractPathSpec
             }
             return null;
         }
+
+        @Override
+        public String toString()
+        {
+            return "UriTemplateMatchedPath[" +
+                "pathSpec=" + pathSpec +
+                ", path=\"" + path + "\"" +
+                ", matcher=" + matcher +
+                ']';
+        }
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
@@ -441,7 +441,7 @@ public class UriTemplatePathSpec extends AbstractPathSpec
         return _variables;
     }
 
-    public static class UriTemplateMatchedPath implements MatchedPath
+    private static class UriTemplateMatchedPath implements MatchedPath
     {
         private final UriTemplatePathSpec pathSpec;
         private final String path;
@@ -491,7 +491,7 @@ public class UriTemplatePathSpec extends AbstractPathSpec
         @Override
         public String toString()
         {
-            return "UriTemplateMatchedPath[" +
+            return getClass().getSimpleName() + "[" +
                 "pathSpec=" + pathSpec +
                 ", path=\"" + path + "\"" +
                 ", matcher=" + matcher +

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java
@@ -455,12 +455,6 @@ public class UriTemplatePathSpec extends AbstractPathSpec
         }
 
         @Override
-        public String getPath()
-        {
-            return this.path;
-        }
-
-        @Override
         public String getPathMatch()
         {
             // TODO: UriTemplatePathSpec has no concept of prefix/suffix, this should be simplified

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-// @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
+// @chxxeckstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class PathMappingsTest
 {
     private void assertMatch(PathMappings<String> pathmap, String path, String expectedValue)
@@ -63,8 +63,6 @@ public class PathMappingsTest
         p.put(new RegexPathSpec("^/animal/.*/chat$"), "animalChat");
         p.put(new RegexPathSpec("^/animal/.*/cam$"), "animalCam");
         p.put(new RegexPathSpec("^/entrance/cam$"), "entranceCam");
-
-        // dumpMappings(p);
 
         assertMatch(p, "/animal/bird/eagle", "birds");
         assertMatch(p, "/animal/fish/bass/sea", "fishes");
@@ -116,8 +114,6 @@ public class PathMappingsTest
         p.put(new UriTemplatePathSpec("/animal/{type}/{name}/cam"), "animalCam");
         p.put(new UriTemplatePathSpec("/entrance/cam"), "entranceCam");
 
-        // dumpMappings(p);
-
         assertMatch(p, "/animal/bird/eagle", "birds");
         assertMatch(p, "/animal/fish/bass/sea", "fishes");
         assertMatch(p, "/animal/peccary/javalina/evolution", "animals");
@@ -148,13 +144,31 @@ public class PathMappingsTest
         p.put(new UriTemplatePathSpec("/{var1}/d"), "endpointD");
         p.put(new UriTemplatePathSpec("/b/{var2}"), "endpointE");
 
-        // dumpMappings(p);
-
         assertMatch(p, "/a/b/c", "endpointB");
         assertMatch(p, "/a/d/c", "endpointA");
         assertMatch(p, "/a/x/y", "endpointC");
 
         assertMatch(p, "/b/d", "endpointE");
+    }
+
+    /**
+     * Test the match order rules for mixed Servlet and Regex path specs
+     */
+    @Test
+    public void testServletAndRegexMatchOrder()
+    {
+        PathMappings<String> p = new PathMappings<>();
+
+        p.put(new ServletPathSpec("/a/*"), "endpointA");
+        p.put(new RegexPathSpec("^.*/middle/.*$"), "middle");
+        p.put(new ServletPathSpec("*.do"), "endpointDo");
+        p.put(new ServletPathSpec("/"), "default");
+
+        assertMatch(p, "/a/b/c", "endpointA");
+        assertMatch(p, "/a/middle/c", "endpointA");
+        assertMatch(p, "/b/middle/c", "middle");
+        assertMatch(p, "/x/y.do", "endpointDo");
+        assertMatch(p, "/b/d", "default");
     }
 
     @Test
@@ -172,11 +186,12 @@ public class PathMappingsTest
         p.put(new ServletPathSpec("/"), "8");
         // p.put(new ServletPathSpec("/XXX:/YYY"), "9"); // special syntax from Jetty 3.1.x
         p.put(new ServletPathSpec(""), "10");
+        // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
         p.put(new ServletPathSpec("/\u20ACuro/*"), "11");
+        // @checkstyle-enable-check : AvoidEscapedUnicodeCharactersCheck
 
         p.put(new ServletPathSpec("/*"), "0");
 
-        // assertEquals("1", p.get("/abs/path"), "Get absolute path");
         assertEquals("/abs/path", p.getMatched("/abs/path").getPathSpec().getDeclaration(), "Match absolute path");
         assertEquals("1", p.getMatched("/abs/path").getResource(), "Match absolute path");
         assertEquals("0", p.getMatched("/abs/path/xxx").getResource(), "Mismatch absolute path");
@@ -202,7 +217,6 @@ public class PathMappingsTest
 
     /**
      * See JIRA issue: JETTY-88.
-     *
      */
     @Test
     public void testPathMappingsOnlyMatchOnDirectoryNames()

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-// @chxxeckstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
+// @checkstyle-disable-check :  AvoidEscapedUnicodeCharactersCheck
 public class PathMappingsTest
 {
     private void assertMatch(PathMappings<String> pathmap, String path, String expectedValue)

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -267,8 +267,8 @@ public class PathMappingsTest
         assertThat(p.put(new UriTemplatePathSpec("/a/{var2}/c"), "resourceAA"), is(false));
         assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceB"), is(true));
         assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceBB"), is(false));
-        assertThat(p.put(new ServletPathSpec("/a/b/c"), "resourceBB"), is(false));
-        assertThat(p.put(new RegexPathSpec("/a/b/c"), "resourceBB"), is(false));
+        assertThat(p.put(new ServletPathSpec("/a/b/c"), "resourceBB"), is(true));
+        assertThat(p.put(new RegexPathSpec("/a/b/c"), "resourceBB"), is(true));
 
         assertThat(p.put(new ServletPathSpec("/*"), "resourceC"), is(true));
         assertThat(p.put(new RegexPathSpec("/(.*)"), "resourceCC"), is(true));
@@ -418,14 +418,14 @@ public class PathMappingsTest
     @Test
     public void testAsPathSpec()
     {
-        assertThat(PathMappings.asPathSpec(""), instanceOf(ServletPathSpec.class));
-        assertThat(PathMappings.asPathSpec("/"), instanceOf(ServletPathSpec.class));
-        assertThat(PathMappings.asPathSpec("/*"), instanceOf(ServletPathSpec.class));
-        assertThat(PathMappings.asPathSpec("/foo/*"), instanceOf(ServletPathSpec.class));
-        assertThat(PathMappings.asPathSpec("*.jsp"), instanceOf(ServletPathSpec.class));
+        assertThat(PathSpec.from(""), instanceOf(ServletPathSpec.class));
+        assertThat(PathSpec.from("/"), instanceOf(ServletPathSpec.class));
+        assertThat(PathSpec.from("/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathSpec.from("/foo/*"), instanceOf(ServletPathSpec.class));
+        assertThat(PathSpec.from("*.jsp"), instanceOf(ServletPathSpec.class));
 
-        assertThat(PathMappings.asPathSpec("^$"), instanceOf(RegexPathSpec.class));
-        assertThat(PathMappings.asPathSpec("^.*"), instanceOf(RegexPathSpec.class));
-        assertThat(PathMappings.asPathSpec("^/"), instanceOf(RegexPathSpec.class));
+        assertThat(PathSpec.from("^$"), instanceOf(RegexPathSpec.class));
+        assertThat(PathSpec.from("^.*"), instanceOf(RegexPathSpec.class));
+        assertThat(PathSpec.from("^/"), instanceOf(RegexPathSpec.class));
     }
 }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -19,8 +19,6 @@
 package org.eclipse.jetty.http.pathmap;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -29,32 +27,23 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class PathMappingsTest
 {
     private void assertMatch(PathMappings<String> pathmap, String path, String expectedValue)
     {
-        String msg = String.format(".getMatch(\"%s\")", path);
-        MappedResource<String> match = pathmap.getMatch(path);
-        assertThat(msg, match, notNullValue());
-        String actualMatch = match.getResource();
+        String msg = String.format(".getMatched(\"%s\")", path);
+        MatchedResource<String> matched = pathmap.getMatched(path);
+        assertThat(msg, matched, notNullValue());
+        String actualMatch = matched.getResource();
         assertEquals(expectedValue, actualMatch, msg);
-    }
-
-    public void dumpMappings(PathMappings<String> p)
-    {
-        for (MappedResource<String> res : p)
-        {
-            System.out.printf("  %s%n", res);
-        }
     }
 
     /**
      * Test the match order rules with a mixed Servlet and regex path specs
-     * <p>
+     *
      * <ul>
      * <li>Exact match</li>
      * <li>Longest prefix match</li>
@@ -107,7 +96,7 @@ public class PathMappingsTest
 
     /**
      * Test the match order rules with a mixed Servlet and URI Template path specs
-     * <p>
+     *
      * <ul>
      * <li>Exact match</li>
      * <li>Longest prefix match</li>
@@ -141,7 +130,7 @@ public class PathMappingsTest
 
     /**
      * Test the match order rules for URI Template based specs
-     * <p>
+     *
      * <ul>
      * <li>Exact match</li>
      * <li>Longest prefix match</li>
@@ -169,7 +158,7 @@ public class PathMappingsTest
     }
 
     @Test
-    public void testPathMap() throws Exception
+    public void testPathMap()
     {
         PathMappings<String> p = new PathMappings<>();
 
@@ -185,74 +174,38 @@ public class PathMappingsTest
         p.put(new ServletPathSpec(""), "10");
         p.put(new ServletPathSpec("/\u20ACuro/*"), "11");
 
-        assertEquals("/Foo/bar", new ServletPathSpec("/Foo/bar").getPathMatch("/Foo/bar"), "pathMatch exact");
-        assertEquals("/Foo", new ServletPathSpec("/Foo/*").getPathMatch("/Foo/bar"), "pathMatch prefix");
-        assertEquals("/Foo", new ServletPathSpec("/Foo/*").getPathMatch("/Foo/"), "pathMatch prefix");
-        assertEquals("/Foo", new ServletPathSpec("/Foo/*").getPathMatch("/Foo"), "pathMatch prefix");
-        assertEquals("/Foo/bar.ext", new ServletPathSpec("*.ext").getPathMatch("/Foo/bar.ext"), "pathMatch suffix");
-        assertEquals("/Foo/bar.ext", new ServletPathSpec("/").getPathMatch("/Foo/bar.ext"), "pathMatch default");
-
-        assertEquals(null, new ServletPathSpec("/Foo/bar").getPathInfo("/Foo/bar"), "pathInfo exact");
-        assertEquals("/bar", new ServletPathSpec("/Foo/*").getPathInfo("/Foo/bar"), "pathInfo prefix");
-        assertEquals("/*", new ServletPathSpec("/Foo/*").getPathInfo("/Foo/*"), "pathInfo prefix");
-        assertEquals("/", new ServletPathSpec("/Foo/*").getPathInfo("/Foo/"), "pathInfo prefix");
-        assertEquals(null, new ServletPathSpec("/Foo/*").getPathInfo("/Foo"), "pathInfo prefix");
-        assertEquals(null, new ServletPathSpec("*.ext").getPathInfo("/Foo/bar.ext"), "pathInfo suffix");
-        assertEquals(null, new ServletPathSpec("/").getPathInfo("/Foo/bar.ext"), "pathInfo default");
-
         p.put(new ServletPathSpec("/*"), "0");
 
         // assertEquals("1", p.get("/abs/path"), "Get absolute path");
-        assertEquals("/abs/path", p.getMatch("/abs/path").getPathSpec().getDeclaration(), "Match absolute path");
-        assertEquals("1", p.getMatch("/abs/path").getResource(), "Match absolute path");
-        assertEquals("0", p.getMatch("/abs/path/xxx").getResource(), "Mismatch absolute path");
-        assertEquals("0", p.getMatch("/abs/pith").getResource(), "Mismatch absolute path");
-        assertEquals("2", p.getMatch("/abs/path/longer").getResource(), "Match longer absolute path");
-        assertEquals("0", p.getMatch("/abs/path/").getResource(), "Not exact absolute path");
-        assertEquals("0", p.getMatch("/abs/path/xxx").getResource(), "Not exact absolute path");
+        assertEquals("/abs/path", p.getMatched("/abs/path").getPathSpec().getDeclaration(), "Match absolute path");
+        assertEquals("1", p.getMatched("/abs/path").getResource(), "Match absolute path");
+        assertEquals("0", p.getMatched("/abs/path/xxx").getResource(), "Mismatch absolute path");
+        assertEquals("0", p.getMatched("/abs/pith").getResource(), "Mismatch absolute path");
+        assertEquals("2", p.getMatched("/abs/path/longer").getResource(), "Match longer absolute path");
+        assertEquals("0", p.getMatched("/abs/path/").getResource(), "Not exact absolute path");
+        assertEquals("0", p.getMatched("/abs/path/xxx").getResource(), "Not exact absolute path");
 
-        assertEquals("3", p.getMatch("/animal/bird/eagle/bald").getResource(), "Match longest prefix");
-        assertEquals("4", p.getMatch("/animal/fish/shark/grey").getResource(), "Match longest prefix");
-        assertEquals("5", p.getMatch("/animal/insect/bug").getResource(), "Match longest prefix");
-        assertEquals("5", p.getMatch("/animal").getResource(), "mismatch exact prefix");
-        assertEquals("5", p.getMatch("/animal/").getResource(), "mismatch exact prefix");
+        assertEquals("3", p.getMatched("/animal/bird/eagle/bald").getResource(), "Match longest prefix");
+        assertEquals("4", p.getMatched("/animal/fish/shark/grey").getResource(), "Match longest prefix");
+        assertEquals("5", p.getMatched("/animal/insect/bug").getResource(), "Match longest prefix");
+        assertEquals("5", p.getMatched("/animal").getResource(), "mismatch exact prefix");
+        assertEquals("5", p.getMatched("/animal/").getResource(), "mismatch exact prefix");
 
-        assertEquals("0", p.getMatch("/suffix/path.tar.gz").getResource(), "Match longest suffix");
-        assertEquals("0", p.getMatch("/suffix/path.gz").getResource(), "Match longest suffix");
-        assertEquals("5", p.getMatch("/animal/path.gz").getResource(), "prefix rather than suffix");
+        assertEquals("0", p.getMatched("/suffix/path.tar.gz").getResource(), "Match longest suffix");
+        assertEquals("0", p.getMatched("/suffix/path.gz").getResource(), "Match longest suffix");
+        assertEquals("5", p.getMatched("/animal/path.gz").getResource(), "prefix rather than suffix");
 
-        assertEquals("0", p.getMatch("/Other/path").getResource(), "default");
+        assertEquals("0", p.getMatched("/Other/path").getResource(), "default");
 
-        assertEquals("", new ServletPathSpec("/*").getPathMatch("/xxx/zzz"), "pathMatch /*");
-        assertEquals("/xxx/zzz", new ServletPathSpec("/*").getPathInfo("/xxx/zzz"), "pathInfo /*");
-
-        assertTrue(new ServletPathSpec("/").matches("/anything"), "match /");
-        assertTrue(new ServletPathSpec("/*").matches("/anything"), "match /*");
-        assertTrue(new ServletPathSpec("/foo").matches("/foo"), "match /foo");
-        assertTrue(!new ServletPathSpec("/foo").matches("/bar"), "!match /foo");
-        assertTrue(new ServletPathSpec("/foo/*").matches("/foo"), "match /foo/*");
-        assertTrue(new ServletPathSpec("/foo/*").matches("/foo/"), "match /foo/*");
-        assertTrue(new ServletPathSpec("/foo/*").matches("/foo/anything"), "match /foo/*");
-        assertTrue(!new ServletPathSpec("/foo/*").matches("/bar"), "!match /foo/*");
-        assertTrue(!new ServletPathSpec("/foo/*").matches("/bar/"), "!match /foo/*");
-        assertTrue(!new ServletPathSpec("/foo/*").matches("/bar/anything"), "!match /foo/*");
-        assertTrue(new ServletPathSpec("*.foo").matches("anything.foo"), "match *.foo");
-        assertTrue(!new ServletPathSpec("*.foo").matches("anything.bar"), "!match *.foo");
-        assertTrue(new ServletPathSpec("/On*").matches("/On*"), "match /On*");
-        assertTrue(!new ServletPathSpec("/On*").matches("/One"), "!match /One");
-
-        assertEquals("10", p.getMatch("/").getResource(), "match / with ''");
-
-        assertTrue(new ServletPathSpec("").matches("/"), "match \"\"");
+        assertEquals("10", p.getMatched("/").getResource(), "match / with ''");
     }
 
     /**
      * See JIRA issue: JETTY-88.
      *
-     * @throws Exception failed test
      */
     @Test
-    public void testPathMappingsOnlyMatchOnDirectoryNames() throws Exception
+    public void testPathMappingsOnlyMatchOnDirectoryNames()
     {
         ServletPathSpec spec = new ServletPathSpec("/xyz/*");
 
@@ -271,40 +224,25 @@ public class PathMappingsTest
     }
 
     @Test
-    public void testPrecidenceVsOrdering() throws Exception
+    public void testPrecedenceVsOrdering()
     {
         PathMappings<String> p = new PathMappings<>();
         p.put(new ServletPathSpec("/dump/gzip/*"), "prefix");
         p.put(new ServletPathSpec("*.txt"), "suffix");
 
-        assertEquals(null, p.getMatch("/foo/bar"));
-        assertEquals("prefix", p.getMatch("/dump/gzip/something").getResource());
-        assertEquals("suffix", p.getMatch("/foo/something.txt").getResource());
-        assertEquals("prefix", p.getMatch("/dump/gzip/something.txt").getResource());
+        assertNull(p.getMatched("/foo/bar"));
+        assertEquals("prefix", p.getMatched("/dump/gzip/something").getResource());
+        assertEquals("suffix", p.getMatched("/foo/something.txt").getResource());
+        assertEquals("prefix", p.getMatched("/dump/gzip/something.txt").getResource());
 
         p = new PathMappings<>();
         p.put(new ServletPathSpec("*.txt"), "suffix");
         p.put(new ServletPathSpec("/dump/gzip/*"), "prefix");
 
-        assertEquals(null, p.getMatch("/foo/bar"));
-        assertEquals("prefix", p.getMatch("/dump/gzip/something").getResource());
-        assertEquals("suffix", p.getMatch("/foo/something.txt").getResource());
-        assertEquals("prefix", p.getMatch("/dump/gzip/something.txt").getResource());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "*",
-        "/foo/*/bar",
-        "*/foo",
-        "*.foo/*"
-    })
-    public void testBadPathSpecs(String str)
-    {
-        assertThrows(IllegalArgumentException.class, () ->
-        {
-            new ServletPathSpec(str);
-        });
+        assertNull(p.getMatched("/foo/bar"));
+        assertEquals("prefix", p.getMatched("/dump/gzip/something").getResource());
+        assertEquals("suffix", p.getMatched("/foo/something.txt").getResource());
+        assertEquals("prefix", p.getMatched("/dump/gzip/something.txt").getResource());
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
@@ -22,10 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegexPathSpecTest
@@ -33,13 +34,13 @@ public class RegexPathSpecTest
     public static void assertMatches(PathSpec spec, String path)
     {
         String msg = String.format("Spec(\"%s\").matches(\"%s\")", spec.getDeclaration(), path);
-        assertThat(msg, spec.matches(path), is(true));
+        assertNotNull(spec.matched(path), msg);
     }
 
     public static void assertNotMatches(PathSpec spec, String path)
     {
         String msg = String.format("!Spec(\"%s\").matches(\"%s\")", spec.getDeclaration(), path);
-        assertThat(msg, spec.matches(path), is(false));
+        assertNull(spec.matched(path), msg);
     }
 
     @Test
@@ -145,6 +146,26 @@ public class RegexPathSpecTest
         assertMatches(spec, "/abcde.do");
         assertMatches(spec, "/abc/efg.do");
 
+        assertNotMatches(spec, "/a");
+        assertNotMatches(spec, "/aa");
+        assertNotMatches(spec, "/aa/bb");
+        assertNotMatches(spec, "/aa/bb.do/more");
+    }
+
+    @Test
+    public void testSuffixSpecMiddle()
+    {
+        RegexPathSpec spec = new RegexPathSpec("^.*/middle/.*$");
+        assertEquals("^.*/middle/.*$", spec.getDeclaration(), "Spec.pathSpec");
+        assertEquals("^.*/middle/.*$", spec.getPattern().pattern(), "Spec.pattern");
+        assertEquals(2, spec.getPathDepth(), "Spec.pathDepth");
+        assertEquals(PathSpecGroup.SUFFIX_GLOB, spec.getGroup(), "Spec.group");
+
+        assertMatches(spec, "/a/middle/c.do");
+        assertMatches(spec, "/a/b/c/d/middle/e/f");
+        assertMatches(spec, "/middle/");
+
+        assertNotMatches(spec, "/a.do");
         assertNotMatches(spec, "/a");
         assertNotMatches(spec, "/aa");
         assertNotMatches(spec, "/aa/bb");

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -186,6 +187,28 @@ public class RegexPathSpecTest
         assertNotMatches(spec, "/a.do");
         assertNotMatches(spec, "/a/middle");
         assertNotMatches(spec, "/middle");
+    }
+
+    @Test
+    public void testNamedRegexGroup()
+    {
+        RegexPathSpec spec = new RegexPathSpec("^(?<name>(.*)/middle/)(?<info>.*)$");
+        assertEquals("^(?<name>(.*)/middle/)(?<info>.*)$", spec.getDeclaration(), "Spec.pathSpec");
+        assertEquals("^(?<name>(.*)/middle/)(?<info>.*)$", spec.getPattern().pattern(), "Spec.pattern");
+        assertEquals(2, spec.getPathDepth(), "Spec.pathDepth");
+        assertEquals(PathSpecGroup.SUFFIX_GLOB, spec.getGroup(), "Spec.group");
+
+        assertMatches(spec, "/a/middle/c.do");
+        assertMatches(spec, "/a/b/c/d/middle/e/f");
+        assertMatches(spec, "/middle/");
+
+        assertNotMatches(spec, "/a.do");
+        assertNotMatches(spec, "/a/middle");
+        assertNotMatches(spec, "/middle");
+
+        MatchedPath matchedPath = spec.matched("/a/middle/c.do");
+        assertThat(matchedPath.getPathMatch(), is("/a/middle/"));
+        assertThat(matchedPath.getPathInfo(), is("c.do"));
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
@@ -166,10 +166,26 @@ public class RegexPathSpecTest
         assertMatches(spec, "/middle/");
 
         assertNotMatches(spec, "/a.do");
-        assertNotMatches(spec, "/a");
-        assertNotMatches(spec, "/aa");
-        assertNotMatches(spec, "/aa/bb");
-        assertNotMatches(spec, "/aa/bb.do/more");
+        assertNotMatches(spec, "/a/middle");
+        assertNotMatches(spec, "/middle");
+    }
+
+    @Test
+    public void testSuffixSpecMiddleWithGroupings()
+    {
+        RegexPathSpec spec = new RegexPathSpec("^(.*)/middle/(.*)$");
+        assertEquals("^(.*)/middle/(.*)$", spec.getDeclaration(), "Spec.pathSpec");
+        assertEquals("^(.*)/middle/(.*)$", spec.getPattern().pattern(), "Spec.pattern");
+        assertEquals(2, spec.getPathDepth(), "Spec.pathDepth");
+        assertEquals(PathSpecGroup.SUFFIX_GLOB, spec.getGroup(), "Spec.group");
+
+        assertMatches(spec, "/a/middle/c.do");
+        assertMatches(spec, "/a/b/c/d/middle/e/f");
+        assertMatches(spec, "/middle/");
+
+        assertNotMatches(spec, "/a.do");
+        assertNotMatches(spec, "/a/middle");
+        assertNotMatches(spec, "/middle");
     }
 
     @Test

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/ServletPathSpecOrderTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/ServletPathSpecOrderTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Tests of {@link PathMappings#getMatch(String)}, with a focus on correct mapping selection order
+ * Tests of {@link PathMappings#getMatched(String)}, with a focus on correct mapping selection order
  */
 @SuppressWarnings("Duplicates")
 public class ServletPathSpecOrderTest
@@ -58,6 +58,7 @@ public class ServletPathSpecOrderTest
         data.add(Arguments.of("/Other/path", "default"));
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
         data.add(Arguments.of("/\u20ACuro/path", "money"));
+        // @checkstyle-enable-check : AvoidEscapedUnicodeCharactersCheck
         data.add(Arguments.of("/", "root"));
 
         // Extra tests
@@ -92,6 +93,6 @@ public class ServletPathSpecOrderTest
     @MethodSource("data")
     public void testMatch(String inputPath, String expectedResource)
     {
-        assertThat("Match on [" + inputPath + "]", mappings.getMatch(inputPath).getResource(), is(expectedResource));
+        assertThat("Match on [" + inputPath + "]", mappings.getMatched(inputPath).getResource(), is(expectedResource));
     }
 }

--- a/jetty-http/src/test/resources/jetty-logging.properties
+++ b/jetty-http/src/test/resources/jetty-logging.properties
@@ -2,4 +2,4 @@ org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.http.LEVEL=DEBUG
-org.eclipse.jetty.http.pathmap.LEVEL=DEBUG
+#org.eclipse.jetty.http.pathmap.LEVEL=DEBUG

--- a/jetty-http/src/test/resources/jetty-logging.properties
+++ b/jetty-http/src/test/resources/jetty-logging.properties
@@ -2,3 +2,4 @@ org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.http.LEVEL=DEBUG
+org.eclipse.jetty.http.pathmap.LEVEL=DEBUG

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNCSARequestLog.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNCSARequestLog.java
@@ -105,7 +105,7 @@ public class AbstractNCSARequestLog extends ContainerLifeCycle implements Reques
     {
         try
         {
-            if (_ignorePathMap != null && _ignorePathMap.getMatch(request.getRequestURI()) != null)
+            if (_ignorePathMap != null && _ignorePathMap.getMatched(request.getRequestURI()) != null)
                 return;
 
             if (!isEnabled())

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -327,7 +327,7 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     {
         try
         {
-            if (_ignorePathMap != null && _ignorePathMap.getMatch(request.getRequestURI()) != null)
+            if (_ignorePathMap != null && _ignorePathMap.getMatched(request.getRequestURI()) != null)
                 return;
 
             StringBuilder sb = _buffers.get();

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
@@ -173,7 +173,7 @@ public class Invoker extends HttpServlet
                 String path = URIUtil.addPaths(servletPath, servlet);
                 MatchedResource<ServletHolder> entry = _servletHandler.getMatchedServlet(path);
 
-                if (entry != null && !entry.getMappedResource().equals(_invokerEntry.getMappedResource()))
+                if (entry != null && !entry.getResource().equals(_invokerEntry.getResource()))
                 {
                     // Use the holder
                     holder = entry.getResource();

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
@@ -173,7 +173,7 @@ public class Invoker extends HttpServlet
                 String path = URIUtil.addPaths(servletPath, servlet);
                 MatchedResource<ServletHolder> entry = _servletHandler.getMatchedServlet(path);
 
-                if (entry != null && !entry.equals(_invokerEntry))
+                if (entry != null && !entry.getMappedResource().equals(_invokerEntry.getMappedResource()))
                 {
                     // Use the holder
                     holder = entry.getResource();

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/Invoker.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.server.Dispatcher;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -71,7 +71,7 @@ public class Invoker extends HttpServlet
 
     private ContextHandler _contextHandler;
     private ServletHandler _servletHandler;
-    private MappedResource<ServletHolder> _invokerEntry;
+    private MatchedResource<ServletHolder> _invokerEntry;
     private Map<String, String> _parameters;
     private boolean _nonContextServlets;
     private boolean _verbose;
@@ -167,11 +167,11 @@ public class Invoker extends HttpServlet
             synchronized (_servletHandler)
             {
                 // find the entry for the invoker (me)
-                _invokerEntry = _servletHandler.getMappedServlet(servletPath);
+                _invokerEntry = _servletHandler.getMatchedServlet(servletPath);
 
                 // Check for existing mapping (avoid threaded race).
                 String path = URIUtil.addPaths(servletPath, servlet);
-                MappedResource<ServletHolder> entry = _servletHandler.getMappedServlet(path);
+                MatchedResource<ServletHolder> entry = _servletHandler.getMatchedServlet(path);
 
                 if (entry != null && !entry.equals(_invokerEntry))
                 {

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -377,7 +377,10 @@ public class ServletHandler extends ScopedHandler
     public MappedResource<ServletHolder> getHolderEntry(String target)
     {
         if (target.startsWith("/"))
-            return getMatchedServlet(target).getMappedResource();
+        {
+            MatchedResource<ServletHolder> matchedResource = getMatchedServlet(target);
+            return new MappedResource<>(matchedResource.getPathSpec(), matchedResource.getResource());
+        }
         return null;
     }
 
@@ -474,8 +477,8 @@ public class ServletHandler extends ScopedHandler
 
             if (matched.getPathSpec() != null)
             {
-                String servletPath = matched.getMatchedPath().getPathMatch();
-                String pathInfo = matched.getMatchedPath().getPathInfo();
+                String servletPath = matched.getPathMatch();
+                String pathInfo = matched.getPathInfo();
 
                 if (DispatcherType.INCLUDE.equals(type))
                 {
@@ -577,8 +580,7 @@ public class ServletHandler extends ScopedHandler
         ServletHolder holder = _servletNameMap.get(target);
         if (holder == null)
             return null;
-        MappedResource<ServletHolder> mappedResource = new MappedResource<>(null, holder);
-        return new MatchedResource<>(mappedResource, MatchedPath.EMPTY);
+        return new MatchedResource<>(holder, null, MatchedPath.EMPTY);
     }
 
     /**
@@ -591,7 +593,8 @@ public class ServletHandler extends ScopedHandler
     @Deprecated
     public MappedResource<ServletHolder> getMappedServlet(String target)
     {
-        return getMatchedServlet(target).getMappedResource();
+        MatchedResource<ServletHolder> matchedResource = getMatchedServlet(target);
+        return new MappedResource<>(matchedResource.getPathSpec(), matchedResource.getResource());
     }
 
     protected FilterChain getFilterChain(Request baseRequest, String pathInContext, ServletHolder servletHolder)

--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHandler.java
@@ -50,6 +50,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.http.pathmap.MatchedPath;
+import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
@@ -369,13 +371,13 @@ public class ServletHandler extends ScopedHandler
      *
      * @param target Path within _context or servlet name
      * @return PathMap Entries pathspec to ServletHolder
-     * @deprecated Use {@link #getMappedServlet(String)}
+     * @deprecated Use {@link #getMatchedServlet(String)} instead
      */
     @Deprecated
     public MappedResource<ServletHolder> getHolderEntry(String target)
     {
         if (target.startsWith("/"))
-            return getMappedServlet(target);
+            return getMatchedServlet(target).getMappedResource();
         return null;
     }
 
@@ -465,16 +467,15 @@ public class ServletHandler extends ScopedHandler
         ServletHolder servletHolder = null;
         UserIdentity.Scope oldScope = null;
 
-        MappedResource<ServletHolder> mapping = getMappedServlet(target);
-        if (mapping != null)
+        MatchedResource<ServletHolder> matched = getMatchedServlet(target);
+        if (matched != null)
         {
-            servletHolder = mapping.getResource();
+            servletHolder = matched.getResource();
 
-            if (mapping.getPathSpec() != null)
+            if (matched.getPathSpec() != null)
             {
-                PathSpec pathSpec = mapping.getPathSpec();
-                String servletPath = pathSpec.getPathMatch(target);
-                String pathInfo = pathSpec.getPathInfo(target);
+                String servletPath = matched.getMatchedPath().getPathMatch();
+                String pathInfo = matched.getMatchedPath().getPathInfo();
 
                 if (DispatcherType.INCLUDE.equals(type))
                 {
@@ -558,24 +559,39 @@ public class ServletHandler extends ScopedHandler
     }
 
     /**
-     * ServletHolder matching path.
+     * ServletHolder matching target path.
      *
      * @param target Path within _context or servlet name
-     * @return MappedResource to the ServletHolder.  Named servlets have a null PathSpec
+     * @return MatchedResource, pointing to the {@link MappedResource} for the {@link ServletHolder}, and also the pathspec specific name/info sections for the match.
+     *      Named servlets have a null PathSpec and {@link MatchedResource}.
      */
-    public MappedResource<ServletHolder> getMappedServlet(String target)
+    public MatchedResource<ServletHolder> getMatchedServlet(String target)
     {
         if (target.startsWith("/"))
         {
             if (_servletPathMap == null)
                 return null;
-            return _servletPathMap.getMatch(target);
+            return _servletPathMap.getMatched(target);
         }
 
         ServletHolder holder = _servletNameMap.get(target);
         if (holder == null)
             return null;
-        return new MappedResource<>(null, holder);
+        MappedResource<ServletHolder> mappedResource = new MappedResource<>(null, holder);
+        return new MatchedResource<>(mappedResource, MatchedPath.EMPTY);
+    }
+
+    /**
+     * ServletHolder matching path.
+     *
+     * @param target Path within _context or servlet name
+     * @return MappedResource to the ServletHolder.  Named servlets have a null PathSpec
+     * @deprecated use {@link #getMatchedServlet(String)} instead
+     */
+    @Deprecated
+    public MappedResource<ServletHolder> getMappedServlet(String target)
+    {
+        return getMatchedServlet(target).getMappedResource();
     }
 
     protected FilterChain getFilterChain(Request baseRequest, String pathInContext, ServletHolder servletHolder)

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import javax.servlet.ServletContext;
 
 import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.http.pathmap.RegexPathSpec;
@@ -82,7 +83,10 @@ public class NativeWebSocketConfiguration extends ContainerLifeCycle implements 
      */
     public MappedResource<WebSocketCreator> getMatch(String target)
     {
-        return this.mappings.getMatched(target).getMappedResource();
+        MatchedResource<WebSocketCreator> matched = this.mappings.getMatched(target);
+        if (matched == null)
+            return null;
+        return matched.getMappedResource();
     }
 
     /**

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
@@ -82,7 +82,7 @@ public class NativeWebSocketConfiguration extends ContainerLifeCycle implements 
      */
     public MappedResource<WebSocketCreator> getMatch(String target)
     {
-        return this.mappings.getMatch(target);
+        return this.mappings.getMatched(target).getMappedResource();
     }
 
     /**

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/NativeWebSocketConfiguration.java
@@ -76,17 +76,30 @@ public class NativeWebSocketConfiguration extends ContainerLifeCycle implements 
     }
 
     /**
-     * Get the matching {@link MappedResource} for the provided target.
+     * Get the matching {@link MatchedResource} for the provided target.
      *
      * @param target the target path
      * @return the matching resource, or null if no match.
      */
+    public MatchedResource<WebSocketCreator> getMatched(String target)
+    {
+        return this.mappings.getMatched(target);
+    }
+
+    /**
+     * Get the matching {@link MappedResource} for the provided target.
+     *
+     * @param target the target path
+     * @return the matching resource, or null if no match.
+     * @deprecated use {@link #getMatched(String)} instead.
+     */
+    @Deprecated
     public MappedResource<WebSocketCreator> getMatch(String target)
     {
         MatchedResource<WebSocketCreator> matched = this.mappings.getMatched(target);
         if (matched == null)
             return null;
-        return matched.getMappedResource();
+        return new MappedResource<>(matched.getPathSpec(), matched.getResource());
     }
 
     /**

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeFilter.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeFilter.java
@@ -31,7 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -302,7 +302,7 @@ public class WebSocketUpgradeFilter implements Filter, MappedWebSocketCreator, D
                 target = target + httpreq.getPathInfo();
             }
 
-            MappedResource<WebSocketCreator> resource = configuration.getMatch(target);
+            MatchedResource<WebSocketCreator> resource = configuration.getMatched(target);
             if (resource == null)
             {
                 // no match.

--- a/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandlerWrapper.java
+++ b/jetty-websocket/websocket-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandlerWrapper.java
@@ -23,7 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.MappedByteBufferPool;
@@ -89,7 +89,7 @@ public class WebSocketUpgradeHandlerWrapper extends HandlerWrapper implements Ma
     {
         if (configuration.getFactory().isUpgradeRequest(request, response))
         {
-            MappedResource<WebSocketCreator> resource = configuration.getMatch(target);
+            MatchedResource<WebSocketCreator> resource = configuration.getMatched(target);
             if (resource == null)
             {
                 // no match.


### PR DESCRIPTION
Introduction of MatchedResource and MatchedPath to capture the results of a PathSpec match.