### PR TITLE
Issue #8578 - `getRequestURL` can append "null" if `getRequestURI` is unspecified in an authority-form request-target

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1278,12 +1278,7 @@ public class Request implements HttpServletRequest
     @Override
     public String getRequestURI()
     {
-        if (_uri == null)
-            return null;
-        if (HttpMethod.CONNECT.is(getMethod()))
-            return _uri.getAuthority();
-        else
-            return _uri.getPath();
+        return _uri == null ? null : _uri.getPath();
     }
 
     @Override
@@ -1291,13 +1286,9 @@ public class Request implements HttpServletRequest
     {
         final StringBuffer url = new StringBuffer(128);
         URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        // only add RequestURI if not a CONNECT method
-        if (!HttpMethod.CONNECT.is(getMethod()))
-        {
-            String requestURI = getRequestURI();
-            if (requestURI != null)
-                url.append(requestURI);
-        }
+        String path = getRequestURI();
+        if (path != null)
+            url.append(path);
         return url;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1278,7 +1278,12 @@ public class Request implements HttpServletRequest
     @Override
     public String getRequestURI()
     {
-        return _uri == null ? null : _uri.getPath();
+        if (_uri == null)
+            return null;
+        if (HttpMethod.CONNECT.is(getMethod()))
+            return _uri.getAuthority();
+        else
+            return _uri.getPath();
     }
 
     @Override
@@ -1286,7 +1291,13 @@ public class Request implements HttpServletRequest
     {
         final StringBuffer url = new StringBuffer(128);
         URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        url.append(getRequestURI());
+        // only add RequestURI if not a CONNECT method
+        if (!HttpMethod.CONNECT.is(getMethod()))
+        {
+            String requestURI = getRequestURI();
+            if (requestURI != null)
+                url.append(requestURI);
+        }
         return url;
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
@@ -854,6 +855,29 @@ public class RequestTest
 
         assertTrue(results.get(i++).startsWith("text/html"));
         assertEquals(" x=z; ", results.get(i));
+    }
+
+    @Test
+    public void testConnectRequestURL() throws Exception
+    {
+        final AtomicReference<String> resultRequestURL = new AtomicReference<>();
+        final AtomicReference<String> resultRequestURI = new AtomicReference<>();
+        _handler._checker = (request, response) ->
+        {
+            resultRequestURL.set("" + request.getRequestURL());
+            resultRequestURI.set("" + request.getRequestURI());
+            return true;
+        };
+
+        String rawResponse = _connector.getResponse(
+            "CONNECT myhost:9999 HTTP/1.1\n" +
+                "Host: myhost:9999\n" +
+                "Connection: close\n" +
+                "\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(resultRequestURL.get(), is("http://myhost:9999"));
+        assertThat(resultRequestURI.get(), is("myhost:9999"));
     }
 
     @Test

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -858,14 +858,14 @@ public class RequestTest
     }
 
     @Test
-    public void testConnectRequestURL() throws Exception
+    public void testConnectRequestURLSameAsHost() throws Exception
     {
         final AtomicReference<String> resultRequestURL = new AtomicReference<>();
         final AtomicReference<String> resultRequestURI = new AtomicReference<>();
         _handler._checker = (request, response) ->
         {
-            resultRequestURL.set("" + request.getRequestURL());
-            resultRequestURI.set("" + request.getRequestURI());
+            resultRequestURL.set(request.getRequestURL().toString());
+            resultRequestURI.set(request.getRequestURI());
             return true;
         };
 
@@ -876,8 +876,31 @@ public class RequestTest
                 "\n");
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        assertThat(resultRequestURL.get(), is("http://myhost:9999"));
-        assertThat(resultRequestURI.get(), is("myhost:9999"));
+        assertThat("request.getRequestURL", resultRequestURL.get(), is("http://myhost:9999/"));
+        assertThat("request.getRequestURI", resultRequestURI.get(), is("/"));
+    }
+
+    @Test
+    public void testConnectRequestURLDifferentThanHost() throws Exception
+    {
+        final AtomicReference<String> resultRequestURL = new AtomicReference<>();
+        final AtomicReference<String> resultRequestURI = new AtomicReference<>();
+        _handler._checker = (request, response) ->
+        {
+            resultRequestURL.set(request.getRequestURL().toString());
+            resultRequestURI.set(request.getRequestURI());
+            return true;
+        };
+
+        String rawResponse = _connector.getResponse(
+            "CONNECT myhost:9999 HTTP/1.1\n" +
+                "Host: otherhost:8888\n" + // per spec, this is ignored if request-target is authority-form
+                "Connection: close\n" +
+                "\n");
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat("request.getRequestURL", resultRequestURL.get(), is("http://myhost:9999/"));
+        assertThat("request.getRequestURI", resultRequestURI.get(), is("/"));
     }
 
     @Test


### PR DESCRIPTION
When working with CONNECT headers, the old implementation of `HttpURI.getPath()` would return the authority component.
The changes in #8014 broke this backward compatibility behavior, causing unintended behaviors on `HttpServletRequest.getRequestURL()` and `HttpServletRequest.getRequestURI()`.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>