### PR TITLE
Issue #8456 - serve jetty-dir.css as resource in jetty-core ResourceService

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -37,12 +37,14 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.QuotedCSV;
 import org.eclipse.jetty.http.QuotedQualityCSV;
+import org.eclipse.jetty.http.ResourceHttpContent;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,14 +73,34 @@ public class ResourceService
     private boolean _dirAllowed = true;
     private boolean _acceptRanges = true;
     private HttpField _cacheControl;
+    private Resource _stylesheet;
 
     public ResourceService()
     {
     }
 
+    /**
+     * @param stylesheet The location of the stylesheet to be used as a String.
+     */
+    public void setStylesheet(Resource stylesheet)
+    {
+        _stylesheet = stylesheet;
+    }
+
+    /**
+     * @return Returns the stylesheet as a Resource.
+     */
+    public Resource getStylesheet()
+    {
+        return _stylesheet;
+    }
+
     public HttpContent getContent(String path) throws IOException
     {
-        return _contentFactory.getContent(path == null ? "" : path);
+        HttpContent content = _contentFactory.getContent(path == null ? "" : path);
+        if ((content == null) && (_stylesheet != null) && (path != null) && path.endsWith("/jetty-dir.css"))
+            content = new ResourceHttpContent(_stylesheet, "text/css");
+        return content;
     }
 
     public HttpContent.ContentFactory getContentFactory()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -74,6 +74,9 @@ public class ResourceHandler extends Handler.Wrapper
 
         setupContentFactory();
 
+        if (_resourceService.getStylesheet() == null)
+            _resourceService.setStylesheet(getServer().getDefaultStyleSheet());
+
         super.doStart();
     }
 
@@ -154,7 +157,7 @@ public class ResourceHandler extends Handler.Wrapper
      */
     public Resource getStylesheet()
     {
-        return getServer().getDefaultStyleSheet();
+        return _resourceService.getStylesheet();
     }
 
     public List<String> getWelcomeFiles()
@@ -301,10 +304,9 @@ public class ResourceHandler extends Handler.Wrapper
     /**
      * @param stylesheet The location of the stylesheet to be used as a String.
      */
-    // TODO accept a Resource instead of a String?
-    public void setStylesheet(String stylesheet)
+    public void setStylesheet(Resource stylesheet)
     {
-        // TODO
+        _resourceService.setStylesheet(stylesheet);
     }
 
     public void setWelcomeFiles(String... welcomeFiles)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -1799,8 +1799,8 @@ public class ResourceHandlerTest
                 Connection: close\r
                 \r
                 """));
-        // TODO fix this!
-        // assertThat(response.getStatus(), is(HttpStatus.OK_200));
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
     }
 
     @Test
@@ -1835,8 +1835,7 @@ public class ResourceHandlerTest
                 \r
                 """));
 
-        // TODO fix this!
-        // assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
 
         response = HttpTester.parseResponse(
             _local.getResponse("""
@@ -1860,8 +1859,7 @@ public class ResourceHandlerTest
                 \r
                 """));
 
-        // TODO fix this!
-        // assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
     }
 
     @Test
@@ -1915,8 +1913,7 @@ public class ResourceHandlerTest
                 \r
                 """));
 
-        // TODO fix this!
-        // assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -206,7 +206,6 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             }
         }
 
-        // TODO move most of this to Resource Service
         String stylesheet = getInitParameter("stylesheet");
         try
         {
@@ -478,7 +477,6 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
             LOG.trace("IGNORED", e);
         }
 
-        // TODO Move to ResourceService
         if ((r == null || !r.exists()) && subUriPath.endsWith("/jetty-dir.css"))
             r = _stylesheet;
 


### PR DESCRIPTION
## Issue #8456

For the jetty-core `ResourceService` now has special handling for the `jetty-dir.css`. This is set on the `ResourceService` through API on the `ResourceHandler` and the ee10 `DefaultServlet`. The ee9 code does not use this mechanism as it uses the old `ResourceService` and has logic on the ee9 `ResourceHandler` and `DefaultServlet` to get servers default and set custom values for the stylesheet.

Similar PR to #8428 