### PR TITLE
MemoryResource

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -48,8 +48,8 @@ import org.eclipse.jetty.util.component.Environment;
 import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.util.resource.MemoryResource;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ShutdownThread;
@@ -671,12 +671,10 @@ public class Server extends Handler.Wrapper implements Attributes
      */
     private Resource newResource(String name)
     {
-        // TODO replace this.  It is needlessly complex and inefficient as it holds a mount of the server jar
-        //      just for things like favicon and default stylesheet
         URL url = getClass().getResource(name);
         if (url == null)
             throw new IllegalStateException("Missing server resource: " + name);
-        return ResourceFactory.of(this).newResource(URI.create(url.toExternalForm()));
+        return new MemoryResource(url);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -48,8 +48,8 @@ import org.eclipse.jetty.util.component.Environment;
 import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
-import org.eclipse.jetty.util.resource.MemoryResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ShutdownThread;
@@ -674,7 +674,7 @@ public class Server extends Handler.Wrapper implements Attributes
         URL url = getClass().getResource(name);
         if (url == null)
             throw new IllegalStateException("Missing server resource: " + name);
-        return new MemoryResource(url);
+        return ResourceFactory.root().newMemoryResource(url);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DefaultHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DefaultHandlerTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultHandlerTest
@@ -134,6 +136,9 @@ public class DefaultHandlerTest
 
             assertEquals(HttpStatus.OK_200, response.getStatus());
             assertEquals("image/x-icon", response.get(HttpHeader.CONTENT_TYPE));
+            byte[] bytes = response.getContentBytes();
+            assertThat(bytes, notNullValue());
+            assertThat(bytes.length, greaterThan(0));
         }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
@@ -1,0 +1,117 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.resource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.eclipse.jetty.util.IO;
+
+/**
+ * <p>An in memory Resource created from a {@link URL}</p>
+ */
+public class MemoryResource extends Resource
+{
+
+    private final URI _uri;
+    private final long _created = System.currentTimeMillis();
+    private final byte[] _bytes;
+
+    public MemoryResource(URL url)
+    {
+        try
+        {
+            _uri = Objects.requireNonNull(url).toURI();
+            _bytes = IO.readBytes(url.openStream());
+        }
+        catch (IOException | URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isContainedIn(Resource r)
+    {
+        return false;
+    }
+
+    @Override
+    public URI getURI()
+    {
+        return _uri;
+    }
+
+    @Override
+    public String getName()
+    {
+        return _uri.getPath();
+    }
+
+    @Override
+    public long lastModified()
+    {
+        return _created;
+    }
+
+    @Override
+    public long length()
+    {
+        return _bytes.length;
+    }
+
+    @Override
+    public InputStream newInputStream() throws IOException
+    {
+        return new ByteArrayInputStream(_bytes);
+    }
+
+    @Override
+    public ReadableByteChannel newReadableByteChannel() throws IOException
+    {
+        return Channels.newChannel(newInputStream());
+    }
+
+    @Override
+    public Resource resolve(String subUriPath)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return true;
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
+}

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
@@ -31,17 +31,19 @@ import org.eclipse.jetty.util.IO;
  */
 public class MemoryResource extends Resource
 {
-
     private final URI _uri;
     private final long _created = System.currentTimeMillis();
     private final byte[] _bytes;
 
-    public MemoryResource(URL url)
+    MemoryResource(URL url)
     {
         try
         {
             _uri = Objects.requireNonNull(url).toURI();
-            _bytes = IO.readBytes(url.openStream());
+            try (InputStream in = url.openStream())
+            {
+                _bytes = IO.readBytes(in);
+            }
         }
         catch (IOException | URISyntaxException e)
         {
@@ -52,13 +54,13 @@ public class MemoryResource extends Resource
     @Override
     public Path getPath()
     {
-        return null;
+        return Path.of(_uri);
     }
 
     @Override
     public boolean isContainedIn(Resource r)
     {
-        return false;
+        return getPath().startsWith(r.getPath());
     }
 
     @Override
@@ -70,7 +72,7 @@ public class MemoryResource extends Resource
     @Override
     public String getName()
     {
-        return _uri.getPath();
+        return getPath().toAbsolutePath().toString();
     }
 
     @Override
@@ -95,12 +97,6 @@ public class MemoryResource extends Resource
     public ReadableByteChannel newReadableByteChannel() throws IOException
     {
         return Channels.newChannel(newInputStream());
-    }
-
-    @Override
-    public Resource resolve(String subUriPath)
-    {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -273,6 +273,8 @@ public abstract class Resource
      */
     public List<String> list() // TODO: should return Path's
     {
+        if (!isDirectory())
+            return null;
         try (DirectoryStream<Path> dir = Files.newDirectoryStream(getPath()))
         {
             List<String> entries = new ArrayList<>();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -104,8 +104,6 @@ public interface ResourceFactory
      * Find a classpath resource.
      * The {@link Class#getResource(String)} method is used to lookup the resource. If it is not
      * found, then the {@link Loader#getResource(String)} method is used.
-     * If it is still not found, then {@link ClassLoader#getSystemResource(String)} is used.
-     * Unlike {@link ClassLoader#getSystemResource(String)} this method does not check for normal resources.
      *
      * @param resource the relative name of the resource
      * @return Resource or null
@@ -127,6 +125,17 @@ public interface ResourceFactory
         {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * Load a URL into a memory resource.
+     * @param url the URL to load into memory
+     * @return Resource or null
+     * @see #newClassPathResource(String)
+     */
+    default Resource newMemoryResource(URL url)
+    {
+        return new MemoryResource(url);
     }
 
     /**

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
@@ -1,0 +1,34 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.resource;
+
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.Loader;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MemoryResourceTest
+{
+    @Test
+    public void testJettyLogging() throws Exception
+    {
+        Resource resource = new MemoryResource(Loader.getResource("jetty-logging.properties"));
+        assertTrue(resource.exists());
+        String contents = IO.toString(resource.newInputStream());
+        assertThat(contents, startsWith("#org.eclipse.jetty.util.LEVEL=DEBUG"));
+    }
+}

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
@@ -26,7 +26,7 @@ public class MemoryResourceTest
     @Test
     public void testJettyLogging() throws Exception
     {
-        Resource resource = new MemoryResource(Loader.getResource("jetty-logging.properties"));
+        Resource resource = ResourceFactory.root().newMemoryResource(Loader.getResource("jetty-logging.properties"));
         assertTrue(resource.exists());
         String contents = IO.toString(resource.newInputStream());
         assertThat(contents, startsWith("#org.eclipse.jetty.util.LEVEL=DEBUG"));


### PR DESCRIPTION
Added MemoryResource to simplify favicon handling.
Using the ResourceFactory mechanism results in an entire jar mounted as a ZipFS in memory that is only needed for favicon.ico