### PR TITLE
exclude log4j-core to avoid problem with m-enforcer-p see https://issues.apache.org/jira/browse/LOG4J2-3241 (#8094)

### DIFF
--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -61,6 +61,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -103,6 +103,13 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -82,6 +82,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-client-hotrod</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -125,6 +125,13 @@
       <artifactId>infinispan-client-hotrod</artifactId>
       <version>${infinispan.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
* exclude log4j-core to avoid problem with m-enforcer-p see https://issues.apache.org/jira/browse/LOG4J2-3241

Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>

cherry-pick d12ee70b5acf2c779693bc737d807a6733c2fe30 from 10.0.x
