### PR TITLE
Fix test-distribution classpath re resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <mariadb.version>3.0.5</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
-    <maven.resolver.version>1.8.0</maven.resolver.version>
+    <maven.resolver.version>1.8.1</maven.resolver.version>
     <maven.version>3.8.4</maven.version>
     <mongodb.version>3.12.11</mongodb.version>
     <openpojo.version>0.9.1</openpojo.version>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${maven.resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${maven.resolver.version}</version>
     </dependency>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -52,6 +52,13 @@
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
       <version>${maven.resolver.version}</version>
+      <exclusions>
+        <!-- Used when running in SISU container to manage beans lifecycle (of locking factories) -->
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
As currently it seems mixed versions of resolver artifacts are
present on classpath. Resolver 1.8.0 introduces a binary
breakage against 1.6.x.

Updated to bugfix 1.8.1 resolver

Anyway, this fixes the thing, as impl was actually coming in
as transitive dep of maven-resolver-provider, that is NOT
the same version as the rest of resolver dependencies.

Relying on transitive while fixing other versions is wrong.

![image](https://user-images.githubusercontent.com/45165/174818010-497136de-3d47-4cc7-bf26-e68d89fa4e8a.png)