### PR TITLE
move from org.glassfish.web:jstl-impl:1.2 to org.glassfish.web:javax.servlet.jsp.jstl:1.2.5

### DIFF
--- a/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
+++ b/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
@@ -22,7 +22,7 @@
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
           <systemPropertyVariables>
-            <org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern>.*/jetty-jakarta-servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-[^/]*\.jar|.*jstl-impl-[^/]*\.jar</org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern>
+            <org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern>.*/jetty-jakarta-servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-[^/]*\.jar|.*jsp.jstl-[^/]*\.jar</org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.glassfish.web</groupId>
-      <artifactId>jstl-impl</artifactId>
+      <artifactId>javax.servlet.jsp.jstl</artifactId>
       <exclusions>
         <exclusion>
           <groupId>javax.servlet.jsp</groupId>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -229,8 +229,8 @@
         </dependency>
         <dependency>
           <groupId>org.glassfish.web</groupId>
-          <artifactId>jstl-impl</artifactId>
-          <version>1.2</version>
+          <artifactId>javax.servlet.jsp.jstl</artifactId>
+          <version>1.2.5</version>
         </dependency>
         <dependency>
           <groupId>org.eclipse.jetty.toolchain</groupId>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <oliver.lamy@gmail.com>
