### PR TITLE
Restore stage separated Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
         configFileProvider(
                 [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS')]) {
-          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -V -B -e -Djetty.testtracker.log=true $cmdline"
+          sh "mvn --no-transfer-progress -Dmaven.test.failure.ignore=true -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -V -B -e -Djetty.testtracker.log=true $cmdline"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
 #!groovy
 
+/**
+ * IMPORTANT: Changes here need to be reflected in 2 other files as well.
+ *    pom.xml
+ *    build/scripts/ci.sh
+ */
+
 pipeline {
   agent {
     node { label 'linux' }
@@ -49,7 +55,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f jetty-integrations", "maven3")
                 }
               }
@@ -62,7 +67,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f jetty-ee10", "maven3")
                 }
               }
@@ -75,7 +79,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f jetty-ee9", "maven3")
                 }
               }
@@ -88,7 +91,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f jetty-ee8", "maven3")
                 }
               }
@@ -101,7 +103,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f jetty-home", "maven3")
                 }
               }
@@ -114,7 +115,6 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean -T4", "maven3")
                   mavenBuild("jdk17", "clean install -f tests", "maven3")
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
               timeout(time: 120, unit: 'MINUTES') {
                 dir("${env.WORKSPACE}/buildy") {
                   //cleanup all projects
-                  mavenBuild("jdk17", "clean install -f jetty-home", "maven3")
+                  mavenBuild("jdk17", "clean install -pl :jetty-home", "maven3")
                 }
               }
             }

--- a/build/scripts/ci.sh
+++ b/build/scripts/ci.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Represents the command line version of the CI build in Jenkinsfile
+
+mvn clean install -f build
+mvn clean install -N
+mvn clean install -f jetty-core
+mvn clean install -f jetty-integrations
+mvn clean install -f jetty-ee10
+mvn clean install -f jetty-ee9
+mvn clean install -f jetty-ee8
+mvn clean install -f jetty-home
+mvn clean install -f tests
+# mvn clean install -f jetty-p2
+# mvn clean install -f documentation
+

--- a/build/scripts/ci.sh
+++ b/build/scripts/ci.sh
@@ -9,7 +9,7 @@ mvn clean install -f jetty-integrations
 mvn clean install -f jetty-ee10
 mvn clean install -f jetty-ee9
 mvn clean install -f jetty-ee8
-mvn clean install -f jetty-home
+mvn clean install -pl :jetty-home
 mvn clean install -f tests
 # mvn clean install -f jetty-p2
 # mvn clean install -f documentation

--- a/pom.xml
+++ b/pom.xml
@@ -182,16 +182,18 @@
   </pluginRepositories>
 
   <modules>
+    <!-- CAUTION: Any changes to this list will need to be represented
+         in the Jenkinsfile and build/scripts/ci.sh as well -->
     <module>build</module>
-<!--    <module>documentation</module>-->
     <module>jetty-core</module>
     <module>jetty-integrations</module>
     <module>jetty-ee8</module>
     <module>jetty-ee9</module>
     <module>jetty-ee10</module>
     <module>jetty-home</module>
-<!--    <module>jetty-p2</module>-->
     <module>tests</module>
+    <!-- <module>jetty-p2</module> -->
+    <!-- <module>documentation</module> -->
   </modules>
 
   <build>


### PR DESCRIPTION
Restore the Stage separated Jenkinsfile from before.

This has the side effect that our Jenkins/CI builds **does not follow the same rules as a maven command line build** (or IDE build).
Building locally will **not** produce the same results as Jenkins/CI.
It is extremely likely that CI will fail, but local build will not.
If you encounter that, blame this stage separated `Jenkinsfile`.
