### PR TITLE
Fix #8067 Use nanotime for DosFilter rate tracker

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -1216,8 +1216,8 @@ public class DoSFilter implements Filter
         }
 
         /**
-         * @param now the time now (in nanoseconds)
-         * @return the current calculated request rate over the last second
+         * @param now the time now (in nanoseconds) used to calculate elapsed time since previous requests.
+         * @return the current calculated request rate over the last second if rate exceeded, else null.
          */
         public OverLimit isRateExceeded(long now)
         {

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -1216,7 +1216,7 @@ public class DoSFilter implements Filter
         }
 
         /**
-         * @param now the time now (in milliseconds)
+         * @param now the time now (in nanoseconds)
          * @return the current calculated request rate over the last second
          */
         public OverLimit isRateExceeded(long now)
@@ -1237,7 +1237,7 @@ public class DoSFilter implements Filter
             long rate = (now - last);
             if (TimeUnit.NANOSECONDS.toSeconds(rate) < 1L)
             {
-                return new Overage(Duration.ofMillis(rate), _maxRequestsPerSecond);
+                return new Overage(Duration.ofNanos(rate), _maxRequestsPerSecond);
             }
             return null;
         }

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/DoSFilter.java
@@ -326,7 +326,7 @@ public class DoSFilter implements Filter
         tracker = getRateTracker(request);
 
         // Calculate the rate and check if it is over the allowed limit
-        final OverLimit overLimit = tracker.isRateExceeded(System.currentTimeMillis());
+        final OverLimit overLimit = tracker.isRateExceeded(System.nanoTime());
 
         // Pass it through if we are not currently over the rate limit.
         if (overLimit == null)
@@ -1235,7 +1235,7 @@ public class DoSFilter implements Filter
             }
 
             long rate = (now - last);
-            if (rate < 1000L)
+            if (TimeUnit.NANOSECONDS.toSeconds(rate) < 1L)
             {
                 return new Overage(Duration.ofMillis(rate), _maxRequestsPerSecond);
             }
@@ -1326,7 +1326,7 @@ public class DoSFilter implements Filter
 
             int latestIndex = _next == 0 ? (_timestamps.length - 1) : (_next - 1);
             long last = _timestamps[latestIndex];
-            boolean hasRecentRequest = last != 0 && (System.currentTimeMillis() - last) < 1000L;
+            boolean hasRecentRequest = last != 0 && TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - last) < 1L;
 
             DoSFilter filter = (DoSFilter)_context.getAttribute(_filterName);
 

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/DoSFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/DoSFilterTest.java
@@ -21,7 +21,6 @@ package org.eclipse.jetty.servlets;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.concurrent.TimeUnit;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -179,7 +178,7 @@ public class DoSFilterTest extends AbstractDoSFilterTest
         for (int i = 0; i < 5; i++)
         {
             Thread.sleep(sleep);
-            if (rateTracker.isRateExceeded(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())) != null)
+            if (rateTracker.isRateExceeded(System.nanoTime()) != null)
                 exceeded = true;
         }
         return exceeded;


### PR DESCRIPTION
Use nano time to avoid false positives when wall clock changes.