### PR TITLE
Issue #8216 - OpenID Connect RP-Initiated Logout

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -42,6 +42,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     private static final String CONFIG_PATH = "/.well-known/openid-configuration";
     private static final String AUTHORIZATION_ENDPOINT = "authorization_endpoint";
     private static final String TOKEN_ENDPOINT = "token_endpoint";
+    private static final String END_SESSION_ENDPOINT = "end_session_endpoint";
     private static final String ISSUER = "issuer";
 
     private final HttpClient httpClient;
@@ -164,11 +165,11 @@ public class OpenIdConfiguration extends ContainerLifeCycle
         tokenEndpoint = (String)discoveryDocument.get(TOKEN_ENDPOINT);
         if (tokenEndpoint == null)
             throw new IllegalStateException(TOKEN_ENDPOINT);
-        
-        endSessionEndpoint = (String)discoveryDocument.get("end_session_endpoint");
+
+        // End session endpoint is optional.
         if (endSessionEndpoint == null)
-            throw new IllegalArgumentException("end_session_endpoint");
-            
+            endSessionEndpoint = (String)discoveryDocument.get(END_SESSION_ENDPOINT);
+
         // We are lenient and not throw here as some major OIDC providers do not conform to this.
         if (!Objects.equals(discoveryDocument.get(ISSUER), issuer))
             LOG.warn("The issuer in the metadata is not correct.");

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -100,7 +100,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
                                @Name("authMethod") String authMethod,
                                @Name("httpClient") HttpClient httpClient)
     {
-        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, authorizationEndpoint, httpClient);
+        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, authMethod, httpClient);
     }
 
     /**

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -49,6 +49,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     private final String authMethod;
     private String authEndpoint;
     private String tokenEndpoint;
+    private String endSessionEndpoint;
     private boolean authenticateNewUsers = false;
 
     /**
@@ -74,9 +75,26 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint,
                                String clientId, String clientSecret, HttpClient httpClient)
     {
-        this(issuer, authorizationEndpoint, tokenEndpoint, clientId, clientSecret, "client_secret_post", httpClient);
+        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, "client_secret_post", httpClient);
     }
-
+    
+    /**
+     * Create an OpenID configuration for a specific OIDC provider.
+     * @param issuer The URL of the OpenID provider.
+     * @param authorizationEndpoint the URL of the OpenID provider's authorization endpoint if configured.
+     * @param tokenEndpoint the URL of the OpenID provider's token endpoint if configured.
+     * @param endSessionEndpoint the URL of the OpdnID provider's end session endpoint if configured.
+     * @param httpClient The {@link HttpClient} instance to use.
+     * @param clientId OAuth 2.0 Client Identifier valid at the Authorization Server.
+     * @param clientSecret The client secret known only by the Client and the Authorization Server.
+     */
+    public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint, String endSesseionEndpoint,
+                               HttpClient httpClient, String clientId, String clientSecret)
+    {
+        this(issuer, authorizationEndpoint, tokenEndpoint, endSesseionEndpoint, clientId, clientSecret, "client_secret_post", 
+             httpClient);
+    }
+    
     /**
      * Create an OpenID configuration for a specific OIDC provider.
      * @param issuer The URL of the OpenID provider.
@@ -95,10 +113,34 @@ public class OpenIdConfiguration extends ContainerLifeCycle
                                @Name("authMethod") String authMethod,
                                @Name("httpClient") HttpClient httpClient)
     {
+        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, authMethod, httpClient);
+    }
+
+    /**
+     * Create an OpenID configuration for a specific OIDC provider.
+     * @param issuer The URL of the OpenID provider.
+     * @param authorizationEndpoint the URL of the OpenID provider's authorization endpoint if configured.
+     * @param tokenEndpoint the URL of the OpenID provider's token endpoint if configured.
+     * @param endSessionEndpoint the URL of the OpdnID provider's end session endpoint if configured.
+     * @param clientId OAuth 2.0 Client Identifier valid at the Authorization Server.
+     * @param clientSecret The client secret known only by the Client and the Authorization Server.
+     * @param authMethod Authentication method to use with the Token Endpoint.
+     * @param httpClient The {@link HttpClient} instance to use.
+     */
+    public OpenIdConfiguration(@Name("issuer") String issuer,
+                               @Name("authorizationEndpoint") String authorizationEndpoint,
+                               @Name("tokenEndpoint") String tokenEndpoint,
+                               @Name("endSessionEndpoint") String endSessionEndpoint,
+                               @Name("clientId") String clientId,
+                               @Name("clientSecret") String clientSecret,
+                               @Name("authMethod") String authMethod,
+                               @Name("httpClient") HttpClient httpClient)
+    {
         this.issuer = issuer;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authEndpoint = authorizationEndpoint;
+        this.endSessionEndpoint = endSessionEndpoint;
         this.tokenEndpoint = tokenEndpoint;
         this.httpClient = httpClient != null ? httpClient : newHttpClient();
         this.authMethod = authMethod;
@@ -130,6 +172,10 @@ public class OpenIdConfiguration extends ContainerLifeCycle
         tokenEndpoint = (String)discoveryDocument.get("token_endpoint");
         if (tokenEndpoint == null)
             throw new IllegalArgumentException("token_endpoint");
+        
+        endSessionEndpoint = (String)discoveryDocument.get("end_session_endpoint");
+        if (endSessionEndpoint == null)
+            throw new IllegalArgumentException("end_session_endpoint");
 
         if (!Objects.equals(discoveryDocument.get("issuer"), issuer))
             LOG.warn("The issuer in the metadata is not correct.");
@@ -197,6 +243,11 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public String getTokenEndpoint()
     {
         return tokenEndpoint;
+    }
+    
+    public String getEndSessionEndpoint() 
+    {
+        return endSessionEndpoint;
     }
 
     public String getAuthMethod()

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -78,26 +78,9 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint,
                                String clientId, String clientSecret, HttpClient httpClient)
     {
-        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, "client_secret_post", httpClient);
+        this(issuer, authorizationEndpoint, tokenEndpoint, clientId, clientSecret, "client_secret_post", httpClient);
     }
-    
-    /**
-     * Create an OpenID configuration for a specific OIDC provider.
-     * @param issuer The URL of the OpenID provider.
-     * @param authorizationEndpoint the URL of the OpenID provider's authorization endpoint if configured.
-     * @param tokenEndpoint the URL of the OpenID provider's token endpoint if configured.
-     * @param endSessionEndpoint the URL of the OpdnID provider's end session endpoint if configured.
-     * @param httpClient The {@link HttpClient} instance to use.
-     * @param clientId OAuth 2.0 Client Identifier valid at the Authorization Server.
-     * @param clientSecret The client secret known only by the Client and the Authorization Server.
-     */
-    public OpenIdConfiguration(String issuer, String authorizationEndpoint, String tokenEndpoint, String endSesseionEndpoint,
-                               HttpClient httpClient, String clientId, String clientSecret)
-    {
-        this(issuer, authorizationEndpoint, tokenEndpoint, endSesseionEndpoint, clientId, clientSecret, "client_secret_post", 
-             httpClient);
-    }
-    
+
     /**
      * Create an OpenID configuration for a specific OIDC provider.
      * @param issuer The URL of the OpenID provider.
@@ -116,7 +99,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
                                @Name("authMethod") String authMethod,
                                @Name("httpClient") HttpClient httpClient)
     {
-        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, authMethod, httpClient);
+        this(issuer, authorizationEndpoint, tokenEndpoint, null, clientId, clientSecret, authorizationEndpoint, httpClient);
     }
 
     /**
@@ -146,7 +129,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
         this.endSessionEndpoint = endSessionEndpoint;
         this.tokenEndpoint = tokenEndpoint;
         this.httpClient = httpClient != null ? httpClient : newHttpClient();
-        this.authMethod = authMethod;
+        this.authMethod = authMethod == null ? "client_secret_post" : authMethod;
 
         if (this.issuer == null)
             throw new IllegalArgumentException("Issuer was not configured");
@@ -185,7 +168,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
         endSessionEndpoint = (String)discoveryDocument.get("end_session_endpoint");
         if (endSessionEndpoint == null)
             throw new IllegalArgumentException("end_session_endpoint");
-        
+            
         // We are lenient and not throw here as some major OIDC providers do not conform to this.
         if (!Objects.equals(discoveryDocument.get(ISSUER), issuer))
             LOG.warn("The issuer in the metadata is not correct.");

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.security.openid;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
@@ -155,6 +157,11 @@ public class OpenIdAuthenticationTest
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
         content = response.getContentAsString();
         assertThat(content, containsString("not authenticated"));
+
+        // Test that the user was logged out successfully on the openid provider.
+        assertThat(openIdProvider.getLoggedInUsers().getCurrent(), equalTo(0L));
+        assertThat(openIdProvider.getLoggedInUsers().getMax(), equalTo(1L));
+        assertThat(openIdProvider.getLoggedInUsers().getTotal(), equalTo(1L));
     }
 
     public static class LoginPage extends HttpServlet
@@ -171,10 +178,9 @@ public class OpenIdAuthenticationTest
     public static class LogoutPage extends HttpServlet
     {
         @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
         {
-            request.getSession().invalidate();
-            response.sendRedirect("/");
+            request.logout();
         }
     }
 

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -104,6 +104,7 @@ public class OpenIdAuthenticationTest
         server.addBean(new OpenIdConfiguration(openIdProvider.getProvider(), CLIENT_ID, CLIENT_SECRET));
         securityHandler.setInitParameter(OpenIdAuthenticator.REDIRECT_PATH, "/redirect_path");
         securityHandler.setInitParameter(OpenIdAuthenticator.ERROR_PAGE, "/error");
+        securityHandler.setInitParameter(OpenIdAuthenticator.LOGOUT_REDIRECT_PATH, "/");
         context.setSecurityHandler(securityHandler);
 
         server.start();

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
@@ -321,7 +321,8 @@ public class OpenIdProvider extends ContainerLifeCycle
             String logoutRedirect = req.getParameter("post_logout_redirect_uri");
             if (logoutRedirect == null)
             {
-                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no post_logout_redirect_uri");
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.getWriter().println("logout success on end_session_endpoint");
                 return;
             }
 

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ public class OpenIdProvider extends ContainerLifeCycle
     private static final String CONFIG_PATH = "/.well-known/openid-configuration";
     private static final String AUTH_PATH = "/auth";
     private static final String TOKEN_PATH = "/token";
+    private static final String END_SESSION_PATH = "/end_session";
     private final Map<String, User> issuedAuthCodes = new HashMap<>();
 
     protected final String clientId;
@@ -58,6 +60,7 @@ public class OpenIdProvider extends ContainerLifeCycle
     private int port = 0;
     private String provider;
     private User preAuthedUser;
+    private final CounterStatistic loggedInUsers = new CounterStatistic();
 
     public static void main(String[] args) throws Exception
     {
@@ -91,9 +94,10 @@ public class OpenIdProvider extends ContainerLifeCycle
 
         ServletContextHandler contextHandler = new ServletContextHandler();
         contextHandler.setContextPath("/");
-        contextHandler.addServlet(new ServletHolder(new OpenIdConfigServlet()), CONFIG_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdAuthEndpoint()), AUTH_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdTokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new ConfigServlet()), CONFIG_PATH);
+        contextHandler.addServlet(new ServletHolder(new AuthEndpoint()), AUTH_PATH);
+        contextHandler.addServlet(new ServletHolder(new TokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new EndSessionEndpoint()), END_SESSION_PATH);
         server.setHandler(contextHandler);
 
         addBean(server);
@@ -110,6 +114,11 @@ public class OpenIdProvider extends ContainerLifeCycle
         String authEndpoint = provider + AUTH_PATH;
         String tokenEndpoint = provider + TOKEN_PATH;
         return new OpenIdConfiguration(provider, authEndpoint, tokenEndpoint, clientId, clientSecret, null);
+    }
+
+    public CounterStatistic getLoggedInUsers()
+    {
+        return loggedInUsers;
     }
 
     @Override
@@ -144,7 +153,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         redirectUris.add(uri);
     }
 
-    public class OpenIdAuthEndpoint extends HttpServlet
+    public class AuthEndpoint extends HttpServlet
     {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -252,7 +261,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         }
     }
 
-    public class OpenIdTokenEndpoint extends HttpServlet
+    private class TokenEndpoint extends HttpServlet
     {
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
@@ -285,12 +294,44 @@ public class OpenIdProvider extends ContainerLifeCycle
                 "\"token_type\": \"Bearer\"" +
                 "}";
 
+            loggedInUsers.increment();
             resp.setContentType("text/plain");
             resp.getWriter().print(response);
         }
     }
 
-    public class OpenIdConfigServlet extends HttpServlet
+    private class EndSessionEndpoint extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            doPost(req, resp);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            String idToken = req.getParameter("id_token_hint");
+            if (idToken == null)
+            {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no id_token_hint");
+                return;
+            }
+
+            String logoutRedirect = req.getParameter("post_logout_redirect_uri");
+            if (logoutRedirect == null)
+            {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no post_logout_redirect_uri");
+                return;
+            }
+
+            loggedInUsers.decrement();
+            resp.setContentType("text/plain");
+            resp.sendRedirect(logoutRedirect);
+        }
+    }
+
+    private class ConfigServlet extends HttpServlet
     {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -299,6 +340,7 @@ public class OpenIdProvider extends ContainerLifeCycle
                 "\"issuer\": \"" + provider + "\"," +
                 "\"authorization_endpoint\": \"" + provider + AUTH_PATH + "\"," +
                 "\"token_endpoint\": \"" + provider + TOKEN_PATH + "\"," +
+                "\"end_session_endpoint\": \"" + provider + END_SESSION_PATH + "\"," +
                 "}";
 
             resp.getWriter().write(discoveryDocument);
@@ -335,6 +377,14 @@ public class OpenIdProvider extends ContainerLifeCycle
         {
             long expiry = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
             return JwtEncoder.createIdToken(provider, clientId, subject, name, expiry);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof User))
+                return false;
+            return Objects.equals(subject, ((User)obj).subject) && Objects.equals(name, ((User)obj).name);
         }
     }
 }


### PR DESCRIPTION
## Issue #8216

see https://openid.net/specs/openid-connect-rpinitiated-1_0.html

- Redirect back to openid provider when `HttpServletRequest.logout()` is called.
- Store the `end_session_endpoint` in the `OpenIdConfiguration`.