### PR TITLE
Drop MAT

### DIFF
--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -49,6 +49,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <argLine>-Dstop.port=@{test.stopPort} -Djetty.port=@{test.jettyPort}</argLine>
@@ -114,11 +115,6 @@
     </plugins>
   </build>
   <dependencies>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>${maven-artifact-transfer.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -147,6 +147,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven.resolver.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-tools-api</artifactId>
     </dependency>

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/AbstractWebAppMojo.java
@@ -45,8 +45,8 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.jetty.maven.plugin.utils.MavenProjectHelper;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.RequestLog;
@@ -357,7 +357,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
      * 
      */
     @Component
-    private ArtifactResolver artifactResolver;
+    private RepositorySystem repositorySystem;
     
     /**
      * The current maven session
@@ -410,7 +410,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
             }
             
             getLog().info("Configuring Jetty for project: " + getProjectName());
-            mavenProjectHelper = new MavenProjectHelper(project, artifactResolver, remoteRepositories, session);
+            mavenProjectHelper = new MavenProjectHelper(project, repositorySystem, remoteRepositories, session);
             mergedSystemProperties = mergeSystemProperties();
             configureSystemProperties();
             augmentPluginClasspath();

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
     <logback.version>1.3.0-alpha16</logback.version>
     <mariadb.version>3.0.5</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
-    <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
     <maven.resolver.version>1.8.0</maven.resolver.version>
     <maven.version>3.8.4</maven.version>
     <mongodb.version>3.12.11</mongodb.version>


### PR DESCRIPTION
As Maven 3.0 is not being supported, no need for artifical indirection
between sonatype/eclipse package for resolver. Drop MAT as it 
drags a LOT of dependencies.