### PR TITLE
Improve cleanup of deflater/inflater pools for PerMessageDeflateExtension

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
@@ -16,9 +16,11 @@ package org.eclipse.jetty.util.compression;
 import java.io.Closeable;
 
 import org.eclipse.jetty.util.Pool;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
-public abstract class CompressionPool<T> extends AbstractLifeCycle
+@ManagedObject
+public abstract class CompressionPool<T> extends ContainerLifeCycle
 {
     public static final int DEFAULT_CAPACITY = 1024;
 
@@ -49,6 +51,11 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
         if (isStarted())
             throw new IllegalStateException("Already Started");
         _capacity = capacity;
+    }
+
+    public Pool<Entry> getPool()
+    {
+        return _pool;
     }
 
     protected abstract T newPooled();
@@ -85,7 +92,10 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
     protected void doStart() throws Exception
     {
         if (_capacity > 0)
+        {
             _pool = new Pool<>(Pool.StrategyType.RANDOM, _capacity, true);
+            addBean(_pool);
+        }
         super.doStart();
     }
 
@@ -95,6 +105,7 @@ public abstract class CompressionPool<T> extends AbstractLifeCycle
         if (_pool != null)
         {
             _pool.close();
+            removeBean(_pool);
             _pool = null;
         }
         super.doStop();

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.websocket.core;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 /**
  * Interface for WebSocket Extensions.
@@ -29,7 +28,7 @@ public interface Extension extends IncomingFrames, OutgoingFrames, Closeable
     /**
      * Used to clean up any resources after connection close.
      */
-    default void close() throws IOException
+    default void close()
     {
     }
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
@@ -13,12 +13,15 @@
 
 package org.eclipse.jetty.websocket.core;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 /**
  * Interface for WebSocket Extensions.
  * <p>
  * That {@link Frame}s are passed through the Extension via the {@link IncomingFrames} and {@link OutgoingFrames} interfaces
  */
-public interface Extension extends IncomingFrames, OutgoingFrames
+public interface Extension extends IncomingFrames, OutgoingFrames, Closeable
 {
 
     void init(ExtensionConfig config, WebSocketComponents components);
@@ -26,7 +29,7 @@ public interface Extension extends IncomingFrames, OutgoingFrames
     /**
      * Used to clean up any resources after connection close.
      */
-    default void close()
+    default void close() throws IOException
     {
     }
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Extension.java
@@ -24,6 +24,13 @@ public interface Extension extends IncomingFrames, OutgoingFrames
     void init(ExtensionConfig config, WebSocketComponents components);
 
     /**
+     * Used to clean up any resources after connection close.
+     */
+    default void close()
+    {
+    }
+
+    /**
      * The active configuration for this extension.
      *
      * @return the configuration for this extension. never null.

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ExtensionStack.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ExtensionStack.java
@@ -60,6 +60,14 @@ public class ExtensionStack implements IncomingFrames, OutgoingFrames, Dumpable
         this.behavior = behavior;
     }
 
+    public void close()
+    {
+        for (Extension e : extensions)
+        {
+            e.close();
+        }
+    }
+
     @ManagedAttribute(name = "Extension List", readonly = true)
     public List<Extension> getExtensions()
     {

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ExtensionStack.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ExtensionStack.java
@@ -62,9 +62,17 @@ public class ExtensionStack implements IncomingFrames, OutgoingFrames, Dumpable
 
     public void close()
     {
-        for (Extension e : extensions)
+        for (Extension ext : extensions)
         {
-            e.close();
+            try
+            {
+                ext.close();
+            }
+            catch (Throwable t)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Extension Error During Close", t);
+            }
         }
     }
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
@@ -44,7 +44,6 @@ public class FrameFlusher extends IteratingCallback
 {
     public static final Frame FLUSH_FRAME = new Frame(OpCode.BINARY);
     private static final Logger LOG = LoggerFactory.getLogger(FrameFlusher.class);
-    private static final Throwable CLOSED_CHANNEL = new ClosedChannelException();
 
     private final AutoLock lock = new AutoLock();
     private final LongAdder messagesOut = new LongAdder();
@@ -185,7 +184,14 @@ public class FrameFlusher extends IteratingCallback
     {
         try (AutoLock l = lock.lock())
         {
-            closedCause = cause == null ? CLOSED_CHANNEL : cause;
+            closedCause = cause == null ? new ClosedChannelException()
+            {
+                @Override
+                public Throwable fillInStackTrace()
+                {
+                    return this;
+                }
+            } : cause;
         }
         iterate();
     }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
@@ -184,6 +184,7 @@ public class FrameFlusher extends IteratingCallback
     {
         try (AutoLock l = lock.lock())
         {
+            // TODO: find a way to not create exception if cause is null.
             closedCause = cause == null ? new ClosedChannelException()
             {
                 @Override

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -159,7 +159,6 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
                 return this;
             }
         };
-        incomingFlusher.close();
         incomingFlusher.failFlusher(exception);
         outgoingFlusher.failFlusher(exception);
         releaseInflater();

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -151,7 +151,15 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
     public void close()
     {
         // TODO: use IteratingCallback.close() instead of creating exception with failFlusher methods.
-        ClosedChannelException exception = new ClosedChannelException();
+        ClosedChannelException exception = new ClosedChannelException()
+        {
+            @Override
+            public Throwable fillInStackTrace()
+            {
+                return this;
+            }
+        };
+        incomingFlusher.close();
         incomingFlusher.failFlusher(exception);
         outgoingFlusher.failFlusher(exception);
         releaseInflater();

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.websocket.core.internal;
 
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -144,6 +145,17 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
         LOG.debug("config: outgoingContextTakover={}, incomingContextTakeover={} : {}", outgoingContextTakeover, incomingContextTakeover, this);
 
         super.init(configNegotiated, components);
+    }
+
+    @Override
+    public void close()
+    {
+        // TODO: use IteratingCallback.close() instead of creating exception with failFlusher methods.
+        ClosedChannelException exception = new ClosedChannelException();
+        incomingFlusher.failFlusher(exception);
+        outgoingFlusher.failFlusher(exception);
+        releaseInflater();
+        releaseDeflater();
     }
 
     private static String toDetail(Inflater inflater)

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/TransformingFlusher.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/TransformingFlusher.java
@@ -83,6 +83,7 @@ public abstract class TransformingFlusher
      */
     public void failFlusher(Throwable t)
     {
+        // TODO: find a way to close the flusher in non error case without exception.
         boolean failed = false;
         try (AutoLock l = lock.lock())
         {
@@ -90,6 +91,10 @@ public abstract class TransformingFlusher
             {
                 failure = t;
                 failed = true;
+            }
+            else
+            {
+                failure.addSuppressed(t);
             }
         }
 

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketCoreSession.java
@@ -254,12 +254,13 @@ public class WebSocketCoreSession implements IncomingFrames, CoreSession, Dumpab
             closeConnection(sessionState.getCloseStatus(), Callback.NOOP);
     }
 
-    public void closeConnection(CloseStatus closeStatus, Callback callback)
+    private void closeConnection(CloseStatus closeStatus, Callback callback)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("closeConnection() {} {}", closeStatus, this);
 
         abort();
+        extensionStack.close();
 
         // Forward Errors to Local WebSocket EndPoint
         if (closeStatus.isAbnormal() && closeStatus.getCause() != null)


### PR DESCRIPTION
- Make Pool class available from `CompressionPool` via JMX.
- Add close method to clean up resources in Extensions.
- Close on `PermessageDeflateExtension` should release deflaters.
- Avoid using static exceptions from `FrameFlusher`.