### PR TITLE
Issue #8474 - Jetty 12 - Introduce `Iterable<Resource>` to base `Resource`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -34,7 +34,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
@@ -166,30 +165,7 @@ public abstract class Resource implements Iterable<Resource>
     @Override
     public Iterator<Resource> iterator()
     {
-        return new Iterator<>()
-        {
-            private boolean next = true;
-
-            @Override
-            public boolean hasNext()
-            {
-                return next;
-            }
-
-            @Override
-            public Resource next()
-            {
-                if (next)
-                {
-                    next = false;
-                    return Resource.this;
-                }
-                else
-                {
-                    throw new NoSuchElementException("No more Resource entries to iterate");
-                }
-            }
-        };
+        return List.of(this).iterator();
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -32,7 +32,9 @@ import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
@@ -47,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * Supports real filesystems, and also <a href="https://docs.oracle.com/en/java/javase/17/docs/api/jdk.zipfs/module-summary.html">ZipFS</a>.
  * </p>
  */
-public abstract class Resource
+public abstract class Resource implements Iterable<Resource>
 {
     private static final Logger LOG = LoggerFactory.getLogger(Resource.class);
     private static final LinkOption[] NO_FOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
@@ -150,6 +152,44 @@ public abstract class Resource
     public boolean isSame(Resource resource)
     {
         return equals(resource);
+    }
+
+    /**
+     * Return an Iterator of all Resource's referenced in this Resource.
+     *
+     * <p>
+     *     This is meaningful if you have a Composite Resource, otherwise it will be a single entry Iterator.
+     * </p>
+     *
+     * @return the iterator of Resources.
+     */
+    @Override
+    public Iterator<Resource> iterator()
+    {
+        return new Iterator<>()
+        {
+            private boolean next = true;
+
+            @Override
+            public boolean hasNext()
+            {
+                return next;
+            }
+
+            @Override
+            public Resource next()
+            {
+                if (next)
+                {
+                    next = false;
+                    return Resource.this;
+                }
+                else
+                {
+                    throw new NoSuchElementException("No more Resource entries to iterate");
+                }
+            }
+        };
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -255,6 +256,12 @@ public class ResourceCollection extends Resource
     public long length()
     {
         return -1;
+    }
+
+    @Override
+    public Iterator<Resource> iterator()
+    {
+        return _resources.iterator();
     }
 
     /**

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -148,7 +148,7 @@ public class PathResourceTest
         Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
         Resource resource = ResourceFactory.root().newResource(rpath);
         int count = 0;
-        for (Resource r: resource)
+        for (Resource r : resource)
             count++;
         assertEquals(1, count);
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.hamcrest.Matchers;
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PathResourceTest
 {
@@ -139,5 +141,20 @@ public class PathResourceTest
             assertThat(ePathResource.isSame(ePathResource2), Matchers.is(true));
             assertThat(ePathResource.equals(ePathResource2), Matchers.is(false));
         }
+    }
+
+    @Test
+    public void testIterable()
+    {
+        Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
+        PathResource resource = (PathResource)ResourceFactory.root().newResource(rpath);
+        Iterator<Resource> iter = resource.iterator();
+        int count = 0;
+        while (iter.hasNext())
+        {
+            iter.next();
+            count++;
+        }
+        assertEquals(1, count);
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Iterator;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.hamcrest.Matchers;
@@ -147,14 +146,10 @@ public class PathResourceTest
     public void testIterable()
     {
         Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
-        PathResource resource = (PathResource)ResourceFactory.root().newResource(rpath);
-        Iterator<Resource> iter = resource.iterator();
+        Resource resource = ResourceFactory.root().newResource(rpath);
         int count = 0;
-        while (iter.hasNext())
-        {
-            iter.next();
+        for (Resource r: resource)
             count++;
-        }
         assertEquals(1, count);
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceCollectionTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceCollectionTest.java
@@ -174,6 +174,49 @@ public class ResourceCollectionTest
     }
 
     @Test
+    public void testIterable()
+    {
+        Path one = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/one");
+        Path two = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/two");
+        Path three = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/three");
+        Path dirFoo = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/two/dir");
+
+        Resource compositeA = Resource.combine(
+            List.of(
+                resourceFactory.newResource(one),
+                resourceFactory.newResource(two),
+                resourceFactory.newResource(three)
+            )
+        );
+
+        Resource compositeB = Resource.combine(
+            List.of(
+                // the original composite Resource
+                compositeA,
+                // a duplicate entry
+                resourceFactory.newResource(two),
+                // a new entry
+                resourceFactory.newResource(dirFoo)
+            )
+        );
+
+        List<URI> actual = new ArrayList<>();
+        for (Resource resource: compositeB)
+        {
+            actual.add(resource.getURI());
+        }
+
+        URI[] expected = new URI[] {
+            one.toUri(),
+            two.toUri(),
+            three.toUri(),
+            dirFoo.toUri()
+        };
+
+        assertThat(actual, contains(expected));
+    }
+
+    @Test
     public void testUserSpaceConfigurationNoGlob() throws Exception
     {
         Path base = workDir.getEmptyPathDir();


### PR DESCRIPTION
Per Issue #8474 - base `Resource` now implements `Iterable<Resource>`.
This eliminates a big need for code to be aware of `ResourceCollection`.

A future PR will use this more appropriately elsewhere in the code (as its expected to be a largish PR)

The purpose of this is to evaluate the implementation for `PathResource` and `ResourceCollection` now, in a small PR.