### PR TITLE
Issue #8354 - Reduce Lock contention during Logging in AdaptiveExecutionStrategy

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -179,7 +179,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
             }
         }
         if (LOG.isDebugEnabled())
-            LOG.debug("{} dispatch {}", this, execute);
+            LOG.debug("{} dispatch {}", toStringLocked(), execute);
         if (execute)
             _executor.execute(_runPendingProducer);
     }
@@ -198,7 +198,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     private void tryProduce(boolean wasPending)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{} tryProduce {}", this, wasPending);
+            LOG.debug("{} tryProduce {}", toStringLocked(), wasPending);
 
         // Takes the lock to atomically check if the thread can produce.
         try (AutoLock l = _lock.lock())
@@ -358,7 +358,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     {
         // Consume and/or execute task according to the selected mode.
         if (LOG.isDebugEnabled())
-            LOG.debug("ss={} t={}/{} {}", subStrategy, task, Invocable.getInvocationType(task), this);
+            LOG.debug("ss={} t={}/{} {}", subStrategy, task, Invocable.getInvocationType(task), toStringLocked());
         switch (subStrategy)
         {
             case PRODUCE_CONSUME:
@@ -521,10 +521,12 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     @Override
     public String toString()
     {
+        String ret;
         try (AutoLock l = _lock.lock())
         {
-            return toStringLocked();
+            ret = toStringLocked();
         }
+        return ret;
     }
 
     public String toStringLocked()

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -521,12 +521,10 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     @Override
     public String toString()
     {
-        String ret;
         try (AutoLock l = _lock.lock())
         {
-            ret = toStringLocked();
+            return toStringLocked();
         }
-        return ret;
     }
 
     public String toStringLocked()


### PR DESCRIPTION
Fixes: 

* #8354

This is a speculative fix, as I cannot replicate the deadlock reported in the issue.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>