### PR TITLE
make jetty-p2 depending jetty-home so we sure it's build last even when using -Tx option see https://github.com/eclipse/jetty.project/issues/8021

### DIFF
--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -43,7 +43,7 @@
         artifacts are created -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-bom</artifactId>
+      <artifactId>jetty-home</artifactId>
       <version>${project.version}</version>
       <type>pom</type>
     </dependency>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>
