### PR TITLE
Issue #8474 - Jetty 12 - Eliminate `Resource.isMemoryMappable`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -1071,14 +1071,16 @@ public class BufferUtil
 
     public static ByteBuffer toMappedBuffer(Resource resource) throws IOException
     {
-        if (!resource.isMemoryMappable())
+        Path path = resource.getPath();
+        if (path == null)
             return null;
         return toMappedBuffer(resource.getPath());
     }
 
     public static ByteBuffer toMappedBuffer(Resource resource, long pos, long len) throws IOException
     {
-        if (!resource.isMemoryMappable())
+        Path path = resource.getPath();
+        if (path == null)
             return null;
         return toMappedBuffer(resource.getPath(), pos, len);
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -1074,7 +1074,7 @@ public class BufferUtil
         Path path = resource.getPath();
         if (path == null)
             return null;
-        return toMappedBuffer(resource.getPath());
+        return toMappedBuffer(path);
     }
 
     public static ByteBuffer toMappedBuffer(Resource resource, long pos, long len) throws IOException
@@ -1082,7 +1082,7 @@ public class BufferUtil
         Path path = resource.getPath();
         if (path == null)
             return null;
-        return toMappedBuffer(resource.getPath(), pos, len);
+        return toMappedBuffer(path, pos, len);
     }
 
     public static String toSummaryString(ByteBuffer buffer)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -280,12 +280,6 @@ public class PathResource extends Resource
     }
 
     @Override
-    public boolean isMemoryMappable()
-    {
-        return "file".equalsIgnoreCase(uri.getScheme());
-    }
-
-    @Override
     public URI getURI()
     {
         return this.uri;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -253,16 +253,6 @@ public abstract class Resource
     }
 
     /**
-     * Checks if the resource supports being loaded as a memory-mapped ByteBuffer.
-     *
-     * @return true if the resource supports memory-mapped ByteBuffer, false otherwise.
-     */
-    public boolean isMemoryMappable()
-    {
-        return false;
-    }
-
-    /**
      * list of resource names contained in the given resource.
      * Ordering is unspecified, so callers may wish to sort the return value to ensure deterministic behavior.
      * Equivalent to {@link Files#newDirectoryStream(Path)} with parameter: {@link #getPath()} then iterating over the returned


### PR DESCRIPTION
Per Issue #8474 - Remove Resource.isMemoryMappable()

This was only used for BufferUtil.toMappedBuffer()

The determination should reside there, along with possibly an alternative API that can return a non-mapped `ByteBuffer` if the size is smallish.
See [javadoc on FileChannel.map()](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/channels/FileChannel.html#map(java.nio.channels.FileChannel.MapMode,long,long)) for reference.
> For most operating systems, mapping a file into memory is more expensive than reading or writing a few tens of kilobytes of data via the usual [read](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/channels/FileChannel.html#read(java.nio.ByteBuffer)) and [write](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/channels/FileChannel.html#write(java.nio.ByteBuffer)) methods. From the standpoint of performance it is generally only worth mapping relatively large files into memory.
