### PR TITLE
Fixes #8007 - Support Loom.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -472,7 +472,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         try
         {
             if (isUseVirtualThreads())
-                VirtualThreads.startVirtualThread(task);
+                VirtualThreads.executeOnVirtualThread(task);
             else
                 _executor.execute(task);
         }


### PR DESCRIPTION
Now using Executors.newVirtualThreadPerTaskExecutor() to execute
tasks, so the executor is tracked by the runtime for thread dumps, etc.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>