### PR TITLE
Jetty 12 : Remove static Resource.isContainedIn API

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -419,19 +419,6 @@ public abstract class Resource implements ResourceFactory
     }
 
     /**
-     * Return true if the Resource r is contained in the Resource containingResource, either because
-     * containingResource is a folder or a jar file or any form of resource capable of containing other resources.
-     *
-     * @param r the contained resource
-     * @param containingResource the containing resource
-     * @return true if the Resource is contained, false otherwise
-     */
-    public static boolean isContainedIn(Resource r, Resource containingResource)
-    {
-        return r.isContainedIn(containingResource);
-    }
-
-    /**
      * Return the Path corresponding to this resource.
      *
      * @return the path.

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
@@ -405,7 +405,7 @@ public class MetaData
         {
             for (Resource r : resources)
             {
-                if (Resource.isContainedIn(resource, r))
+                if (resource.isContainedIn(r))
                 {
                     enclosingResource = r;
                     break;

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -405,7 +405,7 @@ public class MetaData
         {
             for (Resource r : resources)
             {
-                if (Resource.isContainedIn(resource, r))
+                if (resource.isContainedIn(r))
                 {
                     enclosingResource = r;
                     break;


### PR DESCRIPTION
Turns out the static `Resource.isContainedIn(Resource,Resource)` was superfluous.
We have a normal (non-static) `.isContainedIn()` method already.
