### PR TITLE
RegexPathSpec backport of optional group name/info lookup if regex fails

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/RegexPathSpec.java
@@ -294,10 +294,17 @@ public class RegexPathSpec extends AbstractPathSpec
         @Override
         public String getPathMatch()
         {
-            String p = matcher.group("name");
-            if (p != null)
+            try
             {
-                return p;
+                String p = matcher.group("name");
+                if (p != null)
+                {
+                    return p;
+                }
+            }
+            catch (IllegalArgumentException ignore)
+            {
+                // ignore if group name not found.
             }
 
             if (pathSpec.getGroup() == PathSpecGroup.PREFIX_GLOB && matcher.groupCount() >= 1)
@@ -318,10 +325,17 @@ public class RegexPathSpec extends AbstractPathSpec
         @Override
         public String getPathInfo()
         {
-            String p = matcher.group("info");
-            if (p != null)
+            try
             {
-                return p;
+                String p = matcher.group("info");
+                if (p != null)
+                {
+                    return p;
+                }
+            }
+            catch (IllegalArgumentException ignore)
+            {
+                // ignore if group info not found.
             }
 
             // Path Info only valid for PREFIX_GLOB

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/RegexPathSpecTest.java
@@ -134,7 +134,7 @@ public class RegexPathSpecTest
     }
 
     @Test
-    public void testSuffixSpec()
+    public void testSuffixSpecTraditional()
     {
         RegexPathSpec spec = new RegexPathSpec("^(.*).do$");
         assertEquals("^(.*).do$", spec.getDeclaration(), "Spec.pathSpec");
@@ -151,6 +151,47 @@ public class RegexPathSpecTest
         assertNotMatches(spec, "/aa");
         assertNotMatches(spec, "/aa/bb");
         assertNotMatches(spec, "/aa/bb.do/more");
+
+        assertThat(spec.getPathMatch("/a/b/c.do"), equalTo("/a/b/c.do"));
+        assertThat(spec.getPathInfo("/a/b/c.do"), nullValue());
+    }
+
+    /**
+     * A suffix type path spec, where the beginning of the path is evaluated
+     * but the rest of the path is ignored.
+     * The beginning is starts with a glob, contains a literal, and no terminal "$".
+     */
+    @Test
+    public void testSuffixSpecGlobish()
+    {
+        RegexPathSpec spec = new RegexPathSpec("^/[Hh]ello");
+        assertEquals("^/[Hh]ello", spec.getDeclaration(), "Spec.pathSpec");
+        assertEquals("^/[Hh]ello", spec.getPattern().pattern(), "Spec.pattern");
+        assertEquals(1, spec.getPathDepth(), "Spec.pathDepth");
+        assertEquals(PathSpecGroup.SUFFIX_GLOB, spec.getGroup(), "Spec.group");
+
+        assertMatches(spec, "/hello");
+        assertMatches(spec, "/Hello");
+
+        assertNotMatches(spec, "/Hello/World");
+        assertNotMatches(spec, "/a");
+        assertNotMatches(spec, "/aa");
+        assertNotMatches(spec, "/aa/bb");
+        assertNotMatches(spec, "/aa/bb.do/more");
+
+        assertThat(spec.getPathMatch("/hello"), equalTo("/hello"));
+        assertThat(spec.getPathInfo("/hello"), nullValue());
+
+        assertThat(spec.getPathMatch("/Hello"), equalTo("/Hello"));
+        assertThat(spec.getPathInfo("/Hello"), nullValue());
+
+        MatchedPath matchedPath = spec.matched("/hello");
+        assertThat(matchedPath.getPathMatch(), equalTo("/hello"));
+        assertThat(matchedPath.getPathInfo(), nullValue());
+
+        matchedPath = spec.matched("/Hello");
+        assertThat(matchedPath.getPathMatch(), equalTo("/Hello"));
+        assertThat(matchedPath.getPathInfo(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of commit 4e419d80cc53b23b1e82a4ae0c96614d409288cd for `jetty-9.4.x`

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>