### PR TITLE
Issue #8474 - Jetty 12 - Eliminate `Resource.isSame`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -217,25 +217,6 @@ public class PathResource extends Resource
     }
 
     @Override
-    public boolean isSame(Resource resource)
-    {
-        try
-        {
-            if (resource instanceof PathResource)
-            {
-                Path path = resource.getPath();
-                return Files.isSameFile(getPath(), path);
-            }
-        }
-        catch (IOException e)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("ignored", e);
-        }
-        return false;
-    }
-
-    @Override
     public boolean equals(Object obj)
     {
         if (this == obj)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
 
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.URIUtil;
@@ -232,18 +233,7 @@ public class PathResource extends Resource
             return false;
         }
         PathResource other = (PathResource)obj;
-        if (path == null)
-        {
-            if (other.path != null)
-            {
-                return false;
-            }
-        }
-        else if (!path.equals(other.path))
-        {
-            return false;
-        }
-        return true;
+        return Objects.equals(path, other.path);
     }
 
     /**
@@ -275,10 +265,7 @@ public class PathResource extends Resource
     @Override
     public int hashCode()
     {
-        final int prime = 31;
-        int result = 1;
-        result = (prime * result) + ((path == null) ? 0 : path.hashCode());
-        return result;
+        return Objects.hashCode(path);
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -140,19 +140,6 @@ public abstract class Resource
     public abstract boolean isContainedIn(Resource r);
 
     /**
-     * Return true if the passed Resource represents the same resource as the Resource.
-     * For many resource types, this is equivalent to {@link #equals(Object)}, however
-     * for resources types that support aliasing, this maybe some other check (e.g. {@link java.nio.file.Files#isSameFile(Path, Path)}).
-     *
-     * @param resource The resource to check
-     * @return true if the passed resource represents the same resource.
-     */
-    public boolean isSame(Resource resource)
-    {
-        return equals(resource);
-    }
-
-    /**
      * Equivalent to {@link Files#exists(Path, LinkOption...)} with the following parameters:
      * {@link #getPath()} and {@link LinkOption#NOFOLLOW_LINKS}.
      *

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.util.URIUtil;
@@ -284,6 +285,23 @@ public class ResourceCollection extends Resource
         {
             _resources.get(r).copyTo(destination);
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ResourceCollection other = (ResourceCollection)o;
+        return Objects.equals(_resources, other._resources);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(_resources);
     }
 
     /**

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -16,11 +16,9 @@ package org.eclipse.jetty.util.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -111,33 +109,5 @@ public class PathResourceTest
 
         Path path = resource.getPath();
         assertThat("File for default FileSystem", path, is(exampleJar));
-    }
-
-    @Test
-    public void testSame()
-    {
-        Path rpath = MavenTestingUtils.getTestResourcePathFile("resource.txt");
-        Path epath = MavenTestingUtils.getTestResourcePathFile("example.jar");
-        PathResource rPathResource = (PathResource)ResourceFactory.root().newResource(rpath);
-        PathResource ePathResource = (PathResource)ResourceFactory.root().newResource(epath);
-
-        assertThat(rPathResource.isSame(rPathResource), Matchers.is(true));
-        assertThat(rPathResource.isSame(ePathResource), Matchers.is(false));
-
-        PathResource ePathResource2 = null;
-        try
-        {
-            Path epath2 = Files.createSymbolicLink(MavenTestingUtils.getTargetPath().resolve("testSame-symlink"), epath.getParent()).resolve("example.jar");
-            ePathResource2 = (PathResource)ResourceFactory.root().newResource(epath2);
-        }
-        catch (Throwable th)
-        {
-            // Assume symbolic links are not supported
-        }
-        if (ePathResource2 != null)
-        {
-            assertThat(ePathResource.isSame(ePathResource2), Matchers.is(true));
-            assertThat(ePathResource.equals(ePathResource2), Matchers.is(false));
-        }
     }
 }


### PR DESCRIPTION
Per Issue #8474 - Eliminate `Resource.isSame()` as it is not used outside of test cases.