### PR TITLE
Fixing #7975 - ForwardedRequestCustomizer should clear old MethodHandles when renaming headers

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -593,6 +593,8 @@ public class ForwardedRequestCustomizer implements Customizer
 
     private void updateHandles()
     {
+        _handles.clear();
+
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         try
         {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -1112,6 +1112,57 @@ public class ForwardedRequestCustomizerTest
         assertThat("status", response.getStatus(), is(400));
     }
 
+    public static Stream<Arguments> customHeaderNameRequestCases()
+    {
+        return Stream.of(
+            Arguments.of(new Request("Old name then new name")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: myhost",
+                        "X-Forwarded-For: 1.1.1.1",
+                        "X-Custom-For: 2.2.2.2"
+                    )
+                    .configureCustomizer((forwardedRequestCustomizer) ->
+                        forwardedRequestCustomizer.setForwardedForHeader("X-Custom-For")),
+                new Expectations()
+                    .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://myhost/")
+                    .remoteAddr("2.2.2.2").remotePort(0)
+            ),
+            Arguments.of(new Request("New name then old name")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: myhost",
+                        "X-Custom-For: 2.2.2.2",
+                        "X-Forwarded-For: 1.1.1.1"
+                    )
+                    .configureCustomizer((forwardedRequestCustomizer) ->
+                        forwardedRequestCustomizer.setForwardedForHeader("X-Custom-For")),
+                new Expectations()
+                    .scheme("http").serverName("myhost").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://myhost/")
+                    .remoteAddr("2.2.2.2").remotePort(0)
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("customHeaderNameRequestCases")
+    public void testCustomHeaderName(Request request, Expectations expectations) throws Exception
+    {
+        request.configure(customizer);
+
+        String rawRequest = request.getRawRequest((header) -> header);
+        // System.out.println(rawRequest);
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat("status", response.getStatus(), is(200));
+
+        expectations.accept(actual);
+    }
+
     private static class Request
     {
         String description;


### PR DESCRIPTION
* Adding test case to prove report
* Fixing updateHandles() to clear the stored handles list.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>