### PR TITLE
Fixes #7994 - Ability to construct a detached client Request

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -448,7 +448,8 @@ public class HttpClient extends ContainerLifeCycle
             .body(oldRequest.getBody())
             .idleTimeout(oldRequest.getIdleTimeout(), TimeUnit.MILLISECONDS)
             .timeout(oldRequest.getTimeout(), TimeUnit.MILLISECONDS)
-            .followRedirects(oldRequest.isFollowRedirects());
+            .followRedirects(oldRequest.isFollowRedirects())
+            .tag(oldRequest.getTag());
         for (HttpField field : oldRequest.getHeaders())
         {
             HttpHeader header = field.getHeader();

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1618,6 +1618,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .timeout(123231, TimeUnit.SECONDS)
             .idleTimeout(232342, TimeUnit.SECONDS)
             .followRedirects(false)
+            .tag("tag")
             .headers(headers -> headers.put(HttpHeader.ACCEPT, "application/json"))
             .headers(headers -> headers.put("X-Some-Other-Custom-Header", "some-other-value")));
 
@@ -1969,6 +1970,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         assertEquals(original.getIdleTimeout(), copy.getIdleTimeout());
         assertEquals(original.getTimeout(), copy.getTimeout());
         assertEquals(original.isFollowRedirects(), copy.isFollowRedirects());
+        assertEquals(original.getTag(), copy.getTag());
         assertEquals(original.getHeaders(), copy.getHeaders());
     }
 


### PR DESCRIPTION
Implemented copy of the request tag that was mistakenly missing.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>