### PR TITLE
Issue #6328 - avoid binding WebSocket MethodHandles

### DIFF
--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/DefaultServletTest.java
@@ -1564,6 +1564,7 @@ public class DefaultServletTest
 
         rawResponse = connector.getResponse("GET /context/data0.txt HTTP/1.0\r\nHost:localhost:8080\r\n\r\n");
         response = HttpTester.parseResponse(rawResponse);
+        System.err.println(response);
         assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response, containsHeaderValue(HttpHeader.CONTENT_LENGTH, "12"));
         assertThat(response, containsHeaderValue(HttpHeader.CONTENT_TYPE, "text/plain"));

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/AbstractMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/AbstractMessageSink.java
@@ -13,20 +13,20 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 
 import org.eclipse.jetty.websocket.core.CoreSession;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public abstract class AbstractMessageSink implements MessageSink
 {
     protected final CoreSession session;
-    protected final MethodHandle methodHandle;
+    protected final MethodHolder methodHolder;
 
-    public AbstractMessageSink(CoreSession session, MethodHandle methodHandle)
+    public AbstractMessageSink(CoreSession session, MethodHolder methodHolder)
     {
         this.session = Objects.requireNonNull(session, "CoreSession");
-        this.methodHandle = Objects.requireNonNull(methodHandle, "MethodHandle");
+        this.methodHolder = Objects.requireNonNull(methodHolder, "MethodHolder");
     }
 
     @Override

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
 import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.io.ByteBufferCallbackAccumulator;
@@ -22,25 +20,17 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
-import org.eclipse.jetty.websocket.core.exception.InvalidSignatureException;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class ByteArrayMessageSink extends AbstractMessageSink
 {
     private static final byte[] EMPTY_BUFFER = new byte[0];
     private ByteBufferCallbackAccumulator out;
 
-    public ByteArrayMessageSink(CoreSession session, MethodHandle methodHandle)
+    public ByteArrayMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
-
-        // This uses the offset length byte array signature not supported by javax websocket.
-        // The javax layer instead uses decoders for whole byte array messages instead of this message sink.
-        MethodType onMessageType = MethodType.methodType(Void.TYPE, byte[].class, int.class, int.class);
-        if (methodHandle.type().changeReturnType(void.class) != onMessageType.changeReturnType(void.class))
-        {
-            throw InvalidSignatureException.build(onMessageType, methodHandle.type());
-        }
+        super(session, methodHolder);
     }
 
     @Override
@@ -62,10 +52,10 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                 if (frame.hasPayload())
                 {
                     byte[] buf = BufferUtil.toArray(frame.getPayload());
-                    methodHandle.invoke(buf, 0, buf.length);
+                    methodHolder.invoke(buf, 0, buf.length);
                 }
                 else
-                    methodHandle.invoke(EMPTY_BUFFER, 0, 0);
+                    methodHolder.invoke(EMPTY_BUFFER, 0, 0);
 
                 callback.succeeded();
                 session.demand(1);
@@ -86,7 +76,7 @@ public class ByteArrayMessageSink extends AbstractMessageSink
             if (frame.isFin())
             {
                 byte[] buf = out.takeByteArray();
-                methodHandle.invoke(buf, 0, buf.length);
+                methodHolder.invoke(buf, 0, buf.length);
             }
 
             session.demand(1);

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteBufferMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteBufferMessageSink.java
@@ -13,10 +13,7 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 import org.eclipse.jetty.io.ByteBufferCallbackAccumulator;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -24,24 +21,16 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
-import org.eclipse.jetty.websocket.core.exception.InvalidSignatureException;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class ByteBufferMessageSink extends AbstractMessageSink
 {
     private ByteBufferCallbackAccumulator out;
 
-    public ByteBufferMessageSink(CoreSession session, MethodHandle methodHandle)
+    public ByteBufferMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
-
-        // Validate onMessageMethod
-        Objects.requireNonNull(methodHandle, "MethodHandle");
-        MethodType onMessageType = MethodType.methodType(Void.TYPE, ByteBuffer.class);
-        if (methodHandle.type() != onMessageType)
-        {
-            throw InvalidSignatureException.build(onMessageType, methodHandle.type());
-        }
+        super(session, methodHolder);
     }
 
     @Override
@@ -61,9 +50,9 @@ public class ByteBufferMessageSink extends AbstractMessageSink
             if (frame.isFin() && (out == null))
             {
                 if (frame.hasPayload())
-                    methodHandle.invoke(frame.getPayload());
+                    methodHolder.invoke(frame.getPayload());
                 else
-                    methodHandle.invoke(BufferUtil.EMPTY_BUFFER);
+                    methodHolder.invoke(BufferUtil.EMPTY_BUFFER);
 
                 callback.succeeded();
                 session.demand(1);
@@ -89,7 +78,7 @@ public class ByteBufferMessageSink extends AbstractMessageSink
 
                 try
                 {
-                    methodHandle.invoke(buffer);
+                    methodHolder.invoke(buffer);
                 }
                 finally
                 {

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/DispatchedMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/DispatchedMessageSink.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.websocket.core.internal.messages;
 
 import java.io.Closeable;
-import java.lang.invoke.MethodHandle;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -22,6 +21,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 /**
  * Centralized logic for Dispatched Message Handling.
@@ -98,9 +98,9 @@ public abstract class DispatchedMessageSink extends AbstractMessageSink
     private MessageSink typeSink;
     private final Executor executor;
 
-    public DispatchedMessageSink(CoreSession session, MethodHandle methodHandle)
+    public DispatchedMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
         executor = session.getWebSocketComponents().getExecutor();
     }
 
@@ -119,7 +119,7 @@ public abstract class DispatchedMessageSink extends AbstractMessageSink
             {
                 try
                 {
-                    methodHandle.invoke(typeSink);
+                    methodHolder.invoke(typeSink);
                     if (typeSink instanceof Closeable)
                         IO.close((Closeable)typeSink);
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/InputStreamMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/InputStreamMessageSink.java
@@ -13,16 +13,15 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class InputStreamMessageSink extends DispatchedMessageSink
 {
-    public InputStreamMessageSink(CoreSession session, MethodHandle methodHandle)
+    public InputStreamMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
     }
 
     @Override

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialByteArrayMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialByteArrayMessageSink.java
@@ -13,20 +13,19 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class PartialByteArrayMessageSink extends AbstractMessageSink
 {
     private static final byte[] EMPTY_BUFFER = new byte[0];
 
-    public PartialByteArrayMessageSink(CoreSession session, MethodHandle methodHandle)
+    public PartialByteArrayMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
     }
 
     @Override
@@ -37,7 +36,7 @@ public class PartialByteArrayMessageSink extends AbstractMessageSink
             if (frame.hasPayload() || frame.isFin())
             {
                 byte[] buffer = frame.hasPayload() ? BufferUtil.toArray(frame.getPayload()) : EMPTY_BUFFER;
-                methodHandle.invoke(buffer, frame.isFin());
+                methodHolder.invoke(buffer, frame.isFin());
             }
 
             callback.succeeded();

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialByteBufferMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialByteBufferMessageSink.java
@@ -13,17 +13,16 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class PartialByteBufferMessageSink extends AbstractMessageSink
 {
-    public PartialByteBufferMessageSink(CoreSession session, MethodHandle methodHandle)
+    public PartialByteBufferMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
     }
 
     @Override
@@ -32,7 +31,7 @@ public class PartialByteBufferMessageSink extends AbstractMessageSink
         try
         {
             if (frame.hasPayload() || frame.isFin())
-                methodHandle.invoke(frame.getPayload(), frame.isFin());
+                methodHolder.invoke(frame.getPayload(), frame.isFin());
 
             callback.succeeded();
             session.demand(1);

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialStringMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/PartialStringMessageSink.java
@@ -13,22 +13,19 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-import java.util.Objects;
-
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class PartialStringMessageSink extends AbstractMessageSink
 {
     private Utf8StringBuilder out;
 
-    public PartialStringMessageSink(CoreSession session, MethodHandle methodHandle)
+    public PartialStringMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
-        Objects.requireNonNull(methodHandle, "MethodHandle");
+        super(session, methodHolder);
     }
 
     @Override
@@ -42,12 +39,12 @@ public class PartialStringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                methodHandle.invoke(out.toString(), true);
+                methodHolder.invoke(out.toString(), true);
                 out = null;
             }
             else
             {
-                methodHandle.invoke(out.takePartialString(), false);
+                methodHolder.invoke(out.takePartialString(), false);
             }
 
             callback.succeeded();

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ReaderMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ReaderMessageSink.java
@@ -13,16 +13,15 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class ReaderMessageSink extends DispatchedMessageSink
 {
-    public ReaderMessageSink(CoreSession session, MethodHandle methodHandle)
+    public ReaderMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
     }
 
     @Override

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
@@ -13,22 +13,21 @@
 
 package org.eclipse.jetty.websocket.core.internal.messages;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 
 public class StringMessageSink extends AbstractMessageSink
 {
     private Utf8StringBuilder out;
     private int size;
 
-    public StringMessageSink(CoreSession session, MethodHandle methodHandle)
+    public StringMessageSink(CoreSession session, MethodHolder methodHolder)
     {
-        super(session, methodHandle);
+        super(session, methodHolder);
         this.size = 0;
     }
 
@@ -50,7 +49,7 @@ public class StringMessageSink extends AbstractMessageSink
 
             out.append(frame.getPayload());
             if (frame.isFin())
-                methodHandle.invoke(out.toString());
+                methodHolder.invoke(out.toString());
 
             callback.succeeded();
             session.demand(1);

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/BindingMethodHolder.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/BindingMethodHolder.java
@@ -1,0 +1,59 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+class BindingMethodHolder implements MethodHolder
+{
+    public MethodHandle _methodHandle;
+
+    public BindingMethodHolder(MethodHandle methodHandle)
+    {
+        _methodHandle = methodHandle;
+    }
+
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        return _methodHandle.invokeWithArguments(args);
+    }
+
+    @Override
+    public BindingMethodHolder bindTo(Object arg)
+    {
+        _methodHandle = _methodHandle.bindTo(arg);
+        return this;
+    }
+
+    @Override
+    public MethodHolder bindTo(Object arg, int idx)
+    {
+        _methodHandle = MethodHandles.insertArguments(_methodHandle, idx, arg);
+        return this;
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        return _methodHandle.type().parameterType(idx);
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return _methodHandle.type().returnType();
+    }
+}

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/BindingMethodHolder2.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/BindingMethodHolder2.java
@@ -1,0 +1,69 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+public class BindingMethodHolder2 implements MethodHolder
+{
+    public MethodHandle _methodHandle;
+
+    public BindingMethodHolder2(MethodHandle methodHandle)
+    {
+        _methodHandle = methodHandle;
+    }
+
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        return MethodHolder.doInvoke(_methodHandle, args);
+    }
+
+    public MethodHandle getMethodHandler()
+    {
+        return _methodHandle;
+    }
+
+    public Object invoke(Object o1, Object o2) throws Throwable
+    {
+        return MethodHolder.doInvoke(_methodHandle, o1, o2);
+    }
+
+    @Override
+    public BindingMethodHolder2 bindTo(Object arg)
+    {
+        _methodHandle = _methodHandle.bindTo(arg);
+        return this;
+    }
+
+    @Override
+    public MethodHolder bindTo(Object arg, int idx)
+    {
+        _methodHandle = MethodHandles.insertArguments(_methodHandle, idx, arg);
+        return this;
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        return _methodHandle.type().parameterType(idx);
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return _methodHandle.type().returnType();
+    }
+}

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
@@ -139,18 +139,18 @@ public class InvokerUtils
     /**
      * Bind optional arguments to provided method handle
      *
-     * @param methodHandle the method handle to bind to
+     * @param methodHolder the method handle to bind to
      * @param objs the list of optional objects to bind to.
-     * @return the bound MethodHandle, or null if the provided {@code methodHandle} was null.
+     * @return the bound MethodHandle, or null if the provided {@code methodHolder} was null.
      */
-    public static MethodHandle bindTo(MethodHandle methodHandle, Object... objs)
+    public static MethodHolder bindTo(MethodHolder methodHolder, Object... objs)
     {
-        if (methodHandle == null)
+        if (methodHolder == null)
             return null;
-        MethodHandle ret = methodHandle;
+        MethodHolder ret = methodHolder;
         for (Object obj : objs)
         {
-            if (ret.type().parameterType(0).isAssignableFrom(obj.getClass()))
+            if (ret.parameterType(0).isAssignableFrom(obj.getClass()))
             {
                 ret = ret.bindTo(obj);
             }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/LambdaMetafactoryMethodHolder.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/LambdaMetafactoryMethodHolder.java
@@ -1,0 +1,73 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.internal.util;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.Supplier;
+
+public class LambdaMetafactoryMethodHolder implements MethodHolder
+{
+    private final CallSite _callSite;
+
+    public LambdaMetafactoryMethodHolder(MethodHandle methodHandle, MethodHandles.Lookup lookup) throws Throwable
+    {
+        MethodType methodType = methodHandle.type().changeReturnType(Supplier.class);
+        _callSite = LambdaMetafactory.metafactory(
+            lookup,
+            "get",
+            methodType,
+            MethodType.methodType(Object.class),
+            methodHandle,
+            // Supplier method real signature (reified)
+            // trim accepts no parameters and returns String
+            MethodType.methodType(methodType.returnType()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        return ((Supplier<Object>)MethodHolder.doInvoke(_callSite.getTarget(), args)).get();
+    }
+
+    @Override
+    public LambdaMetafactoryMethodHolder bindTo(Object arg)
+    {
+        _callSite.setTarget(_callSite.getTarget().bindTo(arg));
+        return this;
+    }
+
+    @Override
+    public MethodHolder bindTo(Object arg, int idx)
+    {
+        _callSite.setTarget(MethodHandles.insertArguments(_callSite.getTarget(), idx, arg));
+        return this;
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        return _callSite.type().parameterType(idx);
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return _callSite.type().returnType();
+    }
+}

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/MethodHolder.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/MethodHolder.java
@@ -1,0 +1,107 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.internal.util;
+
+import java.lang.invoke.MethodHandle;
+
+/**
+ * An interface for managing invocations of methods whose arguments may need to be augmented, by
+ * binding in certain parameters ahead of time.
+ *
+ * Implementations may use various invocation mechanisms, including:
+ * <ul>
+ *  <li>direct method invocation on an held object</li>
+ *  <li>calling a method pointer</li>
+ *  <li>calling a MethodHandle bound to the known arguments</li>
+ *  <li>calling a MethodHandle without binding to the known arguments</li>
+ * </ul>
+ *
+ * Implementations of this may not be thread safe, so the caller must use some external mutual exclusion
+ * unless they are using a specific implementation known to be thread-safe.
+ */
+public interface MethodHolder
+{
+    String METHOD_HOLDER_BINDING_PROPERTY = "jetty.websocket.methodholder.binding";
+
+    static MethodHolder from(MethodHandle methodHandle)
+    {
+        String property = System.getProperty(METHOD_HOLDER_BINDING_PROPERTY);
+        return from(methodHandle, Boolean.parseBoolean(property));
+    }
+
+    static MethodHolder from(MethodHandle methodHandle, boolean binding)
+    {
+        if (methodHandle == null)
+            return null;
+        return binding ? new BindingMethodHolder(methodHandle) : new NonBindingMethodHolder(methodHandle);
+    }
+
+    Object invoke(Object... args) throws Throwable;
+
+    default MethodHolder bindTo(Object arg)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default MethodHolder bindTo(Object arg, int idx)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default Class<?> parameterType(int idx)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default Class<?> returnType()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    static Object doInvoke(MethodHandle methodHandle, Object arg1, Object arg2) throws Throwable
+    {
+        return methodHandle.invoke(arg1, arg2);
+    }
+
+    static Object doInvoke(MethodHandle methodHandle, Object... args) throws Throwable
+    {
+        return methodHandle.invokeExact(args[0], args[1]);
+
+//        switch (args.length)
+//        {
+//            case 0:
+//                return methodHandle.invoke();
+//            case 1:
+//                return methodHandle.invoke(args[0]);
+//            case 2:
+//                return methodHandle.invoke(args[0], args[1]);
+//            case 3:
+//                return methodHandle.invoke(args[0], args[1], args[2]);
+//            case 4:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3]);
+//            case 5:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3], args[4]);
+//            case 6:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3], args[4], args[5]);
+//            case 7:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+//            case 8:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+//            case 9:
+//                return methodHandle.invoke(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
+//            default:
+//                return methodHandle.invokeWithArguments(args);
+//        }
+    }
+}

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/NonBindingMethodHolder.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/NonBindingMethodHolder.java
@@ -1,0 +1,103 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.WrongMethodTypeException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This implementation of {@link MethodHolder} is not thread safe.
+ * Mutual exclusion should be used when calling {@link #invoke(Object...)}, or this should only
+ * be invoked from a single thread.
+ */
+class NonBindingMethodHolder implements MethodHolder
+{
+    private final MethodHandle _methodHandle;
+    private final Object[] _parameters;
+    private final List<Integer> _unboundParamIndexes = new ArrayList<>();
+
+    public NonBindingMethodHolder(MethodHandle methodHandle)
+    {
+        _methodHandle = Objects.requireNonNull(methodHandle);
+        int numParams = methodHandle.type().parameterCount();
+        _parameters = new Object[numParams];
+        for (int i = 0; i < numParams; i++)
+        {
+            _unboundParamIndexes.add(i);
+        }
+    }
+
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        try
+        {
+            insertArguments(args);
+            return MethodHolder.doInvoke(_methodHandle, _parameters);
+        }
+        finally
+        {
+            clearArguments();
+        }
+    }
+
+    @Override
+    public MethodHolder bindTo(Object arg, int idx)
+    {
+        _parameters[_unboundParamIndexes.get(idx)] = arg;
+        _unboundParamIndexes.remove(idx);
+        return this;
+    }
+
+    @Override
+    public MethodHolder bindTo(Object arg)
+    {
+        return bindTo(arg, 0);
+    }
+
+    private void insertArguments(Object... args)
+    {
+        if (_unboundParamIndexes.size() != args.length)
+            throw new WrongMethodTypeException(String.format("Expected %s params but had %s", _unboundParamIndexes.size(), args.length));
+
+        int argsIndex = 0;
+        for (int index : _unboundParamIndexes)
+        {
+            _parameters[index] = args[argsIndex++];
+        }
+    }
+
+    private void clearArguments()
+    {
+        for (int i : _unboundParamIndexes)
+        {
+            _parameters[i] = null;
+        }
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        return _methodHandle.type().parameterType(_unboundParamIndexes.get(idx));
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return _methodHandle.type().returnType();
+    }
+}

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/PartialStringMessageSinkTest.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/PartialStringMessageSinkTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.messages.PartialStringMessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ public class PartialStringMessageSinkTest
     @BeforeEach
     public void before() throws Exception
     {
-        messageSink = new PartialStringMessageSink(coreSession, endpoint.getMethodHandle());
+        messageSink = new PartialStringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
     }
 
     @Test

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/StringMessageSinkTest.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/StringMessageSinkTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
 import org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,7 +45,7 @@ public class StringMessageSinkTest
     @Test
     public void testMaxMessageSize() throws Exception
     {
-        StringMessageSink messageSink = new StringMessageSink(coreSession, endpoint.getMethodHandle());
+        StringMessageSink messageSink = new StringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
         ByteBuffer utf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0xF0, (byte)0x90, (byte)0x8D, (byte)0x88});
 
         FutureCallback callback = new FutureCallback();
@@ -60,7 +61,7 @@ public class StringMessageSinkTest
     @Test
     public void testValidUtf8() throws Exception
     {
-        StringMessageSink messageSink = new StringMessageSink(coreSession, endpoint.getMethodHandle());
+        StringMessageSink messageSink = new StringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
         ByteBuffer utf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0xF0, (byte)0x90, (byte)0x8D, (byte)0x88});
 
         FutureCallback callback = new FutureCallback();
@@ -73,7 +74,7 @@ public class StringMessageSinkTest
     @Test
     public void testUtf8Continuation() throws Exception
     {
-        StringMessageSink messageSink = new StringMessageSink(coreSession, endpoint.getMethodHandle());
+        StringMessageSink messageSink = new StringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
         ByteBuffer firstUtf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0xF0, (byte)0x90});
         ByteBuffer continuationUtf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0x8D, (byte)0x88});
 
@@ -91,7 +92,7 @@ public class StringMessageSinkTest
     @Test
     public void testInvalidSingleFrameUtf8() throws Exception
     {
-        StringMessageSink messageSink = new StringMessageSink(coreSession, endpoint.getMethodHandle());
+        StringMessageSink messageSink = new StringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
         ByteBuffer invalidUtf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0xF0, (byte)0x90, (byte)0x8D});
 
         FutureCallback callback = new FutureCallback();
@@ -106,7 +107,7 @@ public class StringMessageSinkTest
     @Test
     public void testInvalidMultiFrameUtf8() throws Exception
     {
-        StringMessageSink messageSink = new StringMessageSink(coreSession, endpoint.getMethodHandle());
+        StringMessageSink messageSink = new StringMessageSink(coreSession, MethodHolder.from(endpoint.getMethodHandle()));
         ByteBuffer firstUtf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0xF0, (byte)0x90});
         ByteBuffer continuationUtf8Payload = BufferUtil.toBuffer(new byte[]{(byte)0x8D});
 

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxMessagePartialMethodHolder.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxMessagePartialMethodHolder.java
@@ -1,0 +1,59 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.common;
+
+import java.lang.invoke.WrongMethodTypeException;
+import javax.websocket.MessageHandler;
+
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
+
+class JavaxMessagePartialMethodHolder<T> implements MethodHolder
+{
+    private final MessageHandler.Partial<T> _messageHandler;
+
+    public JavaxMessagePartialMethodHolder(MessageHandler.Partial<T> messageHandler)
+    {
+        _messageHandler = messageHandler;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        if (args.length != 2)
+            throw new WrongMethodTypeException(String.format("Expected %s params but had %s", 2, args.length));
+        _messageHandler.onMessage((T)args[0], (boolean)args[1]);
+        return null;
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        switch (idx)
+        {
+            case 0:
+                return Object.class;
+            case 1:
+                return boolean.class;
+            default:
+                throw new IndexOutOfBoundsException(idx);
+        }
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return void.class;
+    }
+}

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxMessageWholeMethodHolder.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxMessageWholeMethodHolder.java
@@ -1,0 +1,57 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.javax.common;
+
+import java.lang.invoke.WrongMethodTypeException;
+import javax.websocket.MessageHandler;
+
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
+
+class JavaxMessageWholeMethodHolder<T> implements MethodHolder
+{
+    private final MessageHandler.Whole<T> _messageHandler;
+
+    public JavaxMessageWholeMethodHolder(MessageHandler.Whole<T> messageHandler)
+    {
+        _messageHandler = messageHandler;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object invoke(Object... args) throws Throwable
+    {
+        if (args.length != 1)
+            throw new WrongMethodTypeException(String.format("Expected %s params but had %s", 1, args.length));
+        _messageHandler.onMessage((T)args[0]);
+        return null;
+    }
+
+    @Override
+    public Class<?> parameterType(int idx)
+    {
+        switch (idx)
+        {
+            case 0:
+                return Object.class;
+            default:
+                throw new IndexOutOfBoundsException(idx);
+        }
+    }
+
+    @Override
+    public Class<?> returnType()
+    {
+        return void.class;
+    }
+}

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandlerFactory.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.websocket.core.internal.messages.PartialByteArrayMessag
 import org.eclipse.jetty.websocket.core.internal.messages.PartialByteBufferMessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.PartialStringMessageSink;
 import org.eclipse.jetty.websocket.core.internal.util.InvokerUtils;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.core.internal.util.ReflectUtils;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.eclipse.jetty.websocket.javax.common.messages.AbstractDecodedMessageSink;
@@ -56,21 +57,6 @@ import org.eclipse.jetty.websocket.javax.common.messages.DecodedTextStreamMessag
 
 public abstract class JavaxWebSocketFrameHandlerFactory
 {
-    private static final MethodHandle FILTER_RETURN_TYPE_METHOD;
-
-    static
-    {
-        try
-        {
-            FILTER_RETURN_TYPE_METHOD = getServerMethodHandleLookup()
-                .findVirtual(JavaxWebSocketSession.class, "filterReturnType", MethodType.methodType(void.class, Object.class));
-        }
-        catch (Throwable e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
     static InvokerUtils.Arg[] getArgsFor(Class<?> objectType)
     {
         return new InvokerUtils.Arg[]{new InvokerUtils.Arg(Session.class), new InvokerUtils.Arg(objectType).required()};
@@ -135,10 +121,10 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         if (metadata == null)
             return null;
 
-        MethodHandle openHandle = metadata.getOpenHandle();
-        MethodHandle closeHandle = metadata.getCloseHandle();
-        MethodHandle errorHandle = metadata.getErrorHandle();
-        MethodHandle pongHandle = metadata.getPongHandle();
+        MethodHolder openHandle = MethodHolder.from(metadata.getOpenHandle());
+        MethodHolder closeHandle = MethodHolder.from(metadata.getCloseHandle());
+        MethodHolder errorHandle = MethodHolder.from(metadata.getErrorHandle());
+        MethodHolder pongHandle = MethodHolder.from(metadata.getPongHandle());
 
         JavaxWebSocketMessageMetadata textMetadata = JavaxWebSocketMessageMetadata.copyOf(metadata.getTextMetadata());
         JavaxWebSocketMessageMetadata binaryMetadata = JavaxWebSocketMessageMetadata.copyOf(metadata.getBinaryMetadata());
@@ -156,9 +142,9 @@ public abstract class JavaxWebSocketFrameHandlerFactory
             pongHandle = bindTemplateVariables(pongHandle, namedVariables, pathParams);
 
             if (textMetadata != null)
-                textMetadata.setMethodHandle(bindTemplateVariables(textMetadata.getMethodHandle(), namedVariables, pathParams));
+                textMetadata.setMethodHolder(bindTemplateVariables(textMetadata.getMethodHolder(), namedVariables, pathParams));
             if (binaryMetadata != null)
-                binaryMetadata.setMethodHandle(bindTemplateVariables(binaryMetadata.getMethodHandle(), namedVariables, pathParams));
+                binaryMetadata.setMethodHolder(bindTemplateVariables(binaryMetadata.getMethodHolder(), namedVariables, pathParams));
         }
 
         openHandle = InvokerUtils.bindTo(openHandle, endpoint);
@@ -190,15 +176,15 @@ public abstract class JavaxWebSocketFrameHandlerFactory
             if (AbstractDecodedMessageSink.class.isAssignableFrom(msgMetadata.getSinkClass()))
             {
                 MethodHandle ctorHandle = lookup.findConstructor(msgMetadata.getSinkClass(),
-                    MethodType.methodType(void.class, CoreSession.class, MethodHandle.class, List.class));
+                    MethodType.methodType(void.class, CoreSession.class, MethodHolder.class, List.class));
                 List<RegisteredDecoder> registeredDecoders = msgMetadata.getRegisteredDecoders();
-                return (MessageSink)ctorHandle.invoke(session.getCoreSession(), msgMetadata.getMethodHandle(), registeredDecoders);
+                return (MessageSink)ctorHandle.invoke(session.getCoreSession(), msgMetadata.getMethodHolder(), registeredDecoders);
             }
             else
             {
                 MethodHandle ctorHandle = lookup.findConstructor(msgMetadata.getSinkClass(),
-                    MethodType.methodType(void.class, CoreSession.class, MethodHandle.class));
-                return (MessageSink)ctorHandle.invoke(session.getCoreSession(), msgMetadata.getMethodHandle());
+                    MethodType.methodType(void.class, CoreSession.class, MethodHolder.class));
+                return (MessageSink)ctorHandle.invoke(session.getCoreSession(), msgMetadata.getMethodHolder());
             }
         }
         catch (NoSuchMethodException e)
@@ -219,23 +205,19 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         }
     }
 
-    public static MethodHandle wrapNonVoidReturnType(MethodHandle handle, JavaxWebSocketSession session)
+    static MethodHolder wrapNonVoidReturnType(MethodHolder handle, JavaxWebSocketSession session)
     {
         if (handle == null)
             return null;
 
-        if (handle.type().returnType() == Void.TYPE)
+        if (handle.returnType() == Void.TYPE)
             return handle;
 
-        // Technique from  https://stackoverflow.com/questions/48505787/methodhandle-with-general-non-void-return-filter
-
-        // Change the return type of the to be Object so it will match exact with JavaxWebSocketSession.filterReturnType(Object)
-        handle = handle.asType(handle.type().changeReturnType(Object.class));
-
-        // Filter the method return type to a call to JavaxWebSocketSession.filterReturnType() bound to this session
-        handle = MethodHandles.filterReturnValue(handle, FILTER_RETURN_TYPE_METHOD.bindTo(session));
-
-        return handle;
+        return args ->
+        {
+            session.filterReturnType(handle.invoke(args));
+            return null;
+        };
     }
 
     private MethodHandle toMethodHandle(MethodHandles.Lookup lookup, Method method)
@@ -252,7 +234,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
 
     protected JavaxWebSocketFrameHandlerMetadata createEndpointMetadata(EndpointConfig endpointConfig)
     {
-        JavaxWebSocketFrameHandlerMetadata metadata = new JavaxWebSocketFrameHandlerMetadata(endpointConfig, container.getWebSocketComponents());
+        JavaxWebSocketFrameHandlerMetadata metadata = new JavaxWebSocketFrameHandlerMetadata(endpointConfig, components);
         MethodHandles.Lookup lookup = getServerMethodHandleLookup();
 
         Method openMethod = ReflectUtils.findMethod(Endpoint.class, "onOpen", Session.class, EndpointConfig.class);
@@ -360,7 +342,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         if (methodHandle != null)
         {
             msgMetadata.setSinkClass(PartialStringMessageSink.class);
-            msgMetadata.setMethodHandle(methodHandle);
+            msgMetadata.setMethodHolder(MethodHolder.from(methodHandle));
             metadata.setTextMetadata(msgMetadata, onMsg);
             return true;
         }
@@ -370,7 +352,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         if (methodHandle != null)
         {
             msgMetadata.setSinkClass(PartialByteBufferMessageSink.class);
-            msgMetadata.setMethodHandle(methodHandle);
+            msgMetadata.setMethodHolder(MethodHolder.from(methodHandle));
             metadata.setBinaryMetadata(msgMetadata, onMsg);
             return true;
         }
@@ -380,7 +362,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         if (methodHandle != null)
         {
             msgMetadata.setSinkClass(PartialByteArrayMessageSink.class);
-            msgMetadata.setMethodHandle(methodHandle);
+            msgMetadata.setMethodHolder(MethodHolder.from(methodHandle));
             metadata.setBinaryMetadata(msgMetadata, onMsg);
             return true;
         }
@@ -423,7 +405,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
                 objectType = decoder.objectType;
         }
         MethodHandle methodHandle = getMethodHandle.apply(getArgsFor(objectType));
-        msgMetadata.setMethodHandle(methodHandle);
+        msgMetadata.setMethodHolder(MethodHolder.from(methodHandle));
 
         // Set the sinkClass and then set the MessageMetadata on the FrameHandlerMetadata
         if (interfaceType.equals(Decoder.Text.class))
@@ -508,7 +490,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
      * have been statically assigned a converted value (and removed from the resulting {@link MethodHandle#type()}, or null if
      * no {@code target} MethodHandle was provided.
      */
-    public static MethodHandle bindTemplateVariables(MethodHandle target, String[] namedVariables, Map<String, String> templateValues)
+    public static MethodHolder bindTemplateVariables(MethodHolder target, String[] namedVariables, Map<String, String> templateValues)
     {
         if (target == null)
         {
@@ -517,7 +499,7 @@ public abstract class JavaxWebSocketFrameHandlerFactory
 
         final int IDX = 1;
 
-        MethodHandle retHandle = target;
+        MethodHolder retHandle = target;
 
         if ((templateValues == null) || (templateValues.isEmpty()))
         {
@@ -527,54 +509,54 @@ public abstract class JavaxWebSocketFrameHandlerFactory
         for (String variableName : namedVariables)
         {
             String strValue = templateValues.get(variableName);
-            Class<?> type = retHandle.type().parameterType(IDX);
+            Class<?> type = retHandle.parameterType(IDX);
             try
             {
                 if (String.class.isAssignableFrom(type))
                 {
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, strValue);
+                    retHandle = retHandle.bindTo(strValue, IDX);
                 }
                 else if (Integer.class.isAssignableFrom(type) || Integer.TYPE.isAssignableFrom(type))
                 {
                     Integer intValue = Integer.parseInt(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, intValue);
+                    retHandle = retHandle.bindTo(intValue, IDX);
                 }
                 else if (Long.class.isAssignableFrom(type) || Long.TYPE.isAssignableFrom(type))
                 {
                     Long longValue = Long.parseLong(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, longValue);
+                    retHandle = retHandle.bindTo(longValue, IDX);
                 }
                 else if (Short.class.isAssignableFrom(type) || Short.TYPE.isAssignableFrom(type))
                 {
                     Short shortValue = Short.parseShort(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, shortValue);
+                    retHandle = retHandle.bindTo(shortValue, IDX);
                 }
                 else if (Float.class.isAssignableFrom(type) || Float.TYPE.isAssignableFrom(type))
                 {
                     Float floatValue = Float.parseFloat(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, floatValue);
+                    retHandle = retHandle.bindTo(floatValue, IDX);
                 }
                 else if (Double.class.isAssignableFrom(type) || Double.TYPE.isAssignableFrom(type))
                 {
                     Double doubleValue = Double.parseDouble(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, doubleValue);
+                    retHandle = retHandle.bindTo(doubleValue, IDX);
                 }
                 else if (Boolean.class.isAssignableFrom(type) || Boolean.TYPE.isAssignableFrom(type))
                 {
                     Boolean boolValue = Boolean.parseBoolean(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, boolValue);
+                    retHandle = retHandle.bindTo(boolValue, IDX);
                 }
                 else if (Character.class.isAssignableFrom(type) || Character.TYPE.isAssignableFrom(type))
                 {
                     if (strValue.length() != 1)
                         throw new IllegalArgumentException("Invalid Size");
                     Character charValue = strValue.charAt(0);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, charValue);
+                    retHandle = retHandle.bindTo(charValue, IDX);
                 }
                 else if (Byte.class.isAssignableFrom(type) || Byte.TYPE.isAssignableFrom(type))
                 {
                     Byte b = Byte.parseByte(strValue);
-                    retHandle = MethodHandles.insertArguments(retHandle, IDX, b);
+                    retHandle = retHandle.bindTo(b, IDX);
                 }
                 else
                 {

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketMessageMetadata.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketMessageMetadata.java
@@ -13,15 +13,15 @@
 
 package org.eclipse.jetty.websocket.javax.common;
 
-import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 
 public class JavaxWebSocketMessageMetadata
 {
-    private MethodHandle methodHandle;
+    private MethodHolder methodHolder;
     private Class<? extends MessageSink> sinkClass;
     private List<RegisteredDecoder> registeredDecoders;
 
@@ -34,7 +34,7 @@ public class JavaxWebSocketMessageMetadata
             return null;
 
         JavaxWebSocketMessageMetadata copy = new JavaxWebSocketMessageMetadata();
-        copy.methodHandle = metadata.methodHandle;
+        copy.methodHolder = metadata.methodHolder;
         copy.sinkClass = metadata.sinkClass;
         copy.registeredDecoders = metadata.registeredDecoders;
         copy.maxMessageSize = metadata.maxMessageSize;
@@ -58,14 +58,14 @@ public class JavaxWebSocketMessageMetadata
         this.maxMessageSizeSet = true;
     }
 
-    public MethodHandle getMethodHandle()
+    public MethodHolder getMethodHolder()
     {
-        return methodHandle;
+        return methodHolder;
     }
 
-    public void setMethodHandle(MethodHandle methodHandle)
+    public void setMethodHolder(MethodHolder methodHolder)
     {
-        this.methodHandle = methodHandle;
+        this.methodHolder = methodHolder;
     }
 
     public Class<? extends MessageSink> getSinkClass()

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/AbstractDecodedMessageSink.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/AbstractDecodedMessageSink.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.websocket.javax.common.messages;
 
-import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.websocket.CloseReason;
@@ -24,6 +23,7 @@ import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.exception.CloseException;
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,12 +32,12 @@ public abstract class AbstractDecodedMessageSink implements MessageSink
 {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDecodedMessageSink.class);
 
-    private final MethodHandle _methodHandle;
+    private final MethodHolder _methodHolder;
     private final MessageSink _messageSink;
 
-    public AbstractDecodedMessageSink(CoreSession coreSession, MethodHandle methodHandle)
+    public AbstractDecodedMessageSink(CoreSession coreSession, MethodHolder methodHolder)
     {
-        _methodHandle = methodHandle;
+        _methodHolder = methodHolder;
 
         try
         {
@@ -58,7 +58,7 @@ public abstract class AbstractDecodedMessageSink implements MessageSink
     {
         try
         {
-            _methodHandle.invoke(message);
+            _methodHolder.invoke(message);
         }
         catch (Throwable t)
         {
@@ -67,7 +67,7 @@ public abstract class AbstractDecodedMessageSink implements MessageSink
     }
 
     /**
-     * @return a message sink which will first decode the message then pass it to {@link #_methodHandle}.
+     * @return a message sink which will first decode the message then pass it to {@link #_methodHolder}.
      * @throws Exception for any error in creating the message sink.
      */
     abstract MessageSink newMessageSink(CoreSession coreSession) throws Exception;
@@ -90,9 +90,9 @@ public abstract class AbstractDecodedMessageSink implements MessageSink
     {
         protected final List<T> _decoders;
 
-        public Basic(CoreSession coreSession, MethodHandle methodHandle, List<RegisteredDecoder> decoders)
+        public Basic(CoreSession coreSession, MethodHolder methodHolder, List<RegisteredDecoder> decoders)
         {
-            super(coreSession, methodHandle);
+            super(coreSession, methodHolder);
             if (decoders.isEmpty())
                 throw new IllegalArgumentException("Require at least one decoder for " + this.getClass());
             _decoders = decoders.stream()
@@ -105,9 +105,9 @@ public abstract class AbstractDecodedMessageSink implements MessageSink
     {
         protected final T _decoder;
 
-        public Stream(CoreSession coreSession, MethodHandle methodHandle, List<RegisteredDecoder> decoders)
+        public Stream(CoreSession coreSession, MethodHolder methodHolder, List<RegisteredDecoder> decoders)
         {
-            super(coreSession, methodHandle);
+            super(coreSession, methodHolder);
             if (decoders.size() != 1)
                 throw new IllegalArgumentException("Require exactly one decoder for " + this.getClass());
             _decoder = decoders.get(0).getInstance();

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextMessageSink.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextMessageSink.java
@@ -13,8 +13,7 @@
 
 package org.eclipse.jetty.websocket.javax.common.messages;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.util.List;
 import javax.websocket.CloseReason;
 import javax.websocket.DecodeException;
@@ -24,7 +23,7 @@ import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.exception.CloseException;
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink;
-import org.eclipse.jetty.websocket.javax.common.JavaxWebSocketFrameHandlerFactory;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,18 +32,23 @@ public class DecodedTextMessageSink<T> extends AbstractDecodedMessageSink.Basic<
 {
     private static final Logger LOG = LoggerFactory.getLogger(DecodedTextMessageSink.class);
 
-    public DecodedTextMessageSink(CoreSession session, MethodHandle methodHandle, List<RegisteredDecoder> decoders)
+    public DecodedTextMessageSink(CoreSession session, MethodHolder methodHolder, List<RegisteredDecoder> decoders)
     {
-        super(session, methodHandle, decoders);
+        super(session, methodHolder, decoders);
     }
 
     @Override
-    MessageSink newMessageSink(CoreSession coreSession) throws NoSuchMethodException, IllegalAccessException
+    MessageSink newMessageSink(CoreSession coreSession)
     {
-        MethodHandle methodHandle = JavaxWebSocketFrameHandlerFactory.getServerMethodHandleLookup()
-            .findVirtual(getClass(), "onMessage", MethodType.methodType(void.class, String.class))
-            .bindTo(this);
-        return new StringMessageSink(coreSession, methodHandle);
+        MethodHolder methodHolder = args ->
+        {
+            if (args.length != 1)
+                throw new WrongMethodTypeException(String.format("Expected %s params but had %s", 1, args.length));
+            onMessage((String)args[0]);
+            return null;
+        };
+
+        return new StringMessageSink(coreSession, methodHolder);
     }
 
     public void onMessage(String wholeMessage)

--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextStreamMessageSink.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextStreamMessageSink.java
@@ -15,8 +15,7 @@ package org.eclipse.jetty.websocket.javax.common.messages;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.util.List;
 import javax.websocket.CloseReason;
 import javax.websocket.DecodeException;
@@ -26,23 +25,28 @@ import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.exception.CloseException;
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.ReaderMessageSink;
-import org.eclipse.jetty.websocket.javax.common.JavaxWebSocketFrameHandlerFactory;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 
 public class DecodedTextStreamMessageSink<T> extends AbstractDecodedMessageSink.Stream<Decoder.TextStream<T>>
 {
-    public DecodedTextStreamMessageSink(CoreSession session, MethodHandle methodHandle, List<RegisteredDecoder> decoders)
+    public DecodedTextStreamMessageSink(CoreSession session, MethodHolder methodHolder, List<RegisteredDecoder> decoders)
     {
-        super(session, methodHandle, decoders);
+        super(session, methodHolder, decoders);
     }
 
     @Override
-    MessageSink newMessageSink(CoreSession coreSession) throws Exception
+    MessageSink newMessageSink(CoreSession coreSession)
     {
-        MethodHandle methodHandle = JavaxWebSocketFrameHandlerFactory.getServerMethodHandleLookup()
-            .findVirtual(DecodedTextStreamMessageSink.class, "onStreamStart", MethodType.methodType(void.class, Reader.class))
-            .bindTo(this);
-        return new ReaderMessageSink(coreSession, methodHandle);
+        MethodHolder methodHolder = args ->
+        {
+            if (args.length != 1)
+                throw new WrongMethodTypeException(String.format("Expected %s params but had %s", 1, args.length));
+            onStreamStart((Reader)args[0]);
+            return null;
+        };
+
+        return new ReaderMessageSink(coreSession, methodHolder);
     }
 
     public void onStreamStart(Reader reader)

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedBinaryMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedBinaryMessageSinkTest.java
@@ -29,6 +29,7 @@ import javax.websocket.EndpointConfig;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.AbstractSessionTest;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ public class DecodedBinaryMessageSinkTest extends AbstractMessageSinkTest
         DecodedCalendarCopy copy = new DecodedCalendarCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Calendar.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedBinaryMessageSink<Calendar> sink = new DecodedBinaryMessageSink<>(AbstractSessionTest.session.getCoreSession(), copyHandle, decoders);
+        DecodedBinaryMessageSink<Calendar> sink = new DecodedBinaryMessageSink<>(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback finCallback = new FutureCallback();
         ByteBuffer data = ByteBuffer.allocate(16);
@@ -70,7 +71,7 @@ public class DecodedBinaryMessageSinkTest extends AbstractMessageSinkTest
         DecodedCalendarCopy copy = new DecodedCalendarCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Calendar.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedBinaryMessageSink<Calendar> sink = new DecodedBinaryMessageSink<>(AbstractSessionTest.session.getCoreSession(), copyHandle, decoders);
+        DecodedBinaryMessageSink<Calendar> sink = new DecodedBinaryMessageSink<>(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedBinaryStreamMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedBinaryStreamMessageSinkTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +50,7 @@ public class DecodedBinaryStreamMessageSinkTest extends AbstractMessageSinkTest
         DecodedCalendarCopy copy = new DecodedCalendarCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Calendar.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedBinaryStreamMessageSink<Calendar> sink = new DecodedBinaryStreamMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedBinaryStreamMessageSink<Calendar> sink = new DecodedBinaryStreamMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback finCallback = new FutureCallback();
         ByteBuffer data = ByteBuffer.allocate(16);
@@ -72,7 +73,7 @@ public class DecodedBinaryStreamMessageSinkTest extends AbstractMessageSinkTest
         DecodedCalendarCopy copy = new DecodedCalendarCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Calendar.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedBinaryStreamMessageSink<Calendar> sink = new DecodedBinaryStreamMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedBinaryStreamMessageSink<Calendar> sink = new DecodedBinaryStreamMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextMessageSinkTest.java
@@ -30,6 +30,7 @@ import javax.websocket.EndpointConfig;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ public class DecodedTextMessageSinkTest extends AbstractMessageSinkTest
         DecodedDateCopy copy = new DecodedDateCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Date.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedTextMessageSink<Calendar> sink = new DecodedTextMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedTextMessageSink<Calendar> sink = new DecodedTextMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback finCallback = new FutureCallback();
         sink.accept(new Frame(OpCode.TEXT).setPayload("2018.02.13").setFin(true), finCallback);
@@ -65,7 +66,7 @@ public class DecodedTextMessageSinkTest extends AbstractMessageSinkTest
         DecodedDateCopy copy = new DecodedDateCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Date.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedTextMessageSink<Calendar> sink = new DecodedTextMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedTextMessageSink<Calendar> sink = new DecodedTextMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextStreamMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/DecodedTextStreamMessageSinkTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +51,7 @@ public class DecodedTextStreamMessageSinkTest extends AbstractMessageSinkTest
         DecodedDateCopy copy = new DecodedDateCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Date.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedTextStreamMessageSink<Calendar> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedTextStreamMessageSink<Calendar> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback finCallback = new FutureCallback();
         sink.accept(new Frame(OpCode.TEXT).setPayload("2018.02.13").setFin(true), finCallback);
@@ -68,7 +69,7 @@ public class DecodedTextStreamMessageSinkTest extends AbstractMessageSinkTest
         DecodedDateCopy copy = new DecodedDateCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Date.class);
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(GmtDecoder.class, Calendar.class);
-        DecodedTextStreamMessageSink<Calendar> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), copyHandle, decoders);
+        DecodedTextStreamMessageSink<Calendar> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), MethodHolder.from(copyHandle), decoders);
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/InputStreamMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/InputStreamMessageSinkTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.messages.InputStreamMessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.AbstractSessionTest;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ public class InputStreamMessageSinkTest extends AbstractMessageSinkTest
     {
         InputStreamCopy copy = new InputStreamCopy();
         MethodHandle copyHandle = getAcceptHandle(copy, InputStream.class);
-        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), copyHandle);
+        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback finCallback = new FutureCallback();
         ByteBuffer data = BufferUtil.toBuffer("Hello World", UTF_8);
@@ -64,7 +65,7 @@ public class InputStreamMessageSinkTest extends AbstractMessageSinkTest
     {
         InputStreamCopy copy = new InputStreamCopy();
         MethodHandle copyHandle = getAcceptHandle(copy, InputStream.class);
-        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), copyHandle);
+        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback fin1Callback = new FutureCallback();
         ByteBuffer data1 = BufferUtil.toBuffer("Hello World", UTF_8);
@@ -93,7 +94,7 @@ public class InputStreamMessageSinkTest extends AbstractMessageSinkTest
     {
         InputStreamCopy copy = new InputStreamCopy();
         MethodHandle copyHandle = getAcceptHandle(copy, InputStream.class);
-        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), copyHandle);
+        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();
@@ -118,7 +119,7 @@ public class InputStreamMessageSinkTest extends AbstractMessageSinkTest
     {
         InputStreamCopy copy = new InputStreamCopy();
         MethodHandle copyHandle = getAcceptHandle(copy, InputStream.class);
-        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), copyHandle);
+        InputStreamMessageSink sink = new InputStreamMessageSink(AbstractSessionTest.session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/ReaderMessageSinkTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/messages/ReaderMessageSinkTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.messages.ReaderMessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +42,7 @@ public class ReaderMessageSinkTest extends AbstractMessageSinkTest
         CompletableFuture<StringWriter> copyFuture = new CompletableFuture<>();
         ReaderCopy copy = new ReaderCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Reader.class);
-        ReaderMessageSink sink = new ReaderMessageSink(session.getCoreSession(), copyHandle);
+        ReaderMessageSink sink = new ReaderMessageSink(session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback finCallback = new FutureCallback();
         sink.accept(new Frame(OpCode.TEXT).setPayload("Hello World"), finCallback);
@@ -58,7 +59,7 @@ public class ReaderMessageSinkTest extends AbstractMessageSinkTest
         CompletableFuture<StringWriter> copyFuture = new CompletableFuture<>();
         ReaderCopy copy = new ReaderCopy(copyFuture);
         MethodHandle copyHandle = getAcceptHandle(copy, Reader.class);
-        ReaderMessageSink sink = new ReaderMessageSink(session.getCoreSession(), copyHandle);
+        ReaderMessageSink sink = new ReaderMessageSink(session.getCoreSession(), MethodHolder.from(copyHandle));
 
         FutureCallback callback1 = new FutureCallback();
         FutureCallback callback2 = new FutureCallback();

--- a/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/util/InvokerUtilsStaticParamsTest.java
+++ b/jetty-websocket/websocket-javax-common/src/test/java/org/eclipse/jetty/websocket/javax/common/util/InvokerUtilsStaticParamsTest.java
@@ -22,6 +22,7 @@ import javax.websocket.Session;
 
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.websocket.core.internal.util.InvokerUtils;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.core.internal.util.ReflectUtils;
 import org.eclipse.jetty.websocket.javax.common.JavaxWebSocketFrameHandlerFactory;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,12 @@ public class InvokerUtilsStaticParamsTest
     
     private static MethodHandles.Lookup lookup = MethodHandles.lookup();
 
+    private MethodHolder getMethodHolder(Method method, String[] namedVariables, InvokerUtils.Arg... args)
+    {
+        MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, Foo.class, method, new NameParamIdentifier(), namedVariables, args);
+        return MethodHolder.from(methodHandle);
+    }
+
     @Test
     public void testOnlyParamString() throws Throwable
     {
@@ -70,21 +77,21 @@ public class InvokerUtilsStaticParamsTest
         // Raw Calling Args - none specified
 
         // Get basic method handle (without a instance to call against) - this is what the metadata stores
-        MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, Foo.class, method, new NameParamIdentifier(), namedVariables);
+        MethodHolder methodHolder = getMethodHolder(method, namedVariables);
 
         // Some point later an actual instance is needed, which has static named parameters
         Map<String, String> templateValues = new HashMap<>();
         templateValues.put("fruit", "pear");
 
         // Bind the static values, in same order as declared
-        methodHandle = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHandle, namedVariables, templateValues);
+        methodHolder = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHolder, namedVariables, templateValues);
 
         // Assign an instance to call.
         Foo foo = new Foo();
-        methodHandle = methodHandle.bindTo(foo);
+        methodHolder = methodHolder.bindTo(foo);
 
         // Call method against instance
-        String result = (String)methodHandle.invoke();
+        String result = (String)methodHolder.invoke();
         assertThat("Result", result, is("onFruit('pear')"));
     }
 
@@ -99,21 +106,21 @@ public class InvokerUtilsStaticParamsTest
         };
 
         // Get basic method handle (without a instance to call against) - this is what the metadata stores
-        MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, Foo.class, method, new NameParamIdentifier(), namedVariables);
+        MethodHolder methodHolder = getMethodHolder(method, namedVariables);
 
         // Some point later an actual instance is needed, which has static named parameters
         Map<String, String> templateValues = new HashMap<>();
         templateValues.put("count", "2222");
 
         // Bind the static values for the variables, in same order as the variables were declared
-        methodHandle = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHandle, namedVariables, templateValues);
+        methodHolder = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHolder, namedVariables, templateValues);
 
         // Assign an instance to call.
         Foo foo = new Foo();
-        methodHandle = methodHandle.bindTo(foo);
+        methodHolder = methodHolder.bindTo(foo);
 
         // Call method against instance
-        String result = (String)methodHandle.invoke();
+        String result = (String)methodHolder.invoke();
         assertThat("Result", result, is("onCount(2222)"));
     }
 
@@ -130,21 +137,21 @@ public class InvokerUtilsStaticParamsTest
         final InvokerUtils.Arg ARG_LABEL = new InvokerUtils.Arg(String.class).required();
 
         // Get basic method handle (without a instance to call against) - this is what the metadata stores
-        MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, Foo.class, method, new NameParamIdentifier(), namedVariables, ARG_LABEL);
+        MethodHolder methodHolder = getMethodHolder(method, namedVariables, ARG_LABEL);
 
         // Some point later an actual instance is needed, which has static named parameters
         Map<String, String> templateValues = new HashMap<>();
         templateValues.put("count", "444");
 
         // Bind the static values for the variables, in same order as the variables were declared
-        methodHandle = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHandle, namedVariables, templateValues);
+        methodHolder = JavaxWebSocketFrameHandlerFactory.bindTemplateVariables(methodHolder, namedVariables, templateValues);
 
         // Assign an instance to call.
         Foo foo = new Foo();
-        methodHandle = methodHandle.bindTo(foo);
+        methodHolder = methodHolder.bindTo(foo);
 
         // Call method against instance
-        String result = (String)methodHandle.invoke("cherry");
+        String result = (String)methodHolder.invoke("cherry");
         assertThat("Result", result, is("onLabeledCount('cherry', 444)"));
     }
 }

--- a/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/coders/DecoderTextStreamTest.java
+++ b/jetty-websocket/websocket-javax-tests/src/test/java/org/eclipse/jetty/websocket/javax/tests/coders/DecoderTextStreamTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.javax.common.decoders.RegisteredDecoder;
 import org.eclipse.jetty.websocket.javax.common.messages.DecodedTextStreamMessageSink;
 import org.eclipse.jetty.websocket.javax.tests.FunctionMethod;
@@ -80,7 +81,7 @@ public class DecoderTextStreamTest extends AbstractClientSessionTest
         });
 
         List<RegisteredDecoder> decoders = toRegisteredDecoderList(QuotesDecoder.class, Quotes.class);
-        DecodedTextStreamMessageSink<Quotes> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), quoteHandle, decoders);
+        DecodedTextStreamMessageSink<Quotes> sink = new DecodedTextStreamMessageSink<>(session.getCoreSession(), MethodHolder.from(quoteHandle), decoders);
 
         List<FutureCallback> callbacks = new ArrayList<>();
         FutureCallback finCallback = null;

--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.websocket.common;
 
-import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Executor;
@@ -43,6 +42,7 @@ import org.eclipse.jetty.websocket.core.exception.WebSocketException;
 import org.eclipse.jetty.websocket.core.exception.WebSocketTimeoutException;
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
 import org.eclipse.jetty.websocket.core.internal.util.InvokerUtils;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,16 +62,16 @@ public class JettyWebSocketFrameHandler implements FrameHandler
     private final Object endpointInstance;
     private final BatchMode batchMode;
     private final AtomicBoolean closeNotified = new AtomicBoolean();
-    private MethodHandle openHandle;
-    private MethodHandle closeHandle;
-    private MethodHandle errorHandle;
-    private MethodHandle textHandle;
+    private MethodHolder openHandle;
+    private MethodHolder closeHandle;
+    private MethodHolder errorHandle;
+    private MethodHolder textHandle;
     private final Class<? extends MessageSink> textSinkClass;
-    private MethodHandle binaryHandle;
+    private MethodHolder binaryHandle;
     private final Class<? extends MessageSink> binarySinkClass;
-    private MethodHandle frameHandle;
-    private MethodHandle pingHandle;
-    private MethodHandle pongHandle;
+    private MethodHolder frameHandle;
+    private MethodHolder pingHandle;
+    private MethodHolder pongHandle;
     private UpgradeRequest upgradeRequest;
     private UpgradeResponse upgradeResponse;
 
@@ -86,12 +86,12 @@ public class JettyWebSocketFrameHandler implements FrameHandler
 
     public JettyWebSocketFrameHandler(WebSocketContainer container,
                                       Object endpointInstance,
-                                      MethodHandle openHandle, MethodHandle closeHandle, MethodHandle errorHandle,
-                                      MethodHandle textHandle, MethodHandle binaryHandle,
+                                      MethodHolder openHandle, MethodHolder closeHandle, MethodHolder errorHandle,
+                                      MethodHolder textHandle, MethodHolder binaryHandle,
                                       Class<? extends MessageSink> textSinkClass,
                                       Class<? extends MessageSink> binarySinkClass,
-                                      MethodHandle frameHandle,
-                                      MethodHandle pingHandle, MethodHandle pongHandle,
+                                      MethodHolder frameHandle,
+                                      MethodHolder pingHandle, MethodHolder pongHandle,
                                       BatchMode batchMode,
                                       Configuration.Customizer customizer)
     {

--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -58,6 +58,7 @@ import org.eclipse.jetty.websocket.core.internal.messages.PartialStringMessageSi
 import org.eclipse.jetty.websocket.core.internal.messages.ReaderMessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink;
 import org.eclipse.jetty.websocket.core.internal.util.InvokerUtils;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.eclipse.jetty.websocket.core.internal.util.ReflectUtils;
 
 /**
@@ -171,16 +172,16 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
     {
         JettyWebSocketFrameHandlerMetadata metadata = getMetadata(endpointInstance.getClass());
 
-        final MethodHandle openHandle = InvokerUtils.bindTo(metadata.getOpenHandle(), endpointInstance);
-        final MethodHandle closeHandle = InvokerUtils.bindTo(metadata.getCloseHandle(), endpointInstance);
-        final MethodHandle errorHandle = InvokerUtils.bindTo(metadata.getErrorHandle(), endpointInstance);
-        final MethodHandle textHandle = InvokerUtils.bindTo(metadata.getTextHandle(), endpointInstance);
-        final MethodHandle binaryHandle = InvokerUtils.bindTo(metadata.getBinaryHandle(), endpointInstance);
+        final MethodHolder openHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getOpenHandle()), endpointInstance);
+        final MethodHolder closeHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getCloseHandle()), endpointInstance);
+        final MethodHolder errorHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getErrorHandle()), endpointInstance);
+        final MethodHolder textHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getTextHandle()), endpointInstance);
+        final MethodHolder binaryHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getBinaryHandle()), endpointInstance);
         final Class<? extends MessageSink> textSinkClass = metadata.getTextSink();
         final Class<? extends MessageSink> binarySinkClass = metadata.getBinarySink();
-        final MethodHandle frameHandle = InvokerUtils.bindTo(metadata.getFrameHandle(), endpointInstance);
-        final MethodHandle pingHandle = InvokerUtils.bindTo(metadata.getPingHandle(), endpointInstance);
-        final MethodHandle pongHandle = InvokerUtils.bindTo(metadata.getPongHandle(), endpointInstance);
+        final MethodHolder frameHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getFrameHandle()), endpointInstance);
+        final MethodHolder pingHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getPingHandle()), endpointInstance);
+        final MethodHolder pongHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getPongHandle()), endpointInstance);
         BatchMode batchMode = metadata.getBatchMode();
 
         // Decorate the endpointInstance while we are still upgrading for access to things like HttpSession.
@@ -197,7 +198,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
             metadata);
     }
 
-    public static MessageSink createMessageSink(MethodHandle msgHandle, Class<? extends MessageSink> sinkClass, Executor executor, WebSocketSession session)
+    public static MessageSink createMessageSink(MethodHolder msgHandle, Class<? extends MessageSink> sinkClass, Executor executor, WebSocketSession session)
     {
         if (msgHandle == null)
             return null;
@@ -208,7 +209,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
         {
             MethodHandles.Lookup lookup = JettyWebSocketFrameHandlerFactory.getServerMethodHandleLookup();
             MethodHandle ctorHandle = lookup.findConstructor(sinkClass,
-                MethodType.methodType(void.class, CoreSession.class, MethodHandle.class));
+                MethodType.methodType(void.class, CoreSession.class, MethodHolder.class));
             return (MessageSink)ctorHandle.invoke(session.getCoreSession(), msgHandle);
         }
         catch (NoSuchMethodException e)

--- a/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/OutgoingMessageCapture.java
+++ b/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/OutgoingMessageCapture.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.websocket.core.OpCode;
 import org.eclipse.jetty.websocket.core.internal.messages.ByteBufferMessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.MessageSink;
 import org.eclipse.jetty.websocket.core.internal.messages.StringMessageSink;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,7 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
                 String event = String.format("TEXT:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
                 LOG.debug(event);
                 events.offer(event);
-                messageSink = new StringMessageSink(this, wholeTextHandle);
+                messageSink = new StringMessageSink(this, MethodHolder.from(wholeTextHandle));
                 break;
             }
             case OpCode.BINARY:
@@ -105,7 +106,7 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
                 String event = String.format("BINARY:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
                 LOG.debug(event);
                 events.offer(event);
-                messageSink = new ByteBufferMessageSink(this, wholeBinaryHandle);
+                messageSink = new ByteBufferMessageSink(this, MethodHolder.from(wholeBinaryHandle));
                 break;
             }
             case OpCode.CONTINUATION:

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -87,6 +87,14 @@
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-jetty-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
     </dependency>

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/MetafactoryTest.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/MetafactoryTest.java
@@ -1,0 +1,53 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.jmh;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class MetafactoryTest
+{
+
+    @FunctionalInterface
+    public interface Test
+    {
+        Object get();
+    }
+
+    public static void main(String[] args) throws Throwable
+    {
+
+        MethodHandles.Lookup caller = MethodHandles.lookup();
+        MethodHandle methodHandle = caller.findStatic(MetafactoryTest.class, "print", MethodType.methodType(Object.class, String.class));
+        MethodType invokedType = MethodType.methodType(Test.class);
+        CallSite site = LambdaMetafactory.metafactory(caller,
+            "get",
+            invokedType,
+            methodHandle.type(),
+            methodHandle,
+            methodHandle.type());
+        MethodHandle factory = site.getTarget();
+        Test r = (Test)factory.invoke();
+        System.err.println(r.get());
+    }
+
+    private static Object print(String s)
+    {
+        return "hello world";
+    }
+
+}

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/MethodHolderBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/MethodHolderBenchmark.java
@@ -1,0 +1,169 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.jmh;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.websocket.core.internal.util.BindingMethodHolder2;
+import org.eclipse.jetty.websocket.core.internal.util.LambdaMetafactoryMethodHolder;
+import org.eclipse.jetty.websocket.core.internal.util.MethodHolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class MethodHolderBenchmark
+{
+    private MethodHandle methodHandle;
+    private MethodHolder bindingMethodHolder;
+    private MethodHolder nonBindingMethodHolder;
+    private BindingMethodHolder2 methodHolderWithOptimisation;
+    private LambdaMetafactoryMethodHolder lambdaMetafactoryMethodHolder;
+
+    public static void main(String[] args) throws Throwable
+    {
+        MethodType methodType = MethodType.methodType(void.class, Blackhole.class, String.class, String.class);
+        MethodHandle methodHandle = MethodHandles.lookup()
+            .findVirtual(MethodHolderBenchmark.class, "method87964376", methodType);
+        if (methodHandle == null)
+            throw new IllegalStateException();
+
+        LambdaMetafactoryMethodHolder lambdaMetafactoryMethodHolder = new LambdaMetafactoryMethodHolder(methodHandle, MethodHandles.lookup());
+        lambdaMetafactoryMethodHolder = lambdaMetafactoryMethodHolder.bindTo(null);
+        lambdaMetafactoryMethodHolder = lambdaMetafactoryMethodHolder.bindTo(null);
+        System.err.println(lambdaMetafactoryMethodHolder);
+    }
+
+    @Setup(Level.Trial)
+    public void setupTrial(Blackhole blackhole) throws Throwable
+    {
+        MethodType methodType = MethodType.methodType(void.class, Blackhole.class, String.class, String.class);
+        methodHandle = MethodHandles.lookup()
+            .findVirtual(MethodHolderBenchmark.class, "method87964376", methodType);
+        if (methodHandle == null)
+            throw new IllegalStateException();
+
+        bindingMethodHolder = MethodHolder.from(methodHandle, true);
+        bindingMethodHolder.bindTo(this);
+        bindingMethodHolder.bindTo(Objects.requireNonNull(blackhole));
+
+        nonBindingMethodHolder = MethodHolder.from(methodHandle, false);
+        nonBindingMethodHolder.bindTo(this);
+        nonBindingMethodHolder.bindTo(Objects.requireNonNull(blackhole));
+
+        methodHolderWithOptimisation = new BindingMethodHolder2(methodHandle);
+        methodHolderWithOptimisation = methodHolderWithOptimisation.bindTo(this);
+        methodHolderWithOptimisation = methodHolderWithOptimisation.bindTo(Objects.requireNonNull(blackhole));
+
+        optimisedMethodHandle = methodHolderWithOptimisation.getMethodHandler();
+
+        lambdaMetafactoryMethodHolder = new LambdaMetafactoryMethodHolder(methodHandle, MethodHandles.lookup());
+        lambdaMetafactoryMethodHolder = lambdaMetafactoryMethodHolder.bindTo(this);
+        lambdaMetafactoryMethodHolder = lambdaMetafactoryMethodHolder.bindTo(Objects.requireNonNull(blackhole));
+
+
+        methodHandle = methodHandle.bindTo(this);
+        methodHandle = methodHandle.bindTo(Objects.requireNonNull(blackhole));
+    }
+
+    private MethodHandle optimisedMethodHandle;
+
+    public void method87964376(Blackhole blackhole, String a, String b)
+    {
+        blackhole.consume(a);
+        blackhole.consume(b);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void methodHandleTest() throws Throwable
+    {
+        methodHandle.invoke("test", "12");
+    }
+
+//    @Benchmark
+//    @BenchmarkMode({Mode.Throughput})
+//    public void methodHandleWithArgumentsTest() throws Throwable
+//    {
+//        methodHandle.invokeWithArguments("test", "12");
+//    }
+//
+//    @Benchmark
+//    @BenchmarkMode({Mode.Throughput})
+//    public void methodHandleWithArgumentsArrayTest() throws Throwable
+//    {
+//        methodHandle.invokeWithArguments(new Object[]{"test", "12"});
+//    }
+
+//    @Benchmark
+//    @BenchmarkMode({Mode.Throughput})
+//    public void bindingMethodHolderTest() throws Throwable
+//    {
+//        bindingMethodHolder.invoke("test", "12");
+//    }
+
+//    @Benchmark
+//    @BenchmarkMode({Mode.Throughput})
+//    public void nonBindingMethodHolderTest() throws Throwable
+//    {
+//        nonBindingMethodHolder.invoke("test", "12");
+//    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void methodHolderWithOptimisationTest() throws Throwable
+    {
+        methodHolderWithOptimisation.invoke("test", "12");
+//        optimisedMethodHandle.invoke("test", "12");
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void lambdaMetafactoryTest() throws Throwable
+    {
+        lambdaMetafactoryMethodHolder.invoke("test", "12");
+    }
+
+//    public static void main(String[] args) throws RunnerException
+//    {
+//        Options opt = new OptionsBuilder()
+//            .include(MethodHolderBenchmark.class.getSimpleName())
+//            .warmupIterations(5)
+//            .measurementIterations(10)
+//            .addProfiler(LinuxPerfAsmProfiler.class)
+////            .addProfiler(GCProfiler.class)
+//            .forks(1)
+//            .threads(1)
+//            .build();
+//
+//        new Runner(opt).run();
+//    }
+}
+
+

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/WebSocketBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/websocket/jmh/WebSocketBenchmark.java
@@ -1,0 +1,168 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.jmh;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class WebSocketBenchmark
+{
+    private Server _server;
+    private ServerConnector _connector;
+    private WebSocketClient _client;
+
+    @Param({"BINDING", "NON_BINDING"})
+    public static String methodHandleType;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Exception
+    {
+        int capacity;
+
+        switch (methodHandleType)
+        {
+            case "BINDING":
+                System.setProperty("jetty.websocket.methodholder.binding", Boolean.TRUE.toString());
+                break;
+            case "NON_BINDING":
+                System.setProperty("jetty.websocket.methodholder.binding", Boolean.FALSE.toString());
+                break;
+            default:
+                throw new IllegalStateException("Unknown methodHandleType Parameter");
+        }
+
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        _server.setHandler(contextHandler);
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, ((servletContext, container) ->
+            container.addMapping("/", (req, resp) -> new ServerSocket())));
+        _server.start();
+
+        _client = new WebSocketClient();
+        _client.start();
+    }
+
+    @TearDown(Level.Trial)
+    public void stopTrial() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void test() throws Exception
+    {
+        ClientSocket clientSocket = new ClientSocket();
+        URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
+
+        Session session = _client.connect(clientSocket, uri).get(5, TimeUnit.SECONDS);
+        for (int i = 0; i < 1000; i++)
+        {
+            session.getRemote().sendString("fixed string");
+        }
+
+        session.getRemote().sendString("close");
+        if (!clientSocket._closeLatch.await(5, TimeUnit.SECONDS))
+            throw new IllegalStateException();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(WebSocketBenchmark.class.getSimpleName())
+            .warmupIterations(10)
+            .measurementIterations(20)
+            //.addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @WebSocket
+    public static class ServerSocket
+    {
+        @OnWebSocketConnect
+        public void onOpen(Session session)
+        {
+        }
+
+        @OnWebSocketMessage
+        public void onMessage(Session session, String message)
+        {
+            if ("close".equals(message))
+                session.close();
+        }
+    }
+
+    @WebSocket
+    public static class ClientSocket
+    {
+        public CountDownLatch _closeLatch = new CountDownLatch(1);
+
+        @OnWebSocketConnect
+        public void onOpen(Session session)
+        {
+        }
+
+        @OnWebSocketMessage
+        public void onMessage(Session session, String message)
+        {
+        }
+
+        @OnWebSocketClose
+        public void onClose(Session session, int statusCode, String reason)
+        {
+            _closeLatch.countDown();
+        }
+    }
+}
+
+


### PR DESCRIPTION
Fixes #6328

Use a new `JettyMethodHandle` interface so that implementations can be used which avoid binding the MethodHandles for each WebSocket connection. This will avoid the multiple spikes seen on the flamegraph from #6328.

For Javax endpoints we are creating new method handles each time because we cannot have the same MetaData cache as used in the `JettyWebSocketFrameHandlerFactory` because it depends on both the endpointClass and the endpointConfig. However `javax.websocket.MessageHandler` does not actually use method handles at all and has a special implementation of  `JettyMethodHandle`.