### PR TITLE
Issue #8281 Add slf4j impls to forked jetty plugin it tests

### DIFF
--- a/tests/jetty-ee10-test-maven-plugin/src/it/jetty-cdi-start-forked/pom.xml
+++ b/tests/jetty-ee10-test-maven-plugin/src/it/jetty-cdi-start-forked/pom.xml
@@ -69,6 +69,13 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>

--- a/tests/jetty-ee10-test-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/pom.xml
+++ b/tests/jetty-ee10-test-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/pom.xml
@@ -89,6 +89,13 @@
           <stopPort>@jetty.stopPort@</stopPort>
           <stopKey>@jetty.stopKey@</stopKey>
         </configuration>
+        <dependencies>
+            <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+            </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>

--- a/tests/jetty-ee10-test-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/pom.xml
+++ b/tests/jetty-ee10-test-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/pom.xml
@@ -67,6 +67,13 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>

--- a/tests/jetty-ee9-test-maven-plugin/src/it/jetty-cdi-start-forked/pom.xml
+++ b/tests/jetty-ee9-test-maven-plugin/src/it/jetty-cdi-start-forked/pom.xml
@@ -65,6 +65,13 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>

--- a/tests/jetty-ee9-test-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/pom.xml
+++ b/tests/jetty-ee9-test-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/pom.xml
@@ -89,6 +89,13 @@
           <stopPort>@jetty.stopPort@</stopPort>
           <stopKey>@jetty.stopKey@</stopKey>
         </configuration>
+        <dependencies>
+          <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>

--- a/tests/jetty-ee9-test-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/pom.xml
+++ b/tests/jetty-ee9-test-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/pom.xml
@@ -67,6 +67,13 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-slf4j-impl</artifactId>
+              <version>${jetty.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>start-jetty</id>


### PR DESCRIPTION
See #8281 

Adds jetty-slf4j-impl to jetty maven plugin it test executions so jetty log output can be seen.