### PR TITLE
Add jetty maven plugin ITs as part of code coverage as we do it :)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,20 +14,24 @@ pipeline {
               timeout( time: 180, unit: 'MINUTES' ) {
                 mavenBuild( "jdk17", "clean install -Perrorprone", "maven3")
                 // Collect up the jacoco execution results (only on main build)
-                jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
+                jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class'
                        exclusionPattern: '' +
                                // build tools
-                               '**/org/eclipse/jetty/ant/**,*/org/eclipse/jetty/maven/its/**' +
+                               '**/org/eclipse/jetty/ant/**' +
+                               ',*/org/eclipse/jetty/maven/its/**' +
                                ',**/org/eclipse/jetty/its/**' +
                                // example code / documentation
-                               ',**/org/eclipse/jetty/embedded/**' + ',**/org/eclipse/jetty/asyncrest/**' +
+                               ',**/org/eclipse/jetty/embedded/**' +
+                               ',**/org/eclipse/jetty/asyncrest/**' +
                                ',**/org/eclipse/jetty/demo/**' +
                                // special environments / late integrations
-                               ',**/org/eclipse/jetty/gcloud/**' + ',**/org/eclipse/jetty/infinispan/**' +
+                               ',**/org/eclipse/jetty/gcloud/**' +
+                               ',**/org/eclipse/jetty/infinispan/**' +
                                ',**/org/eclipse/jetty/osgi/**' +
                                ',**/org/eclipse/jetty/http/spi/**' +
                                // test classes
-                               ',**/org/eclipse/jetty/tests/**' + ',**/org/eclipse/jetty/test/**',
+                               ',**/org/eclipse/jetty/tests/**' +
+                               ',**/org/eclipse/jetty/test/**'
                        execPattern: '**/target/jacoco.exec',
                        classPattern: '**/target/classes',
                        sourcePattern: '**/src/main/java'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
                 jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
                                // build tools
-                               '**/org/eclipse/jetty/ant/**' + ',**/org/eclipse/jetty/maven/**' +
-                               ',**/org/eclipse/jetty/jspc/**' +
+                               '**/org/eclipse/jetty/ant/**,*/org/eclipse/jetty/maven/its/**' +
+                               ',**/org/eclipse/jetty/its/**' +
                                // example code / documentation
                                ',**/org/eclipse/jetty/embedded/**' + ',**/org/eclipse/jetty/asyncrest/**' +
                                ',**/org/eclipse/jetty/demo/**' +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
               timeout( time: 180, unit: 'MINUTES' ) {
                 mavenBuild( "jdk17", "clean install -Perrorprone", "maven3")
                 // Collect up the jacoco execution results (only on main build)
-                jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class'
+                jacoco inclusionPattern: '**/org/eclipse/jetty/**/*.class',
                        exclusionPattern: '' +
                                // build tools
                                '**/org/eclipse/jetty/ant/**' +
@@ -31,7 +31,7 @@ pipeline {
                                ',**/org/eclipse/jetty/http/spi/**' +
                                // test classes
                                ',**/org/eclipse/jetty/tests/**' +
-                               ',**/org/eclipse/jetty/test/**'
+                               ',**/org/eclipse/jetty/test/**',
                        execPattern: '**/target/jacoco.exec',
                        classPattern: '**/target/classes',
                        sourcePattern: '**/src/main/java'

--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -11,7 +11,6 @@
   <name>Jetty :: Jetty JSPC Maven Plugin</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.jspc.plugin</bundle-symbolic-name>
-    <jacoco.skip>true</jacoco.skip>
   </properties>
   <build>
     <plugins>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -13,7 +13,6 @@
     <bundle-symbolic-name>${project.groupId}.maven.plugin</bundle-symbolic-name>
     <jetty.stopKey>FREEBEER</jetty.stopKey>
     <jetty.jvmArgs></jetty.jvmArgs>
-    <jacoco.skip>true</jacoco.skip>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,7 @@
             <exclude>**/org/eclipse/jetty/tests/**</exclude>
             <exclude>**/org/eclipse/jetty/test/**</exclude>
             <exclude>**/org/eclipse/jetty/maven/its/**</exclude>
+            <exclude>**/org/eclipse/jetty/its/**</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,17 @@
             </goals>
           </execution>
           <execution>
+            <id>jacoco-setup-m-invoker-p</id>
+            <phase>initialize</phase>
+            <configuration>
+              <!-- Enable recording of coverage during execution of maven-invoker-plugin -->
+              <propertyName>invoker.mavenOpts</propertyName>
+            </configuration>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>jacoco-site</id>
             <phase>package</phase>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -326,8 +326,6 @@
           <excludes>
             <!-- build tools -->
             <exclude>**/org/eclipse/jetty/ant/**</exclude>
-            <exclude>**/org/eclipse/jetty/maven/**</exclude>
-            <exclude>**/org/eclipse/jetty/jspc/**</exclude>
             <!-- example code / documentation -->
             <exclude>**/org/eclipse/jetty/embedded/**</exclude>
             <exclude>**/org/eclipse/jetty/asyncrest/**</exclude>
@@ -341,6 +339,7 @@
             <!-- test classes -->
             <exclude>**/org/eclipse/jetty/tests/**</exclude>
             <exclude>**/org/eclipse/jetty/test/**</exclude>
+            <exclude>**/org/eclipse/jetty/maven/its/**</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -339,8 +339,6 @@
             <!-- test classes -->
             <exclude>**/org/eclipse/jetty/tests/**</exclude>
             <exclude>**/org/eclipse/jetty/test/**</exclude>
-            <exclude>**/org/eclipse/jetty/maven/its/**</exclude>
-            <exclude>**/org/eclipse/jetty/its/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
- enable of jacoco coverage for maven its plugin
- do not skip jacoco for maven plugins we want to record we test them
- fix excludes
- fix exclusion
- no need to exclude this
