### PR TITLE
jetty 12.0.x ee8 enable websocket tests

### DIFF
--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
@@ -13,8 +13,6 @@
   <properties>
     <ee9.module>jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests</ee9.module>
     <bundle-symbolic-name>${project.groupId}.javax.tests</bundle-symbolic-name>
-    <!-- FIXME issue #8278 -->
-    <skipTests>true</skipTests>
   </properties>
 
   <dependencies>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
@@ -13,8 +13,6 @@
   <properties>
     <ee9.module>jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests</ee9.module>
     <bundle-symbolic-name>${project.groupId}.tests</bundle-symbolic-name>
-    <!-- FIXME issue #8278 -->
-    <skipTests>true</skipTests>
   </properties>
 
   <dependencies>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/LocalServer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/LocalServer.java
@@ -190,7 +190,7 @@ public class LocalServer extends ContainerLifeCycle implements LocalFuzzer.Provi
             httpConfig.setSendDateHeader(false);
 
             sslContextFactory = new SslContextFactory.Server();
-            sslContextFactory.setKeyStorePath(MavenTestingUtils.getTestResourceFile("keystore.p12").getAbsolutePath());
+            sslContextFactory.setKeyStorePath(MavenTestingUtils.getTargetFile("test-classes/keystore.p12").getAbsolutePath());
             sslContextFactory.setKeyStorePassword("storepwd");
             sslContextFactory.setExcludeCipherSuites("SSL_RSA_WITH_DES_CBC_SHA", "SSL_DHE_RSA_WITH_DES_CBC_SHA", "SSL_DHE_DSS_WITH_DES_CBC_SHA",
                 "SSL_RSA_EXPORT_WITH_RC4_40_MD5", "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA", "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/WSServer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/WSServer.java
@@ -127,7 +127,7 @@ public class WSServer extends LocalServer implements LocalFuzzer.Provider
 
         public void copyWebInf(String testResourceName) throws IOException
         {
-            File testWebXml = MavenTestingUtils.getTestResourceFile(testResourceName);
+            File testWebXml = MavenTestingUtils.getTargetFile("test-classes/" + testResourceName);
             Path webXml = webInf.resolve("web.xml");
             IO.copy(testWebXml, webXml.toFile());
         }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/DecoderTextStreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/DecoderTextStreamTest.java
@@ -51,7 +51,7 @@ public class DecoderTextStreamTest extends AbstractClientSessionTest
     {
         Decoder.TextStream<Quotes> decoder = new QuotesDecoder();
 
-        Path quotesPath = MavenTestingUtils.getTestResourcePath("quotes-ben.txt");
+        Path quotesPath = MavenTestingUtils.getTargetPath("test-classes/quotes-ben.txt");
         try (Reader reader = Files.newBufferedReader(quotesPath))
         {
             Quotes quotes = decoder.decode(reader);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/QuotesUtil.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/QuotesUtil.java
@@ -31,7 +31,7 @@ public class QuotesUtil
     public static List<String> loadLines(String filename) throws IOException
     {
         // read file
-        File qfile = MavenTestingUtils.getTestResourceFile(filename);
+        File qfile = MavenTestingUtils.getTargetFile("test-classes/" + filename);
         List<String> lines = new ArrayList<>();
         try (FileReader reader = new FileReader(qfile);
              BufferedReader buf = new BufferedReader(reader))

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesEncoderTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesEncoderTest.java
@@ -131,7 +131,7 @@ public class QuotesEncoderTest
         Quotes quotes = new Quotes();
 
         // read file
-        File qfile = MavenTestingUtils.getTestResourceFile(filename);
+        File qfile = MavenTestingUtils.getTargetFile("test-classes/" + filename);
         try (FileReader reader = new FileReader(qfile);
              BufferedReader buf = new BufferedReader(reader))
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesUtil.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesUtil.java
@@ -31,7 +31,7 @@ public class QuotesUtil
     public static List<String> loadLines(String filename) throws IOException
     {
         // read file
-        File qfile = MavenTestingUtils.getTestResourceFile(filename);
+        File qfile = MavenTestingUtils.getTargetFile("test-classes/" + filename);
         List<String> lines = new ArrayList<>();
         try (FileReader reader = new FileReader(qfile);
              BufferedReader buf = new BufferedReader(reader))

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/StreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/StreamTest.java
@@ -116,7 +116,7 @@ public class StreamTest
 
     private void upload(String filename) throws Exception
     {
-        File inputFile = MavenTestingUtils.getTestResourceFile("data/" + filename);
+        File inputFile = MavenTestingUtils.getTargetFile("test-classes/data/" + filename);
 
         WebSocketContainer client = ContainerProvider.getWebSocketContainer();
         try
@@ -127,7 +127,7 @@ public class StreamTest
             socket.uploadFile(inputFile);
             socket.awaitClose();
 
-            File sha1File = MavenTestingUtils.getTestResourceFile("data/" + filename + ".sha");
+            File sha1File = MavenTestingUtils.getTargetFile("test-classes/data/" + filename + ".sha");
             assertFileUpload(new File(outputDir, filename), sha1File);
         }
         finally

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketFilterTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketFilterTest.java
@@ -308,7 +308,7 @@ public class JettyWebSocketFilterTest
     {
         String defaultIdleTimeout = Long.toString(WebSocketConstants.DEFAULT_IDLE_TIMEOUT.toMillis());
         JettyWebSocketWebApp webApp = new JettyWebSocketWebApp("wsuf-ordering1");
-        Path webXml = MavenTestingUtils.getTestResourcePath("wsuf-ordering1.xml");
+        Path webXml = MavenTestingUtils.getTargetPath("test-classes/wsuf-ordering1.xml");
         webApp.copyWebXml(webXml);
         webApp.copyClass(WebSocketEchoServletContextListener.class);
         webApp.copyClass(WebSocketEchoServletContextListener.EchoSocket.class);
@@ -342,7 +342,7 @@ public class JettyWebSocketFilterTest
     {
         String timeoutFromAltFilter = "5999";
         JettyWebSocketWebApp webApp = new JettyWebSocketWebApp("wsuf-ordering2");
-        Path webXml = MavenTestingUtils.getTestResourcePath("wsuf-ordering2.xml");
+        Path webXml = MavenTestingUtils.getTargetPath("test-classes/wsuf-ordering2.xml");
         webApp.copyWebXml(webXml);
         webApp.copyClass(WebSocketEchoServletContextListener.class);
         webApp.copyClass(WebSocketEchoServletContextListener.EchoSocket.class);

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <jmhjar.name>benchmarks</jmhjar.name>
     <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.slf4j.import.packages>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
     <!-- dependency versions -->
     <alpn.agent.version>2.0.10</alpn.agent.version>


### PR DESCRIPTION
- renable tests for jetty-ee8-websocket-javax-tests
- fix some test resources path
