### PR TITLE
Jetty 12 : Remove `java.io.File` usage from `jetty-start`

### DIFF
--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseHome.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseHome.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
@@ -69,15 +68,6 @@ public class BaseHome
             return dir.resolve(FS.separators(subpath));
         }
 
-        public SearchDir setDir(File path)
-        {
-            if (path != null)
-            {
-                return setDir(path.toPath());
-            }
-            return this;
-        }
-
         public SearchDir setDir(Path path)
         {
             if (path != null)
@@ -99,7 +89,7 @@ public class BaseHome
         public String toShortForm(Path path)
         {
             Path relative = dir.relativize(path);
-            return String.format("${%s}%c%s", name, File.separatorChar, relative.toString());
+            return String.format("${%s}%s%s", name, FS.separator(), relative);
         }
     }
 
@@ -399,17 +389,6 @@ public class BaseHome
     }
 
     /**
-     * Convenience method for <code>toShortForm(file.toPath())</code>
-     *
-     * @param path the path to shorten
-     * @return the short form of the path as a String
-     */
-    public String toShortForm(final File path)
-    {
-        return toShortForm(path.toPath());
-    }
-
-    /**
      * Replace/Shorten arbitrary path with property strings <code>"${jetty.home}"</code> or <code>"${jetty.base}"</code> where appropriate.
      *
      * @param path the path to shorten
@@ -430,7 +409,7 @@ public class BaseHome
                     if (dirsource.isPropertyBased())
                     {
                         Path relative = dir.relativize(apath);
-                        return String.format("%s%c%s", dirsource.getId(), File.separatorChar, relative.toString());
+                        return String.format("%s%s%s", dirsource.getId(), FS.separator(), relative.toString());
                     }
                     else
                     {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
@@ -13,42 +13,27 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 public class CommandLineBuilder
 {
-    public static File findExecutable(File root, String path)
-    {
-        String npath = path.replace('/', File.separatorChar);
-        File exe = new File(root, npath);
-        if (!exe.exists())
-        {
-            return null;
-        }
-        return exe;
-    }
-
     public static String findJavaBin()
     {
-        File javaHome = new File(System.getProperty("java.home"));
-        if (!javaHome.exists())
-        {
+        Path javaHome = Paths.get(System.getProperty("java.home"));
+        if (!Files.exists(javaHome))
             return null;
-        }
 
-        File javabin = findExecutable(javaHome, "bin/java");
-        if (javabin != null)
-        {
-            return javabin.getAbsolutePath();
-        }
+        Path javabin = javaHome.resolve("bin/java");
+        if (Files.exists(javabin))
+            return javabin.toAbsolutePath().toString();
 
-        javabin = findExecutable(javaHome, "bin/java.exe");
-        if (javabin != null)
-        {
-            return javabin.getAbsolutePath();
-        }
+        javabin = javaHome.resolve("bin/java.exe");
+        if (Files.exists(javabin))
+            return javabin.toAbsolutePath().toString();
 
         return "java";
     }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Environment.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Environment.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -167,9 +167,9 @@ public class Environment
             if (Files.isReadable(path))
             {
                 Properties props = new Properties();
-                try
+                try (InputStream in = Files.newInputStream(path))
                 {
-                    props.load(new FileInputStream(path.toFile()));
+                    props.load(in);
                     for (Object key : props.keySet())
                     {
                         out.printf(" %s:%s = %s%n", p, key, props.getProperty(String.valueOf(key)));
@@ -235,7 +235,7 @@ public class Environment
 
             for (Path libpath : _baseHome.getPaths(libref))
             {
-                getClasspath().addComponent(libpath.toFile());
+                getClasspath().addComponent(libpath);
             }
         }
     }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/FS.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/FS.java
@@ -28,6 +28,16 @@ import java.util.zip.ZipFile;
 
 public class FS
 {
+    public static String separator()
+    {
+        return FileSystems.getDefault().getSeparator();
+    }
+
+    public static String pathSeparator()
+    {
+        return File.pathSeparator;
+    }
+
     public static boolean canReadDirectory(Path path)
     {
         return Files.exists(path) && Files.isDirectory(path) && Files.isReadable(path);
@@ -125,9 +135,9 @@ public class FS
         return filename.toLowerCase(Locale.ENGLISH).endsWith(".xml");
     }
 
-    public static String toRelativePath(File baseDir, File path)
+    public static String toRelativePath(Path baseDir, Path path)
     {
-        return baseDir.toURI().relativize(path.toURI()).toASCIIString();
+        return baseDir.toUri().relativize(path.toUri()).toASCIIString();
     }
 
     public static boolean isPropertyFile(String filename)

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/JarVersion.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/JarVersion.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
@@ -136,9 +136,9 @@ public class JarVersion
         return null; // no valid impl version entries found
     }
 
-    public static String getVersion(File file)
+    public static String getVersion(Path file)
     {
-        try (JarFile jar = new JarFile(file))
+        try (JarFile jar = new JarFile(file.toFile()))
         {
             String version = null;
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.start;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -153,7 +152,7 @@ public class Main
         out.println("      changes to the --module=name command line options will be reflected here.");
 
         int i = 0;
-        for (File element : classpath.getElements())
+        for (Path element : classpath.getElements())
         {
             out.printf("%2d: %24s | %s\n", i++, getVersion(element), baseHome.toShortForm(element));
         }
@@ -164,16 +163,16 @@ public class Main
         return baseHome;
     }
 
-    private String getVersion(File element)
+    private String getVersion(Path element)
     {
-        if (element.isDirectory())
+        if (Files.isDirectory(element))
         {
             return "(dir)";
         }
 
-        if (element.isFile())
+        if (Files.isRegularFile(element))
         {
-            String name = element.getName().toLowerCase(Locale.ENGLISH);
+            String name = element.toString().toLowerCase(Locale.ENGLISH);
             if (name.endsWith(".jar"))
             {
                 return JarVersion.getVersion(element);

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,7 +71,7 @@ public class Modules implements Iterable<Module>
             Path deprecatedPath = _baseHome.getPath("modules/deprecated.properties");
             if (deprecatedPath != null && FS.exists(deprecatedPath))
             {
-                try (FileInputStream inputStream = new FileInputStream(deprecatedPath.toFile()))
+                try (InputStream inputStream = Files.newInputStream(deprecatedPath))
                 {
                     _deprecated.load(inputStream);
                 }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/NaturalSort.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/NaturalSort.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.text.CollationKey;
 import java.text.Collator;
@@ -33,19 +32,6 @@ public class NaturalSort
         {
             CollationKey key1 = collator.getCollationKey(o1.toString());
             CollationKey key2 = collator.getCollationKey(o2.toString());
-            return key1.compareTo(key2);
-        }
-    }
-
-    public static class Files implements Comparator<File>
-    {
-        private final Collator collator = Collator.getInstance();
-
-        @Override
-        public int compare(File o1, File o2)
-        {
-            CollationKey key1 = collator.getCollationKey(o1.getAbsolutePath());
-            CollationKey key2 = collator.getCollationKey(o2.getAbsolutePath());
             return key1.compareTo(key2);
         }
     }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/PathFinder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/PathFinder.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystemLoopException;
 import java.nio.file.FileVisitResult;
@@ -57,14 +56,9 @@ public class PathFinder extends SimpleFileVisitor<Path>
         return fileMatcher;
     }
 
-    public List<File> getHitList()
+    public List<Path> getHitList()
     {
-        List<File> ret = new ArrayList<>();
-        for (Path path : hits.values())
-        {
-            ret.add(path.toFile());
-        }
-        return ret;
+        return new ArrayList<>(hits.values());
     }
 
     public Collection<Path> getHits()

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/PathMatchers.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/PathMatchers.java
@@ -13,13 +13,13 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 
 /**
  * Common PathMatcher implementations.
@@ -45,7 +45,7 @@ public class PathMatchers
 
     private static final char[] GLOB_CHARS = "*?".toCharArray();
     private static final char[] SYNTAXED_GLOB_CHARS = "{}[]|:".toCharArray();
-    private static final Path EMPTY_PATH = new File(".").toPath();
+    private static final Path EMPTY_PATH = Paths.get(".");
 
     /**
      * Convert a pattern to a Path object.
@@ -64,7 +64,7 @@ public class PathMatchers
         {
             test = test.substring("regex:".length());
         }
-        return new File(test).toPath();
+        return Paths.get(test);
     }
 
     public static PathMatcher getMatcher(final String rawpattern)
@@ -221,7 +221,7 @@ public class PathMatchers
     /**
      * Determine if part is a glob pattern.
      *
-     * @param part the string to check
+     * @param c the char to check
      * @param syntaxed true if overall pattern is syntaxed with <code>"glob:"</code> or <code>"regex:"</code>
      * @return true if part has glob characters
      */

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/CommandLineConfigSource.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/CommandLineConfigSource.java
@@ -13,11 +13,11 @@
 
 package org.eclipse.jetty.start.config;
 
-import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,7 +114,7 @@ public class CommandLineConfigSource implements ConfigSource
                 // ${jetty.home} is relative to found BaseHome class
                 try
                 {
-                    Path home = new File(new URI(m.group(1))).getParentFile().toPath();
+                    Path home = Paths.get(new URI(m.group(1))).getParent();
                     setProperty(BaseHome.JETTY_HOME, home.toString(), ORIGIN_INTERNAL_FALLBACK);
                     return home;
                 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.start;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +24,6 @@ import java.util.List;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,7 @@ public class BaseHomeTest
         List<String> actual = new ArrayList<>();
         for (Path path : finder.getHits())
         {
-            actual.add(hb.toShortForm(path.toFile()));
+            actual.add(hb.toShortForm(path));
         }
 
         if (actual.size() != expected.size())
@@ -63,7 +64,7 @@ public class BaseHomeTest
         List<String> actual = new ArrayList<>();
         for (Path path : paths)
         {
-            actual.add(hb.toShortForm(path.toFile()));
+            actual.add(hb.toShortForm(path));
         }
 
         if (actual.size() != expected.size())
@@ -82,16 +83,6 @@ public class BaseHomeTest
         assertThat(message + ": " + Utils.join(actual, ", "), actual, containsInAnyOrder(expected.toArray()));
     }
 
-    public static void assertFileList(BaseHome hb, String message, List<String> expected, List<File> files)
-    {
-        List<String> actual = new ArrayList<>();
-        for (File file : files)
-        {
-            actual.add(hb.toShortForm(file));
-        }
-        assertThat(message + ": " + Utils.join(actual, ", "), actual, containsInAnyOrder(expected.toArray()));
-    }
-
     @Test
     public void testGetPathOnlyHome() throws IOException
     {
@@ -106,7 +97,7 @@ public class BaseHomeTest
         String ref = hb.toShortForm(startIni);
         assertThat("Reference", ref, startsWith("${jetty.home}"));
 
-        String contents = IO.readToString(startIni.toFile());
+        String contents = Files.readString(startIni, StandardCharsets.UTF_8);
         assertThat("Contents", contents, containsString("Home Ini"));
     }
 
@@ -203,7 +194,7 @@ public class BaseHomeTest
         String ref = hb.toShortForm(startIni);
         assertThat("Reference", ref, startsWith("${jetty.base}"));
 
-        String contents = IO.readToString(startIni.toFile());
+        String contents = Files.readString(startIni, StandardCharsets.UTF_8);
         assertThat("Contents", contents, containsString("Base Ini"));
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/JarVersionTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/JarVersionTest.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ public class JarVersionTest
 {
     private void assertJarVersion(String jarname, String expectedVersion)
     {
-        File jarfile = MavenTestingUtils.getTestResourceFile(jarname);
+        Path jarfile = MavenTestingUtils.getTestResourcePathFile(jarname);
         assertThat("Jar: " + jarname, JarVersion.getVersion(jarfile), containsString(expectedVersion));
     }
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.start;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,16 +47,16 @@ public class ModulesTest
     public void testLoadAllModules() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("dist-home");
-        File baseDir = testdir.getEmptyPathDir().toFile();
+        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);
@@ -142,16 +143,16 @@ public class ModulesTest
     public void testResolveServerHttp() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("dist-home");
-        File baseDir = testdir.getEmptyPathDir().toFile();
+        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);
@@ -205,16 +206,16 @@ public class ModulesTest
     public void testResolveNotRequiredModuleNotFound() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("non-required-deps");
-        File baseDir = testdir.getEmptyPathDir().toFile();
+        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=cannot-find-me"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);
@@ -254,16 +255,16 @@ public class ModulesTest
     public void testResolveNotRequiredModuleFound() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("non-required-deps");
-        File baseDir = testdir.getEmptyPathDir().toFile();
+        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=dive"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);
@@ -305,16 +306,16 @@ public class ModulesTest
     public void testResolveNotRequiredModuleFoundDynamic() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("non-required-deps");
-        File baseDir = testdir.getEmptyPathDir().toFile();
+        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=dynamic"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/TestEnv.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/TestEnv.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.start;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -29,8 +28,8 @@ public class TestEnv
     public static void copyTestDir(String testResourceDir, Path destDir) throws IOException
     {
         FS.ensureDirExists(destDir);
-        File srcDir = MavenTestingUtils.getTestResourceDir(testResourceDir);
-        IO.copyDir(srcDir, destDir.toFile());
+        Path srcDir = MavenTestingUtils.getTestResourcePathDir(testResourceDir);
+        IO.copyDir(srcDir.toFile(), destDir.toFile());
     }
 
     public static void makeFile(Path dir, String relFilePath, String... contents) throws IOException

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
@@ -111,7 +111,7 @@ public class ConfigSourcesTest
 
         // Create common
         Path common = testdir.getPathFile("common");
-        FS.ensureEmpty(common.toFile());
+        FS.ensureEmpty(common);
         common = common.toRealPath();
 
         // Create base

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -196,7 +196,7 @@ public class MavenLocalRepoFileInitializerTest
         Files.deleteIfExists(destination);
         repo.download(coords.toCentralURI(), destination);
         assertThat(Files.exists(destination), is(true));
-        assertThat(destination.toFile().length(), is(986193L));
+        assertThat(Files.size(destination), is(986193L));
     }
 
     @Test
@@ -224,7 +224,7 @@ public class MavenLocalRepoFileInitializerTest
         Path destination = baseHome.getBasePath().resolve("jetty-rewrite-11.0.0-SNAPSHOT.jar");
         repo.download(coords, destination);
         assertThat(Files.exists(destination), is(true));
-        assertThat("Snapshot File size", destination.toFile().length(), greaterThan(10_000L));
+        assertThat("Snapshot File size", Files.size(destination), greaterThan(10_000L));
     }
 
     @Test

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
@@ -116,7 +116,7 @@ public class EnvironmentsTest extends AbstractUseCase
             Environment environment = results.getEnvironment(e);
             assertThat(environment, notNullValue());
             assertThat(environment.getName(), is(e));
-            assertThat(environment.getClasspath().getElements(), contains(baseDir.resolve("lib/%s.jar".formatted(e)).toFile()));
+            assertThat(environment.getClasspath().getElements(), contains(baseDir.resolve("lib/%s.jar".formatted(e))));
             assertThat(environment.getXmlFiles(), contains(baseDir.resolve("etc/%s.xml".formatted(e))));
             assertThat(environment.getProperties().getProp("feature.option").value, is(e));
         }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/RebuildTestResources.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/RebuildTestResources.java
@@ -124,7 +124,7 @@ public class RebuildTestResources
     {
         System.out.println("Copying libs (lib dir) ...");
         Path libsDir = destDir.resolve("lib");
-        FS.ensureDirExists(libsDir.toFile());
+        FS.ensureDirExists(libsDir);
 
         PathMatcher matcher = getPathMatcher("glob:**.jar");
         Renamer renamer = new RegexRenamer("-9\\.[0-9.]*(v[0-9-]*)?(-SNAPSHOT)?(RC[0-9])?(M[0-9])?", "-" + JETTY_VERSION);
@@ -136,7 +136,7 @@ public class RebuildTestResources
     {
         System.out.println("Copying modules ...");
         Path modulesDir = destDir.resolve("modules");
-        FS.ensureDirExists(modulesDir.toFile());
+        FS.ensureDirExists(modulesDir);
 
         PathMatcher matcher = getPathMatcher("glob:**.mod");
         Renamer renamer = new NoRenamer();
@@ -148,7 +148,7 @@ public class RebuildTestResources
     {
         System.out.println("Copying xmls (etc dir) ...");
         Path xmlDir = destDir.resolve("etc");
-        FS.ensureDirExists(xmlDir.toFile());
+        FS.ensureDirExists(xmlDir);
 
         PathMatcher matcher = getPathMatcher("glob:**.xml");
         Renamer renamer = new NoRenamer();


### PR DESCRIPTION
* This corrects our URL/URI/URLClassLoader behaviors
  to always produce to-spec URIs for `file://` references.