### PR TITLE
port stats handler responsesThrown changes to 12.0.x

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -256,13 +256,13 @@ public class StatisticsHandler extends Handler.Wrapper
     @ManagedAttribute("number of requests that threw an exception during processing")
     public int getProcessThrows()
     {
-        return _handleThrows.intValue();
+        return _processThrows.intValue();
     }
 
     @ManagedAttribute("")
     public int getHandlings()
     {
-        return (int)_handleStats.getCurrent();
+        return (int)_handleStats.getTotal();
     }
 
     @ManagedAttribute("")

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -41,6 +41,7 @@ public class StatisticsHandler extends Handler.Wrapper
     private final SampleStatistic _handleTimeStats = new SampleStatistic();
     private final SampleStatistic _processTimeStats = new SampleStatistic();
 
+    private final LongAdder _responsesThrown = new LongAdder();
     private final LongAdder _responses1xx = new LongAdder();
     private final LongAdder _responses2xx = new LongAdder();
     private final LongAdder _responses3xx = new LongAdder();
@@ -51,87 +52,22 @@ public class StatisticsHandler extends Handler.Wrapper
     public Request.Processor handle(Request request) throws Exception
     {
         long beginTimeStamp = System.nanoTime();
-        _connectionStats.computeIfAbsent(request.getConnectionMetaData().getId(), id ->
-        {
-            // TODO test this with localconnector endpoint that has multiple requests per connection.
-            request.getConnectionMetaData().getConnection().addEventListener(new Connection.Listener()
-            {
-                @Override
-                public void onClosed(Connection connection)
-                {
-                    // complete connections stats
-                    _connectionStats.remove(id);
-                }
-            });
-            return "SomeConnectionStatsObject";
-        });
-
-        StatisticsRequest statisticsRequest = new StatisticsRequest(request);
         _handleStats.increment();
-        _requestStats.increment();
+        StatisticsRequest statisticsRequest = new StatisticsRequest(request);
 
-        // TODO don't need to do this until we see a Processor
-        request.addHttpStreamWrapper(s -> new HttpStream.Wrapper(s)
+        try
         {
-            @Override
-            public void send(MetaData.Request request, MetaData.Response response, boolean last, Callback callback, ByteBuffer... content)
-            {
-                if (response != null)
-                {
-                    switch (response.getStatus() / 100)
-                    {
-                        case 1 -> _responses1xx.increment();
-                        case 2 -> _responses2xx.increment();
-                        case 3 -> _responses3xx.increment();
-                        case 4 -> _responses4xx.increment();
-                        case 5 -> _responses5xx.increment();
-                        default ->
-                        {
-                        }
-                    }
-                }
-
-                for (ByteBuffer b : content)
-                {
-                    statisticsRequest._bytesWritten.add(b.remaining());
-                }
-
-                super.send(request, response, last, callback, content);
-            }
-
-            @Override
-            public Content readContent()
-            {
-                Content content =  super.readContent();
-                if (content != null)
-                    statisticsRequest._bytesRead.add(content.remaining());
-                return content;
-            }
-
-            @Override
-            public void succeeded()
-            {
-                super.succeeded();
-                _processStats.decrement();
-                _requestStats.decrement();
-                _processTimeStats.record(System.nanoTime() - statisticsRequest._processStartTimeStamp);
-                _requestTimeStats.record(System.nanoTime() - getNanoTimeStamp());
-            }
-
-            @Override
-            public void failed(Throwable x)
-            {
-                super.failed(x);
-                _processStats.decrement();
-                _requestStats.decrement();
-                _processTimeStats.record(System.nanoTime() - statisticsRequest._processStartTimeStamp);
-                _requestTimeStats.record(System.nanoTime() - getNanoTimeStamp());
-            }
-        });
-
-        Request.Processor processor = super.handle(statisticsRequest);
-        _handleTimeStats.record(System.nanoTime() - beginTimeStamp);
-        return processor == null ? null : statisticsRequest.wrapProcessor(processor);
+            return statisticsRequest.wrapProcessor(super.handle(statisticsRequest));
+        }
+        catch (Throwable t)
+        {
+            _responsesThrown.increment();
+            throw t;
+        }
+        finally
+        {
+            _handleTimeStats.record(System.nanoTime() - beginTimeStamp);
+        }
     }
 
     private class StatisticsRequest extends Request.WrapperProcessor
@@ -175,9 +111,93 @@ public class StatisticsHandler extends Handler.Wrapper
         @Override
         public void process(Request ignored, Response response, Callback callback) throws Exception
         {
-            _processStats.increment();
             _processStartTimeStamp = System.nanoTime();
-            super.process(this, response, callback);
+            _processStats.increment();
+            _requestStats.increment();
+
+            _connectionStats.computeIfAbsent(getConnectionMetaData().getId(), id ->
+            {
+                // TODO test this with localconnector endpoint that has multiple requests per connection.
+                getConnectionMetaData().getConnection().addEventListener(new Connection.Listener()
+                {
+                    @Override
+                    public void onClosed(Connection connection)
+                    {
+                        // complete connections stats
+                        _connectionStats.remove(id);
+                    }
+                });
+                return "SomeConnectionStatsObject";
+            });
+
+            addHttpStreamWrapper(s -> new HttpStream.Wrapper(s)
+            {
+                @Override
+                public void send(MetaData.Request request, MetaData.Response response, boolean last, Callback callback, ByteBuffer... content)
+                {
+                    if (response != null)
+                    {
+                        switch (response.getStatus() / 100)
+                        {
+                            case 1 -> _responses1xx.increment();
+                            case 2 -> _responses2xx.increment();
+                            case 3 -> _responses3xx.increment();
+                            case 4 -> _responses4xx.increment();
+                            case 5 -> _responses5xx.increment();
+                            default ->
+                            {
+                            }
+                        }
+                    }
+
+                    for (ByteBuffer b : content)
+                    {
+                        _bytesWritten.add(b.remaining());
+                    }
+
+                    super.send(request, response, last, callback, content);
+                }
+
+                @Override
+                public Content readContent()
+                {
+                    Content content =  super.readContent();
+                    if (content != null)
+                        _bytesRead.add(content.remaining());
+                    return content;
+                }
+
+                @Override
+                public void succeeded()
+                {
+                    super.succeeded();
+                    _requestStats.decrement();
+                    _requestTimeStats.record(System.nanoTime() - getNanoTimeStamp());
+                }
+
+                @Override
+                public void failed(Throwable x)
+                {
+                    super.failed(x);
+                    _requestStats.decrement();
+                    _requestTimeStats.record(System.nanoTime() - getNanoTimeStamp());
+                }
+            });
+
+            try
+            {
+                super.process(this, response, callback);
+            }
+            catch (Throwable t)
+            {
+                _responsesThrown.increment();
+                throw t;
+            }
+            finally
+            {
+                _processStats.decrement();
+                _processTimeStats.record(System.nanoTime() - _processStartTimeStamp);
+            }
         }
     }
 
@@ -227,6 +247,12 @@ public class StatisticsHandler extends Handler.Wrapper
     public int getResponses5xx()
     {
         return _responses5xx.intValue();
+    }
+
+    @ManagedAttribute("number of requests that threw an exception during handling or processing")
+    public int getResponsesThrown()
+    {
+        return _responsesThrown.intValue();
     }
 
     @ManagedAttribute("")


### PR DESCRIPTION
## Issue #7979
 port stats handler responsesThrown changes to `12.0.x`

Also made some other changes:
- do wrapping of stream in process method not handle
- `_processTimeStats` now records only time in process method
- request stats is only modified if request is accepted and processed by the wrapped handler