### PR TITLE
Jetty 12 : Enable `jetty-jmh`

### DIFF
--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -36,11 +36,12 @@
             </goals>
             <configuration>
               <finalName>${jmhjar.name}</finalName>
-              <shadeTestJar>true</shadeTestJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>
@@ -49,6 +50,11 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/NOTICE.txt</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>LICENSE</exclude>
+                    <exclude>THIRD-PARTY</exclude>
+                    <exclude>**/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -71,10 +77,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -94,6 +93,12 @@
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,8 +20,7 @@
   <modules>
     <module>jetty-ee9-test-maven-plugin</module>
     <module>jetty-ee10-test-maven-plugin</module>
-    <!-- TODO -->
-    <!-- module>jetty-jmh</module -->
+    <module>jetty-jmh</module>
     <module>test-distribution</module>
     <!-- module>test-jpms</module -->
   </modules>


### PR DESCRIPTION
* Remove `servlet-api` from pom (not used)
* Fix `maven-shade-plugin` config
  - no test shade artifact (test scope not used)
  - more excludes to avoid conflicts
  - add `META-INF/services` transformer