### PR TITLE
Improve Resource to mapped ByteBuffer logic

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
@@ -209,15 +209,7 @@ public class CachingContentFactory implements HttpContent.ContentFactory
             if (_useFileMappedBuffer)
             {
                 // map the content into memory
-                // TODO this is assuming the resource can be mapped! Inefficient to throw to test this
-                try
-                {
-                    byteBuffer = BufferUtil.toMappedBuffer(httpContent.getResource().getPath(), 0, _contentLengthValue);
-                }
-                catch (Throwable t)
-                {
-                    LOG.trace("ignored", t);
-                }
+                byteBuffer = BufferUtil.toMappedBuffer(httpContent.getResource(), 0, _contentLengthValue);
             }
 
             if (byteBuffer == null)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
@@ -204,13 +204,9 @@ public class CachingContentFactory implements HttpContent.ContentFactory
             super(httpContent);
             _etag = precalculatedEtag;
             _contentLengthValue = httpContent.getContentLengthValue(); // TODO getContentLengthValue() could return -1
-            ByteBuffer byteBuffer = null;
 
-            if (_useFileMappedBuffer)
-            {
-                // map the content into memory
-                byteBuffer = BufferUtil.toMappedBuffer(httpContent.getResource(), 0, _contentLengthValue);
-            }
+            // map the content into memory if possible
+            ByteBuffer byteBuffer = _useFileMappedBuffer ? BufferUtil.toMappedBuffer(httpContent.getResource(), 0, _contentLengthValue) : null;
 
             if (byteBuffer == null)
             {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -339,8 +339,8 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         // a non shared resource.  Also ignore max buffer size
         try
         {
-            if (_useFileMappedBuffer && resource.getPath() != null && resource.length() < Integer.MAX_VALUE)
-                return BufferUtil.toMappedBuffer(resource.getPath());
+            if (_useFileMappedBuffer && resource.getPath() != null && resource.length() <= Integer.MAX_VALUE)
+                return BufferUtil.toMappedBuffer(resource);
         }
         catch (IOException | IllegalArgumentException e)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.RandomAccessFile;
 import java.nio.Buffer;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
@@ -1055,11 +1054,6 @@ public class BufferUtil
         return buf;
     }
 
-    public static ByteBuffer toMappedBuffer(File file) throws IOException
-    {
-        return toMappedBuffer(file.toPath(), 0, file.length());
-    }
-
     public static ByteBuffer toMappedBuffer(Path path) throws IOException
     {
         return toMappedBuffer(path, 0, Files.size(path));
@@ -1071,6 +1065,20 @@ public class BufferUtil
         {
             return channel.map(MapMode.READ_ONLY, pos, len);
         }
+    }
+
+    public static ByteBuffer toMappedBuffer(Resource resource) throws IOException
+    {
+        if (!resource.isMemoryMappable())
+            return null;
+        return toMappedBuffer(resource.getPath());
+    }
+
+    public static ByteBuffer toMappedBuffer(Resource resource, long pos, long len) throws IOException
+    {
+        if (!resource.isMemoryMappable())
+            return null;
+        return toMappedBuffer(resource.getPath(), pos, len);
     }
 
     public static String toSummaryString(ByteBuffer buffer)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -285,6 +285,12 @@ public class PathResource extends Resource
     }
 
     @Override
+    public boolean isMemoryMappable()
+    {
+        return "file".equalsIgnoreCase(uri.getScheme());
+    }
+
+    @Override
     public URI getURI()
     {
         return this.uri;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -507,6 +507,16 @@ public abstract class Resource implements ResourceFactory
     }
 
     /**
+     * Checks if the resource supports being loaded as a memory-mapped ByteBuffer.
+     *
+     * @return true if the resource supports memory-mapped ByteBuffer, false otherwise.
+     */
+    public boolean isMemoryMappable()
+    {
+        return false;
+    }
+
+    /**
      * Deletes the given resource
      * Equivalent to {@link Files#deleteIfExists(Path)} with the following parameter:
      * {@link #getPath()}.

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
@@ -339,10 +339,10 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         // a non shared resource.  Also ignore max buffer size
         try
         {
-            if (_useFileMappedBuffer && resource.getPath() != null && resource.length() < Integer.MAX_VALUE)
-                return BufferUtil.toMappedBuffer(resource.getPath());
+            if (_useFileMappedBuffer && resource.getPath() != null && resource.length() <= Integer.MAX_VALUE)
+                return BufferUtil.toMappedBuffer(resource);
         }
-        catch (IOException | IllegalArgumentException | UnsupportedOperationException e)
+        catch (IOException | IllegalArgumentException e)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Unable to get Mapped Buffer for {}", resource, e);


### PR DESCRIPTION
Closes https://github.com/eclipse/jetty.project/issues/8285.
Expose a way to figure if a Resource supports mmap'ing or not, and add extra BufferUtil methods that make use of that new API.