### PR TITLE
Rework static exceptions in ContentProducer

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncContentProducer.java
@@ -19,6 +19,7 @@ import java.util.concurrent.locks.Condition;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
@@ -31,8 +32,8 @@ import org.slf4j.LoggerFactory;
 class AsyncContentProducer implements ContentProducer
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncContentProducer.class);
-    private static final HttpInput.ErrorContent RECYCLED_ERROR_CONTENT = new HttpInput.ErrorContent(new IllegalStateException("ContentProducer has been recycled"));
-    private static final Throwable UNCONSUMED_CONTENT_EXCEPTION = new IOException("Unconsumed content")
+    private static final HttpInput.ErrorContent RECYCLED_ERROR_CONTENT = new HttpInput.ErrorContent(new StaticException("ContentProducer has been recycled"));
+    private static final Throwable UNCONSUMED_CONTENT_EXCEPTION = new StaticException("Unconsumed content")
     {
         @Override
         public Throwable fillInStackTrace()
@@ -190,7 +191,7 @@ class AsyncContentProducer implements ContentProducer
         Throwable x = UNCONSUMED_CONTENT_EXCEPTION;
         if (LOG.isDebugEnabled())
         {
-            x = new IOException("Unconsumed content");
+            x = new StaticException("Unconsumed content");
             LOG.debug("consumeAll {}", this, x);
         }
         failCurrentContent(x);

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/StaticException.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/StaticException.java
@@ -1,0 +1,29 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util;
+
+/**
+ * This exception can safely be stored in a static variable as suppressed exceptions are disabled,
+ * meaning calling {@link #addSuppressed(Throwable)} has no effect.
+ * This prevents potential memory leaks where a statically-stored exception would accumulate
+ * suppressed exceptions added to them.
+ */
+public class StaticException extends Exception
+{
+    public StaticException(String message)
+    {
+        // Make sure to call the super constructor that disables suppressed exception.
+        super(message, null, false, true);
+    }
+}


### PR DESCRIPTION
As this is a potential memory leak if `Throwable.addSuppressed()` is ever called on the static exception, or on the exception contained in the static `ErrorContent`.