### PR TITLE
use surefire 3.0.0 M7 SNAPSHOT so we can restore running all tests with -Dmaven.test.failure.ignore=true

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,7 +141,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
         configFileProvider(
                 [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS')]) {
-          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Pci --show-version --batch-mode --errors -Djetty.testtracker.log=true  $cmdline"
+          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Pci --show-version --batch-mode --errors -Djetty.testtracker.log=true -Dmaven.test.failure.ignore=true $cmdline"
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
     <maven.site.plugin.version>3.10.0</maven.site.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.0.0-M7-SNAPSHOT</maven.surefire.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <spotbugs.maven.plugin.version>4.5.3.0</spotbugs.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,19 @@
     <url>https://github.com/eclipse/jetty.project</url>
   </scm>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <modules>
     <module>build</module>
 <!--    <module>documentation</module>-->


### PR DESCRIPTION
- test surefire 3.0.0-M7-SNAPSHOT and restore -Dmaven.test.failure.ignore=true
- add apache snapshots repository

@joakime why we need need this :)
because we need https://issues.apache.org/jira/browse/SUREFIRE-1426 which is fixed in M6 (if not we do not see jpms issues) but M6 has this https://issues.apache.org/jira/browse/SUREFIRE-2057
