### PR TITLE
exclude log4j-core to avoid problem with m-enforcer-p see https://issues.apache.org/jira/browse/LOG4J2-3241

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -437,6 +437,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- to make infinispan-common source sane -->
     <dependency>

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -17,10 +17,10 @@
       <artifactId>infinispan-core</artifactId>
       <optional>true</optional>
       <exclusions>
-          <exclusion>
-              <groupId>org.wildfly.common</groupId>
-              <artifactId>wildfly-common</artifactId>
-          </exclusion>
+        <exclusion>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -46,13 +46,6 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -46,6 +46,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -102,6 +102,13 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -81,6 +81,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1876,6 +1876,13 @@
         <version>${infinispan.version}</version>
         <type>pom</type>
         <scope>import</scope>
+        <exclusions>
+          <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1876,13 +1876,6 @@
         <version>${infinispan.version}</version>
         <type>pom</type>
         <scope>import</scope>
-        <exclusions>
-          <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
-          <exclusion>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -129,6 +129,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>

to avoid issues such 
```
Downloading from public-jboss: https://repository.jboss.org/nexus/content/groups/public-jboss/org/apache/logging/log4j/log4j-core-java9/2.13.3/log4j-core-java9-2.13.3.pom
[WARNING] Rule 6: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Could not build dependency tree Could not collect dependencies: org.eclipse.jetty:infinispan-common:jar:11.0.10-SNAPSHOT ()
```