### PR TITLE
Issue #8212 - Exclude spec 8.1.2.6

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
@@ -23,6 +23,7 @@
           <reportsDirectory>${project.build.directory}/h2spec-reports</reportsDirectory>
           <excludeSpecs>
             <excludeSpec>3.5 - Sends invalid connection preface</excludeSpec>
+            <excludeSpec>8.1.2.6. Malformed Requests and Responses</excludeSpec>
           </excludeSpecs>
         </configuration>
         <executions>

--- a/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
@@ -15,6 +15,7 @@
       <plugin>
         <groupId>org.mortbay.jetty</groupId>
         <artifactId>h2spec-maven-plugin</artifactId>
+        <version>1.0.10-SNAPSHOT</version>
         <configuration>
           <mainClass>org.eclipse.jetty.http2.tests.H2SpecServer</mainClass>
           <skip>${skipTests}</skip>
@@ -23,7 +24,7 @@
           <reportsDirectory>${project.build.directory}/h2spec-reports</reportsDirectory>
           <excludeSpecs>
             <excludeSpec>3.5 - Sends invalid connection preface</excludeSpec>
-            <excludeSpec>8.1.2.6. Malformed Requests and Responses</excludeSpec>
+            <excludeSpec>8.1.2.3 - 8.1.2.6. Malformed Requests and Responses</excludeSpec>
           </excludeSpecs>
         </configuration>
         <executions>


### PR DESCRIPTION
Exclude spec "8.1.2.6. Malformed Requests and Responses" from executing (for now).