### PR TITLE
Jetty-12 : Review MultiException in light of addSuppressed options

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MultiException.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MultiException.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.jetty.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Wraps multiple exceptions.
@@ -24,74 +24,44 @@ import java.util.List;
  *
  * The MultiException itself should not be thrown instead one of the
  * ifExceptionThrow* methods should be called instead.
+ * TODO: Remove entirely in favor of Error lists with {@link TypeUtil#withSuppressed(Throwable, List)}?
+ * TODO: Deprecate this now (if we do above)?
  */
 @SuppressWarnings("serial")
 public class MultiException extends Exception
 {
     private static final String DEFAULT_MESSAGE = "Multiple exceptions";
 
-    private List<Throwable> nested;
-
     public MultiException()
     {
-        // Avoid filling in stack trace information.
-        super(DEFAULT_MESSAGE, null, false, false);
-        this.nested = new ArrayList<>();
+        this(DEFAULT_MESSAGE);
     }
 
-    /**
-     * Create a MultiException which may be thrown.
-     *
-     * @param nested The nested exceptions which will be suppressed by this
-     * exception.
-     */
-    private MultiException(List<Throwable> nested)
+    public MultiException(String message)
     {
-        super(DEFAULT_MESSAGE);
-        this.nested = new ArrayList<>(nested);
-
-        if (nested.size() > 0)
-            initCause(nested.get(0));
-
-        for (Throwable t : nested)
-        {
-            if (t != this && t != getCause())
-                addSuppressed(t);
-        }
+        // Avoid filling in stack trace information.
+        super(message, null, true, false);
     }
 
     public void add(Throwable e)
     {
-        if (e instanceof MultiException)
+        if (e instanceof MultiException mex)
         {
-            MultiException me = (MultiException)e;
-            nested.addAll(me.nested);
+            for (Throwable throwable : mex.getSuppressed())
+            {
+                addSuppressed(throwable);
+            }
         }
         else
-            nested.add(e);
-    }
-
-    public int size()
-    {
-        return (nested == null) ? 0 : nested.size();
-    }
-
-    public List<Throwable> getThrowables()
-    {
-        if (nested == null)
-            return Collections.emptyList();
-        return nested;
-    }
-
-    public Throwable getThrowable(int i)
-    {
-        return nested.get(i);
+        {
+            addSuppressed(e);
+        }
     }
 
     /**
-     * Throw a multiexception.
+     * Throw a MultiException.
      * If this multi exception is empty then no action is taken. If it
-     * contains a single exception that is thrown, otherwise the this
+     * contains a single exception that is thrown, otherwise then this
      * multi exception is thrown.
      *
      * @throws Exception the Error or Exception if nested is 1, or the MultiException itself if nested is more than 1.
@@ -99,29 +69,27 @@ public class MultiException extends Exception
     public void ifExceptionThrow()
         throws Exception
     {
-        if (nested == null)
+        Throwable[] suppressed = getSuppressed();
+        int count = suppressed.length;
+
+        if (count <= 0)
             return;
 
-        switch (nested.size())
+        if (count == 1)
         {
-            case 0:
-                break;
-            case 1:
-                Throwable th = nested.get(0);
-                if (th instanceof Error)
-                    throw (Error)th;
-                if (th instanceof Exception)
-                    throw (Exception)th;
-                throw new MultiException(nested);
-            default:
-                throw new MultiException(nested);
+            if (suppressed[0] instanceof Error)
+                throw (Error)suppressed[0];
+            if (suppressed[0] instanceof Exception ex)
+                throw ex;
         }
+
+        throw this;
     }
 
     /**
      * Throw a Runtime exception.
      * If this multi exception is empty then no action is taken. If it
-     * contains a single error or runtime exception that is thrown, otherwise the this
+     * contains a single error or runtime exception that is thrown, otherwise then this
      * multi exception is thrown, wrapped in a runtime exception.
      *
      * @throws Error If this exception contains exactly 1 {@link Error}
@@ -129,90 +97,57 @@ public class MultiException extends Exception
      * or it contains more than 1 {@link Throwable} of any type.
      */
     public void ifExceptionThrowRuntime()
-        throws Error
+    throws RuntimeException
     {
-        if (nested == null)
+        Throwable[] suppressed = getSuppressed();
+        int count = suppressed.length;
+
+        if (count <= 0)
             return;
 
-        switch (nested.size())
+        if (count == 1)
         {
-            case 0:
-                break;
-            case 1:
-                Throwable th = nested.get(0);
-                if (th instanceof Error)
-                    throw (Error)th;
-                else if (th instanceof RuntimeException)
-                    throw (RuntimeException)th;
-                else
-                    throw new RuntimeException(th);
-            default:
-                throw new RuntimeException(new MultiException(nested));
+            if (suppressed[0] instanceof Error)
+                throw (Error)suppressed[0];
+            if (suppressed[0] instanceof RuntimeException ex)
+                throw ex;
+            else
+                throw new RuntimeException(getMessage(), suppressed[0]);
         }
+
+        throw new RuntimeException(getMessage(), this);
     }
 
     /**
      * Throw a multiexception.
      * If this multi exception is empty then no action is taken. If it
-     * contains a any exceptions then this
-     * multi exception is thrown.
+     * contains any exceptions then this multi exception is thrown.
      *
      * @throws MultiException the multiexception if there are nested exception
      */
     public void ifExceptionThrowMulti()
         throws MultiException
     {
-        if (nested == null)
+        Throwable[] suppressed = getSuppressed();
+        int count = suppressed.length;
+
+        if (count <= 0)
             return;
 
-        if (nested.size() > 0)
-        {
-            throw new MultiException(nested);
-        }
-    }
-
-    /**
-     * Throw an Exception, potentially with suppress.
-     * If this multi exception is empty then no action is taken. If the first
-     * exception added is an Error or Exception, then it is throw with
-     * any additional exceptions added as suppressed. Otherwise a MultiException
-     * is thrown, with all exceptions added as suppressed.
-     *
-     * @throws Exception the Error or Exception if at least one is added.
-     */
-    public void ifExceptionThrowSuppressed()
-        throws Exception
-    {
-        if (nested == null || nested.size() == 0)
-            return;
-
-        Throwable th = nested.get(0);
-        if (!Error.class.isInstance(th) && !Exception.class.isInstance(th))
-            th = new MultiException(Collections.emptyList());
-
-        for (Throwable s : nested)
-        {
-            if (s != th)
-                th.addSuppressed(s);
-        }
-        if (Error.class.isInstance(th))
-            throw (Error)th;
-        throw (Exception)th;
+        throw this;
     }
 
     @Override
     public String toString()
     {
-        StringBuilder str = new StringBuilder();
-        str.append(MultiException.class.getSimpleName());
-        if ((nested == null) || (nested.size() <= 0))
-        {
-            str.append("[]");
-        }
-        else
-        {
-            str.append(nested);
-        }
-        return str.toString();
+        return Stream.of(getSuppressed())
+            .map(throwable ->
+            {
+                if (throwable.getMessage() == null)
+                    return throwable.getClass().getName();
+                else
+                    return String.format("%s:%s", throwable.getClass().getName(), throwable.getMessage());
+            })
+            .collect(Collectors.joining(", ", MultiException.class.getSimpleName() + "[", "]"));
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -622,6 +622,19 @@ public class TypeUtil
     }
 
     /**
+     * Decorate a Throwable with the suppressed errors and return it.
+     * @param t the throwable
+     * @param errors the list of errors
+     * @return the original throwable with suppressed errors
+     * @param <T> of type Throwable
+     */
+    public static <T extends Throwable> T withSuppressed(T t, List<Throwable> errors)
+    {
+        errors.forEach(t::addSuppressed);
+        return t;
+    }
+
+    /**
      * @param o Object to test for true
      * @return True if passed object is not null and is either a Boolean with value true or evaluates to a string that evaluates to true.
      */


### PR DESCRIPTION
After a conversation with @lorban it was pointed out that `MultiException` should be removed in favor of just using `addSuppressed(Throwable)` instead.

* Cleanup of `MultiException` to be easier to follow/understand by using Suppressed Throwables internally.
* Improved `MultiExceptionTest`
* Add `TypeUtil.withSuppressed(Throwable, List<Throwable> suppressed)` to make working with error lists easier.
* Converted `HandlerCollection` and `XmlConfiguration` to show how to use Error Lists instead.

