### PR TITLE
Jetty-12 Completion handling

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -75,7 +75,7 @@ import org.slf4j.LoggerFactory;
 public class HttpChannelState implements HttpChannel, Components
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpChannelState.class);
-    private static final Throwable NO_SEND = new Throwable("No Send");
+    private static final Throwable DO_NOT_SEND = new Throwable("No Send");
     private static final HttpField CONTENT_LENGTH_0 = new PreEncodedHttpField(HttpHeader.CONTENT_LENGTH, "0")
     {
         @Override
@@ -573,11 +573,11 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             // There are many instances of code that wants to ensure the output is closed, so
-            // it does a redundant write(true, callback).  The NO_SEND option supports this by
+            // it does a redundant write(true, callback).  The DO_NOT_SEND option supports this by
             // turning such writes into a NOOP.
             case LAST_WRITTEN, LAST_WRITE_COMPLETED -> (length > 0)
                 ? new IllegalStateException("last already written")
-                : NO_SEND;
+                : DO_NOT_SEND;
         };
     }
 
@@ -1149,7 +1149,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 stream.send(_request._metaData, responseMetaData, last, this, content);
             }
-            else if (failure == NO_SEND)
+            else if (failure == DO_NOT_SEND)
             {
                 httpChannel._serializedInvoker.run(callback::succeeded);
             }
@@ -1449,7 +1449,7 @@ public class HttpChannelState implements HttpChannel, Components
 
             if (failure == null)
                 _stream.send(_request._metaData, responseMetaData, last, last ? Callback.from(this::lastWriteCompleted, callback) : callback, content);
-            else if (failure == NO_SEND)
+            else if (failure == DO_NOT_SEND)
                 httpChannel._serializedInvoker.run(callback::succeeded);
             else
                 httpChannel._serializedInvoker.run(() -> callback.failed(failure));

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -55,7 +55,6 @@ import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Attributes;
-import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -78,6 +77,7 @@ import org.slf4j.LoggerFactory;
 public class HttpChannelState implements HttpChannel, Components
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpChannelState.class);
+    private static final Throwable NO_SEND = new Throwable("No Send");
     private static final HttpField CONTENT_LENGTH_0 = new PreEncodedHttpField(HttpHeader.CONTENT_LENGTH, "0")
     {
         @Override
@@ -115,7 +115,10 @@ public class HttpChannelState implements HttpChannel, Components
         }
     };
 
-    enum State
+    /**
+     * State of the processing of the request
+     */
+    enum ProcessState
     {
         /** Idle state */
         IDLE,
@@ -130,12 +133,24 @@ public class HttpChannelState implements HttpChannel, Components
         /** The Request.Processor call has returned prior to callback completion.
          * The Content.Reader APIs are enabled. */
         PROCESSED,
+    }
 
-        /** Callback completion has been called prior to Request.Processor completion. */
-        COMPLETED,
+    /**
+     * The state of the written response
+     */
+    enum WriteState
+    {
+        /** Not yet written */
+        IDLE,
 
-        /** The Request.Processor call has returned and the callback is complete */
-        PROCESSED_AND_COMPLETED,
+        /** Written but not yet last */
+        WRITTEN,
+
+        /** Last content written, but write not yet completed */
+        LAST_WRITTEN,
+
+        /** Last content written and completed */
+        LAST_WRITE_COMPLETE,
     }
 
     private final AutoLock _lock = new AutoLock();
@@ -144,8 +159,9 @@ public class HttpChannelState implements HttpChannel, Components
     private final SerializedInvoker _serializedInvoker;
     private final Attributes _requestAttributes = new Attributes.Lazy();
     private final ResponseHttpFields _responseHeaders = new ResponseHttpFields();
-    private State _state = State.IDLE; // TODO could this be an AtomicReference?
-    private boolean _lastWrite = false;
+    private ProcessState _processState = ProcessState.IDLE;
+    private WriteState _writeState = WriteState.IDLE;
+    private boolean _completed = false;
     private Throwable _failure;
     private ChannelRequest _request;
     private HttpStream _stream;
@@ -171,7 +187,7 @@ public class HttpChannelState implements HttpChannel, Components
                 boolean completed;
                 try (AutoLock ignore = _lock.lock())
                 {
-                    completed = _state.ordinal() >= State.COMPLETED.ordinal();
+                    completed = _completed;
                     request = _request;
                     error = _request == null ? null : _error;
                 }
@@ -226,8 +242,9 @@ public class HttpChannelState implements HttpChannel, Components
             // Recycle.
             _requestAttributes.clearAttributes();
             _responseHeaders.reset();
-            _state = State.IDLE;
-            _lastWrite = false;
+            _processState = ProcessState.IDLE;
+            _writeState = WriteState.IDLE;
+            _completed = false;
             _failure = null;
             _committedContentLength = -1;
             if (_responseTrailers != null)
@@ -388,7 +405,7 @@ public class HttpChannelState implements HttpChannel, Components
     {
         try (AutoLock ignored = _lock.lock())
         {
-            return _state.ordinal() >= State.HANDLING.ordinal();
+            return _processState.ordinal() >= ProcessState.HANDLING.ordinal();
         }
     }
 
@@ -468,9 +485,9 @@ public class HttpChannelState implements HttpChannel, Components
                 boolean handled;
                 try (AutoLock ignore = _lock.lock())
                 {
-                    handled = _state.ordinal() >= State.HANDLING.ordinal();
+                    handled = _processState.ordinal() >= ProcessState.HANDLING.ordinal();
                     if (!handled)
-                        _state = State.PROCESSED;
+                        _processState = ProcessState.PROCESSED;
                 }
                 if (handled)
                 {
@@ -546,19 +563,18 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
-    private void changeState(State from, State to)
+    private Throwable checkWrite(boolean last, long length)
     {
-        try (AutoLock ignored = _lock.lock())
+        return switch (_writeState)
         {
-            changeStateLocked(from, to);
-        }
-    }
-
-    private void changeStateLocked(State from, State to)
-    {
-        if (!_lock.isHeldByCurrentThread() || _state != from)  // TODO do we need the lock check?
-            throw new IllegalStateException(String.valueOf(_state));
-        _state = to;
+            case IDLE, WRITTEN ->
+            {
+                _writeState = last ? WriteState.LAST_WRITTEN : WriteState.WRITTEN;
+                _request._response._contentBytesWritten += length;
+                yield null;
+            }
+            case LAST_WRITTEN, LAST_WRITE_COMPLETE -> (length > 0) ? new IllegalStateException("last already written") : NO_SEND;
+        };
     }
 
     @Override
@@ -566,7 +582,7 @@ public class HttpChannelState implements HttpChannel, Components
     {
         try (AutoLock ignored = _lock.lock())
         {
-            return String.format("%s@%x{s=%s,r=%s}", this.getClass().getSimpleName(), hashCode(), _state, _request);
+            return String.format("%s@%x{s=%s,r=%s}", this.getClass().getSimpleName(), hashCode(), _processState, _request);
         }
     }
 
@@ -582,7 +598,7 @@ public class HttpChannelState implements HttpChannel, Components
             ChannelRequest request;
             try (AutoLock ignored = _lock.lock())
             {
-                changeStateLocked(State.IDLE, State.HANDLING);
+                _processState = ProcessState.HANDLING;
                 request = _request;
             }
 
@@ -617,7 +633,10 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = t;
             }
 
-            changeState(State.HANDLING, State.PROCESSING);
+            try (AutoLock ignored1 = _lock.lock())
+            {
+                _processState = ProcessState.PROCESSING;
+            }
 
             try
             {
@@ -632,10 +651,10 @@ public class HttpChannelState implements HttpChannel, Components
                 ((Callback)request._callback).failed(failure);
 
             HttpStream stream;
-            boolean complete;
+            boolean completeStream;
             try (AutoLock ignored = _lock.lock())
             {
-                complete = _state == State.COMPLETED;
+                _processState = ProcessState.PROCESSED;
 
                 if (_failure != null)
                 {
@@ -647,15 +666,11 @@ public class HttpChannelState implements HttpChannel, Components
                     failure = _failure;
                 }
 
-                if (complete)
-                    changeStateLocked(State.COMPLETED, State.PROCESSED_AND_COMPLETED);
-                else
-                    changeStateLocked(State.PROCESSING, State.PROCESSED);
-
+                completeStream = _completed && (failure != null || _writeState == WriteState.LAST_WRITE_COMPLETE);
                 stream = _stream;
             }
-            if (complete)
-                complete(stream, failure);
+            if (completeStream)
+                completeStream(stream, failure);
         }
 
         /**
@@ -665,23 +680,16 @@ public class HttpChannelState implements HttpChannel, Components
         public void succeeded()
         {
             HttpStream stream;
-            boolean complete;
-            boolean needLastWrite;
-            MetaData.Response responseMetaData = null;
+            boolean completeStream;
             try (AutoLock ignored = _lock.lock())
             {
-                needLastWrite = !_lastWrite;
-                _lastWrite = true;
-                if (needLastWrite && _responseHeaders.commit())
-                    responseMetaData = _request._response.lockedPrepareResponse(HttpChannelState.this, true);
-                complete = _state == State.PROCESSED_AND_COMPLETED;
+                _writeState = WriteState.LAST_WRITE_COMPLETE;
+                completeStream = _completed && _processState == ProcessState.PROCESSED;
                 stream = _stream;
             }
 
-            if (needLastWrite)
-                stream.send(_request._metaData, responseMetaData, true, this);
-            else if (complete)
-                complete(stream, null);
+            if (completeStream)
+                completeStream(stream, null);
         }
 
         /**
@@ -691,10 +699,11 @@ public class HttpChannelState implements HttpChannel, Components
         public void failed(Throwable failure)
         {
             HttpStream stream;
-            boolean complete;
+            boolean completeStream;
             try (AutoLock ignored = _lock.lock())
             {
-                complete = _state == State.PROCESSED_AND_COMPLETED;
+                _writeState = WriteState.LAST_WRITE_COMPLETE;
+                completeStream = _completed && _processState == ProcessState.PROCESSED;
                 stream = _stream;
                 if (_failure == null)
                     _failure = failure;
@@ -704,11 +713,11 @@ public class HttpChannelState implements HttpChannel, Components
                     failure = _failure;
                 }
             }
-            if (complete)
-                complete(stream, failure);
+            if (completeStream)
+                completeStream(stream, failure);
         }
 
-        private void complete(HttpStream stream, Throwable failure)
+        private void completeStream(HttpStream stream, Throwable failure)
         {
             try
             {
@@ -921,7 +930,7 @@ public class HttpChannelState implements HttpChannel, Components
                 if (error != null)
                     return error;
 
-                if (httpChannel._state.ordinal() < State.PROCESSING.ordinal())
+                if (httpChannel._processState.ordinal() < ProcessState.PROCESSING.ordinal())
                     return new Content.Error(new IllegalStateException("not processing"));
 
                 stream = httpChannel._stream;
@@ -943,7 +952,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 HttpChannelState httpChannel = lockedGetHttpChannel();
 
-                error = httpChannel._error != null || httpChannel._state.ordinal() < State.PROCESSING.ordinal();
+                error = httpChannel._error != null || httpChannel._processState.ordinal() < ProcessState.PROCESSING.ordinal();
                 if (!error)
                 {
                     if (httpChannel._onContentAvailable != null)
@@ -1076,40 +1085,34 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public void write(boolean last, Callback callback, ByteBuffer... content)
         {
-            long written;
+            long length = 0;
+            for (ByteBuffer b : content)
+                length += b.remaining();
+
+            long totalWritten;
             HttpChannelState httpChannel;
             HttpStream stream = null;
-            Throwable failure = null;
+            Throwable failure;
             MetaData.Response responseMetaData = null;
-            boolean noop = false;
             try (AutoLock ignored = _request._lock.lock())
             {
                 httpChannel = _request.lockedGetHttpChannel();
 
                 if (httpChannel._writeCallback != null)
                     failure = new IllegalStateException("write pending");
-                else if (httpChannel._state.ordinal() < State.PROCESSING.ordinal())
+                else if (httpChannel._processState.ordinal() < ProcessState.PROCESSING.ordinal())
                     failure = new IllegalStateException("not processing");
                 else if (httpChannel._error != null)
                     failure = httpChannel._error.getCause();
-                else if (last && httpChannel._lastWrite)
-                {
-                    if (BufferUtil.remaining(content) > 0)
-                        failure = new IllegalStateException("last already written");
-                    else
-                        noop = true;
-                }
+                else
+                    failure = httpChannel.checkWrite(last, length);
 
-                if (failure == null && !noop)
+                if (failure == null)
                 {
                     httpChannel._writeCallback = callback;
-                    for (ByteBuffer b : content)
-                        _contentBytesWritten += b.remaining();
-
-                    httpChannel._lastWrite |= last;
 
                     stream = httpChannel._stream;
-                    written = _contentBytesWritten;
+                    totalWritten = _contentBytesWritten;
 
                     if (httpChannel._responseHeaders.commit())
                         responseMetaData = lockedPrepareResponse(httpChannel, last);
@@ -1118,11 +1121,11 @@ public class HttpChannelState implements HttpChannel, Components
                     long committedContentLength = httpChannel._committedContentLength;
                     if (committedContentLength >= 0)
                     {
-                        String lengthError = (written > committedContentLength) ? "written %d > %d content-length"
-                            : (last && written < committedContentLength) ? "written %d < %d content-length" : null;
+                        String lengthError = (totalWritten > committedContentLength) ? "written %d > %d content-length"
+                            : (last && totalWritten < committedContentLength) ? "written %d < %d content-length" : null;
                         if (lengthError != null)
                         {
-                            String message = lengthError.formatted(written, committedContentLength);
+                            String message = lengthError.formatted(totalWritten, committedContentLength);
                             if (LOG.isDebugEnabled())
                                 LOG.debug("fail {} {}", callback, message);
                             failure = new IOException(message);
@@ -1131,18 +1134,18 @@ public class HttpChannelState implements HttpChannel, Components
                 }
             }
 
-            if (failure != null)
+            if (failure == null)
             {
-                Throwable t = failure;
-                httpChannel._serializedInvoker.run(() -> callback.failed(t));
+                stream.send(_request._metaData, responseMetaData, last, this, content);
             }
-            else if (noop)
+            else if (failure == NO_SEND)
             {
                 httpChannel._serializedInvoker.run(callback::succeeded);
             }
             else
             {
-                stream.send(_request._metaData, responseMetaData, last, this, content);
+                Throwable t = failure;
+                httpChannel._serializedInvoker.run(() -> callback.failed(t));
             }
         }
 
@@ -1157,6 +1160,8 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel = _request.lockedGetHttpChannel();
                 callback = httpChannel._writeCallback;
                 httpChannel._writeCallback = null;
+                if (httpChannel._writeState == WriteState.LAST_WRITTEN)
+                    httpChannel._writeState = WriteState.LAST_WRITE_COMPLETE;
             }
             if (LOG.isDebugEnabled())
                 LOG.debug("write succeeded {}", callback);
@@ -1201,11 +1206,8 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 if (_request._httpChannel == null)
                     return false;
-                return switch (_request._httpChannel._state)
-                {
-                    case COMPLETED, PROCESSED_AND_COMPLETED -> _request._httpChannel._failure == null;
-                    default -> false;
-                };
+
+                return _request._httpChannel._completed && _request._httpChannel._failure == null;
             }
         }
 
@@ -1268,12 +1270,12 @@ public class HttpChannelState implements HttpChannel, Components
             HttpChannelState httpChannelState;
             Throwable failure = null;
             MetaData.Response responseMetaData = null;
-            boolean complete;
+            boolean completeStream;
             try (AutoLock ignored = _request._lock.lock())
             {
-                complete = complete();
+                onComplete();
                 httpChannelState = _request._httpChannel;
-                needLastWrite = !httpChannelState._lastWrite;
+                completeStream = httpChannelState._processState == ProcessState.PROCESSED && httpChannelState._writeState == WriteState.LAST_WRITE_COMPLETE;
 
                 // We are being tough on handler implementations and expect them
                 // to not have pending operations when calling succeeded or failed.
@@ -1284,16 +1286,21 @@ public class HttpChannelState implements HttpChannel, Components
                 if (httpChannelState._error != null)
                     throw new IllegalStateException("error " + httpChannelState._error, httpChannelState._error.getCause());
 
+                needLastWrite = switch (httpChannelState._writeState)
+                {
+                    case IDLE, WRITTEN -> true;
+                    case LAST_WRITTEN, LAST_WRITE_COMPLETE -> false;
+                };
                 stream = httpChannelState._stream;
 
                 if (httpChannelState._responseHeaders.commit())
                     responseMetaData = _request._response.lockedPrepareResponse(httpChannelState, true);
 
-                long written = _request._response._contentBytesWritten;
+                long totalWritten = _request._response._contentBytesWritten;
                 long committedContentLength = httpChannelState._committedContentLength;
 
-                if (committedContentLength >= 0 && committedContentLength != written)
-                    failure = httpChannelState._failure = new IOException("content-length %d != %d written".formatted(committedContentLength, written));
+                if (committedContentLength >= 0 && committedContentLength != totalWritten)
+                    failure = httpChannelState._failure = new IOException("content-length %d != %d written".formatted(committedContentLength, totalWritten));
 
                 // is the request fully consumed?
                 Throwable unconsumed = stream.consumeAll();
@@ -1311,8 +1318,8 @@ public class HttpChannelState implements HttpChannel, Components
 
             if (failure == null && needLastWrite)
                 stream.send(_request._metaData, responseMetaData, true, httpChannelState._handlerInvoker);
-            else if (complete)
-                httpChannelState._handlerInvoker.complete(stream, failure);
+            else if (completeStream)
+                httpChannelState._handlerInvoker.completeStream(stream, failure);
         }
 
         @Override
@@ -1323,12 +1330,14 @@ public class HttpChannelState implements HttpChannel, Components
             boolean writeErrorResponse;
             ChannelRequest request;
             HttpChannelState httpChannelState;
-            boolean complete;
+            boolean completeStream;
             try (AutoLock ignored = _request._lock.lock())
             {
-                complete = complete();
+                onComplete();
+
                 httpChannelState = _request._httpChannel;
                 httpChannelState._failure = failure;
+                completeStream = httpChannelState._processState == ProcessState.PROCESSED;
 
                 // Verify whether we can write an error response.
                 writeErrorResponse = !httpChannelState._stream.isCommitted();
@@ -1345,6 +1354,7 @@ public class HttpChannelState implements HttpChannel, Components
                     // Cannot log or recycle just yet, since we need to generate the error response.
                     _request._response._status = HttpStatus.INTERNAL_SERVER_ERROR_500;
                     httpChannelState._responseHeaders.reset();
+                    httpChannelState._writeState = WriteState.IDLE;
                 }
             }
 
@@ -1353,16 +1363,16 @@ public class HttpChannelState implements HttpChannel, Components
 
             if (writeErrorResponse)
             {
-                ErrorResponse response = new ErrorResponse(request, stream);
-                Response.writeError(request, response, httpChannelState._handlerInvoker, failure);
+                ErrorResponse response = new ErrorResponse(request, stream, failure);
+                Response.writeError(request, response, response, failure);
             }
-            else if (complete)
+            else if (completeStream)
             {
-                httpChannelState._handlerInvoker.complete(stream, failure);
+                httpChannelState._handlerInvoker.completeStream(stream, failure);
             }
         }
 
-        private boolean complete()
+        private void onComplete()
         {
             HttpChannelState httpChannelState = _request._httpChannel;
             if (httpChannelState == null)
@@ -1372,30 +1382,15 @@ public class HttpChannelState implements HttpChannel, Components
                 throw new IllegalStateException("channel already completed");
             }
 
-            return switch (httpChannelState._state)
+            if (httpChannelState._completed)
             {
-                case PROCESSING ->
-                {
-                    if (LOG.isDebugEnabled())
-                        _completedBy = new Throwable(Thread.currentThread().getName());
-                    httpChannelState._state = State.COMPLETED;
-                    yield false;
-                }
-                case PROCESSED ->
-                {
-                    if (LOG.isDebugEnabled())
-                        _completedBy = new Throwable(Thread.currentThread().getName());
-                    httpChannelState._state = State.PROCESSED_AND_COMPLETED;
-                    yield true;
-                }
-                case PROCESSED_AND_COMPLETED, COMPLETED ->
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.warn("already completed {} by", _request, _completedBy);
-                    throw new IllegalStateException("already completed");
-                }
-                default -> throw new IllegalStateException("not processing");
-            };
+                if (LOG.isDebugEnabled())
+                    LOG.warn("already completed {} by", _request, _completedBy);
+                throw new IllegalStateException("already completed");
+            }
+            if (LOG.isDebugEnabled())
+                _completedBy = new Throwable(Thread.currentThread().getName());
+            httpChannelState._completed = true;
         }
 
         @Override
@@ -1406,38 +1401,92 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
-    private static class ErrorResponse extends Response.Wrapper
+    private static class ErrorResponse extends Response.Wrapper implements Callback
     {
         private final ChannelRequest _request;
         private final ChannelResponse _response;
         private final HttpStream _stream;
+        private final Throwable _failure;
 
-        public ErrorResponse(ChannelRequest request, HttpStream stream)
+        public ErrorResponse(ChannelRequest request, HttpStream stream, Throwable failure)
         {
             super(request, request._response);
             _request = request;
             _response = request._response;
             _stream = stream;
+            _failure = failure;
         }
 
         @Override
         public void write(boolean last, Callback callback, ByteBuffer... content)
         {
+            long length = 0;
+            for (ByteBuffer b : content)
+                length += b.remaining();
+
+            HttpChannelState httpChannel;
+            Throwable failure;
             MetaData.Response responseMetaData = null;
             try (AutoLock ignored = _request._lock.lock())
             {
-                HttpChannelState httpChannel = _request.lockedGetHttpChannel();
-
+                httpChannel = _request.lockedGetHttpChannel();
                 httpChannel._writeCallback = callback;
-                for (ByteBuffer b : content)
-                    _response._contentBytesWritten += b.remaining();
-
-                httpChannel._lastWrite |= last;
-
+                failure = httpChannel.checkWrite(last, length);
                 if (httpChannel._responseHeaders.commit())
                     responseMetaData = _request._response.lockedPrepareResponse(httpChannel, last);
             }
-            _stream.send(_request._metaData, responseMetaData, last, callback, content);
+
+            if (failure == null)
+                _stream.send(_request._metaData, responseMetaData, last, last ? Callback.from(this::lastWriteCompleted, callback) : callback, content);
+            else if (failure == NO_SEND)
+                httpChannel._serializedInvoker.run(callback::succeeded);
+            else
+                httpChannel._serializedInvoker.run(() -> callback.failed(failure));
+        }
+
+        private void lastWriteCompleted()
+        {
+            try (AutoLock ignored = _request._lock.lock())
+            {
+                _request.lockedGetHttpChannel()._writeState = WriteState.LAST_WRITE_COMPLETE;
+            }
+        }
+
+        @Override
+        public void succeeded()
+        {
+            boolean needLastWrite;
+            MetaData.Response responseMetaData = null;
+            HttpChannelState httpChannel;
+            try (AutoLock ignored = _request._lock.lock())
+            {
+                httpChannel = _request.getHttpChannel();
+
+                // Did the errorProcessor do the last write?
+                needLastWrite = httpChannel._writeState.ordinal() <= WriteState.LAST_WRITTEN.ordinal();
+                if (needLastWrite && httpChannel._responseHeaders.commit())
+                    responseMetaData = _request._response.lockedPrepareResponse(httpChannel, true);
+            }
+
+            if (needLastWrite)
+                _stream.send(_request._metaData, responseMetaData, true,
+                    Callback.from(() -> httpChannel._handlerInvoker.failed(_failure),
+                        x ->
+                        {
+                            if (!TypeUtil.isAssociated(_failure, x))
+                                _failure.addSuppressed(x);
+                            httpChannel._handlerInvoker.failed(_failure);
+                        }));
+            else
+                httpChannel._handlerInvoker.failed(_failure);
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            if (!TypeUtil.isAssociated(_failure, x))
+                _failure.addSuppressed(x);
+            _request.getHttpChannel()._handlerInvoker.failed(_failure);
         }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -32,6 +33,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.handler.DumpHandler;
 import org.eclipse.jetty.server.handler.EchoHandler;
@@ -39,12 +41,15 @@ import org.eclipse.jetty.server.handler.HelloHandler;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.SerializedInvoker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -600,7 +605,9 @@ public class HttpChannelTest
             public void process(Request request, Response response, Callback callback)
             {
                 response.setContentLength(10);
-                response.write(false, Callback.from(() -> response.write(true, callback)), BufferUtil.toBuffer("12345"));
+                response.write(false,
+                    Callback.from(() ->
+                        response.write(true, callback)), BufferUtil.toBuffer("12345"));
             }
         };
         _server.setHandler(handler);
@@ -1279,5 +1286,160 @@ public class HttpChannelTest
         assertTrue(completed.await(5, TimeUnit.SECONDS));
         assertTrue(stream.isComplete());
         assertFalse(stream.isDemanding());
+    }
+
+    enum CompletionTestEvent
+    {
+        PROCESSED,
+        WRITE,
+        SUCCEED,
+        FAIL,
+        SENT
+    }
+
+    public static Stream<List<CompletionTestEvent>> completionEvents()
+    {
+        return Stream.of(
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED),
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED),
+
+            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED, CompletionTestEvent.SENT),
+
+            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.FAIL, CompletionTestEvent.SENT)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("completionEvents")
+    public void testCompletion(List<CompletionTestEvent> events) throws Exception
+    {
+        testCompletion(events, null, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("completionEvents")
+    public void testCompletionNoWriteErrorProcessor(List<CompletionTestEvent> events) throws Exception
+    {
+        Request.Processor errorProcessor = (request, response, callback) -> callback.succeeded();
+        testCompletion(events, errorProcessor, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("completionEvents")
+    public void testCompletionFailedErrorProcessor(List<CompletionTestEvent> events) throws Exception
+    {
+        Request.Processor errorProcessor = (request, response, callback) -> callback.failed(new QuietException.Exception("Error processor failed"));
+        testCompletion(events, errorProcessor, false);
+    }
+
+    private void testCompletion(List<CompletionTestEvent> events, Request.Processor errorProcessor, boolean expectErrorResponse) throws Exception
+    {
+        CountDownLatch processing = new CountDownLatch(1);
+        CountDownLatch processed = new CountDownLatch(1);
+        AtomicReference<Response> responseRef = new AtomicReference<>();
+        AtomicReference<Callback> callbackRef = new AtomicReference<>();
+
+        Handler handler = new Handler.Processor()
+        {
+            @Override
+            public void process(Request request, Response response, Callback callback) throws Exception
+            {
+                response.setStatus(200);
+                response.setHeader("Test", "Value");
+                responseRef.set(response);
+                callbackRef.set(callback);
+                processing.countDown();
+                processed.await();
+            }
+        };
+
+        _server.setHandler(handler);
+        if (errorProcessor != null)
+            _server.setErrorProcessor(errorProcessor);
+        _server.start();
+
+        ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
+        HttpChannel channel = new HttpChannelState(connectionMetaData);
+
+        AtomicReference<Callback> sendCallback = new AtomicReference<>();
+        MockHttpStream stream = new MockHttpStream(channel)
+        {
+            @Override
+            public void send(MetaData.Request request, MetaData.Response response, boolean last, Callback callback, ByteBuffer... content)
+            {
+                sendCallback.set(callback);
+                super.send(request, response, last, NOOP, content);
+            }
+        };
+
+        HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
+        MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        Runnable task = channel.onRequest(request);
+
+        // Process the request
+        Thread processor = new Thread(task);
+        processor.start();
+        assertTrue(processing.await(5, TimeUnit.SECONDS));
+
+        Response response = responseRef.get();
+        Callback callback = callbackRef.get();
+        FutureCallback written = null;
+
+        for (CompletionTestEvent event : events)
+        {
+            switch (event)
+            {
+                case WRITE ->
+                {
+                    if (written != null)
+                        throw new IllegalStateException();
+                    written = new FutureCallback();
+                    response.write(true, written);
+                }
+
+                case SUCCEED -> callback.succeeded();
+
+                case FAIL -> callback.failed(new QuietException.Exception("FAILED"));
+
+                case PROCESSED ->
+                {
+                    processed.countDown();
+                    processor.join(10000);
+                    assertFalse(processor.isAlive());
+                }
+
+                case SENT ->
+                {
+                    if (sendCallback.get() != null)
+                        sendCallback.get().succeeded();
+                    if (written != null)
+                    {
+                        written.get(5, TimeUnit.SECONDS);
+                        assertTrue(written.isDone());
+                    }
+                }
+            }
+        }
+
+        boolean failed = events.contains(CompletionTestEvent.FAIL);
+
+        assertThat(stream.isComplete(), is(true));
+        assertThat(stream.getFailure(), failed ? notNullValue() : nullValue());
+        if (!failed || expectErrorResponse)
+        {
+            assertThat(stream.getResponse(), notNullValue());
+            assertThat(stream.getResponse().getStatus(), equalTo(failed ? 500 : 200));
+            assertThat(stream.getResponseHeaders().get("Test"), failed ? nullValue() : equalTo("Value"));
+        }
+        else
+        {
+            assertThat(stream.getResponse(), nullValue());
+        }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1294,24 +1294,24 @@ public class HttpChannelTest
         WRITE,
         SUCCEED,
         FAIL,
-        SENT
+        STREAM_COMPLETE
     }
 
     public static Stream<List<CompletionTestEvent>> completionEvents()
     {
         return Stream.of(
-            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED),
-            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED),
-            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED),
-            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.WRITE, CompletionTestEvent.SENT, CompletionTestEvent.SUCCEED),
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED),
+            List.of(CompletionTestEvent.WRITE, CompletionTestEvent.PROCESSED, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.SUCCEED),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.WRITE, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.SUCCEED),
 
-            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED),
-            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT),
-            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED, CompletionTestEvent.SENT),
+            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.SUCCEED, CompletionTestEvent.PROCESSED, CompletionTestEvent.STREAM_COMPLETE),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.SUCCEED, CompletionTestEvent.STREAM_COMPLETE),
 
-            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.SENT, CompletionTestEvent.PROCESSED),
-            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.PROCESSED, CompletionTestEvent.SENT),
-            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.FAIL, CompletionTestEvent.SENT)
+            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.STREAM_COMPLETE, CompletionTestEvent.PROCESSED),
+            List.of(CompletionTestEvent.FAIL, CompletionTestEvent.PROCESSED, CompletionTestEvent.STREAM_COMPLETE),
+            List.of(CompletionTestEvent.PROCESSED, CompletionTestEvent.FAIL, CompletionTestEvent.STREAM_COMPLETE)
         );
     }
 
@@ -1414,7 +1414,7 @@ public class HttpChannelTest
                     assertFalse(processor.isAlive());
                 }
 
-                case SENT ->
+                case STREAM_COMPLETE ->
                 {
                     if (sendCallback.get() != null)
                         sendCallback.get().succeeded();


### PR DESCRIPTION
Split the state handling in HttpChannelState to:
 + processState
 + writeState
 + completed boolean

The stream is not completed until callback is completed, processing has returned and the last write has completed.

Extensive tests added