### PR TITLE
QueuedThreadPool: Prevent incomplete stop due to InterruptedException

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -320,8 +320,13 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
             long canWait = TimeUnit.NANOSECONDS.toMillis(stopByNanos - System.nanoTime());
             if (LOG.isDebugEnabled())
                 LOG.debug("Waiting for {} for {}", thread, canWait);
-            if (canWait > 0)
-                thread.join(canWait);
+            if (canWait > 0) {
+                try {
+                    thread.join(canWait);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
         }
     }
 


### PR DESCRIPTION
QueuedThreadPool#doStop may fail to execute completely if a thread
throws InterruptedException upon Thread#join.

Fixes https://github.com/eclipse/jetty.project/issues/8206

Signed-off-by: Christian Kohlschütter <christian@kohlschutter.com>