### PR TITLE
Jetty 12.0.x cookie cache rewrite

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -32,7 +33,7 @@ public class CookieCache
 {
     protected static final Logger LOG = LoggerFactory.getLogger(CookieCache.class);
     protected final List<String> _rawFields = new ArrayList<>();
-    protected final List<HttpCookie> _cookieList = new ArrayList<>();
+    protected List<HttpCookie> _cookieList;
     private final CookieCutter _cookieCutter;
 
     public CookieCache()
@@ -92,13 +93,23 @@ public class CookieCache
             _rawFields.add(value);
         }
 
+        if (!building && raw.hasNext())
+        {
+            building = true;
+            while (raw.hasNext())
+            {
+                raw.next();
+                raw.remove();
+            }
+        }
+
         if (building)
         {
-            _cookieList.clear();
+            _cookieList = new ArrayList<>();
             _cookieCutter.parseFields(_rawFields);
         }
 
-        return _cookieList;
+        return _cookieList == null ? Collections.emptyList() : _cookieList;
     }
 
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -243,6 +243,11 @@ public class HttpCookie
         return builder.toString();
     }
 
+    public String toString()
+    {
+        return "%x@%s".formatted(hashCode(), asString());
+    }
+
     private static void quoteOnlyOrAppend(StringBuilder buf, String s, boolean quote)
     {
         if (quote)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCacheTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CookieCacheTest.java
@@ -1,0 +1,178 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import org.eclipse.jetty.http.CookieCache;
+import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class CookieCacheTest
+{
+    CookieCache _cache;
+    HttpFields.Mutable _fields;
+
+    @BeforeEach
+    public void prepare() throws Exception
+    {
+        _cache = new CookieCache();
+        _fields = HttpFields.build();
+    }
+
+    @Test
+    public void testNoFields() throws Exception
+    {
+        List<HttpCookie> cookies = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies, empty());
+        cookies = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies, empty());
+    }
+
+    @Test
+    public void testNoCookies() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Other", "header");
+        List<HttpCookie> cookies = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies, empty());
+        cookies = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies, empty());
+    }
+
+    @Test
+    public void testOneCookie() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Cookie", "name=value");
+        _fields.put("Other", "header");
+        List<HttpCookie> cookies0 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies0, hasSize(1));
+        HttpCookie cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+
+        List<HttpCookie> cookies1 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies1, hasSize(1));
+        assertThat(cookies1, sameInstance(cookies0));
+    }
+
+    @Test
+    public void testDeleteCookie() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Cookie", "name=value");
+        _fields.put("Other", "header");
+        List<HttpCookie> cookies0 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies0, hasSize(1));
+        HttpCookie cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+
+        _fields.remove(HttpHeader.COOKIE);
+        List<HttpCookie> cookies1 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies1, empty());
+        assertThat(cookies1, not(sameInstance(cookies0)));
+    }
+
+    @Test
+    public void testChangedCookie() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Cookie", "name=value");
+        _fields.put("Other", "header");
+        List<HttpCookie> cookies0 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies0, hasSize(1));
+        HttpCookie cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+
+        _fields.put(HttpHeader.COOKIE, "name=different");
+        List<HttpCookie> cookies1 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies1, hasSize(1));
+        assertThat(cookies1, not(sameInstance(cookies0)));
+        cookie = cookies1.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("different"));
+    }
+
+    @Test
+    public void testChangedFirstCookie() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Cookie", "name=value");
+        _fields.put("Other", "header");
+        _fields.add(HttpHeader.COOKIE, "other=different");
+        List<HttpCookie> cookies0 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies0, hasSize(2));
+        HttpCookie cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+        cookie = cookies0.get(1);
+        assertThat(cookie.getName(), is("other"));
+        assertThat(cookie.getValue(), is("different"));
+
+        ListIterator<HttpField> i = _fields.listIterator();
+        i.next();
+        i.next();
+        i.set(new HttpField("Cookie", "Name=Changed"));
+
+        List<HttpCookie> cookies1 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies1, hasSize(2));
+        assertThat(cookies1, not(sameInstance(cookies0)));
+        cookie = cookies1.get(0);
+        assertThat(cookie.getName(), is("Name"));
+        assertThat(cookie.getValue(), is("Changed"));
+        cookie = cookies0.get(1);
+        assertThat(cookie.getName(), is("other"));
+        assertThat(cookie.getValue(), is("different"));
+    }
+
+    @Test
+    public void testAddCookie() throws Exception
+    {
+        _fields.put("Some", "Header");
+        _fields.put("Cookie", "name=value");
+        _fields.put("Other", "header");
+        List<HttpCookie> cookies0 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies0, hasSize(1));
+        HttpCookie cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+
+        _fields.add(HttpHeader.COOKIE, "other=different");
+        List<HttpCookie> cookies1 = _cache.getCookies(_fields.asImmutable());
+        assertThat(cookies1, hasSize(2));
+        assertThat(cookies1, not(sameInstance(cookies0)));
+        cookie = cookies0.get(0);
+        assertThat(cookie.getName(), is("name"));
+        assertThat(cookie.getValue(), is("value"));
+        cookie = cookies1.get(1);
+        assertThat(cookie.getName(), is("other"));
+        assertThat(cookie.getValue(), is("different"));
+    }
+
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -13,9 +13,16 @@
 
 package org.eclipse.jetty.server;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.LocalConnector.LocalEndPoint;
 import org.eclipse.jetty.server.handler.DumpHandler;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +30,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RequestTest
 {
@@ -76,5 +85,69 @@ public class RequestTest
         assertEquals(HttpStatus.OK_200, response.getStatus());
         assertThat(response.getContent(), containsString("httpURI.path=/fo%6f%2fbar"));
         assertThat(response.getContent(), containsString("pathInContext=/foo%2Fbar"));
+    }
+
+    /**
+     * Test that multiple requests on the same connection with different cookies
+     * do not bleed cookies.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testDifferentCookies() throws Exception
+    {
+        server.stop();
+        server.setHandler(new Handler.Processor()
+        {
+            @Override
+            public void process(org.eclipse.jetty.server.Request request, Response response, Callback callback) throws Exception
+            {
+                response.setStatus(200);
+                response.setContentType("text/plain");
+                ByteArrayOutputStream buff = new ByteArrayOutputStream();
+
+                List<HttpCookie> coreCookies = org.eclipse.jetty.server.Request.getCookies(request);
+                if (coreCookies != null)
+                {
+                    for (HttpCookie c : coreCookies)
+                        buff.writeBytes(("Core Cookie: " + c.getName() + "=" + c.getValue() + "\n").getBytes());
+                }
+                Response.write(response, true, ByteBuffer.wrap(buff.toByteArray()));
+            }
+        });
+        
+        server.start();
+        String sessionId1 = "JSESSIONID=node0o250bm47otmz1qjqqor54fj6h0.node0";
+        String sessionId2 = "JSESSIONID=node0q4z00xb0pnyl1f312ec6e93lw1.node0";
+        String sessionId3 = "JSESSIONID=node0gqgmw5fbijm0f9cid04b4ssw2.node0";
+        String request1 = "GET /ctx HTTP/1.1\r\nHost: localhost\r\nCookie: " + sessionId1 + "\r\n\r\n";
+        String request2 = "GET /ctx HTTP/1.1\r\nHost: localhost\r\nCookie: " + sessionId2 + "\r\n\r\n";
+        String request3 = "GET /ctx HTTP/1.1\r\nHost: localhost\r\nCookie: " + sessionId3 + "\r\n\r\n";
+        
+        LocalEndPoint lep = connector.connect();
+        lep.addInput(request1);
+        HttpTester.Response response = HttpTester.parseResponse(lep.getResponse());
+        checkCookieResult(sessionId1, new String[] {sessionId2, sessionId3}, response.getContent());
+        lep.addInput(request2);
+        response = HttpTester.parseResponse(lep.getResponse());
+        checkCookieResult(sessionId2, new String[] {sessionId1, sessionId3}, response.getContent());
+        lep.addInput(request3);
+        response = HttpTester.parseResponse(lep.getResponse());
+        checkCookieResult(sessionId3, new String[] {sessionId1, sessionId2}, response.getContent());
+
+    }
+
+    private static void checkCookieResult(String containedCookie, String[] notContainedCookies, String response)
+    {
+        assertNotNull(containedCookie);
+        assertNotNull(response);
+        assertThat(response, containsString("Core Cookie: " + containedCookie));
+        if (notContainedCookies != null)
+        {
+            for (String notContainsCookie : notContainedCookies)
+            {
+                assertThat(response, not(containsString(notContainsCookie)));
+            }
+        }
     }
 }


### PR DESCRIPTION
CookieCache was leaking cookies from one request to the next.  It was too complex so I just rewrote it and added a unit test