### PR TITLE
remove old Resource defaultUseCache mechanism

### DIFF
--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ScanningAppProviderRuntimeUpdatesTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ScanningAppProviderRuntimeUpdatesTest.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.deploy.test.XmlConfiguredJetty;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Scanner;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -50,7 +49,6 @@ public class ScanningAppProviderRuntimeUpdatesTest
     public void setupEnvironment() throws Exception
     {
         testdir.ensureEmpty();
-        Resource.setDefaultUseCaches(false);
 
         jetty = new XmlConfiguredJetty(testdir.getEmptyPathDir());
         jetty.addConfiguration("jetty.xml");

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -77,27 +77,6 @@ public abstract class Resource implements ResourceFactory
         .with("jar:")
         .build();
 
-    // TODO remove
-    public static boolean __defaultUseCaches = true;
-
-    /**
-     * Change the default setting for url connection caches.
-     * Subsequent URLConnections will use this default.
-     *
-     * @param useCaches true to enable URL connection caches, false otherwise.
-     * TODO remove
-     */
-    public static void setDefaultUseCaches(boolean useCaches)
-    {
-        __defaultUseCaches = useCaches;
-    }
-
-    // TODO remove
-    public static boolean getDefaultUseCaches()
-    {
-        return __defaultUseCaches;
-    }
-
     /**
      * <p>Mount a URI if it is needed.</p>
      * @param uri The URI to mount that may require a FileSystem (e.g. "jar:file://tmp/some.jar!/directory/file.txt")

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/JarServerTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/JarServerTest.java
@@ -13,15 +13,25 @@
 
 package org.eclipse.jetty.ee10.demos;
 
+import java.io.FileNotFoundException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.ee10.servlet.DefaultServlet;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,11 +41,21 @@ import static org.hamcrest.Matchers.is;
 public class JarServerTest extends AbstractEmbeddedTest
 {
     private Server server;
+    private Resource.Mount mount;
 
     @BeforeEach
     public void startServer() throws Exception
     {
-        server = JarServer.createServer(0);
+        Path jarFile = Paths.get("src/main/other/content.jar");
+        if (!Files.exists(jarFile))
+            throw new FileNotFoundException(jarFile.toString());
+
+        mount = Resource.mountJar(jarFile);
+        server = new Server(0);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setBaseResource(mount.root().getPath());
+        context.addServlet(new ServletHolder(new DefaultServlet()), "/");
+        server.setHandler(new Handler.Collection(context, new DefaultHandler()));
         server.start();
     }
 
@@ -43,9 +63,9 @@ public class JarServerTest extends AbstractEmbeddedTest
     public void stopServer() throws Exception
     {
         server.stop();
+        IO.close(mount);
     }
 
-    @Disabled //TODO
     @Test
     public void testGetDir0Test0() throws Exception
     {
@@ -62,7 +82,6 @@ public class JarServerTest extends AbstractEmbeddedTest
         assertThat("Response Content", responseBody, containsString("test0"));
     }
 
-    @Disabled //TODO
     @Test
     public void testGetDir1Test1() throws Exception
     {

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
@@ -217,9 +217,7 @@ public class JettyEmbedder extends AbstractLifeCycle
     public void doStart() throws Exception
     {
         super.doStart();
-        
-        Resource.setDefaultUseCaches(false);
-        
+
         configure();
         configureShutdownMonitor();
         server.start();

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -22,6 +22,7 @@ import java.net.URLClassLoader;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -719,21 +720,29 @@ public class MetaInfConfiguration extends AbstractConfiguration
     public Collection<URL> getTlds(URI uri) throws IOException
     {
         HashSet<URL> tlds = new HashSet<>();
-        URI jarUri = uriJarPrefix(uri, "!/");
-        try (Resource.Mount mount = Resource.mount(jarUri);
+        try (Resource.Mount mount = Resource.mount(uriJarPrefix(uri, "!/"));
              Stream<Path> stream = Files.walk(mount.root().getPath()))
         {
-            Iterator<String> it = stream
-                .map(Path::toString)
-                .filter(filename -> filename.startsWith("META-INF") && filename.endsWith(".tld"))
+            Iterator<Path> it = stream
+                .filter(MetaInfConfiguration::isTldFile)
                 .iterator();
-            String prefix = jarUri.toString();
             while (it.hasNext())
             {
-                tlds.add(new URL(prefix + it.next()));
+                Path entry = it.next();
+                tlds.add(entry.toUri().toURL());
             }
         }
         return tlds;
+    }
+
+    private static boolean isTldFile(Path path)
+    {
+        if (path.getNameCount() < 2)
+            return false;
+        if (!path.getName(0).toString().equalsIgnoreCase("META-INF"))
+            return false;
+        String filename = path.getFileName().toString();
+        return filename.toLowerCase(Locale.ENGLISH).endsWith(".tld");
     }
 
     protected List<Resource> findClassDirs(WebAppContext context)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -720,8 +720,11 @@ public class MetaInfConfiguration extends AbstractConfiguration
     public Collection<URL> getTlds(URI uri) throws IOException
     {
         HashSet<URL> tlds = new HashSet<>();
-        try (Resource.Mount mount = Resource.mount(uriJarPrefix(uri, "!/"));
-             Stream<Path> stream = Files.walk(mount.root().getPath()))
+        Resource.Mount mount = Resource.mount(uriJarPrefix(uri, "!/"));
+        if (_mountedResources == null)
+            _mountedResources = new ArrayList<>();
+        _mountedResources.add(mount);
+        try (Stream<Path> stream = Files.walk(mount.root().getPath()))
         {
             Iterator<Path> it = stream
                 .filter(MetaInfConfiguration::isTldFile)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -737,6 +737,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
     private static boolean isTldFile(Path path)
     {
+        if (!Files.isRegularFile(path))
+            return false;
         if (path.getNameCount() < 2)
             return false;
         if (!path.getName(0).toString().equalsIgnoreCase("META-INF"))

--- a/jetty-ee10/test-ee10-sessions/test-ee10-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee10/test-ee10-sessions/test-ee10-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -55,7 +54,6 @@ public class ReloadedSessionMissingClassTest
     @Test
     public void testSessionReloadWithMissingClass() throws Exception
     {
-        Resource.setDefaultUseCaches(false);
         String contextPath = "/foo";
 
         File unpackedWarDir = testdir.getEmptyPathDir().toFile();

--- a/jetty-ee10/test-ee10-sessions/test-ee10-jdbc-sessions/src/test/java/org/eclipse/jetty/session/WebAppObjectInSessionTest.java
+++ b/jetty-ee10/test-ee10-sessions/test-ee10-jdbc-sessions/src/test/java/org/eclipse/jetty/session/WebAppObjectInSessionTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.session;
 
 import org.eclipse.jetty.ee10.session.AbstractWebAppObjectInSessionTest;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,6 @@ public class WebAppObjectInSessionTest extends AbstractWebAppObjectInSessionTest
     @Override
     public SessionDataStoreFactory createSessionDataStoreFactory()
     {
-        Resource.setDefaultUseCaches(false);
         return JdbcTestHelper.newSessionDataStoreFactory();
     }
 

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
@@ -217,9 +217,7 @@ public class JettyEmbedder extends AbstractLifeCycle
     public void doStart() throws Exception
     {
         super.doStart();
-        
-        Resource.setDefaultUseCaches(false);
-        
+
         configure();
         configureShutdownMonitor();
         server.start();

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee9.webapp;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -30,17 +29,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.PatternMatcher;
@@ -714,25 +712,21 @@ public class MetaInfConfiguration extends AbstractConfiguration
      */
     public Collection<URL> getTlds(URI uri) throws IOException
     {
-        HashSet<URL> tlds = new HashSet<URL>();
-
+        HashSet<URL> tlds = new HashSet<>();
         URI jarUri = uriJarPrefix(uri, "!/");
-        URL url = jarUri.toURL();
-        JarURLConnection jarConn = (JarURLConnection)url.openConnection();
-        jarConn.setUseCaches(Resource.getDefaultUseCaches());
-        JarFile jarFile = jarConn.getJarFile();
-        Enumeration<JarEntry> entries = jarFile.entries();
-        while (entries.hasMoreElements())
+        try (Resource.Mount mount = Resource.mount(jarUri);
+             Stream<Path> stream = Files.walk(mount.root().getPath()))
         {
-            JarEntry e = entries.nextElement();
-            String name = e.getName();
-            if (name.startsWith("META-INF") && name.endsWith(".tld"))
+            Iterator<String> it = stream
+                .map(Path::toString)
+                .filter(filename -> filename.startsWith("META-INF") && filename.endsWith(".tld"))
+                .iterator();
+            String prefix = jarUri.toString();
+            while (it.hasNext())
             {
-                tlds.add(new URL(jarUri + name));
+                tlds.add(new URL(prefix + it.next()));
             }
         }
-        if (!Resource.getDefaultUseCaches())
-            jarFile.close();
         return tlds;
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -713,8 +713,11 @@ public class MetaInfConfiguration extends AbstractConfiguration
     public Collection<URL> getTlds(URI uri) throws IOException
     {
         HashSet<URL> tlds = new HashSet<>();
-        try (Resource.Mount mount = Resource.mount(uriJarPrefix(uri, "!/"));
-             Stream<Path> stream = Files.walk(mount.root().getPath()))
+        Resource.Mount mount = Resource.mount(uriJarPrefix(uri, "!/"));
+        if (_mountedResources == null)
+            _mountedResources = new ArrayList<>();
+        _mountedResources.add(mount);
+        try (Stream<Path> stream = Files.walk(mount.root().getPath()))
         {
             Iterator<Path> it = stream
                 .filter(MetaInfConfiguration::isTldFile)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -730,6 +730,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
     private static boolean isTldFile(Path path)
     {
+        if (!Files.isRegularFile(path))
+            return false;
         if (path.getNameCount() < 2)
             return false;
         if (!path.getName(0).toString().equalsIgnoreCase("META-INF"))

--- a/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -55,7 +54,6 @@ public class ReloadedSessionMissingClassTest
     @Test
     public void testSessionReloadWithMissingClass() throws Exception
     {
-        Resource.setDefaultUseCaches(false);
         String contextPath = "/foo";
 
         File unpackedWarDir = testdir.getEmptyPathDir().toFile();

--- a/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/WebAppObjectInSessionTest.java
+++ b/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/WebAppObjectInSessionTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.session;
 
 import org.eclipse.jetty.ee9.session.AbstractWebAppObjectInSessionTest;
-import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,6 @@ public class WebAppObjectInSessionTest extends AbstractWebAppObjectInSessionTest
     @Override
     public SessionDataStoreFactory createSessionDataStoreFactory()
     {
-        Resource.setDefaultUseCaches(false);
         return JdbcTestHelper.newSessionDataStoreFactory();
     }
 


### PR DESCRIPTION
Tentative of getting rid of the `Resource` `defaultUseCaches` mechanism. 
It control two things:

1) The parameter passed to `JarURLConnection.setUseCaches()`.
2) Whether or not the `JarFile` backing the `JarURLConnection` gets closed after browsing or not.


(1) isn't relevant anymore if we mount the JAR as a resource instead of using a `JarURLConnection` to browse it, and for (2) I'm not sure why `JarFile`s were left open as I don't think we're going to browse those JARs more than once, unless I missed something.

Let's keep this on hold until https://github.com/eclipse/jetty.project/pull/8328 gets merged.