### PR TITLE
Issue #8319 Grow request queue instead of pre-allocating it

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -132,7 +132,10 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
 
     protected Queue<HttpExchange> newExchangeQueue(HttpClient client)
     {
-        return new BlockingArrayQueue<>(client.getMaxRequestsQueuedPerDestination());
+        int maxCapacity = client.getMaxRequestsQueuedPerDestination();
+        if (maxCapacity > 32)
+            return new BlockingArrayQueue<>(32, 32, maxCapacity);
+        return new BlockingArrayQueue<>(maxCapacity);
     }
 
     protected ClientConnectionFactory newSslClientConnectionFactory(SslContextFactory.Client sslContextFactory, ClientConnectionFactory connectionFactory)


### PR DESCRIPTION
To avoid excess allocation, in particular for higher values of
`MaxRequestsQueuedPerDestination`, the per-destination request queue is
now initialized with a capacity of 32 entries and configured to grow 32
entries at a time until the maximum is reached.

Resolves #8319.
