### PR TITLE
Jetty 12 : Remove `maxBuffer` from `ContentFactory.getContent(String)` parameters

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CachingContentFactory.java
@@ -165,7 +165,7 @@ public class CachingContentFactory implements HttpContent.ContentFactory
     }
 
     @Override
-    public HttpContent getContent(String path, int maxBuffer) throws IOException
+    public HttpContent getContent(String path) throws IOException
     {
         // TODO load precompressed otherwise it is never served from cache
         CachingHttpContent cachingHttpContent = _cache.get(path);
@@ -177,7 +177,7 @@ public class CachingContentFactory implements HttpContent.ContentFactory
                 removeFromCache(cachingHttpContent);
         }
 
-        HttpContent httpContent = _authority.getContent(path, maxBuffer);
+        HttpContent httpContent = _authority.getContent(path);
         // Do not cache directories or files that are too big
         if (httpContent != null && !httpContent.getResource().isDirectory() && httpContent.getContentLengthValue() <= _maxCachedFileSize)
         {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpContent.java
@@ -73,11 +73,9 @@ public interface HttpContent
     {
         /**
          * @param path The path within the context to the resource
-         * @param maxBuffer The maximum buffer to allocated for this request.
          * @return A {@link HttpContent}
          * @throws IOException if unable to get content
          */
-        // TODO maxBuffer is not needed anymore
-        HttpContent getContent(String path, int maxBuffer) throws IOException;
+        HttpContent getContent(String path) throws IOException;
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java
@@ -32,26 +32,19 @@ public class ResourceHttpContent implements HttpContent
     final Resource _resource;
     final Path _path;
     final String _contentType;
-    final int _maxBuffer;
     Map<CompressedContentFormat, HttpContent> _precompressedContents;
     String _etag;
 
     public ResourceHttpContent(final Resource resource, final String contentType)
     {
-        this(resource, contentType, -1, null);
+        this(resource, contentType, null);
     }
 
-    public ResourceHttpContent(final Resource resource, final String contentType, int maxBuffer)
-    {
-        this(resource, contentType, maxBuffer, null);
-    }
-
-    public ResourceHttpContent(final Resource resource, final String contentType, int maxBuffer, Map<CompressedContentFormat, HttpContent> precompressedContents)
+    public ResourceHttpContent(final Resource resource, final String contentType, Map<CompressedContentFormat, HttpContent> precompressedContents)
     {
         _resource = resource;
         _path = resource.getPath();
         _contentType = contentType;
-        _maxBuffer = maxBuffer;
         if (precompressedContents == null)
         {
             _precompressedContents = null;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.PrecompressedHttpContent;
 import org.eclipse.jetty.http.ResourceHttpContent;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
@@ -157,7 +156,6 @@ public class CachedContentFactory implements HttpContent.ContentFactory
      * <p>Returns an entry from the cache, or creates a new one.</p>
      *
      * @param pathInContext The key into the cache
-     * @param maxBufferSize The maximum buffer size allocated for this request.
      * @return The entry matching {@code pathInContext}, or a new entry
      * if no matching entry was found. If the content exists but is not cacheable,
      * then a {@link ResourceHttpContent} instance is returned. If
@@ -165,7 +163,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
      * @throws IOException if the resource cannot be retrieved
      */
     @Override
-    public HttpContent getContent(String pathInContext, int maxBufferSize) throws IOException
+    public HttpContent getContent(String pathInContext) throws IOException
     {
         // Is the content in this cache?
         CachedHttpContent content = _cache.get(pathInContext);
@@ -174,14 +172,14 @@ public class CachedContentFactory implements HttpContent.ContentFactory
 
         // try loading the content from our factory.
         Resource resource = _factory.resolve(pathInContext);
-        HttpContent loaded = load(pathInContext, resource, maxBufferSize);
+        HttpContent loaded = load(pathInContext, resource);
         if (loaded != null)
             return loaded;
 
         // Is the content in the parent cache?
         if (_parent != null)
         {
-            HttpContent httpContent = _parent.getContent(pathInContext, maxBufferSize);
+            HttpContent httpContent = _parent.getContent(pathInContext);
             if (httpContent != null)
                 return httpContent;
         }
@@ -204,13 +202,13 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         return (len > 0 && (_useFileMappedBuffer || (len < _maxCachedFileSize && len < _maxCacheSize)));
     }
 
-    private HttpContent load(String pathInContext, Resource resource, int maxBufferSize) throws IOException
+    private HttpContent load(String pathInContext, Resource resource) throws IOException
     {
         if (resource == null || !resource.exists())
             return null;
 
         if (resource.isDirectory())
-            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()), getMaxCachedFileSize());
+            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()));
 
         // Will it fit in the cache?
         if (isCacheable(resource))
@@ -278,13 +276,13 @@ public class CachedContentFactory implements HttpContent.ContentFactory
                 if (compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
-                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext), maxBufferSize));
+                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));
             }
             if (!compressedContents.isEmpty())
-                return new ResourceHttpContent(resource, mt, maxBufferSize, compressedContents);
+                return new ResourceHttpContent(resource, mt, compressedContents);
         }
 
-        return new ResourceHttpContent(resource, mt, maxBufferSize);
+        return new ResourceHttpContent(resource, mt);
     }
 
     private void shrinkCache()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceContentFactory.java
@@ -49,13 +49,13 @@ public class ResourceContentFactory implements ContentFactory
     }
 
     @Override
-    public HttpContent getContent(String pathInContext, int maxBufferSize) throws IOException
+    public HttpContent getContent(String pathInContext) throws IOException
     {
         try
         {
             // try loading the content from our factory.
             Resource resource = _factory.resolve(pathInContext);
-            return load(pathInContext, resource, maxBufferSize);
+            return load(pathInContext, resource);
         }
         catch (Throwable t)
         {
@@ -72,14 +72,14 @@ public class ResourceContentFactory implements ContentFactory
         }
     }
 
-    private HttpContent load(String pathInContext, Resource resource, int maxBufferSize)
+    private HttpContent load(String pathInContext, Resource resource)
         throws IOException
     {
         if (resource == null || !resource.exists())
             return null;
 
         if (resource.isDirectory())
-            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()), maxBufferSize);
+            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()));
 
         // Look for a precompressed resource or content
         String mt = _mimeTypes.getMimeByExtension(pathInContext);
@@ -94,12 +94,12 @@ public class ResourceContentFactory implements ContentFactory
                 if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
-                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext), maxBufferSize));
+                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));
             }
             if (!compressedContents.isEmpty())
-                return new ResourceHttpContent(resource, mt, maxBufferSize, compressedContents);
+                return new ResourceHttpContent(resource, mt, compressedContents);
         }
-        return new ResourceHttpContent(resource, mt, maxBufferSize);
+        return new ResourceHttpContent(resource, mt);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -75,9 +75,9 @@ public class ResourceService
     {
     }
 
-    public HttpContent getContent(String path, int outputBufferSize) throws IOException
+    public HttpContent getContent(String path) throws IOException
     {
-        return _contentFactory.getContent(path == null ? "" : path, outputBufferSize);
+        return _contentFactory.getContent(path == null ? "" : path);
     }
 
     public HttpContent.ContentFactory getContentFactory()
@@ -445,11 +445,10 @@ public class ResourceService
             case SERVE ->
             {
                 // TODO : check conditional headers.
-                // TODO output buffer size????
-                HttpContent c = _contentFactory.getContent(welcomeAction.target, 16 * 1024);
+                HttpContent c = _contentFactory.getContent(welcomeAction.target);
                 sendData(request, response, callback, c, null);
             }
-        };
+        }
     }
 
     private WelcomeAction processWelcome(Request request, Response response) throws IOException

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -107,7 +107,7 @@ public class ResourceHandler extends Handler.Wrapper
             return super.handle(request);
         }
 
-        HttpContent content = _resourceService.getContent(request.getPathInContext(), request.getConnectionMetaData().getHttpConfiguration().getOutputBufferSize());
+        HttpContent content = _resourceService.getContent(request.getPathInContext());
         if (content == null)
             return super.handle(request); // no content - try other handlers
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceCacheTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceCacheTest.java
@@ -214,12 +214,12 @@ public class ResourceCacheTest
         cache.setMaxCachedFileSize(85);
         cache.setMaxCachedFiles(4);
 
-        assertNull(cache.getContent("does not exist", 4096));
-        assertTrue(cache.getContent(names[9], 4096) instanceof ResourceHttpContent);
-        assertNotNull(cache.getContent(names[9], 4096).getBuffer());
+        assertNull(cache.getContent("does not exist"));
+        assertTrue(cache.getContent(names[9]) instanceof ResourceHttpContent);
+        assertNotNull(cache.getContent(names[9]).getBuffer());
 
         HttpContent content;
-        content = cache.getContent(names[8], 4096);
+        content = cache.getContent(names[8]);
         assertThat(content, is(not(nullValue())));
         assertEquals(80, content.getContentLengthValue());
         assertEquals(0, cache.getCachedSize());
@@ -240,7 +240,7 @@ public class ResourceCacheTest
             cache.setMaxCachedFileSize(85);
             cache.setMaxCachedFiles(4);
 
-            content = cache.getContent(names[8], 4096);
+            content = cache.getContent(names[8]);
             content.getBuffer();
             assertEquals(cache.isUseFileMappedBuffer() ? 0 : 80, cache.getCachedSize());
 
@@ -254,7 +254,7 @@ public class ResourceCacheTest
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[1], 4096);
+        content = cache.getContent(names[1]);
         assertEquals(80, cache.getCachedSize());
         content.getBuffer();
         assertEquals(90, cache.getCachedSize());
@@ -262,35 +262,35 @@ public class ResourceCacheTest
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[2], 4096);
+        content = cache.getContent(names[2]);
         content.getBuffer();
         assertEquals(30, cache.getCachedSize());
         assertEquals(2, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[3], 4096);
+        content = cache.getContent(names[3]);
         content.getBuffer();
         assertEquals(60, cache.getCachedSize());
         assertEquals(3, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[4], 4096);
+        content = cache.getContent(names[4]);
         content.getBuffer();
         assertEquals(90, cache.getCachedSize());
         assertEquals(3, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[5], 4096);
+        content = cache.getContent(names[5]);
         content.getBuffer();
         assertEquals(90, cache.getCachedSize());
         assertEquals(2, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[6], 4096);
+        content = cache.getContent(names[6]);
         content.getBuffer();
         assertEquals(60, cache.getCachedSize());
         assertEquals(1, cache.getCachedFiles());
@@ -301,42 +301,42 @@ public class ResourceCacheTest
         {
             out.write(' ');
         }
-        content = cache.getContent(names[7], 4096);
+        content = cache.getContent(names[7]);
         content.getBuffer();
         assertEquals(70, cache.getCachedSize());
         assertEquals(1, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[6], 4096);
+        content = cache.getContent(names[6]);
         content.getBuffer();
         assertEquals(71, cache.getCachedSize());
         assertEquals(2, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[0], 4096);
+        content = cache.getContent(names[0]);
         content.getBuffer();
         assertEquals(72, cache.getCachedSize());
         assertEquals(3, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[1], 4096);
+        content = cache.getContent(names[1]);
         content.getBuffer();
         assertEquals(82, cache.getCachedSize());
         assertEquals(4, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[2], 4096);
+        content = cache.getContent(names[2]);
         content.getBuffer();
         assertEquals(32, cache.getCachedSize());
         assertEquals(4, cache.getCachedFiles());
 
         Thread.sleep(200);
 
-        content = cache.getContent(names[3], 4096);
+        content = cache.getContent(names[3]);
         content.getBuffer();
         assertEquals(61, cache.getCachedSize());
         assertEquals(4, cache.getCachedFiles());
@@ -366,7 +366,7 @@ public class ResourceCacheTest
 
     static String getContent(CachedContentFactory rc, String path) throws Exception
     {
-        HttpContent content = rc.getContent(path, rc.getMaxCachedFileSize());
+        HttpContent content = rc.getContent(path);
         if (content == null)
             return null;
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -325,7 +325,7 @@ public class DefaultServlet extends HttpServlet
         boolean included = req.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI) != null;
         try
         {
-            HttpContent content = _resourceService.getContent(pathInContext, resp.getBufferSize());
+            HttpContent content = _resourceService.getContent(pathInContext);
             if (content == null || !content.getResource().exists())
             {
                 if (included)
@@ -906,9 +906,9 @@ public class DefaultServlet extends HttpServlet
         }
 
         @Override
-        public HttpContent getContent(String path, int outputBufferSize) throws IOException
+        public HttpContent getContent(String path) throws IOException
         {
-            HttpContent httpContent = super.getContent(path, outputBufferSize);
+            HttpContent httpContent = super.getContent(path);
 
             if (httpContent != null)
             {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.PrecompressedHttpContent;
 import org.eclipse.jetty.http.ResourceHttpContent;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
@@ -156,7 +155,6 @@ public class CachedContentFactory implements HttpContent.ContentFactory
      * <p>Returns an entry from the cache, or creates a new one.</p>
      *
      * @param pathInContext The key into the cache
-     * @param maxBufferSize The maximum buffer size allocated for this request.  For cached content, a larger buffer may have
      * previously been allocated and returned by the {@link HttpContent#getBuffer()} calls.
      * @return The entry matching {@code pathInContext}, or a new entry
      * if no matching entry was found. If the content exists but is not cacheable,
@@ -165,7 +163,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
      * @throws IOException if the resource cannot be retrieved
      */
     @Override
-    public HttpContent getContent(String pathInContext, int maxBufferSize) throws IOException
+    public HttpContent getContent(String pathInContext) throws IOException
     {
         // Is the content in this cache?
         CachedHttpContent content = _cache.get(pathInContext);
@@ -174,14 +172,14 @@ public class CachedContentFactory implements HttpContent.ContentFactory
 
         // try loading the content from our factory.
         Resource resource = _factory.resolve(pathInContext);
-        HttpContent loaded = load(pathInContext, resource, maxBufferSize);
+        HttpContent loaded = load(pathInContext, resource);
         if (loaded != null)
             return loaded;
 
         // Is the content in the parent cache?
         if (_parent != null)
         {
-            HttpContent httpContent = _parent.getContent(pathInContext, maxBufferSize);
+            HttpContent httpContent = _parent.getContent(pathInContext);
             if (httpContent != null)
                 return httpContent;
         }
@@ -204,13 +202,13 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         return (len > 0 && (_useFileMappedBuffer || (len < _maxCachedFileSize && len < _maxCacheSize)));
     }
 
-    private HttpContent load(String pathInContext, Resource resource, int maxBufferSize) throws IOException
+    private HttpContent load(String pathInContext, Resource resource) throws IOException
     {
         if (resource == null || !resource.exists())
             return null;
 
         if (resource.isDirectory())
-            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()), getMaxCachedFileSize());
+            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()));
 
         // Will it fit in the cache?
         if (isCacheable(resource))
@@ -278,13 +276,13 @@ public class CachedContentFactory implements HttpContent.ContentFactory
                 if (compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
-                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext), maxBufferSize));
+                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));
             }
             if (!compressedContents.isEmpty())
-                return new ResourceHttpContent(resource, mt, maxBufferSize, compressedContents);
+                return new ResourceHttpContent(resource, mt, compressedContents);
         }
 
-        return new ResourceHttpContent(resource, mt, maxBufferSize);
+        return new ResourceHttpContent(resource, mt);
     }
 
     private void shrinkCache()

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceContentFactory.java
@@ -45,13 +45,13 @@ public class ResourceContentFactory implements ContentFactory
     }
 
     @Override
-    public HttpContent getContent(String pathInContext, int maxBufferSize) throws IOException
+    public HttpContent getContent(String pathInContext) throws IOException
     {
         try
         {
             // try loading the content from our factory.
             Resource resource = _factory.resolve(pathInContext);
-            return load(pathInContext, resource, maxBufferSize);
+            return load(pathInContext, resource);
         }
         catch (Throwable t)
         {
@@ -68,14 +68,14 @@ public class ResourceContentFactory implements ContentFactory
         }
     }
 
-    private HttpContent load(String pathInContext, Resource resource, int maxBufferSize)
+    private HttpContent load(String pathInContext, Resource resource)
         throws IOException
     {
         if (resource == null || !resource.exists())
             return null;
 
         if (resource.isDirectory())
-            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()), maxBufferSize);
+            return new ResourceHttpContent(resource, _mimeTypes.getMimeByExtension(resource.toString()));
 
         // Look for a precompressed resource or content
         String mt = _mimeTypes.getMimeByExtension(pathInContext);
@@ -90,12 +90,12 @@ public class ResourceContentFactory implements ContentFactory
                 if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
-                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext), maxBufferSize));
+                        new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));
             }
             if (!compressedContents.isEmpty())
-                return new ResourceHttpContent(resource, mt, maxBufferSize, compressedContents);
+                return new ResourceHttpContent(resource, mt, compressedContents);
         }
-        return new ResourceHttpContent(resource, mt, maxBufferSize);
+        return new ResourceHttpContent(resource, mt);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -238,7 +238,7 @@ public class ResourceService
         try
         {
             // Find the content
-            content = _contentFactory.getContent(pathInContext, response.getBufferSize());
+            content = _contentFactory.getContent(pathInContext);
             if (LOG.isDebugEnabled())
                 LOG.debug("content={}", content);
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
@@ -59,7 +59,6 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.TypeUtil;
-import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -1239,10 +1238,10 @@ public class DefaultServletTest
 
         ResourceContentFactory factory = (ResourceContentFactory)context.getServletContext().getAttribute("resourceCache");
 
-        HttpContent content = factory.getContent("/index.html", 200);
+        HttpContent content = factory.getContent("/index.html");
         ByteBuffer buffer = content.getBuffer();
         assertThat("Buffer is direct", buffer.isDirect(), is(true));
-        content = factory.getContent("/index.html", 5);
+        content = factory.getContent("/index.html");
         buffer = content.getBuffer();
         assertThat("Direct buffer", buffer, is(nullValue()));
     }


### PR DESCRIPTION
Per the TODO in `ContentFactory.getContent()` remove the `maxBuffer` argument

https://github.com/eclipse/jetty.project/blob/74a11a153f91b51b3c54efab3e5adf26aac0dc4d/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpContent.java#L74-L81