### PR TITLE
Jetty 12.0.x canonical uri

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -381,7 +381,7 @@ public interface HttpURI
         public String getCanonicalPath()
         {
             if (_canonicalPath == null && _path != null)
-                _canonicalPath = URIUtil.normalizePath(URIUtil.canonicalEncodedPath(_path));
+                _canonicalPath = URIUtil.canonicalPath(_path);
             return _canonicalPath;
         }
 
@@ -750,7 +750,7 @@ public interface HttpURI
         public String getCanonicalPath()
         {
             if (_canonicalPath == null && _path != null)
-                _canonicalPath = URIUtil.normalizePath(URIUtil.canonicalEncodedPath(_path));
+                _canonicalPath = URIUtil.canonicalPath(_path);
             return _canonicalPath;
         }
 
@@ -1412,8 +1412,7 @@ public interface HttpURI
             {
                 // The RFC requires this to be canonical before decoding, but this can leave dot segments and dot dot segments
                 // which are not canonicalized and could be used in an attempt to bypass security checks.
-                String decodedNonCanonical = URIUtil.canonicalEncodedPath(_path);
-                _canonicalPath = URIUtil.normalizePath(decodedNonCanonical);
+                _canonicalPath = URIUtil.canonicalPath(_path);
                 if (_canonicalPath == null)
                     throw new IllegalArgumentException("Bad URI");
             }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -381,7 +381,7 @@ public interface HttpURI
         public String getCanonicalPath()
         {
             if (_canonicalPath == null && _path != null)
-                _canonicalPath = URIUtil.canonicalPath(URIUtil.normalizePath(_path));
+                _canonicalPath = URIUtil.normalizePath(URIUtil.canonicalEncodedPath(_path));
             return _canonicalPath;
         }
 
@@ -532,7 +532,7 @@ public interface HttpURI
          * <a href="https://tools.ietf.org/html/rfc3986#section-5.2.4">Remove Dot Segments</a>
          * algorithm.  This results in some ambiguity as dot segments can result from later
          * parameter removal or % encoding expansion, that are not removed from the URI
-         * by {@link URIUtil#canonicalPath(String)}.  Thus this class flags such ambiguous
+         * by {@link URIUtil#normalizePath(String)}.  Thus this class flags such ambiguous
          * path segments, so that they may be rejected by the server if so configured.
          */
         private static final Index<Boolean> __ambiguousSegments = new Index.Builder<Boolean>()
@@ -750,7 +750,7 @@ public interface HttpURI
         public String getCanonicalPath()
         {
             if (_canonicalPath == null && _path != null)
-                _canonicalPath = URIUtil.canonicalPath(URIUtil.normalizePath(_path));
+                _canonicalPath = URIUtil.normalizePath(URIUtil.canonicalEncodedPath(_path));
             return _canonicalPath;
         }
 
@@ -1412,8 +1412,8 @@ public interface HttpURI
             {
                 // The RFC requires this to be canonical before decoding, but this can leave dot segments and dot dot segments
                 // which are not canonicalized and could be used in an attempt to bypass security checks.
-                String decodedNonCanonical = URIUtil.normalizePath(_path);
-                _canonicalPath = URIUtil.canonicalPath(decodedNonCanonical);
+                String decodedNonCanonical = URIUtil.canonicalEncodedPath(_path);
+                _canonicalPath = URIUtil.normalizePath(decodedNonCanonical);
                 if (_canonicalPath == null)
                     throw new IllegalArgumentException("Bad URI");
             }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -487,8 +487,8 @@ public class HttpURITest
         try
         {
             HttpURI uri = HttpURI.from(input);
-            assertThat(uri.getCanonicalPath(), is(canonicalPath));
             assertThat(uri.getDecodedPath(), is(decodedPath));
+
             EnumSet<Violation> ambiguous = EnumSet.copyOf(expected);
             ambiguous.retainAll(EnumSet.complementOf(EnumSet.of(Violation.UTF16_ENCODINGS)));
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -393,14 +393,14 @@ public interface Request extends Attributes, Content.Source
             if (location.startsWith("/"))
             {
                 // absolute in context
-                location = URIUtil.canonicalURI(location);
+                location = URIUtil.normalizePathQuery(location);
             }
             else
             {
                 // relative to request
                 String path = uri.getPath();
                 String parent = (path.endsWith("/")) ? path : URIUtil.parentPath(path);
-                location = URIUtil.canonicalURI(URIUtil.addEncodedPaths(parent, location));
+                location = URIUtil.normalizePathQuery(URIUtil.addEncodedPaths(parent, location));
                 if (location != null && !location.startsWith("/"))
                     url.append('/');
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -740,7 +740,7 @@ public class URIUtil
         {
             Utf8StringBuilder builder = null;
             int end = offset + length;
-            boolean slash = false;
+            boolean slash = true;
             boolean normal = true;
             for (int i = offset; i < end; i++)
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -81,12 +81,12 @@ public class URIUtil
         false, // 0x1d is illegal
         false, // 0x1e is illegal
         false, // 0x1f is illegal
-        false, // 0x20 is illegal
+        false, // 0x20 space is illegal
         true,  // 0x21
-        false, // 0x22 is illegal
-        false, // # is special
+        false, // 0x22 " is illegal
+        false, // 0x23 # is special
         true,  // 0x24
-        false, // % must remain encoded
+        false, // 0x25 % must remain encoded
         true,  // 0x26
         true,  // 0x27
         true,  // 0x28
@@ -96,7 +96,7 @@ public class URIUtil
         true,  // 0x2c
         true,  // 0x2d
         true,  // 0x2e
-        false, // / is a delimiter
+        false, // 0x2f / is a delimiter
         true,  // 0x30
         true,  // 0x31
         true,  // 0x32
@@ -108,11 +108,11 @@ public class URIUtil
         true,  // 0x38
         true,  // 0x39
         true,  // 0x3a
-        false, // ; is path parameter
-        false, // 0x3c is illegal
+        false, // 0x3b ; is path parameter
+        false, // 0x3c < is illegal
         true,  // 0x3d
-        false, // 0x3e is illegal
-        false, // ? is special
+        false, // 0x3e > is illegal
+        false, // 0x3f ? is special
         true,  // 0x40
         true,  // 0x41
         true,  // 0x42
@@ -140,12 +140,12 @@ public class URIUtil
         true,  // 0x58
         true,  // 0x59
         true,  // 0x5a
-        false, // 0x5b is illegal
-        false, // 0x5c is illegal
-        false, // 0x5d is illegal
-        false, // 0x5e is illegal
+        false, // 0x5b [ is illegal
+        false, // 0x5c \ is illegal
+        false, // 0x5d ] is illegal
+        false, // 0x5e ^ is illegal
         true,  // 0x5f
-        false, // 0x60 is illegal
+        false, // 0x60 ` is illegal
         true,  // 0x61
         true,  // 0x62
         true,  // 0x63
@@ -172,11 +172,11 @@ public class URIUtil
         true,  // 0x78
         true,  // 0x79
         true,  // 0x7a
-        false, // 0x7b is illegal
-        false, // 0x7c is illegal
-        false, // 0x7d is illegal
+        false, // 0x7b { is illegal
+        false, // 0x7c | is illegal
+        false, // 0x7d } is illegal
         true,  // 0x7e
-        false, // 0x7f is illegal
+        false, // 0x7f DEL is illegal
     };
 
     private URIUtil()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -596,7 +596,7 @@ public abstract class Resource implements ResourceFactory
         // Check that the path is within the root,
         // but use the original path to create the
         // resource, to preserve aliasing.
-        if (URIUtil.canonicalPath(subUriPath) == null)
+        if (URIUtil.normalizePath(subUriPath) == null)
             throw new IOException(subUriPath);
 
         if (URIUtil.SLASH.equals(subUriPath))
@@ -677,7 +677,7 @@ public abstract class Resource implements ResourceFactory
     public String getListHTML(String base, boolean parent, String query) throws IOException
     {
         // This method doesn't check aliases, so it is OK to canonicalize here.
-        base = URIUtil.canonicalPath(base);
+        base = URIUtil.normalizePath(base);
         if (base == null || !isDirectory())
             return null;
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -596,6 +596,7 @@ public abstract class Resource implements ResourceFactory
         // Check that the path is within the root,
         // but use the original path to create the
         // resource, to preserve aliasing.
+        // TODO should we canonicalize here? Or perhaps just do a URI safe encoding
         if (URIUtil.normalizePath(subUriPath) == null)
             throw new IOException(subUriPath);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilNormalizePathTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilNormalizePathTest.java
@@ -24,11 +24,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class URIUtilCanonicalPathTest
+public class URIUtilNormalizePathTest
 {
     public static Stream<Arguments> paths()
     {
-        String[][] canonical =
+        String[][] unNormalAndNormal =
             {
                 // Examples from RFC
                 {"/a/b/c/./../../g", "/a/g"},
@@ -130,7 +130,7 @@ public class URIUtilCanonicalPathTest
             };
 
         ArrayList<Arguments> ret = new ArrayList<>();
-        for (String[] args : canonical)
+        for (String[] args : unNormalAndNormal)
         {
             ret.add(Arguments.of((Object[])args));
         }
@@ -139,23 +139,23 @@ public class URIUtilCanonicalPathTest
 
     @ParameterizedTest
     @MethodSource("paths")
-    public void testCanonicalPath(String input, String expectedResult)
+    public void testNormalizePath(String input, String expectedResult)
     {
         // Check canonicalPath
-        assertThat(URIUtil.canonicalPath(input), is(expectedResult));
+        assertThat(URIUtil.normalizePath(input), is(expectedResult));
 
         // Check canonicalURI
         if (expectedResult == null)
         {
-            assertThat(URIUtil.canonicalURI(input), nullValue());
+            assertThat(URIUtil.normalizePathQuery(input), nullValue());
         }
         else
         {
             // mostly encodedURI will be the same
-            assertThat(URIUtil.canonicalURI(input), is(expectedResult));
+            assertThat(URIUtil.normalizePathQuery(input), is(expectedResult));
             // but will terminate on fragments and queries
-            assertThat(URIUtil.canonicalURI(input + "?/foo/../bar/."), is(expectedResult + "?/foo/../bar/."));
-            assertThat(URIUtil.canonicalURI(input + "#/foo/../bar/."), is(expectedResult + "#/foo/../bar/."));
+            assertThat(URIUtil.normalizePathQuery(input + "?/foo/../bar/."), is(expectedResult + "?/foo/../bar/."));
+            assertThat(URIUtil.normalizePathQuery(input + "#/foo/../bar/."), is(expectedResult + "#/foo/../bar/."));
         }
     }
 
@@ -174,7 +174,7 @@ public class URIUtilCanonicalPathTest
     @MethodSource("queries")
     public void testQuery(String input, String expectedPath)
     {
-        String actual = URIUtil.canonicalURI(input);
+        String actual = URIUtil.normalizePathQuery(input);
         assertThat(actual, is(expectedPath));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -138,6 +138,7 @@ public class URIUtilTest
         arguments.add(Arguments.of("abc%u3040", "abc\u3040", "abc\u3040"));
 
         // Canonical paths are also normalized
+        arguments.add(Arguments.of("./bar", "bar", "./bar"));
         arguments.add(Arguments.of("/foo/./bar", "/foo/bar", "/foo/./bar"));
         arguments.add(Arguments.of("/foo/../bar", "/bar", "/foo/../bar"));
         arguments.add(Arguments.of("/foo/.../bar", "/foo/.../bar", "/foo/.../bar"));

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -141,15 +141,15 @@ public class URIUtilTest
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("decodePathSource")
-    public void testNormalizePath(String encodedPath, String safePath, String decodedPath)
+    public void testCanonicalEncodedPath(String encodedPath, String canonicalPath, String decodedPath)
     {
-        String path = URIUtil.normalizePath(encodedPath);
-        assertEquals(safePath, path);
+        String path = URIUtil.canonicalEncodedPath(encodedPath);
+        assertEquals(canonicalPath, path);
     }
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("decodePathSource")
-    public void testDecodePath(String encodedPath, String safePath, String decodedPath)
+    public void testDecodePath(String encodedPath, String canonicalPath, String decodedPath)
     {
         String path = URIUtil.decodePath(encodedPath);
         assertEquals(decodedPath, path);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -136,14 +136,24 @@ public class URIUtilTest
 
         // Deprecated Microsoft Percent-U encoding
         arguments.add(Arguments.of("abc%u3040", "abc\u3040", "abc\u3040"));
+
+        // Canonical paths are also normalized
+        arguments.add(Arguments.of("/foo/./bar", "/foo/bar", "/foo/./bar"));
+        arguments.add(Arguments.of("/foo/../bar", "/bar", "/foo/../bar"));
+        arguments.add(Arguments.of("/foo/.../bar", "/foo/.../bar", "/foo/.../bar"));
+        arguments.add(Arguments.of("/foo/%2e/bar", "/foo/bar", "/foo/./bar")); // Not by the RFC, but safer
+        arguments.add(Arguments.of("/foo/%2e%2e/bar", "/bar", "/foo/../bar")); // Not by the RFC, but safer
+        arguments.add(Arguments.of("/foo/%2e%2e%2e/bar", "/foo/.../bar", "/foo/.../bar"));
+
         return arguments.stream();
+
     }
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("decodePathSource")
     public void testCanonicalEncodedPath(String encodedPath, String canonicalPath, String decodedPath)
     {
-        String path = URIUtil.canonicalEncodedPath(encodedPath);
+        String path = URIUtil.canonicalPath(encodedPath);
         assertEquals(canonicalPath, path);
     }
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -361,8 +361,8 @@ public class MavenWebAppContext extends WebAppContext
         // /WEB-INF/classes
         if ((resource == null || !resource.exists()) && pathInContext != null && _classes != null)
         {
-            // Canonicalize again to look for the resource inside /WEB-INF subdirectories.
-            String uri = URIUtil.canonicalPath(pathInContext);
+            // Normalize again to look for the resource inside /WEB-INF subdirectories.
+            String uri = URIUtil.normalizePath(pathInContext);
             if (uri == null)
                 return null;
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/SelectiveJarResource.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/SelectiveJarResource.java
@@ -13,12 +13,9 @@
 
 package org.eclipse.jetty.ee10.maven.plugin;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -165,7 +162,7 @@ public class SelectiveJarResource extends Resource
 
                 LOG.debug("Looking at {}", entryName);
                 // make sure no access out of the root entry is present
-                String dotCheck = URIUtil.canonicalPath(entryName);
+                String dotCheck = URIUtil.normalizePath(entryName);
                 if (dotCheck == null)
                 {
                     LOG.info("Invalid entry: {}", entryName);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -398,7 +398,7 @@ public class ServletChannel implements Runnable
                             {
                                 String contextPath = _request.getContext().getContextPath();
                                 HttpURI.Immutable dispatchUri = HttpURI.from(dispatchString);
-                                pathInContext = URIUtil.normalizePath(dispatchUri.getPath());
+                                pathInContext = URIUtil.canonicalEncodedPath(dispatchUri.getPath());
                                 uri = HttpURI.build(_request.getHttpURI())
                                     .path(URIUtil.addPaths(contextPath, pathInContext))
                                     .query(dispatchUri.getQuery());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -398,7 +398,7 @@ public class ServletChannel implements Runnable
                             {
                                 String contextPath = _request.getContext().getContextPath();
                                 HttpURI.Immutable dispatchUri = HttpURI.from(dispatchString);
-                                pathInContext = URIUtil.canonicalEncodedPath(dispatchUri.getPath());
+                                pathInContext = URIUtil.canonicalPath(dispatchUri.getPath());
                                 uri = HttpURI.build(_request.getHttpURI())
                                     .path(URIUtil.addPaths(contextPath, pathInContext))
                                     .query(dispatchUri.getQuery());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -3066,11 +3066,10 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public String getRealPath(String path)
         {
-            // This is an API call from the application which may have arbitrary non normal paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize here?
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -3099,11 +3098,10 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            // This is an API call from the application which may have arbitrary non normal paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             Resource resource = ServletContextHandler.this.getResource(path);
@@ -3136,11 +3134,10 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public Set<String> getResourcePaths(String path)
         {
-            // This is an API call from the application which may have arbitrary non normal paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             return ServletContextHandler.this.getResourcePaths(path);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -3066,10 +3066,11 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public String getRealPath(String path)
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non normal paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize here?
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -3098,10 +3099,11 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non normal paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             Resource resource = ServletContextHandler.this.getResource(path);
@@ -3134,10 +3136,11 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         @Override
         public Set<String> getResourcePaths(String path)
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non normal paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             return ServletContextHandler.this.getResourcePaths(path);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
@@ -361,8 +361,8 @@ public class MavenWebAppContext extends WebAppContext
         // /WEB-INF/classes
         if ((resource == null || !resource.exists()) && pathInContext != null && _classes != null)
         {
-            // Canonicalize again to look for the resource inside /WEB-INF subdirectories.
-            String uri = URIUtil.canonicalPath(pathInContext);
+            // Normalize again to look for the resource inside /WEB-INF subdirectories.
+            String uri = URIUtil.normalizePath(pathInContext);
             if (uri == null)
                 return null;
 

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/SelectiveJarResource.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/SelectiveJarResource.java
@@ -162,7 +162,7 @@ public class SelectiveJarResource extends Resource
 
                 LOG.debug("Looking at {}", entryName);
                 // make sure no access out of the root entry is present
-                String dotCheck = URIUtil.canonicalPath(entryName);
+                String dotCheck = URIUtil.normalizePath(entryName);
                 if (dotCheck == null)
                 {
                     LOG.info("Invalid entry: {}", entryName);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -68,12 +68,10 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Handler.Nested;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.ContextRequest;
-import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Index;
@@ -1660,7 +1658,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                         : URIUtil.encodePath(servletContext.getContextPath());
                     if (!StringUtil.isEmpty(encodedContextPath))
                     {
-                        encodedPathQuery = URIUtil.canonicalPath(URIUtil.addEncodedPaths(encodedContextPath, encodedPathQuery));
+                        encodedPathQuery = URIUtil.normalizePath(URIUtil.addEncodedPaths(encodedContextPath, encodedPathQuery));
                         if (encodedPathQuery == null)
                             throw new BadMessageException(500, "Bad dispatch path");
                     }
@@ -1832,10 +1830,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public String getRealPath(String path)
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non nomral paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize?
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -1864,10 +1863,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non normal paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize here?
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             Resource resource = ContextHandler.this.getResource(path);
@@ -1900,10 +1900,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public Set<String> getResourcePaths(String path)
         {
-            // This is an API call from the application which may have arbitrary non canonical paths passed
-            // Thus we canonicalize here, to avoid the enforcement of only canonical paths in
+            // This is an API call from the application which may have arbitrary non normal paths passed
+            // Thus we normalize here, to avoid the enforcement of only normal paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            // TODO should we also canonicalize
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             return ContextHandler.this.getResourcePaths(path);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1830,11 +1830,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public String getRealPath(String path)
         {
-            // This is an API call from the application which may have arbitrary non nomral paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize?
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -1863,11 +1862,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            // This is an API call from the application which may have arbitrary non normal paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize here?
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             Resource resource = ContextHandler.this.getResource(path);
@@ -1900,11 +1898,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         @Override
         public Set<String> getResourcePaths(String path)
         {
-            // This is an API call from the application which may have arbitrary non normal paths passed
-            // Thus we normalize here, to avoid the enforcement of only normal paths in
+            // This is an API call from the application which may pass non-canonical paths.
+            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
             // ContextHandler.this.getResource(path).
-            // TODO should we also canonicalize
-            path = URIUtil.normalizePath(path);
+            path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
             return ContextHandler.this.getResourcePaths(path);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -588,14 +588,14 @@ public class Response implements HttpServletResponse
             if (location.startsWith("/"))
             {
                 // absolute in context
-                location = URIUtil.canonicalURI(location);
+                location = URIUtil.normalizePathQuery(location);
             }
             else
             {
                 // relative to request
                 String path = _channel.getRequest().getRequestURI();
                 String parent = (path.endsWith("/")) ? path : URIUtil.parentPath(path);
-                location = URIUtil.canonicalURI(URIUtil.addEncodedPaths(parent, location));
+                location = URIUtil.normalizePathQuery(URIUtil.addEncodedPaths(parent, location));
                 if (location != null && !location.startsWith("/"))
                     buf.append('/');
             }


### PR DESCRIPTION
+ Correct the usage of the terms canonical and normal in `URIUtil`
+ canonical paths are always normalized
+ canonicalize rather than just normalize paths from the servlet API methods