### PR TITLE
Fixes #7935 - Review HTTP/2 error handling

### DIFF
--- a/jetty-http3/http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpChannelOverHTTP3.java
+++ b/jetty-http3/http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpChannelOverHTTP3.java
@@ -161,13 +161,11 @@ public class HttpChannelOverHTTP3 extends HttpChannel
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("onRequest() failure", x);
-            onBadMessage(x);
-            return null;
+            return () -> onBadMessage(x);
         }
         catch (Throwable x)
         {
-            onBadMessage(new BadMessageException(HttpStatus.INTERNAL_SERVER_ERROR_500, null, x));
-            return null;
+            return () -> onBadMessage(new BadMessageException(HttpStatus.INTERNAL_SERVER_ERROR_500, null, x));
         }
     }
 


### PR DESCRIPTION
Fixed HTTP/3 in similar way as HTTP/2.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>