### PR TITLE
Allow to access underlyng HttpServletRequest from JakartaServerUpgradeRequest

### DIFF
--- a/jetty-websocket/websocket-jakarta-server/src/main/java/org/eclipse/jetty/websocket/jakarta/server/internal/JakartaServerUpgradeRequest.java
+++ b/jetty-websocket/websocket-jakarta-server/src/main/java/org/eclipse/jetty/websocket/jakarta/server/internal/JakartaServerUpgradeRequest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.websocket.jakarta.server.internal;
 import java.net.URI;
 import java.security.Principal;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.websocket.core.server.ServerUpgradeRequest;
 import org.eclipse.jetty.websocket.jakarta.common.UpgradeRequest;
 
@@ -44,5 +45,13 @@ public class JakartaServerUpgradeRequest implements UpgradeRequest
     public String getPathInContext()
     {
         return servletRequest.getPathInContext();
+    }
+
+    /**
+     * @return Immutable version of {@link HttpServletRequest}
+     */
+    public HttpServletRequest getHttpServletRequest()
+    {
+        return servletRequest.getHttpServletRequest();
     }
 }


### PR DESCRIPTION
We are migrating to Jakarta WebSockets (from Jetty WebSockets) and run into some API limitations. In certain context we need access to underlying `HttpServletRequest` associated with particular `UpgradeRequest`. 

From the API perspective, both `ServerUpgradeRequest` and `JettyServerUpgradeRequest`  do allow to access the underlying `HttpServletRequest` , but `JakartaServerUpgradeRequest` does not. The change is pretty trivial and hopefully non-controversial, matching other `UpgradeRequest` implementation on the server side.