### PR TITLE
Cherry pick to Jetty 9.4.x 8014 review httprequest uri

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -197,6 +197,8 @@ public class HttpRequest implements Request
             String rawPath = uri.getRawPath();
             if (rawPath == null)
                 rawPath = "";
+            if (!rawPath.startsWith("/"))
+                rawPath = "/" + rawPath;
             this.path = rawPath;
             String query = uri.getRawQuery();
             if (query != null)
@@ -925,14 +927,14 @@ public class HttpRequest implements Request
         return result;
     }
 
-    private URI newURI(String uri)
+    private URI newURI(String path)
     {
         try
         {
             // Handle specially the "OPTIONS *" case, since it is possible to create a URI from "*" (!).
-            if ("*".equals(uri))
+            if ("*".equals(path))
                 return null;
-            URI result = new URI(uri);
+            URI result = new URI(path);
             return result.isOpaque() ? null : result;
         }
         catch (URISyntaxException x)

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -308,7 +308,7 @@ public class HttpURI
         _uri = uri;
 
         if (HttpMethod.CONNECT.is(method))
-            _path = uri;
+            parse(State.HOST, uri, 0, uri.length());
         else
             parse(uri.startsWith("/") ? State.PATH : State.START, uri, 0, uri.length());
     }
@@ -1032,9 +1032,20 @@ public class HttpURI
      */
     public void setAuthority(String host, int port)
     {
+        if (host != null && !isPathValidForAuthority(_path))
+            throw new IllegalArgumentException("Relative path with authority");
         _host = host;
         _port = port;
         _uri = null;
+    }
+
+    private boolean isPathValidForAuthority(String path)
+    {
+        if (path == null)
+            return true;
+        if (path.isEmpty() || "*".equals(path))
+            return true;
+        return path.startsWith("/");
     }
 
     /**
@@ -1042,6 +1053,8 @@ public class HttpURI
      */
     public void setPath(String path)
     {
+        if (hasAuthority() && !isPathValidForAuthority(path))
+            throw new IllegalArgumentException("Relative path with authority");
         _uri = null;
         _path = null;
         if (path != null)
@@ -1050,6 +1063,8 @@ public class HttpURI
 
     public void setPathQuery(String pathQuery)
     {
+        if (hasAuthority() && !isPathValidForAuthority(pathQuery))
+            throw new IllegalArgumentException("Relative path with authority");
         _uri = null;
         _path = null;
         _decodedPath = null;
@@ -1061,6 +1076,11 @@ public class HttpURI
          */
         if (pathQuery != null)
             parse(State.PATH, pathQuery, 0, pathQuery.length());
+    }
+
+    private boolean hasAuthority()
+    {
+        return _host != null;
     }
 
     public void setQuery(String query)

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -117,6 +117,32 @@ public class HttpURITest
     }
 
     @Test
+    public void testCONNECT()
+    {
+        HttpURI uri = new HttpURI();
+
+        uri.parseRequestTarget("CONNECT", "host:80");
+        assertThat(uri.getHost(), is("host"));
+        assertThat(uri.getPort(), is(80));
+        assertThat(uri.getPath(), nullValue());
+
+        uri.parseRequestTarget("CONNECT", "host");
+        assertThat(uri.getHost(), is("host"));
+        assertThat(uri.getPort(), is(-1));
+        assertThat(uri.getPath(), nullValue());
+
+        uri.parseRequestTarget("CONNECT", "192.168.0.1:8080");
+        assertThat(uri.getHost(), is("192.168.0.1"));
+        assertThat(uri.getPort(), is(8080));
+        assertThat(uri.getPath(), nullValue());
+
+        uri.parseRequestTarget("CONNECT", "[::1]:8080");
+        assertThat(uri.getHost(), is("[::1]"));
+        assertThat(uri.getPort(), is(8080));
+        assertThat(uri.getPath(), nullValue());
+    }
+
+    @Test
     public void testExtB() throws Exception
     {
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -788,5 +814,65 @@ public class HttpURITest
     {
         HttpURI httpURI = new HttpURI(input);
         assertThat("[" + input + "] .query", httpURI.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testRelativePathWithAuthority()
+    {
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setAuthority("host", 0);
+            httpURI.setPath("path");
+        });
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setAuthority("host", 8080);
+            httpURI.setPath(";p=v/url");
+        });
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setAuthority("host", 0);
+            httpURI.setPath(";");
+        });
+
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setPath("path");
+            httpURI.setAuthority("host", 0);
+        });
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setPath(";p=v/url");
+            httpURI.setAuthority("host", 8080);
+        });
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            HttpURI httpURI = new HttpURI();
+            httpURI.setPath(";");
+            httpURI.setAuthority("host", 0);
+        });
+
+        HttpURI uri = new HttpURI();
+        uri.setPath("*");
+        uri.setAuthority("host", 0);
+        assertEquals("//host*", uri.toString());
+        uri = new HttpURI();
+        uri.setAuthority("host", 0);
+        uri.setPath("*");
+        assertEquals("//host*", uri.toString());
+
+        uri = new HttpURI();
+        uri.setPath("");
+        uri.setAuthority("host", 0);
+        assertEquals("//host", uri.toString());
+        uri = new HttpURI();
+        uri.setAuthority("host", 0);
+        uri.setPath("");
+        assertEquals("//host", uri.toString());
     }
 }

--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ConnectHandler.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ConnectHandler.java
@@ -195,7 +195,7 @@ public class ConnectHandler extends HandlerWrapper
     {
         if (HttpMethod.CONNECT.is(request.getMethod()))
         {
-            String serverAddress = request.getRequestURI();
+            String serverAddress = baseRequest.getHttpURI().getAuthority();
             if (LOG.isDebugEnabled())
                 LOG.debug("CONNECT request for {}", serverAddress);
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1836,9 +1836,18 @@ public class Request implements HttpServletRequest
                 throw new BadMessageException(badMessage);
         }
 
-        _originalURI = uri.isAbsolute() && request.getHttpVersion() != HttpVersion.HTTP_2 ? uri.toString() : uri.getPathQuery();
+        String encoded;
+        if (HttpMethod.CONNECT.is(request.getMethod()))
+        {
+            _originalURI = uri.getAuthority();
+            encoded = "/";
+        }
+        else
+        {
+            _originalURI = uri.isAbsolute() && request.getHttpVersion() != HttpVersion.HTTP_2 ? uri.toString() : uri.getPathQuery();
+            encoded = uri.getPath();
+        }
 
-        String encoded = uri.getPath();
         String path;
         if (encoded == null)
         {


### PR DESCRIPTION
Now always adding a "/" before the path, if not already present.
Parse CONNECT URIs as Authority

Co-authored-by: Greg Wilkins <gregw@webtide.com>
(cherry picked from commit d1e64f469362bb9371d530cccded5ecb13fa1cb5)