### PR TITLE
`NullPointerException` at `AsyncMiddleManServlet.onContinue()`

### DIFF
--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AsyncMiddleManServlet.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AsyncMiddleManServlet.java
@@ -174,7 +174,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
     {
         super.onContinue(clientRequest, proxyRequest);
         Runnable action = (Runnable)proxyRequest.getAttributes().get(CONTINUE_ACTION_ATTRIBUTE);
-        action.run();
+        if (action != null) 
+        {
+            action.run();
+        }
     }
 
     private void transform(ContentTransformer transformer, ByteBuffer input, boolean finished, List<ByteBuffer> output) throws IOException


### PR DESCRIPTION
org.eclipse.jetty.proxy.AsyncMiddleManServlet.onContinue(AsyncMiddleManServlet.java:177) #8538

https://github.com/eclipse/jetty.project/issues/8538