### PR TITLE
Issue #8578 - `getRequestURL` can append "null" if `getRequestURI` is unspecified in an authority-form request-target

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelOverHttp.java
@@ -102,10 +102,10 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
     }
 
     @Override
-    public boolean startRequest(String method, String uri, HttpVersion version)
+    public boolean startRequest(String method, String requestTarget, HttpVersion version)
     {
         _metadata.setMethod(method);
-        _metadata.getURI().parseRequestTarget(method, uri);
+        _metadata.getURI().parseRequestTarget(method, requestTarget);
         _metadata.setHttpVersion(version);
         _unknownExpectation = false;
         _expect100Continue = false;
@@ -127,7 +127,7 @@ public class HttpChannelOverHttp extends HttpChannel implements HttpParser.Reque
                     break;
 
                 case HOST:
-                    if (!_metadata.getURI().isAbsolute() && field instanceof HostPortHttpField)
+                    if (!HttpMethod.CONNECT.is(_metadata.getMethod()) && !_metadata.getURI().isAbsolute() && field instanceof HostPortHttpField)
                     {
                         HostPortHttpField hp = (HostPortHttpField)field;
                         _metadata.getURI().setAuthority(hp.getHost(), hp.getPort());

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1341,7 +1341,17 @@ public class Request implements HttpServletRequest
     public String getRequestURI()
     {
         MetaData.Request metadata = _metaData;
-        return (metadata == null) ? null : metadata.getURI().getPath();
+        if (metadata == null)
+            return null;
+        HttpURI uri = metadata.getURI();
+        if (uri == null)
+            return null;
+        // maintain backward compat for CONNECT method
+        if (HttpMethod.CONNECT.is(getMethod()))
+            return uri.getAuthority();
+        else
+            // spec compliant path
+            return uri.getPath();
     }
 
     /*
@@ -1352,7 +1362,9 @@ public class Request implements HttpServletRequest
     {
         final StringBuffer url = new StringBuffer(128);
         URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        url.append(getRequestURI());
+        // only add RequestURI if not a CONNECT method
+        if (!HttpMethod.CONNECT.is(getMethod()))
+            url.append(getRequestURI());
         return url;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1341,17 +1341,7 @@ public class Request implements HttpServletRequest
     public String getRequestURI()
     {
         MetaData.Request metadata = _metaData;
-        if (metadata == null)
-            return null;
-        HttpURI uri = metadata.getURI();
-        if (uri == null)
-            return null;
-        // maintain backward compat for CONNECT method
-        if (HttpMethod.CONNECT.is(getMethod()))
-            return uri.getAuthority();
-        else
-            // spec compliant path
-            return uri.getPath();
+        return (metadata == null) ? null : metadata.getURI().getPath();
     }
 
     /*
@@ -1362,9 +1352,9 @@ public class Request implements HttpServletRequest
     {
         final StringBuffer url = new StringBuffer(128);
         URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        // only add RequestURI if not a CONNECT method
-        if (!HttpMethod.CONNECT.is(getMethod()))
-            url.append(getRequestURI());
+        String path = getRequestURI();
+        if (path != null)
+            url.append(path);
         return url;
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -876,10 +876,12 @@ public class RequestTest
     @Test
     public void testConnectRequestURL() throws Exception
     {
-        final AtomicReference<String> result = new AtomicReference<>();
+        final AtomicReference<String> resultRequestURL = new AtomicReference<>();
+        final AtomicReference<String> resultRequestURI = new AtomicReference<>();
         _handler._checker = (request, response) ->
         {
-            result.set("" + request.getRequestURL());
+            resultRequestURL.set("" + request.getRequestURL());
+            resultRequestURI.set("" + request.getRequestURI());
             return true;
         };
 
@@ -890,7 +892,8 @@ public class RequestTest
                 "\n");
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        assertThat(result.get(), is("http://myhost:9999"));
+        assertThat(resultRequestURL.get(), is("http://myhost:9999"));
+        assertThat(resultRequestURI.get(), is("myhost:9999"));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -55,6 +55,7 @@ import javax.servlet.http.Part;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpComplianceSection;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.Connection;
@@ -870,6 +871,26 @@ public class RequestTest
 
         assertTrue(results.get(i++).startsWith("text/html"));
         assertEquals(" x=z; ", results.get(i++));
+    }
+
+    @Test
+    public void testConnectRequestURL() throws Exception
+    {
+        final AtomicReference<String> result = new AtomicReference<>();
+        _handler._checker = (request, response) ->
+        {
+            result.set("" + request.getRequestURL());
+            return true;
+        };
+
+        String rawResponse = _connector.getResponse(
+            "CONNECT myhost:9999 HTTP/1.1\n" +
+                "Host: myhost:9999\n" +
+                "Connection: close\n" +
+                "\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(result.get(), is("http://myhost:9999"));
     }
 
     @Test


### PR DESCRIPTION
When working with CONNECT headers, the old implementation of `HttpURI.getPath()` would return the authority component.
The changes in #8014 broke this backward compatibility behavior, causing unintended behaviors on `HttpServletRequest.getRequestURL()` and `HttpServletRequest.getRequestURI()`.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>