### PR TITLE
define the resourceBase in well-known ContextHandler to allow alias checking

### DIFF
--- a/jetty-server/src/main/config/etc/well-known.xml
+++ b/jetty-server/src/main/config/etc/well-known.xml
@@ -2,15 +2,19 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
+  <Call id="resourceBase" name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
+    <Arg><Property name="jetty.base"/></Arg>
+    <Arg><Property name="jetty.wellknown.dir" default=".well-known"/></Arg>
+  </Call>
   <New id="WellKnownHandler" class="org.eclipse.jetty.server.handler.ContextHandler">
     <Set name="contextPath">/.well-known</Set>
+    <Set name="resourceBase">
+      <Ref refid="resourceBase"/>
+    </Set>
     <Set name="handler">
       <New class="org.eclipse.jetty.server.handler.ResourceHandler">
         <Set name="resourceBase">
-          <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-            <Arg><Property name="jetty.base"/></Arg>
-            <Arg><Property name="jetty.wellknown.dir" default=".well-known"/></Arg>
-          </Call>
+          <Ref refid="resourceBase"/>
         </Set>
         <Set name="directoriesListed"><Property name="jetty.wellknown.listDirectories" default="false"/></Set>
       </New>


### PR DESCRIPTION
The resourceBase must be defined in the WellKnownHandler if the `SymlinkAllowedResourceAliasChecker` is to work.