### PR TITLE
Issue #8474 - Jetty 12 - Change signature of `Resource.lastModified()`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateGenerator.java
@@ -67,7 +67,7 @@ public class DateGenerator
      */
     public static String formatDate(Instant instant)
     {
-        return __dateGenerator.get().doFormatDate(instant.toEpochMilli());
+        return formatDate(instant.toEpochMilli());
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateGenerator.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.http;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -56,6 +57,17 @@ public class DateGenerator
     public static String formatDate(long date)
     {
         return __dateGenerator.get().doFormatDate(date);
+    }
+
+    /**
+     * Format HTTP date "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+     *
+     * @param instant the date/time instant
+     * @return the formatted date
+     */
+    public static String formatDate(Instant instant)
+    {
+        return __dateGenerator.get().doFormatDate(instant.toEpochMilli());
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,15 +99,15 @@ public class ResourceHttpContent implements HttpContent
     @Override
     public HttpField getLastModified()
     {
-        long lm = _resource.lastModified();
-        return lm >= 0 ? new HttpField(HttpHeader.LAST_MODIFIED, DateGenerator.formatDate(lm)) : null;
+        Instant lm = _resource.lastModified();
+        return new HttpField(HttpHeader.LAST_MODIFIED, DateGenerator.formatDate(lm));
     }
 
     @Override
     public String getLastModifiedValue()
     {
-        long lm = _resource.lastModified();
-        return lm >= 0 ? DateGenerator.formatDate(lm) : null;
+        Instant lm = _resource.lastModified();
+        return DateGenerator.formatDate(lm);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -294,10 +294,10 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             // Scan the entire cache and generate an ordered list by last accessed time.
             SortedSet<CachedHttpContent> sorted = new TreeSet<>((c1, c2) ->
             {
-                if (c1._lastAccessed < c2._lastAccessed)
+                if (c1._lastAccessed.isBefore(c2._lastAccessed))
                     return -1;
 
-                if (c1._lastAccessed > c2._lastAccessed)
+                if (c1._lastAccessed.isAfter(c2._lastAccessed))
                     return 1;
 
                 if (c1._contentLengthValue < c2._contentLengthValue)
@@ -388,7 +388,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         private final AtomicReference<ByteBuffer> _indirectBuffer = new AtomicReference<>();
         private final AtomicReference<ByteBuffer> _directBuffer = new AtomicReference<>();
         private final AtomicReference<ByteBuffer> _mappedBuffer = new AtomicReference<>();
-        private volatile long _lastAccessed;
+        private volatile Instant _lastAccessed;
 
         CachedHttpContent(String pathInContext, Resource resource, Map<CompressedContentFormat, CachedHttpContent> precompressedResources)
         {
@@ -411,7 +411,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             if (_cachedFiles.incrementAndGet() > _maxCachedFiles)
                 shrinkCache();
 
-            _lastAccessed = System.currentTimeMillis();
+            _lastAccessed = Instant.now();
 
             _etag = CachedContentFactory.this._etags ? new PreEncodedHttpField(HttpHeader.ETAG, resource.getWeakETag()) : null;
 
@@ -461,7 +461,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         {
             if (_lastModifiedValue == _resource.lastModified() && _contentLengthValue == _resource.length())
             {
-                _lastAccessed = System.currentTimeMillis();
+                _lastAccessed = Instant.now();
                 return true;
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CachedContentFactory.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
@@ -292,19 +293,10 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         while (_cache.size() > 0 && (_cachedFiles.get() > _maxCachedFiles || _cachedSize.get() > _maxCacheSize))
         {
             // Scan the entire cache and generate an ordered list by last accessed time.
-            SortedSet<CachedHttpContent> sorted = new TreeSet<>((c1, c2) ->
-            {
-                if (c1._lastAccessed.isBefore(c2._lastAccessed))
-                    return -1;
-
-                if (c1._lastAccessed.isAfter(c2._lastAccessed))
-                    return 1;
-
-                if (c1._contentLengthValue < c2._contentLengthValue)
-                    return -1;
-
-                return c1._key.compareTo(c2._key);
-            });
+            SortedSet<CachedHttpContent> sorted = new TreeSet<>(
+                Comparator.comparing((CachedHttpContent c) -> c._lastAccessed)
+                    .thenComparingLong(c -> c._contentLengthValue)
+                    .thenComparing(c -> c._key));
             sorted.addAll(_cache.values());
 
             // Invalidate least recently used first

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceContentFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceContentFactory.java
@@ -91,7 +91,7 @@ public class ResourceContentFactory implements ContentFactory
             {
                 String compressedPathInContext = pathInContext + format.getExtension();
                 Resource compressedResource = this._factory.newResource(compressedPathInContext);
-                if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
+                if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified().isAfter(resource.lastModified()) &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
                         new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
@@ -13,8 +13,10 @@
 
 package org.eclipse.jetty.server;
 
-import java.text.DateFormat;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -198,7 +200,9 @@ public class ResourceListing
             buf.append("</tr>\n");
         }
 
-        DateFormat dfmt = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
+        // TODO: Use Locale and/or ZoneId from Request?
+        DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.MEDIUM)
+            .withZone(ZoneId.systemDefault());
 
         for (Resource item : listing)
         {
@@ -224,7 +228,7 @@ public class ResourceListing
             // Last Modified
             buf.append("<td class=\"lastmodified\">");
             Instant lastModified = item.lastModified();
-            buf.append(dfmt.format(lastModified));
+            buf.append(formatter.format(lastModified));
             buf.append("&nbsp;</td>");
 
             // Size

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
@@ -14,9 +14,9 @@
 package org.eclipse.jetty.server;
 
 import java.text.DateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 
 import org.eclipse.jetty.util.Fields;
@@ -223,9 +223,8 @@ public class ResourceListing
 
             // Last Modified
             buf.append("<td class=\"lastmodified\">");
-            long lastModified = item.lastModified();
-            if (lastModified > 0)
-                buf.append(dfmt.format(new Date(item.lastModified())));
+            Instant lastModified = item.lastModified();
+            buf.append(dfmt.format(lastModified));
             buf.append("&nbsp;</td>");
 
             // Size

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.jetty.util.IO;
@@ -32,7 +33,7 @@ import org.eclipse.jetty.util.IO;
 public class MemoryResource extends Resource
 {
     private final URI _uri;
-    private final long _created = System.currentTimeMillis();
+    private final Instant _created = Instant.now();
     private final byte[] _bytes;
 
     MemoryResource(URL url)
@@ -76,7 +77,7 @@ public class MemoryResource extends Resource
     }
 
     @Override
-    public long lastModified()
+    public Instant lastModified()
     {
         return _created;
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -29,6 +29,7 @@ import java.nio.file.ProviderNotFoundException;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
@@ -175,24 +176,31 @@ public abstract class Resource
     }
 
     /**
-     * Time resource was last modified.
-     * Equivalent to {@link Files#getLastModifiedTime(Path, LinkOption...)} with the following parameter:
-     * {@link #getPath()} then returning {@link FileTime#toMillis()}.
+     * The time the resource was last modified.
      *
-     * @return the last modified time as milliseconds since unix epoch or
-     * 0 if {@link Files#getLastModifiedTime(Path, LinkOption...)} throws {@link IOException}.
+     * Equivalent to {@link Files#getLastModifiedTime(Path, LinkOption...)} with the following parameter:
+     * {@link #getPath()} then returning {@link FileTime#toInstant()}.
+     *
+     * @return the last modified time instant, or null if resource doesn't exist or doesn't have a last modified time.
      */
-    public long lastModified()
+    public Instant lastModified()
     {
+        Path path = getPath();
+        if (path == null)
+            return null;
+
+        if (!Files.exists(path))
+            return null;
+
         try
         {
-            FileTime ft = Files.getLastModifiedTime(getPath(), FOLLOW_LINKS);
-            return ft.toMillis();
+            FileTime ft = Files.getLastModifiedTime(path, FOLLOW_LINKS);
+            return ft.toInstant();
         }
         catch (IOException e)
         {
             LOG.trace("IGNORED", e);
-            return 0;
+            return null;
         }
     }
 
@@ -433,7 +441,7 @@ public abstract class Resource
         }
 
         Base64.Encoder encoder = Base64.getEncoder().withoutPadding();
-        b.append(encoder.encodeToString(longToBytes(lastModified() ^ lhash)));
+        b.append(encoder.encodeToString(longToBytes(lastModified().toEpochMilli() ^ lhash)));
         b.append(encoder.encodeToString(longToBytes(length() ^ lhash)));
         b.append(suffix);
         b.append('"');

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -181,16 +181,16 @@ public abstract class Resource
      * Equivalent to {@link Files#getLastModifiedTime(Path, LinkOption...)} with the following parameter:
      * {@link #getPath()} then returning {@link FileTime#toInstant()}.
      *
-     * @return the last modified time instant, or null if resource doesn't exist or doesn't have a last modified time.
+     * @return the last modified time instant, or {@link Instant#EPOCH} if unable to obtain last modified.
      */
     public Instant lastModified()
     {
         Path path = getPath();
         if (path == null)
-            return null;
+            return Instant.EPOCH;
 
         if (!Files.exists(path))
-            return null;
+            return Instant.EPOCH;
 
         try
         {
@@ -200,7 +200,7 @@ public abstract class Resource
         catch (IOException e)
         {
             LOG.trace("IGNORED", e);
-            return null;
+            return Instant.EPOCH;
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollators.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollators.java
@@ -37,7 +37,7 @@ public class ResourceCollators
         Collections.reverseOrder(BY_NAME_ASCENDING);
 
     private static Comparator<? super Resource> BY_LAST_MODIFIED_ASCENDING =
-        Comparator.comparingLong(Resource::lastModified);
+        Comparator.comparing(Resource::lastModified);
 
     private static Comparator<? super Resource> BY_LAST_MODIFIED_DESCENDING =
         Collections.reverseOrder(BY_LAST_MODIFIED_ASCENDING);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -238,17 +239,18 @@ public class ResourceCollection extends Resource
     }
 
     @Override
-    public long lastModified()
+    public Instant lastModified()
     {
+        Instant instant = null;
         for (Resource r : _resources)
         {
-            long lm = r.lastModified();
-            if (lm != -1)
+            Instant lm = r.lastModified();
+            if (instant == null || lm.isAfter(instant))
             {
-                return lm;
+                instant = lm;
             }
         }
-        return -1;
+        return instant;
     }
 
     @Override

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -30,6 +30,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -352,21 +352,21 @@ public class FileSystemResourceTest
         Path file = workDir.getPathFile("foo");
         Files.createFile(file);
 
-        long expected = Files.getLastModifiedTime(file).toMillis();
+        Instant expected = Files.getLastModifiedTime(file).toInstant();
 
         Resource base = ResourceFactory.root().newResource(dir);
         Resource res = base.resolve("foo");
-        assertThat("foo.lastModified", res.lastModified() / 1000 * 1000, lessThanOrEqualTo(expected));
+        assertThat("foo.lastModified", res.lastModified(), is(expected));
     }
 
     @Test
-    public void testLastModifiedNotExists() throws Exception
+    public void testLastModifiedNotExists()
     {
         Path dir = workDir.getEmptyPathDir();
 
         Resource base = ResourceFactory.root().newResource(dir);
         Resource res = base.resolve("foo");
-        assertThat("foo.lastModified", res.lastModified(), is(0L));
+        assertThat("foo.lastModified", res.lastModified(), nullValue());
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -366,7 +366,7 @@ public class FileSystemResourceTest
 
         Resource base = ResourceFactory.root().newResource(dir);
         Resource res = base.resolve("foo");
-        assertThat("foo.lastModified", res.lastModified(), nullValue());
+        assertThat("foo.lastModified", res.lastModified(), is(Instant.EPOCH));
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
@@ -213,7 +213,7 @@ public class JarResourceTest
             long last = zf.getEntry("subdir/numbers").getTime();
 
             Resource r = resourceFactory.newResource(uri);
-            assertEquals(last, r.lastModified());
+            assertEquals(last, r.lastModified().toEpochMilli());
         }
     }
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee10.maven.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 
 import org.eclipse.jetty.util.resource.Resource;
@@ -84,9 +85,17 @@ public class Overlay
     {
         if (dir == null)
             throw new IllegalStateException("No overly unpack directory");
-        //only unpack if the overlay is newer
-        Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
-        if (!dir.exists() || getResource().lastModified().isAfter(dirLastModified))
-            getResource().copyTo(dir.toPath());
+        Path pathDir = dir.toPath();
+        // only unpack if the overlay is newer
+        if (!Files.exists(pathDir))
+        {
+            getResource().copyTo(pathDir);
+        }
+        else
+        {
+            Instant dirLastModified = Files.getLastModifiedTime(pathDir).toInstant();
+            if (getResource().lastModified().isAfter(dirLastModified))
+                getResource().copyTo(pathDir);
+        }
     }
 }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
@@ -86,7 +86,7 @@ public class Overlay
             throw new IllegalStateException("No overly unpack directory");
         //only unpack if the overlay is newer
         Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
-        if (!dir.exists() || (getResource().lastModified().isAfter(dirLastModified)))
+        if (!dir.exists() || getResource().lastModified().isAfter(dirLastModified))
             getResource().copyTo(dir.toPath());
     }
 }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.ee10.maven.plugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
 
 import org.eclipse.jetty.util.resource.Resource;
 
@@ -78,12 +80,13 @@ public class Overlay
      * @param dir the directory into which to unpack the overlay
      * @throws IOException 
      */
-    public void unpackTo(File dir) throws IOException
+    public void unpackTo(File dir) throws IOException // TODO: change to Path
     {
         if (dir == null)
             throw new IllegalStateException("No overly unpack directory");
         //only unpack if the overlay is newer
-        if (!dir.exists() || (getResource().lastModified() > dir.lastModified()))
+        Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
+        if (!dir.exists() || (getResource().lastModified().isAfter(dirLastModified)))
             getResource().copyTo(dir.toPath());
     }
 }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -381,7 +381,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                     {
                         // Only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
                         // Use the original War Resource to obtain lastModified to avoid filesystem locks on MS Windows.
-                        if (originalWarResource.lastModified() > Files.getLastModifiedTime(extractedWebAppDir).toMillis() || extractionLock.exists())
+                        if (originalWarResource.lastModified().isAfter(Files.getLastModifiedTime(extractedWebAppDir).toInstant()) || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
                             IO.delete(extractedWebAppDir);

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,9 +104,9 @@ public class OrderingTest
         }
 
         @Override
-        public long lastModified()
+        public Instant lastModified()
         {
-            return 0;
+            return null;
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,12 +100,6 @@ public class OrderingTest
         public boolean isDirectory()
         {
             return false;
-        }
-
-        @Override
-        public Instant lastModified()
-        {
-            return null;
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee9.maven.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 
 import org.eclipse.jetty.util.resource.Resource;
@@ -84,9 +85,18 @@ public class Overlay
     {
         if (dir == null)
             throw new IllegalStateException("No overly unpack directory");
-        //only unpack if the overlay is newer
-        Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
-        if (!dir.exists() || getResource().lastModified().isAfter(dirLastModified))
-            getResource().copyTo(dir.toPath());
+
+        Path pathDir = dir.toPath();
+        // only unpack if the overlay is newer
+        if (!Files.exists(pathDir))
+        {
+            getResource().copyTo(pathDir);
+        }
+        else
+        {
+            Instant dirLastModified = Files.getLastModifiedTime(pathDir).toInstant();
+            if (getResource().lastModified().isAfter(dirLastModified))
+                getResource().copyTo(pathDir);
+        }
     }
 }

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.ee9.maven.plugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
 
 import org.eclipse.jetty.util.resource.Resource;
 
@@ -78,12 +80,13 @@ public class Overlay
      * @param dir the directory into which to unpack the overlay
      * @throws IOException 
      */
-    public void unpackTo(File dir) throws IOException
+    public void unpackTo(File dir) throws IOException // TODO: change to Path
     {
         if (dir == null)
             throw new IllegalStateException("No overly unpack directory");
         //only unpack if the overlay is newer
-        if (!dir.exists() || (getResource().lastModified() > dir.lastModified()))
+        Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
+        if (!dir.exists() || (getResource().lastModified().isAfter(dirLastModified)))
             getResource().copyTo(dir.toPath());
     }
 }

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
@@ -86,7 +86,7 @@ public class Overlay
             throw new IllegalStateException("No overly unpack directory");
         //only unpack if the overlay is newer
         Instant dirLastModified = Files.getLastModifiedTime(dir.toPath()).toInstant();
-        if (!dir.exists() || (getResource().lastModified().isAfter(dirLastModified)))
+        if (!dir.exists() || getResource().lastModified().isAfter(dirLastModified))
             getResource().copyTo(dir.toPath());
     }
 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
@@ -292,19 +293,10 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         while (_cache.size() > 0 && (_cachedFiles.get() > _maxCachedFiles || _cachedSize.get() > _maxCacheSize))
         {
             // Scan the entire cache and generate an ordered list by last accessed time.
-            SortedSet<CachedHttpContent> sorted = new TreeSet<>((c1, c2) ->
-            {
-                if (c1._lastAccessed.isBefore(c2._lastAccessed))
-                    return -1;
-
-                if (c1._lastAccessed.isAfter(c2._lastAccessed))
-                    return 1;
-
-                if (c1._contentLengthValue < c2._contentLengthValue)
-                    return -1;
-
-                return c1._key.compareTo(c2._key);
-            });
+            SortedSet<CachedHttpContent> sorted = new TreeSet<>(
+                Comparator.comparing((CachedHttpContent c) -> c._lastAccessed)
+                    .thenComparingLong(c -> c._contentLengthValue)
+                    .thenComparing(c -> c._key));
             sorted.addAll(_cache.values());
 
             // Invalidate least recently used first

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
@@ -294,10 +294,10 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             // Scan the entire cache and generate an ordered list by last accessed time.
             SortedSet<CachedHttpContent> sorted = new TreeSet<>((c1, c2) ->
             {
-                if (c1._lastAccessed < c2._lastAccessed)
+                if (c1._lastAccessed.isBefore(c2._lastAccessed))
                     return -1;
 
-                if (c1._lastAccessed > c2._lastAccessed)
+                if (c1._lastAccessed.isAfter(c2._lastAccessed))
                     return 1;
 
                 if (c1._contentLengthValue < c2._contentLengthValue)
@@ -386,7 +386,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         private final HttpField _etag;
         private final Map<CompressedContentFormat, CachedPrecompressedHttpContent> _precompressed;
         private final AtomicReference<ByteBuffer> _buffer = new AtomicReference<>();
-        private volatile long _lastAccessed;
+        private volatile Instant _lastAccessed;
 
         CachedHttpContent(String pathInContext, Resource resource, Map<CompressedContentFormat, CachedHttpContent> precompressedResources)
         {
@@ -409,7 +409,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             if (_cachedFiles.incrementAndGet() > _maxCachedFiles)
                 shrinkCache();
 
-            _lastAccessed = System.currentTimeMillis();
+            _lastAccessed = Instant.now();
 
             _etag = CachedContentFactory.this._etags ? new PreEncodedHttpField(HttpHeader.ETAG, resource.getWeakETag()) : null;
 
@@ -459,7 +459,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         {
             if (_lastModifiedValue == _resource.lastModified() && _contentLengthValue == _resource.length())
             {
-                _lastAccessed = System.currentTimeMillis();
+                _lastAccessed = Instant.now();
                 return true;
             }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CachedContentFactory.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee9.nested;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -227,7 +228,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
                     {
                         compressedContent = null;
                         Resource compressedResource = _factory.newResource(compressedPathInContext);
-                        if (compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
+                        if (compressedResource.exists() && compressedResource.lastModified().isAfter(resource.lastModified()) &&
                             compressedResource.length() < resource.length())
                         {
                             compressedContent = new CachedHttpContent(compressedPathInContext, compressedResource, null);
@@ -268,12 +269,12 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             {
                 String compressedPathInContext = pathInContext + format.getExtension();
                 CachedHttpContent compressedContent = _cache.get(compressedPathInContext);
-                if (compressedContent != null && compressedContent.isValid() && compressedContent.getResource().lastModified() >= resource.lastModified())
+                if (compressedContent != null && compressedContent.isValid() && compressedContent.getResource().lastModified().isAfter(resource.lastModified()))
                     compressedContents.put(format, compressedContent);
 
                 // Is there a precompressed resource?
                 Resource compressedResource = _factory.newResource(compressedPathInContext);
-                if (compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
+                if (compressedResource.exists() && compressedResource.lastModified().isAfter(resource.lastModified()) &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
                         new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));
@@ -381,7 +382,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
         private final MimeTypes.Type _mimeType;
         private final HttpField _contentLength;
         private final HttpField _lastModified;
-        private final long _lastModifiedValue;
+        private final Instant _lastModifiedValue;
         private final HttpField _etag;
         private final Map<CompressedContentFormat, CachedPrecompressedHttpContent> _precompressed;
         private final AtomicReference<ByteBuffer> _buffer = new AtomicReference<>();
@@ -398,8 +399,8 @@ public class CachedContentFactory implements HttpContent.ContentFactory
             _mimeType = _contentType == null ? null : MimeTypes.CACHE.get(MimeTypes.getContentTypeWithoutCharset(contentType));
 
             boolean exists = resource.exists();
-            _lastModifiedValue = exists ? resource.lastModified() : -1L;
-            _lastModified = _lastModifiedValue == -1 ? null
+            _lastModifiedValue = exists ? resource.lastModified() : null;
+            _lastModified = _lastModifiedValue == null ? null
                 : new PreEncodedHttpField(HttpHeader.LAST_MODIFIED, DateGenerator.formatDate(_lastModifiedValue));
 
             _contentLengthValue = exists ? resource.length() : 0;
@@ -615,7 +616,7 @@ public class CachedContentFactory implements HttpContent.ContentFactory
 
         public boolean isValid()
         {
-            return _precompressedContent.isValid() && _content.isValid() && _content.getResource().lastModified() <= _precompressedContent.getResource().lastModified();
+            return _precompressedContent.isValid() && _content.isValid() && _content.getResource().lastModified().isBefore(_precompressedContent.getResource().lastModified());
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceContentFactory.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceContentFactory.java
@@ -87,7 +87,7 @@ public class ResourceContentFactory implements ContentFactory
             {
                 String compressedPathInContext = pathInContext + format.getExtension();
                 Resource compressedResource = _factory.newResource(compressedPathInContext);
-                if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified() >= resource.lastModified() &&
+                if (compressedResource != null && compressedResource.exists() && compressedResource.lastModified().isAfter(resource.lastModified()) &&
                     compressedResource.length() < resource.length())
                     compressedContents.put(format,
                         new ResourceHttpContent(compressedResource, _mimeTypes.getMimeByExtension(compressedPathInContext)));

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -597,7 +597,7 @@ public class ResourceService
                 }
 
                 long ifmsl = request.getDateHeader(HttpHeader.IF_MODIFIED_SINCE.asString());
-                if (ifmsl != -1 && content.getResource().lastModified() / 1000 <= ifmsl / 1000)
+                if (ifmsl != -1 && content.getResource().lastModified().toEpochMilli() <= ifmsl)
                 {
                     sendStatus(response, HttpServletResponse.SC_NOT_MODIFIED, content::getETagValue);
                     return false;
@@ -605,7 +605,7 @@ public class ResourceService
             }
 
             // Parse the if[un]modified dates and compare to resource
-            if (ifums != -1 && content.getResource().lastModified() / 1000 > ifums / 1000)
+            if (ifums != -1 && content.getResource().lastModified().toEpochMilli() > ifums)
             {
                 response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED);
                 return false;

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -379,7 +379,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                     {
                         // Only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
                         // Use the original War Resource to obtain lastModified to avoid filesystem locks on MS Windows.
-                        if (originalWarResource.lastModified() > Files.getLastModifiedTime(extractedWebAppDir).toMillis() || extractionLock.exists())
+                        if (originalWarResource.lastModified().isAfter(Files.getLastModifiedTime(extractedWebAppDir).toInstant()) || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
                             IO.delete(extractedWebAppDir);

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,9 +104,9 @@ public class OrderingTest
         }
 
         @Override
-        public long lastModified()
+        public Instant lastModified()
         {
-            return 0;
+            return null;
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,12 +100,6 @@ public class OrderingTest
         public boolean isDirectory()
         {
             return false;
-        }
-
-        @Override
-        public Instant lastModified()
-        {
-            return null;
         }
 
         @Override


### PR DESCRIPTION
Per Issue https://github.com/eclipse/jetty.project/issues/8474 - Now `Resource.lastModified()` returns `Instant` instead of a `long`.