### PR TITLE
exclude some infinispan dependencies to avoid problem with m-enforcer-p

### DIFF
--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -65,11 +65,7 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core-java9</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api-java9</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -65,7 +65,11 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
+          <artifactId>log4j-core-java9</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api-java9</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -107,11 +107,7 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core-java9</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api-java9</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -107,7 +107,11 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
+          <artifactId>log4j-core-java9</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api-java9</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -86,11 +86,7 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core-java9</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api-java9</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -86,7 +86,11 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
+          <artifactId>log4j-core-java9</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api-java9</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -129,7 +129,11 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
+          <artifactId>log4j-core-java9</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api-java9</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -129,11 +129,7 @@
         <!-- this is depending on an old log4j version which have this issue https://issues.apache.org/jira/browse/LOG4J2-3241 -->
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core-java9</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api-java9</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
the fix from #8113 didn't work for me on `9.4.x` but with these changes I can get a green build

- exclude `org.apache.logging.log4j:log4j-core-java9`
- exclude `org.apache.logging.log4j:log4j-api-java9`