### PR TITLE
add getter for the WebSocketUpgradeHandler configuration

### DIFF
--- a/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketUpgradeHandler.java
+++ b/jetty-websocket/websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketUpgradeHandler.java
@@ -50,6 +50,11 @@ public class WebSocketUpgradeHandler extends HandlerWrapper
         mappings.addMapping(pathSpec, negotiator);
     }
 
+    public Configuration getConfiguration()
+    {
+        return customizer;
+    }
+
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
     {


### PR DESCRIPTION
There is currently no way to access the default configuration of the `WebSocketUpgradeHandler`.

Configuration can currently be set in `WebSocketNegotiator` and the `CoreSession` but there is no way to access the `WebSocketUpgradeHandler.customizer`.