### PR TITLE
Issue #8296 and #8259 -  AllowedResourceAliasChecker improvements

### DIFF
--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/WebAppProvider.java
@@ -271,8 +271,8 @@ public class WebAppProvider extends ScanningAppProvider
         // Resource aliases (after getting name) to ensure baseResource is not an alias
         if (resource.isAlias())
         {
-            file = new File(resource.getAlias()).toPath().toRealPath().toFile();
-            resource = Resource.newResource(file);
+            resource = Resource.resolveAlias(resource);
+            file = resource.getFile();
             if (!resource.exists())
                 throw new IllegalStateException("App resource does not exist " + resource);
         }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
@@ -43,6 +44,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     protected static final LinkOption[] NO_FOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
 
     private final ContextHandler _contextHandler;
+    private final Supplier<Resource> _resourceBaseSupplier;
     private final List<Path> _protected = new ArrayList<>();
     private final AllowedResourceAliasCheckListener _listener = new AllowedResourceAliasCheckListener();
     private boolean _initialized;
@@ -53,7 +55,18 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
      */
     public AllowedResourceAliasChecker(ContextHandler contextHandler)
     {
+        this(contextHandler, contextHandler::getBaseResource);
+    }
+
+    public AllowedResourceAliasChecker(ContextHandler contextHandler, Resource baseResource)
+    {
+        this(contextHandler, () -> baseResource);
+    }
+
+    public AllowedResourceAliasChecker(ContextHandler contextHandler, Supplier<Resource> resourceBaseSupplier)
+    {
         _contextHandler = Objects.requireNonNull(contextHandler);
+        _resourceBaseSupplier = Objects.requireNonNull(resourceBaseSupplier);
     }
 
     protected ContextHandler getContextHandler()
@@ -63,7 +76,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
 
     private void extractBaseResourceFromContext()
     {
-        _base = getPath(_contextHandler.getBaseResource());
+        _base = getPath(_resourceBaseSupplier.get());
         if (_base == null)
             return;
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -45,6 +45,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     private final ContextHandler _contextHandler;
     private final List<Path> _protected = new ArrayList<>();
     private final AllowedResourceAliasCheckListener _listener = new AllowedResourceAliasCheckListener();
+    private boolean _initialized;
     protected Path _base;
 
     /**
@@ -60,7 +61,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
         return _contextHandler;
     }
 
-    protected void initialize()
+    private void extractBaseResourceFromContext()
     {
         _base = getPath(_contextHandler.getBaseResource());
         if (_base == null)
@@ -82,6 +83,12 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
             LOG.warn("Base resource failure ({} is disabled): {}", this.getClass().getName(), _base, e);
             _base = null;
         }
+    }
+
+    protected void initialize()
+    {
+        extractBaseResourceFromContext();
+        _initialized = true;
     }
 
     @Override
@@ -106,6 +113,8 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Co
     @Override
     public boolean check(String pathInContext, Resource resource)
     {
+        if (!_initialized)
+            extractBaseResourceFromContext();
         if (_base == null)
             return false;
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,11 @@ public class SymlinkAllowedResourceAliasChecker extends AllowedResourceAliasChec
     public SymlinkAllowedResourceAliasChecker(ContextHandler contextHandler)
     {
         super(contextHandler);
+    }
+
+    public SymlinkAllowedResourceAliasChecker(ContextHandler contextHandler, Resource baseResource)
+    {
+        super(contextHandler, baseResource);
     }
 
     @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -861,9 +861,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         if (getBaseResource() != null && getBaseResource().isAlias())
         {
             // We may have symlink to baseResource, try to resolve symlink if possible.
-            File file = getBaseResource().getFile();
-            if (file != null)
-                _baseResource = Resource.newResource(file.toPath().toRealPath());
+            _baseResource = Resource.resolveAlias(_baseResource);
 
             LOG.warn("BaseResource {} is aliased to {} in {}. May not be supported in future releases.",
                 getBaseResource(), getBaseResource().getAlias(), this);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -859,8 +859,15 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             throw new IllegalStateException("Null contextPath");
 
         if (getBaseResource() != null && getBaseResource().isAlias())
+        {
+            // We may have symlink to baseResource, try to resolve symlink if possible.
+            File file = getBaseResource().getFile();
+            if (file != null)
+                _baseResource = Resource.newResource(file.toPath().toRealPath());
+
             LOG.warn("BaseResource {} is aliased to {} in {}. May not be supported in future releases.",
                 getBaseResource(), getBaseResource().getAlias(), this);
+        }
 
         _availability.set(Availability.STARTING);
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -77,6 +77,26 @@ public abstract class Resource implements ResourceFactory, Closeable
         return __defaultUseCaches;
     }
 
+    public static Resource resolveAlias(Resource resource)
+    {
+        if (!resource.isAlias())
+            return resource;
+
+        try
+        {
+            File file = resource.getFile();
+            if (file != null)
+                return Resource.newResource(file.toPath().toRealPath());
+        }
+        catch (IOException e)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("resolve alias failed", e);
+        }
+
+        return resource;
+    }
+
     /**
      * Construct a resource from a uri.
      *

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -77,6 +77,11 @@ public abstract class Resource implements ResourceFactory, Closeable
         return __defaultUseCaches;
     }
 
+    /**
+     * Attempt to resolve the real path of a Resource to potentially remove any symlinks causing the Resource to be an alias.
+     * @param resource the resource to resolve.
+     * @return a new Resource resolved to the real path of the original Resource, or the original resource if it was not an alias.
+     */
     public static Resource resolveAlias(Resource resource)
     {
         if (!resource.isAlias())

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
@@ -32,8 +32,8 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,13 +42,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AliasCheckerMultipleResourceBasesTest
 {
-    private static Server _server;
-    private static ServerConnector _connector;
-    private static HttpClient _client;
-    private static ServletContextHandler _context;
-    private static Path _webRootPath;
-    private static Path _altDir1Symlink;
-    private static Path _altDir2Symlink;
+    private Server _server;
+    private ServerConnector _connector;
+    private HttpClient _client;
+    private ServletContextHandler _context;
+    private Path _webRootPath;
+    private Path _altDir1Symlink;
+    private Path _altDir2Symlink;
 
     private static Path getResource(String path) throws Exception
     {
@@ -62,7 +62,7 @@ public class AliasCheckerMultipleResourceBasesTest
         IO.delete(path.toFile());
     }
 
-    private static void setAliasCheckers(ContextHandler.AliasCheck... aliasChecks)
+    private void setAliasCheckers(ContextHandler.AliasCheck... aliasChecks)
     {
         _context.clearAliasChecks();
         if (aliasChecks != null)
@@ -74,8 +74,8 @@ public class AliasCheckerMultipleResourceBasesTest
         }
     }
 
-    @BeforeAll
-    public static void beforeAll() throws Exception
+    @BeforeEach
+    public void before() throws Exception
     {
         _webRootPath = getResource("webroot");
 
@@ -106,8 +106,8 @@ public class AliasCheckerMultipleResourceBasesTest
         _client.start();
     }
 
-    @AfterAll
-    public static void afterAll() throws Exception
+    @AfterEach
+    public void after() throws Exception
     {
         Files.delete(_altDir1Symlink);
         Files.delete(_altDir2Symlink);
@@ -119,8 +119,6 @@ public class AliasCheckerMultipleResourceBasesTest
     @Test
     public void test() throws Exception
     {
-        System.err.println(_webRootPath.toAbsolutePath());
-
         ServletHolder servletHolder;
         servletHolder = _context.addServlet(DefaultServlet.class, "/defaultServlet1/*");
         servletHolder.setInitParameter("resourceBase", _altDir1Symlink.toString());

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
@@ -1,0 +1,161 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.util.resource.Resource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AliasCheckerMultipleResourceBasesTest
+{
+    private static Server _server;
+    private static ServerConnector _connector;
+    private static HttpClient _client;
+    private static ServletContextHandler _context;
+    private static Path _webRootPath;
+    private static Path _altDir1Symlink;
+    private static Path _altDir2Symlink;
+
+    private static Path getResource(String path) throws Exception
+    {
+        URL url = AliasCheckerMultipleResourceBasesTest.class.getClassLoader().getResource(path);
+        assertNotNull(url);
+        return new File(url.toURI()).toPath();
+    }
+
+    private static void delete(Path path)
+    {
+        IO.delete(path.toFile());
+    }
+
+    private static void setAliasCheckers(ContextHandler.AliasCheck... aliasChecks)
+    {
+        _context.clearAliasChecks();
+        if (aliasChecks != null)
+        {
+            for (ContextHandler.AliasCheck aliasCheck : aliasChecks)
+            {
+                _context.addAliasCheck(aliasCheck);
+            }
+        }
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception
+    {
+        _webRootPath = getResource("webroot");
+
+        _altDir1Symlink = _webRootPath.resolve("../altDir1Symlink");
+        delete(_altDir1Symlink);
+        Path altDir1 = _webRootPath.resolve("../altDir1").toAbsolutePath();
+        Files.createSymbolicLink(_altDir1Symlink, altDir1).toFile().deleteOnExit();
+
+        _altDir2Symlink = _webRootPath.resolve("../altDir2Symlink");
+        delete(_altDir2Symlink);
+        Path altDir2 = _webRootPath.resolve("../altDir2").toAbsolutePath();
+        Files.createSymbolicLink(_altDir2Symlink, altDir2).toFile().deleteOnExit();
+
+        // Create and start Server and Client.
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+        _context = new ServletContextHandler();
+
+        _context.setContextPath("/");
+        _context.setBaseResource(new PathResource(_webRootPath));
+        _context.setWelcomeFiles(new String[]{"index.html"});
+        _context.getMimeTypes().addMimeMapping("txt", "text/plain;charset=utf-8");
+        _server.setHandler(_context);
+        _context.clearAliasChecks();
+
+        _client = new HttpClient();
+        _client.start();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception
+    {
+        Files.delete(_altDir1Symlink);
+        Files.delete(_altDir2Symlink);
+
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        System.err.println(_webRootPath.toAbsolutePath());
+
+        ServletHolder servletHolder;
+        servletHolder = _context.addServlet(DefaultServlet.class, "/defaultServlet1/*");
+        servletHolder.setInitParameter("resourceBase", _altDir1Symlink.toString());
+        servletHolder.setInitParameter("pathInfoOnly", "true");
+        servletHolder = _context.addServlet(DefaultServlet.class, "/defaultServlet2/*");
+        servletHolder.setInitParameter("resourceBase", _altDir2Symlink.toString());
+        servletHolder.setInitParameter("pathInfoOnly", "true");
+
+        setAliasCheckers(
+            new SymlinkAllowedResourceAliasChecker(_context, Resource.newResource(_altDir1Symlink)),
+            new SymlinkAllowedResourceAliasChecker(_context, Resource.newResource(_altDir2Symlink))
+        );
+
+        _server.start();
+
+        // Can access file 1 only through default servlet 1.
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/defaultServlet1/file1");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), is("file 1 contents"));
+
+        // File 2 cannot be found with default servlet 1.
+        uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/defaultServlet1/file2");
+        response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+
+        // Can access file 2 only through default servlet 2.
+        uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/defaultServlet2/file2");
+        response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), is("file 2 contents"));
+
+        // File 1 cannot be found with default servlet 2.
+        uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/defaultServlet2/file1");
+        response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+}

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
@@ -35,8 +35,8 @@ import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.PathResource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,11 +48,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AliasCheckerWebRootIsSymlinkTest
 {
-    private static Server _server;
-    private static ServerConnector _connector;
-    private static HttpClient _client;
-    private static ServletContextHandler _context;
-    private static Path _webrootSymlink;
+    private Server _server;
+    private ServerConnector _connector;
+    private HttpClient _client;
+    private ServletContextHandler _context;
+    private Path _webrootSymlink;
 
     private static Path getResource(String path) throws Exception
     {
@@ -66,15 +66,15 @@ public class AliasCheckerWebRootIsSymlinkTest
         IO.delete(path.toFile());
     }
 
-    private static void setAliasChecker(ContextHandler.AliasCheck aliasChecker)
+    private void setAliasChecker(ContextHandler.AliasCheck aliasChecker)
     {
         _context.clearAliasChecks();
         if (aliasChecker != null)
             _context.addAliasCheck(aliasChecker);
     }
 
-    @BeforeAll
-    public static void beforeAll() throws Exception
+    @BeforeEach
+    public void before() throws Exception
     {
         Path webRootPath = getResource("webroot");
 
@@ -101,8 +101,8 @@ public class AliasCheckerWebRootIsSymlinkTest
         _client.start();
     }
 
-    @AfterAll
-    public static void afterAll() throws Exception
+    @AfterEach
+    public void after() throws Exception
     {
         // Try to delete all files now so that the symlinks do not confuse other tests.
         Files.delete(_webrootSymlink);

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
@@ -136,6 +136,7 @@ public class AliasCheckerWebRootIsSymlinkTest
             }
         });
         _server.start();
+        assertThat(_context.getBaseResource().isAlias(), equalTo(false));
 
         // We can access web.xml with ServletContext.getResource().
         InputStream webXml = resource.get(5, TimeUnit.SECONDS);

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerWebRootIsSymlinkTest.java
@@ -1,0 +1,158 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AliasCheckerWebRootIsSymlinkTest
+{
+    private static Server _server;
+    private static ServerConnector _connector;
+    private static HttpClient _client;
+    private static ServletContextHandler _context;
+    private static Path _webrootSymlink;
+
+    private static Path getResource(String path) throws Exception
+    {
+        URL url = AliasCheckerWebRootIsSymlinkTest.class.getClassLoader().getResource(path);
+        assertNotNull(url);
+        return new File(url.toURI()).toPath();
+    }
+
+    private static void delete(Path path)
+    {
+        IO.delete(path.toFile());
+    }
+
+    private static void setAliasChecker(ContextHandler.AliasCheck aliasChecker)
+    {
+        _context.clearAliasChecks();
+        if (aliasChecker != null)
+            _context.addAliasCheck(aliasChecker);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception
+    {
+        Path webRootPath = getResource("webroot");
+
+        // External symlink to webroot.
+        _webrootSymlink = webRootPath.resolve("../webrootSymlink");
+        delete(_webrootSymlink);
+        Files.createSymbolicLink(_webrootSymlink, webRootPath).toFile().deleteOnExit();
+
+        // Create and start Server and Client.
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+        _context = new ServletContextHandler();
+
+        _context.setContextPath("/");
+        _context.setBaseResource(new PathResource(_webrootSymlink));
+        _context.setWelcomeFiles(new String[]{"index.html"});
+        _context.getMimeTypes().addMimeMapping("txt", "text/plain;charset=utf-8");
+        _server.setHandler(_context);
+        _context.addServlet(DefaultServlet.class, "/");
+        _context.clearAliasChecks();
+
+        _client = new HttpClient();
+        _client.start();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception
+    {
+        // Try to delete all files now so that the symlinks do not confuse other tests.
+        Files.delete(_webrootSymlink);
+
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        // WEB-INF is a protected target, and enable symlink alias checker.
+        _context.setProtectedTargets(new String[]{"/WEB-INF"});
+        setAliasChecker(new SymlinkAllowedResourceAliasChecker(_context));
+
+        CompletableFuture<InputStream> resource = new CompletableFuture<>();
+        _context.addEventListener(new ServletContextListener()
+        {
+            @Override
+            public void contextInitialized(ServletContextEvent sce)
+            {
+                try
+                {
+                    // Getting resource with API should allow you to bypass security constraints.
+                    resource.complete(sce.getServletContext().getResourceAsStream("/WEB-INF/web.xml"));
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        _server.start();
+
+        // We can access web.xml with ServletContext.getResource().
+        InputStream webXml = resource.get(5, TimeUnit.SECONDS);
+        assertNotNull(webXml);
+        String content = IO.toString(webXml);
+        assertThat(content, equalTo("This is the web.xml file."));
+
+        // Can access normal files in the webroot dir.
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/file");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), is("This file is inside webroot."));
+
+        // Cannot access web.xml with an external request.
+        uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/WEB-INF/web.xml");
+        response = _client.GET(uri);
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+        assertThat(response.getContentAsString(), not(containsString("This file is inside webroot.")));
+    }
+}

--- a/tests/test-integration/src/test/resources/altDir1/file1
+++ b/tests/test-integration/src/test/resources/altDir1/file1
@@ -1,0 +1,1 @@
+file 1 contents

--- a/tests/test-integration/src/test/resources/altDir2/file2
+++ b/tests/test-integration/src/test/resources/altDir2/file2
@@ -1,0 +1,1 @@
+file 2 contents


### PR DESCRIPTION
## Issue #8296 and #8259

- change `AllowedResourceAliasChecker` and `SymlinkAllowedResourceAliasChecker` to allow custom resource base directory, so we can more easily support use case of multiple default servlets with different resource bases from #8259
- allow `AllowedResourceAliasChecker` to be used when `ContextHandler` is still starting, by always extracting resource base when needed before `lifeCycleStarted` is called.
- resolve symlinks in the `baseResource` during `ContextHandler.doStart()` so that not every path from it is also an alias.