### PR TITLE
Add codeql-analysis.yml GitHub Actions Workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,87 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'jetty-10.[1-9]?[0-9].x', 'jetty-11.[1-9]?[0-9].x', 'jetty-12.[1-9]?[0-9].x' ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ 'jetty-10.[1-9]?[0-9].x', 'jetty-11.[1-9]?[0-9].x', 'jetty-12.[1-9]?[0-9].x' ]
+  schedule:
+    - cron: '22 1 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java', 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install and setup JDK 11
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3
+        if: ${{
+          startsWith(github.ref, 'refs/heads/jetty-10.') ||
+          startsWith(github.ref, 'refs/heads/jetty-11.') ||
+          startsWith(github.base_ref, 'jetty-10.') ||
+          startsWith(github.base_ref, 'jetty-11.')
+          }}
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      # Install and setup JDK 17
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        if: ${{
+          startsWith(github.ref, 'refs/heads/jetty-12.') ||
+          startsWith(github.base_ref, 'jetty-12.')
+          }}
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Hello! Your friendly neighborhood security researcher here!

GitHub is slowly (not entirely there yet) migrating away from LGTM.com
to establishing a way for security researchers to work with CodeQL databases
fully through GitHub.com. This 'new' way requires that databases get built
via GitHub actions and uploaded to GitHub.

The old way, supported by the `.lgtm.yaml` file will continue to exist for a while
(and I'll continue to use it), but as a researcher, if the Jetty project also built a
CodeQL database and uploaded it, I'd find it incredibly useful.

In summary, this PR adds a GitHub action to build a CodeQL database and runs
GitHub's CodeQL analysis tool which audits the code for security vulnerabilities.
