### PR TITLE
improve performance of alias checking

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -228,7 +228,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     private final List<ContextScopeListener> _contextListeners = new CopyOnWriteArrayList<>();
     private final Set<EventListener> _durableListeners = new HashSet<>();
     private Index<ProtectedTargetType> _protectedTargets = Index.empty(false);
-    private final List<AliasCheck> _aliasChecks = new CopyOnWriteArrayList<>();
+    private final List<AliasCheck> _aliasChecks = new ArrayList<>();
 
     public enum Availability
     {
@@ -1967,7 +1967,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                 LOG.debug("Aliased resource: {}~={}", resource, resource.getAlias());
 
             // alias checks
-            for (AliasCheck check : getAliasChecks())
+            for (AliasCheck check : _aliasChecks)
             {
                 if (check.check(path, resource))
                 {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -228,7 +228,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     private final List<ContextScopeListener> _contextListeners = new CopyOnWriteArrayList<>();
     private final Set<EventListener> _durableListeners = new HashSet<>();
     private Index<ProtectedTargetType> _protectedTargets = Index.empty(false);
-    private final List<AliasCheck> _aliasChecks = new ArrayList<>();
+    private final List<AliasCheck> _aliasChecks = new CopyOnWriteArrayList<>();
 
     public enum Availability
     {


### PR DESCRIPTION
We don't want to create the unmodifiableList every time we check an alias, so use `_aliasChecks` directly instead of using the getter.

<s>Also I don't think we need the `CopyOnWriteArrayList` because we do not allow modifications after the `ContextHandler` has been started.</s>