### PR TITLE
Use getSchemaTableName also in the create table statement

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
@@ -268,7 +268,7 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
             String longType = _dbAdaptor.getLongType();
             String stringType = _dbAdaptor.getStringType();
 
-            return "create table " + _tableName + " (" + _idColumn + " " + stringType + "(120), " +
+            return "create table " + getSchemaTableName() + " (" + _idColumn + " " + stringType + "(120), " +
                 _contextPathColumn + " " + stringType + "(60), " + _virtualHostColumn + " " + stringType + "(60), " + _lastNodeColumn + " " + stringType + "(60), " + _accessTimeColumn + " " + longType + ", " +
                 _lastAccessTimeColumn + " " + longType + ", " + _createTimeColumn + " " + longType + ", " + _cookieTimeColumn + " " + longType + ", " +
                 _lastSavedTimeColumn + " " + longType + ", " + _expiryTimeColumn + " " + longType + ", " + _maxIntervalColumn + " " + longType + ", " +


### PR DESCRIPTION
When all other sql statements are built, this method is used for including the schema name in front of the table name (if specified). So to make it more consistent, it would be better to also create the table in the specified schema.

PS: Please indulge me for not opening an issue, as i think this optimization is pretty trivial and need no big discussion.

Signed-off-by: Michael Weigmann <michael.weigmann@hsh-berlin.com>