### PR TITLE
Using -DskipTests should not run maven-invoker-plugin tests

### DIFF
--- a/tests/jetty-ee10-test-maven-plugin/pom.xml
+++ b/tests/jetty-ee10-test-maven-plugin/pom.xml
@@ -116,7 +116,6 @@
           </execution>
         </executions>
         <configuration>
-          <skipInvocation>false</skipInvocation>
           <addTestClassPath>true</addTestClassPath>
           <ignoreFailures>true</ignoreFailures>
           <setupIncludes>

--- a/tests/jetty-ee9-test-maven-plugin/pom.xml
+++ b/tests/jetty-ee9-test-maven-plugin/pom.xml
@@ -118,7 +118,6 @@
           </execution>
         </executions>
         <configuration>
-          <skipInvocation>false</skipInvocation>
           <addTestClassPath>true</addTestClassPath>
           <ignoreFailures>true</ignoreFailures>
           <setupIncludes>


### PR DESCRIPTION
there are more duplicated which could be inherited, we could fix later.
But this one will make a quick build using `-DskipTests` really quicker :)