### PR TITLE
fix some filtering of files for ee9 to ee8 conversion

### DIFF
--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -118,11 +118,11 @@
 <!--        <artifactId>jetty-ee8-proxy</artifactId>-->
 <!--        <version>${project.version}</version>-->
 <!--      </dependency>-->
-<!--      <dependency>-->
-<!--        <groupId>org.eclipse.jetty.ee8</groupId>-->
-<!--        <artifactId>jetty-ee8-quickstart</artifactId>-->
-<!--        <version>${project.version}</version>-->
-<!--      </dependency>-->
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-quickstart</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-nested</artifactId>

--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -370,11 +370,10 @@
       <artifactId>asm-analysis</artifactId>
     </dependency>
 
-
-<!--    <dependency>-->
-<!--      <groupId>org.eclipse.jetty.ee8</groupId>-->
-<!--      <artifactId>jetty-ee8-quickstart</artifactId>-->
-<!--    </dependency>-->
+    <dependency>
+      <groupId>org.eclipse.jetty.ee8</groupId>
+      <artifactId>jetty-ee8-quickstart</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-servlet</artifactId>

--- a/jetty-ee8/jetty-ee8-plus/pom.xml
+++ b/jetty-ee8/jetty-ee8-plus/pom.xml
@@ -14,8 +14,6 @@
     <ee9.module>jetty-ee9-plus</ee9.module>
     <bundle-symbolic-name>${project.groupId}.plus</bundle-symbolic-name>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.plus.*</spotbugs.onlyAnalyze>
-    <!-- see issue #8209 -->
-    <skipTests>true</skipTests>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-quickstart/pom.xml
+++ b/jetty-ee8/jetty-ee8-quickstart/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.eclipse.jetty.ee8</groupId>
+    <artifactId>jetty-ee8</artifactId>
+    <version>12.0.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jetty-ee8-quickstart</artifactId>
+  <name>EE8 :: Jetty :: Quick Start</name>
+  <description>Jetty Quick Start</description>
+
+  <properties>
+    <ee9.module>jetty-ee9-quickstart</ee9.module>
+    <bundle-symbolic-name>${project.groupId}.quickstart</bundle-symbolic-name>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Require-Capability>
+              osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
+            </Require-Capability>
+            <Provide-Capability>
+              osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.ee8.webapp.Configuration
+            </Provide-Capability>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee8</groupId>
+      <artifactId>jetty-ee8-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee8</groupId>
+      <artifactId>jetty-ee8-plus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee8</groupId>
+      <artifactId>jetty-ee8-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee8/jetty-ee8-quickstart/src/main/config/etc/jetty-ee8-quickstart.xml
+++ b/jetty-ee8/jetty-ee8-quickstart/src/main/config/etc/jetty-ee8-quickstart.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call class="org.eclipse.jetty.ee8.quickstart.QuickStartConfiguration" name="configureMode">
+    <Arg><Ref refid="Server"/></Arg>
+    <Arg><Property name="jetty.quickstart.mode"/></Arg>
+  </Call>
+
+  <Ref refid="WebAppProvider">
+      <Get name="properties">
+        <Put name="jetty.deploy.attribute.org.eclipse.jetty.quickstart.mode"><Property name="jetty.quickstart.mode"/></Put>
+        <Put name="jetty.deploy.attribute.org.eclipse.jetty.quickstart.origin"><Property name="jetty.quickstart.origin"/></Put>
+        <Put name="jetty.deploy.attribute.org.eclipse.jetty.quickstart.xml"><Property name="jetty.quickstart.xml"/></Put>
+      </Get>
+  </Ref>
+
+</Configure>

--- a/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
+++ b/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
@@ -1,0 +1,24 @@
+# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+
+[description]
+Enables the Jetty Quickstart module for rapid deployment of preconfigured web applications.
+
+[environment]
+ee8
+
+[depend]
+server
+ee8-deploy
+
+[lib]
+lib/jetty-ee8-quickstart-${jetty.version}.jar
+
+[xml]
+etc/jetty-ee8-quickstart.xml
+
+[ini-template]
+
+# Modes are AUTO, GENERATE, QUICKSTART
+# jetty.quickstart.mode=AUTO
+# jetty.quickstart.origin=origin
+# jetty.quickstart.xml=

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -58,6 +58,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>p12</nonFilteredFileExtension>
+            <nonFilteredFileExtension>raw</nonFilteredFileExtension>
+            <nonFilteredFileExtension>jar</nonFilteredFileExtension>
+            <nonFilteredFileExtension>war</nonFilteredFileExtension>
+            <nonFilteredFileExtension>jks</nonFilteredFileExtension>
+            <nonFilteredFileExtension>tga</nonFilteredFileExtension>
+            <nonFilteredFileExtension>zip</nonFilteredFileExtension>
+            <nonFilteredFileExtension>gz</nonFilteredFileExtension>
+            <nonFilteredFileExtension>tif</nonFilteredFileExtension>
+            <nonFilteredFileExtension>tiff</nonFilteredFileExtension>
+            <nonFilteredFileExtension>svgz</nonFilteredFileExtension>
+            <nonFilteredFileExtension>jp2</nonFilteredFileExtension>
+            <nonFilteredFileExtension>rar</nonFilteredFileExtension>
+            <nonFilteredFileExtension>bz2</nonFilteredFileExtension>
+            <nonFilteredFileExtension>br</nonFilteredFileExtension>
+            <nonFilteredFileExtension>xcf</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -97,9 +117,6 @@
                 <mavenFilteringHint>ee9-to-ee8</mavenFilteringHint>
               </mavenFilteringHints>
               <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-              <nonFilteredFileExtensions>
-                <nonFilteredFileExtension>p12</nonFilteredFileExtension>
-              </nonFilteredFileExtensions>
               <resources>
                 <resource>
                   <filtering>true</filtering>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -102,6 +102,7 @@
               </nonFilteredFileExtensions>
               <resources>
                 <resource>
+                  <filtering>true</filtering>
                   <directory>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}/src/test/resources</directory>
                 </resource>
               </resources>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -97,6 +97,9 @@
                 <mavenFilteringHint>ee9-to-ee8</mavenFilteringHint>
               </mavenFilteringHints>
               <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+              <nonFilteredFileExtensions>
+                <nonFilteredFileExtension>p12</nonFilteredFileExtension>
+              </nonFilteredFileExtensions>
               <resources>
                 <resource>
                   <directory>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}/src/test/resources</directory>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -22,6 +22,7 @@
     <checkstyle.skip>true</checkstyle.skip>
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
+    <modify-sources-plugin.version>1.0.0-SNAPSHOT</modify-sources-plugin.version>
   </properties>
 
   <modules>
@@ -49,7 +50,7 @@
         <plugin>
           <groupId>org.eclipse.jetty.toolchain</groupId>
           <artifactId>jetty-modify-sources-maven-plugin</artifactId>
-          <version>1.0.0-SNAPSHOT</version>
+          <version>${modify-sources-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -57,6 +58,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>3.3.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-modify-sources-maven-plugin</artifactId>
+            <version>${modify-sources-plugin.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>copy-ee8-resources</id>
@@ -80,6 +93,9 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <mavenFilteringHints>
+                <mavenFilteringHint>ee9-to-ee8</mavenFilteringHint>
+              </mavenFilteringHints>
               <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
               <resources>
                 <resource>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -35,6 +35,7 @@
     <module>jetty-ee8-jndi</module>
     <module>jetty-ee8-annotations</module>
     <module>jetty-ee8-websocket</module>
+    <module>jetty-ee8-quickstart</module>
     <module>jetty-ee8-bom</module>
     <module>jetty-ee8-demos</module>
     <module>jetty-ee8-home</module>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -106,6 +106,26 @@
               </resources>
             </configuration>
           </execution>
+          <!-- TODO this would be nice to reuse mod files from ee9 but the mod file name need to be changed as well as the content -->
+<!--          <execution>-->
+<!--            <id>copy-ee8-modules-resources</id>-->
+<!--            <phase>generate-resources</phase>-->
+<!--            <goals>-->
+<!--              <goal>copy-resources</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <mavenFilteringHints>-->
+<!--                <mavenFilteringHint>ee9-to-ee8</mavenFilteringHint>-->
+<!--              </mavenFilteringHints>-->
+<!--              <outputDirectory>${project.build.directory}/jetty-config-files</outputDirectory>-->
+<!--              <resources>-->
+<!--                <resource>-->
+<!--                  <filtering>true</filtering>-->
+<!--                  <directory>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}/src/main/config</directory>-->
+<!--                </resource>-->
+<!--              </resources>-->
+<!--            </configuration>-->
+<!--          </execution>-->
           <execution>
             <id>copy-ee8-test-resources</id>
             <phase>generate-test-resources</phase>

--- a/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
@@ -124,7 +124,7 @@ public class TestQuickStart
         quickstart.addConfiguration(new QuickStartConfiguration());
         quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
         quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
-        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        quickstart.setDescriptor(MavenTestingUtils.getTargetFile("test-classes/web.xml").getAbsolutePath());
         quickstart.setContextPath("/foo");
         server.setHandler(quickstart);
         server.setDryRun(true);
@@ -167,7 +167,7 @@ public class TestQuickStart
         quickstart.addConfiguration(new QuickStartConfiguration());
         quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
         quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
-        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        quickstart.setDescriptor(MavenTestingUtils.getTargetFile("test-classes/web.xml").getAbsolutePath());
         quickstart.setContextPath("/foo");
         server.setHandler(quickstart);
         server.setDryRun(true);
@@ -237,10 +237,10 @@ public class TestQuickStart
         quickstart.addConfiguration(new QuickStartConfiguration());
         quickstart.setWar(testDir.toURI().toURL().toExternalForm());
         quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
-        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        quickstart.setDescriptor(MavenTestingUtils.getTargetFile("test-classes/web.xml").getAbsolutePath());
 
         //apply the context xml file
-        XmlConfiguration xmlConfig = new XmlConfiguration(Resource.newResource(MavenTestingUtils.getTestResourceFile("context.xml").toPath()));
+        XmlConfiguration xmlConfig = new XmlConfiguration(Resource.newResource(MavenTestingUtils.getTargetFile("test-classes/context.xml").toPath()));
         xmlConfig.configure(quickstart);
 
         //generate the quickstart
@@ -258,7 +258,7 @@ public class TestQuickStart
         quickstart.getServerClassMatcher().exclude("org.eclipse.jetty.ee9.quickstart.");
         quickstart.addConfiguration(new QuickStartConfiguration());
         quickstart.setWar(testDir.toURI().toURL().toExternalForm());
-        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        quickstart.setDescriptor(MavenTestingUtils.getTargetFile("test-classes/web.xml").getAbsolutePath());
         quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.AUTO);
         server.setHandler(quickstart);
         


### PR DESCRIPTION
- restore ee8-quickstart
- fix some tests but yeah filtering of the resources is the issue...
- use our special resources filtering
- enable back ee8-plus as filtering is working as well
- dot not filter p12 files
