### PR TITLE
fix bom for jetty-cdi

### DIFF
--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -108,7 +108,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-cdi</artifactId>
-        <version>10.0.3-SNAPSHOT</version>
+        <version>11.0.10-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
ooops https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-bom/11.0.9/jetty-bom-11.0.9.pom :(