### PR TITLE
Jetty 9.4.x : fix client remove idle destinations

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -516,15 +516,17 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     @Override
     public String toString()
     {
-        return String.format("%s@%x[c=%d/%d/%d,a=%d,i=%d,q=%d]",
+        return String.format("%s@%x[s=%s,c=%d/%d/%d,a=%d,i=%d,q=%d,p=%s]",
             getClass().getSimpleName(),
             hashCode(),
+            getState(),
             getPendingConnectionCount(),
             getConnectionCount(),
             getMaxConnectionCount(),
             getActiveConnectionCount(),
             getIdleConnectionCount(),
-            destination.getQueuedRequestCount());
+            destination.getQueuedRequestCount(),
+            pool);
     }
 
     private class FutureConnection extends Promise.Completable<Connection>

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -306,7 +306,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         {
             pending.decrementAndGet();
             if (LOG.isDebugEnabled())
-                LOG.debug("Not creating connection as pool is full, pending: {}", pending);
+                LOG.debug("Not creating connection as pool {} is full, pending: {}", pool, pending);
             return;
         }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1138,12 +1138,12 @@ public class HttpClient extends ContainerLifeCycle
      *
      * @param removeIdleDestinations whether destinations that have no connections should be removed
      * @see org.eclipse.jetty.client.DuplexConnectionPool
-     * @deprecated replaced by {@link #setDestinationIdleTimeout(long)}, calls the latter with a value of 5000 ms.
+     * @deprecated replaced by {@link #setDestinationIdleTimeout(long)}, calls the latter with a value of 10000 ms.
      */
     @Deprecated
     public void setRemoveIdleDestinations(boolean removeIdleDestinations)
     {
-        setDestinationIdleTimeout(removeIdleDestinations ? 5000 : 0);
+        setDestinationIdleTimeout(removeIdleDestinations ? 10_000 : 0);
     }
 
     /**

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -73,7 +73,6 @@ public class HttpClientProxyProtocolTest
         clientThreads.setName("client");
         client = new HttpClient();
         client.setExecutor(clientThreads);
-        client.setRemoveIdleDestinations(false);
         client.start();
     }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -544,10 +544,11 @@ public class HttpClientTest extends AbstractHttpClientServerTest
     public void testRetryWithDestinationIdleTimeoutEnabled(Scenario scenario) throws Exception
     {
         start(scenario, new EmptyServerHandler());
-
+        client.stop();
         client.setDestinationIdleTimeout(1000);
         client.setIdleTimeout(1000);
         client.setMaxConnectionsPerDestination(1);
+        client.start();
 
         try (StacklessLogging ignored = new StacklessLogging(org.eclipse.jetty.server.HttpChannel.class))
         {

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -103,6 +104,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -570,6 +572,13 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 .idleTimeout(100, TimeUnit.MILLISECONDS)
                 .send();
         }
+
+        // Wait for the sweeper to remove the idle HttpDestination.
+        await().atMost(10, TimeUnit.SECONDS).until(() ->
+        {
+            Collection<HttpDestination> destinations = client.getBeans(HttpDestination.class);
+            return destinations.isEmpty();
+        });
     }
 
     @ParameterizedTest

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpDestinationOverHTTPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpDestinationOverHTTPTest.java
@@ -302,8 +302,10 @@ public class HttpDestinationOverHTTPTest extends AbstractHttpClientServerTest
     public void testDestinationIsRemoved(Scenario scenario) throws Exception
     {
         start(scenario, new EmptyServerHandler());
-
+        client.stop();
         client.setDestinationIdleTimeout(1000);
+        client.start();
+
         String host = "localhost";
         int port = connector.getLocalPort();
         Destination destinationBefore = client.getDestination(scenario.getScheme(), host, port);
@@ -336,10 +338,12 @@ public class HttpDestinationOverHTTPTest extends AbstractHttpClientServerTest
     public void testDestinationIsRemovedAfterConnectionError(Scenario scenario) throws Exception
     {
         start(scenario, new EmptyServerHandler());
+        client.stop();
+        client.setDestinationIdleTimeout(1000);
+        client.start();
 
         String host = "localhost";
         int port = connector.getLocalPort();
-        client.setDestinationIdleTimeout(1000);
         assertTrue(client.getDestinations().isEmpty(), "Destinations of a fresh client must be empty");
 
         server.stop();

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpDestinationOverHTTPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpDestinationOverHTTPTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.AbstractHttpClientServerTest;
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.ConnectionPoolHelper;
@@ -302,6 +303,7 @@ public class HttpDestinationOverHTTPTest extends AbstractHttpClientServerTest
     {
         start(scenario, new EmptyServerHandler());
 
+        client.setDestinationIdleTimeout(1000);
         String host = "localhost";
         int port = connector.getLocalPort();
         Destination destinationBefore = client.getDestination(scenario.getScheme(), host, port);
@@ -316,7 +318,7 @@ public class HttpDestinationOverHTTPTest extends AbstractHttpClientServerTest
         Destination destinationAfter = client.getDestination(scenario.getScheme(), host, port);
         assertSame(destinationBefore, destinationAfter);
 
-        client.setRemoveIdleDestinations(true);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> client.getDestinations().isEmpty());
 
         response = client.newRequest(host, port)
             .scheme(scenario.getScheme())
@@ -337,18 +339,14 @@ public class HttpDestinationOverHTTPTest extends AbstractHttpClientServerTest
 
         String host = "localhost";
         int port = connector.getLocalPort();
-        client.setRemoveIdleDestinations(true);
+        client.setDestinationIdleTimeout(1000);
         assertTrue(client.getDestinations().isEmpty(), "Destinations of a fresh client must be empty");
 
         server.stop();
         Request request = client.newRequest(host, port).scheme(scenario.getScheme());
         assertThrows(Exception.class, request::send);
 
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
-        while (!client.getDestinations().isEmpty() && System.nanoTime() < deadline)
-        {
-            Thread.sleep(10);
-        }
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> client.getDestinations().isEmpty());
         assertTrue(client.getDestinations().isEmpty(), "Destination must be removed after connection error");
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -131,8 +131,6 @@ public class Pool<T> implements AutoCloseable, Dumpable
      */
     public Pool(StrategyType strategyType, int maxEntries, boolean cache)
     {
-        if (maxEntries < 1)
-            throw new IllegalArgumentException("maxEntries must be > 0");
         this.maxEntries = maxEntries;
         this.strategyType = Objects.requireNonNull(strategyType);
         this.cache = cache ? new ThreadLocal<>() : null;


### PR DESCRIPTION
Solves #8493 for 9.4.x by implementing the solution proposed by @sbordet.