### PR TITLE
Jetty 12 gzip handler

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponse.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponse.java
@@ -309,11 +309,13 @@ public class GzipResponse extends Response.Wrapper
                         content = BufferUtil.EMPTY_BUFFER;
                     else if (_index < _content.length)
                     {
+                        content = _content[_index];
                         while (BufferUtil.isEmpty(content))
                         {
+                            _index++;
                             if (_index >= _content.length)
                                 break;
-                            content = _content[_index++];
+                            content = _content[_index];
                         }
                     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponse.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponse.java
@@ -110,7 +110,7 @@ public class GzipResponse extends Response.Wrapper
             callback.succeeded();
     }
 
-    protected void commit(boolean complete, Callback callback, ByteBuffer... content)
+    protected void commit(boolean last, Callback callback, ByteBuffer... content)
     {
         // Are we excluding because of status?
         Response response = GzipResponse.this;
@@ -133,7 +133,7 @@ public class GzipResponse extends Response.Wrapper
                 }
             }
 
-            super.write(complete, callback, content);
+            super.write(last, callback, content);
             return;
         }
 
@@ -146,7 +146,7 @@ public class GzipResponse extends Response.Wrapper
             {
                 LOG.debug("{} exclude by mimeType {}", this, ct);
                 noCompression();
-                super.write(complete, callback, content);
+                super.write(last, callback, content);
                 return;
             }
         }
@@ -158,7 +158,7 @@ public class GzipResponse extends Response.Wrapper
         {
             LOG.debug("{} exclude by content-encoding {}", this, ce);
             noCompression();
-            super.write(complete, callback, content);
+            super.write(last, callback, content);
             return;
         }
 
@@ -170,7 +170,7 @@ public class GzipResponse extends Response.Wrapper
                 fields.ensureField(_vary);
 
             long contentLength = response.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
-            if (contentLength < 0 && complete)
+            if (contentLength < 0 && last)
                 contentLength = Arrays.stream(content).map(BufferUtil::length).mapToLong(Long::valueOf).sum();
 
             _deflaterEntry = _factory.getDeflaterEntry(request, contentLength);
@@ -178,7 +178,7 @@ public class GzipResponse extends Response.Wrapper
             {
                 LOG.debug("{} exclude no deflater", this);
                 _state.set(GZState.NOT_COMPRESSING);
-                super.write(complete, callback, content);
+                super.write(last, callback, content);
                 return;
             }
 
@@ -197,11 +197,11 @@ public class GzipResponse extends Response.Wrapper
             if (BufferUtil.isEmpty(content))
             {
                 // We are committing, but have no content to compress, so flush empty buffer to write headers.
-                super.write(complete, callback);
+                super.write(last, callback);
             }
             else
             {
-                gzip(complete, callback, content);
+                gzip(last, callback, content);
             }
         }
         else
@@ -325,8 +325,13 @@ public class GzipResponse extends Response.Wrapper
                     {
                         if (_last)
                             deflater.finish();
-                        else
+                        else if (BufferUtil.isEmpty(_buffer))
                             return Action.SUCCEEDED;
+                        else
+                        {
+                            GzipResponse.this.getWrapped().write(false, this, _buffer);
+                            return Action.SCHEDULED;
+                        }
                     }
                     else
                     {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -468,8 +468,6 @@ public class GzipHandlerTest
 
     public static Stream<Arguments> scenarios()
     {
-//        if (true) return Stream.of(Arguments.of(1, 32 * 1024 + 1, true, false, false));
-
         List<Arguments> args = new ArrayList<>();
         for (int writes : List.of(0, 1, 2, 32))
         {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -512,17 +512,12 @@ public class GzipHandlerTest
 
         response = HttpTester.parseResponse(_connector.getResponse(request.generate()));
 
-//        System.err.println(response);
-//        System.err.println(response.getContentBytes().length);
-
         assertThat(response.getStatus(), is(200));
 
         int expectedSize = writes * bufferSize;
 
         int actualWrites = writes + (knownLast ? 0 : 1);
         boolean gzipped = expectedSize >= GzipHandler.DEFAULT_MIN_GZIP_SIZE || !contentLength && actualWrites > 1;
-
-//        System.err.printf("actualWrites=%d gzipped=%b%n", actualWrites, gzipped);
 
         byte[] bytes;
         if (gzipped)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -472,6 +472,8 @@ public class GzipHandlerTest
 
     public static Stream<Arguments> scenarios()
     {
+//        if (true) return Stream.of(Arguments.of(1, 32 * 1024 + 1, true, false, false));
+
         List<Arguments> args = new ArrayList<>();
         for (int writes : List.of(0, 1, 2, 32))
         {
@@ -528,10 +530,10 @@ public class GzipHandlerTest
         byte[] bytes;
         try
         {
-            InputStream testIn = new GZIPInputStream(new ByteArrayInputStream(response.getContentBytes()));
+            ByteArrayInputStream rawContentStream = new ByteArrayInputStream(response.getContentBytes());
+            InputStream testIn = gzipped ? new GZIPInputStream(rawContentStream) : rawContentStream;
             ByteArrayOutputStream testOut = new ByteArrayOutputStream();
             IO.copy(testIn, testOut);
-
             bytes = testOut.toByteArray();
         }
         catch (EOFException | ZipException e)

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerBreakEvenSizeTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerBreakEvenSizeTest.java
@@ -84,7 +84,6 @@ public class GzipHandlerBreakEvenSizeTest
             .headers(headers -> headers.put(HttpHeader.ACCEPT_ENCODING, HttpHeaderValue.GZIP))
             .send();
 
-        System.err.println(response.getHeaders());
         assertThat("Status Code", response.getStatus(), is(200));
         assertThat("Size Requested", response.getHeaders().getField("X-SizeRequested").getIntValue(), is(size));
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerBreakEvenSizeTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerBreakEvenSizeTest.java
@@ -54,7 +54,6 @@ public class GzipHandlerBreakEvenSizeTest
         server.addConnector(connector);
 
         GzipHandler gzipHandler = new GzipHandler();
-        gzipHandler.setMinGzipSize(0);
 
         ServletContextHandler context = new ServletContextHandler(gzipHandler, "/");
         context.addServlet(VeryCompressibleContentServlet.class, "/content");
@@ -78,15 +77,18 @@ public class GzipHandlerBreakEvenSizeTest
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 10, 15, 20, 21, 22, 23, 24, 25, 50, 100, 300, 500})
     public void testRequestSized(int size) throws Exception
     {
+        // TODO no idea what this is really testing
+
         URI uri = server.getURI().resolve("/content?size=" + size);
         ContentResponse response = client.newRequest(uri)
             .headers(headers -> headers.put(HttpHeader.ACCEPT_ENCODING, HttpHeaderValue.GZIP))
             .send();
 
+        System.err.println(response.getHeaders());
         assertThat("Status Code", response.getStatus(), is(200));
         assertThat("Size Requested", response.getHeaders().getField("X-SizeRequested").getIntValue(), is(size));
 
-        if (size > GzipHandler.BREAK_EVEN_GZIP_SIZE)
+        if (size < GzipHandler.DEFAULT_MIN_GZIP_SIZE)
             assertThat("Response Size", response.getHeaders().getField(HttpHeader.CONTENT_LENGTH).getIntValue(), lessThanOrEqualTo(size));
     }
 


### PR DESCRIPTION
Whilst fixing some ee9 tests, I found a few issues in the core GzipHandler
@lachlan-roberts and I believed we fixed it, but review of the fix would be good.

The problem was mostly due to complications from support gather writes and/or writes of empty buffers.