### PR TITLE
Issue #8474 - Jetty 12 - `Resource.list()` API change + `Resource.getFileName()` addition

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,9 @@ public class ResourceListing
         if (base == null || !resource.isDirectory())
             return null;
 
-        List<Resource> listing = resource.list().stream().filter(distinctBy(Resource::getFileName)).collect(Collectors.toList());
+        List<Resource> listing = resource.list().stream()
+            .filter(distinctBy(Resource::getFileName))
+            .collect(Collectors.toCollection(ArrayList::new));
 
         boolean sortOrderAscending = true;
         String sortColumn = "N"; // name (or "M" for Last Modified, or "S" for Size)
@@ -252,6 +255,7 @@ public class ResourceListing
         return buf.toString();
     }
 
+    /* TODO: see if we can use {@link Collectors#groupingBy} */
     private static <T> Predicate<T> distinctBy(Function<? super T, Object> keyExtractor)
     {
         Map<Object, Boolean> map = new ConcurrentHashMap<>();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
@@ -13,14 +13,17 @@
 
 package org.eclipse.jetty.server;
 
-import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.StringUtil;
@@ -56,7 +59,7 @@ public class ResourceListing
         if (base == null || !resource.isDirectory())
             return null;
 
-        List<Resource> listing = new ArrayList<>(resource.list().stream().map(URIUtil::encodePath).map(resource::resolve).toList());
+        List<Resource> listing = resource.list().stream().filter(distinctBy(Resource::getFileName)).collect(Collectors.toList());
 
         boolean sortOrderAscending = true;
         String sortColumn = "N"; // name (or "M" for Last Modified, or "S" for Size)
@@ -208,14 +211,11 @@ public class ResourceListing
         for (Resource item : listing)
         {
             // Listings always return non-composite Resource entries
-            Path filePath = item.getPath();
-            if (filePath == null)
-                continue; // skip, can't represent this in a listing anyway.
-
-            String name = filePath.getFileName().toString();
+            String name = item.getFileName();
             if (StringUtil.isBlank(name))
-                continue;
+                continue; // a resource either not backed by a filename (eg: MemoryResource), or has no filename (eg: a segment-less root "/")
 
+            // Ensure name has a slash if it's a directory
             if (item.isDirectory() && !name.endsWith("/"))
                 name += URIUtil.SLASH;
 
@@ -250,6 +250,12 @@ public class ResourceListing
         buf.append("</body></html>\n");
 
         return buf.toString();
+    }
+
+    private static <T> Predicate<T> distinctBy(Function<? super T, Object> keyExtractor)
+    {
+        Map<Object, Boolean> map = new ConcurrentHashMap<>();
+        return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceListing.java
@@ -19,9 +19,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -258,8 +257,8 @@ public class ResourceListing
     /* TODO: see if we can use {@link Collectors#groupingBy} */
     private static <T> Predicate<T> distinctBy(Function<? super T, Object> keyExtractor)
     {
-        Map<Object, Boolean> map = new ConcurrentHashMap<>();
-        return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
+        HashSet<Object> map = new HashSet<>();
+        return t -> map.add(keyExtractor.apply(t));
     }
 
     /**

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceCacheTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceCacheTest.java
@@ -179,7 +179,7 @@ public class ResourceCacheTest
             @Override
             public boolean isCacheable(Resource resource)
             {
-                return super.isCacheable(resource) && resource.getName().indexOf("2.txt") < 0;
+                return super.isCacheable(resource) && !resource.getFileName().equals("2.txt");
             }
         };
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
@@ -151,10 +151,10 @@ public class FileID
     }
 
     /**
-     * Test if Path is any supported Java Archive type (ends in {@code .jar}, {@code .war}, or {@code .zip}).
+     * Test if Path is any supported Java Archive type (ends in {@code .jar}, or {@code .zip}).
      *
      * @param path the path to test
-     * @return true if path is a file, and an extension of {@code .jar}, {@code .war}, or {@code .zip}
+     * @return true if path is a file, and an extension of {@code .jar}, or {@code .zip}
      * @see #getExtension(Path)
      */
     public static boolean isArchive(Path path)
@@ -162,14 +162,14 @@ public class FileID
         String ext = getExtension(path);
         if (ext == null)
             return false;
-        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+        return (ext.equals(".jar") || ext.equals(".zip"));
     }
 
     /**
-     * Test if filename is any supported Java Archive type (ends in {@code .jar}, {@code .war}, or {@code .zip}).
+     * Test if filename is any supported Java Archive type (ends in {@code .jar}, or {@code .zip}).
      *
      * @param filename the filename to test
-     * @return true if path is a file and name ends with {@code .jar}, {@code .war}, or {@code .zip}
+     * @return true if path is a file and name ends with {@code .jar}, or {@code .zip}
      * @see #getExtension(String)
      */
     public static boolean isArchive(String filename)
@@ -177,14 +177,14 @@ public class FileID
         String ext = getExtension(filename);
         if (ext == null)
             return false;
-        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+        return (ext.equals(".jar") || ext.equals(".zip"));
     }
 
     /**
      * Test if URI is any supported Java Archive type.
      *
      * @param uri the URI to test
-     * @return true if the URI has a path that seems to point to a ({@code .jar}, {@code .war}, or {@code .zip}).
+     * @return true if the URI has a path that seems to point to a ({@code .jar}, or {@code .zip}).
      * @see #isArchive(String)
      */
     public static boolean isArchive(URI uri)
@@ -192,7 +192,7 @@ public class FileID
         String ext = getExtension(uri);
         if (ext == null)
             return false;
-        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+        return (ext.equals(".jar") || ext.equals(".zip"));
     }
 
     /**
@@ -365,7 +365,7 @@ public class FileID
      * Is the path a TLD File
      *
      * @param path the path to test.
-     * @return True if a .war file.
+     * @return True if a .tld file.
      */
     public static boolean isTld(Path path)
     {
@@ -385,6 +385,17 @@ public class FileID
     public static boolean isWebArchive(Path path)
     {
         return ".war".equals(getExtension(path));
+    }
+
+    /**
+     * Is the path a Web Archive File (not directory)
+     *
+     * @param uri the uri to test.
+     * @return True if a .war file.
+     */
+    public static boolean isWebArchive(URI uri)
+    {
+        return ".war".equals(getExtension(uri));
     }
 
     /**
@@ -418,5 +429,27 @@ public class FileID
     public static boolean isXml(String filename)
     {
         return ".xml".equals(getExtension(filename));
+    }
+
+    /**
+     * Is the Path a file that ends in ZIP?
+     *
+     * @param path the path to test
+     * @return true if a .zip, false otherwise
+     */
+    public static boolean isZip(Path path)
+    {
+        return ".zip".equals(getExtension(path));
+    }
+
+    /**
+     * Is the Path a file that ends in ZIP?
+     *
+     * @param filename the filename to test
+     * @return true if a .zip, false otherwise
+     */
+    public static boolean isZip(String filename)
+    {
+        return ".zip".equals(getExtension(filename));
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
@@ -151,13 +151,58 @@ public class FileID
     }
 
     /**
-     * Test if Path is any supported Java Archive type (ends in {@code .jar}, or {@code .zip}).
+     * Test if Path is any supported Java Archive type (ends in {@code .jar}, {@code .war}, or {@code .zip}).
+     *
+     * @param path the path to test
+     * @return true if path is a file, and an extension of {@code .jar}, {@code .war}, or {@code .zip}
+     * @see #getExtension(Path)
+     */
+    public static boolean isArchive(Path path)
+    {
+        String ext = getExtension(path);
+        if (ext == null)
+            return false;
+        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+    }
+
+    /**
+     * Test if filename is any supported Java Archive type (ends in {@code .jar}, {@code .war}, or {@code .zip}).
+     *
+     * @param filename the filename to test
+     * @return true if path is a file and name ends with {@code .jar}, {@code .war}, or {@code .zip}
+     * @see #getExtension(String)
+     */
+    public static boolean isArchive(String filename)
+    {
+        String ext = getExtension(filename);
+        if (ext == null)
+            return false;
+        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+    }
+
+    /**
+     * Test if URI is any supported Java Archive type.
+     *
+     * @param uri the URI to test
+     * @return true if the URI has a path that seems to point to a ({@code .jar}, {@code .war}, or {@code .zip}).
+     * @see #isArchive(String)
+     */
+    public static boolean isArchive(URI uri)
+    {
+        String ext = getExtension(uri);
+        if (ext == null)
+            return false;
+        return (ext.equals(".jar") || ext.equals(".war") || ext.equals(".zip"));
+    }
+
+    /**
+     * Test if Path is any supported Java Library Archive type (suitable to use as a library in a classpath/classloader)
      *
      * @param path the path to test
      * @return true if path is a file, and an extension of {@code .jar}, or {@code .zip}
      * @see #getExtension(Path)
      */
-    public static boolean isArchive(Path path)
+    public static boolean isLibArchive(Path path)
     {
         String ext = getExtension(path);
         if (ext == null)
@@ -166,13 +211,13 @@ public class FileID
     }
 
     /**
-     * Test if filename is any supported Java Archive type (ends in {@code .jar}, or {@code .zip}).
+     * Test if filename is any supported Java Library Archive type (suitable to use as a library in a classpath/classloader)
      *
      * @param filename the filename to test
      * @return true if path is a file and name ends with {@code .jar}, or {@code .zip}
      * @see #getExtension(String)
      */
-    public static boolean isArchive(String filename)
+    public static boolean isLibArchive(String filename)
     {
         String ext = getExtension(filename);
         if (ext == null)
@@ -181,13 +226,13 @@ public class FileID
     }
 
     /**
-     * Test if URI is any supported Java Archive type.
+     * Test if URI is any supported Java Library Archive type (suitable to use as a library in a classpath/classloader)
      *
      * @param uri the URI to test
-     * @return true if the URI has a path that seems to point to a ({@code .jar}, or {@code .zip}).
-     * @see #isArchive(String)
+     * @return true if the URI has a path that seems to point to a ({@code .jar},  or {@code .zip}).
+     * @see #getExtension(URI)
      */
-    public static boolean isArchive(URI uri)
+    public static boolean isLibArchive(URI uri)
     {
         String ext = getExtension(uri);
         if (ext == null)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1963,7 +1963,7 @@ public final class URIUtil
         Objects.requireNonNull(uri, "URI");
         String scheme = Objects.requireNonNull(uri.getScheme(), "URI scheme");
 
-        if (!FileID.isArchive(uri))
+        if (!FileID.isArchive(uri) && !FileID.isWebArchive(uri))
             return uri;
 
         boolean hasInternalReference = uri.getRawSchemeSpecificPart().indexOf("!/") > 0;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1922,7 +1922,7 @@ public final class URIUtil
                         {
                             listStream
                                 .filter(Files::isRegularFile)
-                                .filter(FileID::isArchive)
+                                .filter(FileID::isLibArchive)
                                 .sorted(Comparator.naturalOrder())
                                 .forEach(path -> uris.add(toJarFileUri(path.toUri())));
                         }
@@ -1963,7 +1963,7 @@ public final class URIUtil
         Objects.requireNonNull(uri, "URI");
         String scheme = Objects.requireNonNull(uri.getScheme(), "URI scheme");
 
-        if (!FileID.isArchive(uri) && !FileID.isWebArchive(uri))
+        if (!FileID.isArchive(uri))
             return uri;
 
         boolean hasInternalReference = uri.getRawSchemeSpecificPart().indexOf("!/") > 0;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MemoryResource.java
@@ -23,6 +23,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jetty.util.IO;
@@ -73,7 +75,22 @@ public class MemoryResource extends Resource
     @Override
     public String getName()
     {
-        return getPath().toAbsolutePath().toString();
+        Path p = getPath();
+        if (p == null)
+            return null;
+        return p.toAbsolutePath().toString();
+    }
+
+    @Override
+    public String getFileName()
+    {
+        Path p = getPath();
+        if (p == null)
+            return null;
+        Path fn = p.getFileName();
+        if (fn == null)
+            return ""; // no segments, so no filename
+        return fn.toString();
     }
 
     @Override
@@ -104,6 +121,18 @@ public class MemoryResource extends Resource
     public boolean exists()
     {
         return true;
+    }
+
+    @Override
+    public List<Resource> list()
+    {
+        return List.of(); // empty
+    }
+
+    @Override
+    public Collection<Resource> getAllResources()
+    {
+        return List.of(); // empty
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
@@ -44,4 +44,16 @@ public class MountedPathResource extends PathResource
     {
         return containerUri == null ? null : Path.of(containerUri);
     }
+
+    @Override
+    public String getName()
+    {
+        Path abs = getPath();
+        // If a "jar:file:" based path, we should normalize here, as the toAbsolutePath() does not resolve "/../" style segments in all cases
+        if ("jar".equalsIgnoreCase(abs.toUri().getScheme()))
+            abs = abs.normalize();
+        // Get the absolute path
+        abs = abs.toAbsolutePath();
+        return abs.toString();
+    }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
@@ -30,7 +30,7 @@ public class MountedPathResource extends PathResource
 
     MountedPathResource(URI uri) throws IOException
     {
-        super(uri, true);
+        super(uri, false);
         containerUri = URIUtil.unwrapContainer(getURI());
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
@@ -30,7 +30,7 @@ public class MountedPathResource extends PathResource
 
     MountedPathResource(URI uri) throws IOException
     {
-        super(uri, false);
+        super(uri, true);
         containerUri = URIUtil.unwrapContainer(getURI());
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -294,13 +294,7 @@ public class PathResource extends Resource
     @Override
     public String getName()
     {
-        Path abs = path;
-        // If a "jar:file:" based path, we should normalize here, as the toAbsolutePath() does not resolve "/../" style segments in all cases
-        if ("jar".equalsIgnoreCase(path.toUri().getScheme()))
-            abs = path.normalize();
-        // Get the absolute path
-        abs = abs.toAbsolutePath();
-        return abs.toString();
+        return path.toAbsolutePath().toString();
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -243,11 +243,9 @@ public abstract class Resource implements Iterable<Resource>
     public abstract String getName();
 
     /**
-     * The file name of the resource.
+     * <p>The file name of the resource.</p>
      *
-     * <p>
-     *     This is the last segment of the path.
-     * </p>
+     * <p>This is the last segment of the path.</p>
      *
      * @return the filename of the resource, or "" if there are no path segments (eg: path of "/"), or null if not backed by a Path
      */
@@ -276,7 +274,7 @@ public abstract class Resource implements Iterable<Resource>
     }
 
     /**
-     * <p>List of Resources contained in the given resource.</p>
+     * <p>List of existing Resources contained in the given resource.</p>
      *
      * <p>Ordering is unspecified, so callers may wish to sort the return value to ensure deterministic behavior.</p>
      *

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -276,13 +276,12 @@ public abstract class Resource implements Iterable<Resource>
     }
 
     /**
-     * List of Resources contained in the given resource.
+     * <p>List of Resources contained in the given resource.</p>
      *
-     * <p>
-     * Ordering is unspecified, so callers may wish to sort the return value to ensure deterministic behavior.
-     * </p>
+     * <p>Ordering is unspecified, so callers may wish to sort the return value to ensure deterministic behavior.</p>
      *
-     * @return a list of resource contained in the tracked resources, or empty list if an exception was thrown while building the list.
+     * @return a mutable list of resources contained in the tracked resource,
+     * or an empty immutable list if unable to build the list.
      */
     public List<Resource> list()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollators.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollators.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Locale;
 
-// TODO remove
 public class ResourceCollators
 {
     private static Comparator<? super Resource> BY_NAME_ASCENDING =
@@ -33,8 +32,23 @@ public class ResourceCollators
             }
         };
 
+    private static Comparator<? super Resource> BY_FILENAME_ASCENDING =
+        new Comparator<>()
+        {
+            private final Collator collator = Collator.getInstance(Locale.ENGLISH);
+
+            @Override
+            public int compare(Resource o1, Resource o2)
+            {
+                return collator.compare(o1.getFileName(), o2.getFileName());
+            }
+        };
+
     private static Comparator<? super Resource> BY_NAME_DESCENDING =
         Collections.reverseOrder(BY_NAME_ASCENDING);
+
+    private static Comparator<? super Resource> BY_FILENAME_DESCENDING =
+        Collections.reverseOrder(BY_FILENAME_ASCENDING);
 
     private static Comparator<? super Resource> BY_LAST_MODIFIED_ASCENDING =
         Comparator.comparing(Resource::lastModified);
@@ -69,6 +83,18 @@ public class ResourceCollators
         else
         {
             return BY_NAME_DESCENDING;
+        }
+    }
+
+    public static Comparator<? super Resource> byFileName(boolean sortOrderAscending)
+    {
+        if (sortOrderAscending)
+        {
+            return BY_FILENAME_ASCENDING;
+        }
+        else
+        {
+            return BY_FILENAME_DESCENDING;
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -279,9 +279,6 @@ public class ResourceCollection extends Resource
         return _resources.iterator();
     }
 
-    /**
-     * @return The list of resource names(merged) contained in the collection of resources.
-     */
     @Override
     public List<Resource> list()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java
@@ -22,8 +22,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -221,6 +219,20 @@ public class ResourceCollection extends Resource
     }
 
     @Override
+    public String getFileName()
+    {
+        for (Resource r : _resources)
+        {
+            String filename = r.getFileName();
+            if (filename != null)
+            {
+                return filename;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public URI getURI()
     {
         for (Resource r : _resources)
@@ -271,18 +283,13 @@ public class ResourceCollection extends Resource
      * @return The list of resource names(merged) contained in the collection of resources.
      */
     @Override
-    public List<String> list()
+    public List<Resource> list()
     {
-        HashSet<String> set = new HashSet<>();
+        List<Resource> result = new ArrayList<>();
         for (Resource r : _resources)
         {
-            List<String> list = r.list();
-            if (list != null)
-                set.addAll(list);
+            result.addAll(r.list());
         }
-
-        ArrayList<String> result = new ArrayList<>(set);
-        result.sort(Comparator.naturalOrder());
         return result;
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -185,7 +185,7 @@ public interface ResourceFactory
 
     default Resource newJarFileResource(URI uri)
     {
-        if (!FileID.isArchive(uri))
+        if (!FileID.isArchive(uri) && !FileID.isWebArchive(uri))
             throw new IllegalArgumentException("Path is not a Java Archive: " + uri);
         if (!uri.getScheme().equalsIgnoreCase("file"))
             throw new IllegalArgumentException("Not an allowed path: " + uri);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -185,7 +185,7 @@ public interface ResourceFactory
 
     default Resource newJarFileResource(URI uri)
     {
-        if (!FileID.isArchive(uri) && !FileID.isWebArchive(uri))
+        if (!FileID.isArchive(uri))
             throw new IllegalArgumentException("Path is not a Java Archive: " + uri);
         if (!uri.getScheme().equalsIgnoreCase("file"))
             throw new IllegalArgumentException("Not an allowed path: " + uri);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
@@ -230,8 +230,9 @@ public class FileIDTest
         "jar:file:/home/user/project/with.jar/in/path/name",
         "file:/home/user/project/directory/",
         "file:/home/user/hello.ear",
-        "/home/user/hello.jar",
-        "/home/user/app.war"
+        "file:/opt/websites/webapps/company.war", // war files are not archives in the strictest sense (the classes are not in the right place)
+        "/home/user/app.war",  // not a absolute URI
+        "/home/user/hello.jar"
     })
     public void testIsArchiveUriFalse(String rawUri)
     {
@@ -244,7 +245,6 @@ public class FileIDTest
         "jar:file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar!/",
         "jar:file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar",
         "file:/home/user/install/jetty-home-12.0.0.zip",
-        "file:/opt/websites/webapps/company.war",
         "jar:file:/home/user/.m2/repository/jakarta/servlet/jakarta.servlet-api/6.0.0/jakarta.servlet-api-6.0.0.jar!/META-INF/resources"
     })
     public void testIsArchiveUriTrue(String rawUri)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
@@ -80,7 +80,6 @@ public class FileIDTest
     @MethodSource("basenameCases")
     public void testGetBasename(String input, String expected) throws IOException
     {
-
         Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
@@ -230,13 +229,13 @@ public class FileIDTest
         "jar:file:/home/user/project/with.jar/in/path/name",
         "file:/home/user/project/directory/",
         "file:/home/user/hello.ear",
-        "file:/opt/websites/webapps/company.war", // war files are not archives in the strictest sense (the classes are not in the right place)
+        "file:/opt/websites/webapps/company.war", // war files are not lib archives (the classes are not in the right place)
         "/home/user/app.war",  // not a absolute URI
         "/home/user/hello.jar"
     })
-    public void testIsArchiveUriFalse(String rawUri)
+    public void testIsLibArchiveUriFalse(String rawUri)
     {
-        assertFalse(FileID.isArchive(URI.create(rawUri)), "Should be detected as a JAR URI: " + rawUri);
+        assertFalse(FileID.isLibArchive(URI.create(rawUri)), "Should not be detected as a Lib Archive: " + rawUri);
     }
 
     @ParameterizedTest
@@ -247,9 +246,67 @@ public class FileIDTest
         "file:/home/user/install/jetty-home-12.0.0.zip",
         "jar:file:/home/user/.m2/repository/jakarta/servlet/jakarta.servlet-api/6.0.0/jakarta.servlet-api-6.0.0.jar!/META-INF/resources"
     })
+    public void testIsLibArchiveUriTrue(String rawUri)
+    {
+        assertTrue(FileID.isLibArchive(URI.create(rawUri)), "Should be detected as a Lib Archive: " + rawUri);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "jar:file:/home/user/project/with.jar/in/path/name",
+        "/home/user/project/with.jar/in/path/name",
+        "/home/user/project/directory/",
+        "/home/user/hello.ear",
+        "/opt/websites/webapps/company.war",
+        "/home/user/app.war",
+        "/home/user/hello.tar.gz",
+        "webapp.war",
+        "name"
+    })
+    public void testIsLibArchiveStringFalse(String str)
+    {
+        assertFalse(FileID.isLibArchive(str), "Should not be detected as a Lib Archive: " + str);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/home/user/.m2/repository/com/company/1.0/company-1.0.jar",
+        "company-1.0.jar",
+        "jar:file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar",
+        "file:/home/user/install/jetty-home-12.0.0.zip",
+        "/home/user/install/jetty-home-12.0.0.zip",
+        "jetty-util-12.jar"
+    })
+    public void testIsLibArchiveStringTrue(String str)
+    {
+        assertTrue(FileID.isLibArchive(str), "Should be detected as a Lib Archive: " + str);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "jar:file:/home/user/project/with.jar/in/path/name",
+        "file:/home/user/project/directory/",
+        "file:/home/user/hello.ear",
+        "/home/user/app.war",  // not a absolute URI
+        "/home/user/hello.jar"
+    })
+    public void testIsArchiveUriFalse(String rawUri)
+    {
+        assertFalse(FileID.isArchive(URI.create(rawUri)), "Should not be detected as an Archive: " + rawUri);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar",
+        "jar:file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar!/",
+        "jar:file:/home/user/.m2/repository/com/company/1.0/company-1.0.jar",
+        "file:/home/user/install/jetty-home-12.0.0.zip",
+        "file:/opt/websites/webapps/company.war",
+        "jar:file:/home/user/.m2/repository/jakarta/servlet/jakarta.servlet-api/6.0.0/jakarta.servlet-api-6.0.0.jar!/META-INF/resources"
+    })
     public void testIsArchiveUriTrue(String rawUri)
     {
-        assertTrue(FileID.isArchive(URI.create(rawUri)), "Should be detected as a JAR URI: " + rawUri);
+        assertTrue(FileID.isArchive(URI.create(rawUri)), "Should be detected as an Archive: " + rawUri);
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
@@ -404,7 +404,7 @@ public class FileIDTest
         "cee.jar",
         "cee.zip"
     })
-    public void testIsWebArchiveFalse(String input) throws IOException
+    public void testIsWebArchiveStringFalse(String input) throws IOException
     {
         assertFalse(FileID.isWebArchive(input), "isWebArchive((String) \"%s\")".formatted(input));
         Path path = touchTestPath(input);
@@ -420,7 +420,7 @@ public class FileIDTest
         "ZED.WAR",
         "Zed.War"
     })
-    public void testIsWebArchiveTrue(String input) throws IOException
+    public void testIsWebArchiveStringTrue(String input) throws IOException
     {
         assertTrue(FileID.isWebArchive(input), "isWebArchive((String) \"%s\")".formatted(input));
         Path path = touchTestPath(input);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -541,11 +541,9 @@ public class URIUtilTest
         actual = URIUtil.addPath(uri, "foo/..\\bar");
         assertThat(actual.toASCIIString(), is("file:////c:/foo/..%5Cbar"));
 
-        // java.net.URI will encode `\\` to `%5C` per URI rules
-        uri = URI.create("file:///opt/foo.txt");
-        actual = URIUtil.addPath(uri, "bar.dat");
+        // Adding a "file" to a URI that ends in a "file", what should it do?
+        actual = URIUtil.addPath(URI.create("file:///opt/foo.txt"), "bar.dat");
         assertThat(actual.toASCIIString(), is("file:///opt/foo.txt/bar.dat"));
-
     }
 
     public static Stream<Arguments> ensureSafeEncodingSource()

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -540,6 +540,12 @@ public class URIUtilTest
         // java.net.URI will encode `\\` to `%5C` per URI rules
         actual = URIUtil.addPath(uri, "foo/..\\bar");
         assertThat(actual.toASCIIString(), is("file:////c:/foo/..%5Cbar"));
+
+        // java.net.URI will encode `\\` to `%5C` per URI rules
+        uri = URI.create("file:///opt/foo.txt");
+        actual = URIUtil.addPath(uri, "bar.dat");
+        assertThat(actual.toASCIIString(), is("file:///opt/foo.txt/bar.dat"));
+
     }
 
     public static Stream<Arguments> ensureSafeEncodingSource()

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -27,6 +27,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemException;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -158,7 +159,7 @@ public class FileSystemResourceTest
     @Test
     public void testNotFileURI()
     {
-        assertThrows(IllegalStateException.class,
+        assertThrows(FileSystemNotFoundException.class,
             () -> ResourceFactory.root().newResource(new URI("https://www.eclipse.org/jetty/")));
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.FS;
@@ -51,6 +50,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
@@ -59,7 +59,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -450,6 +449,18 @@ public class FileSystemResourceTest
     }
 
     @Test
+    public void testFileName() throws Exception
+    {
+        Path dir = workDir.getEmptyPathDir();
+        Files.createDirectories(dir);
+
+        String expected = dir.getFileName().toString();
+
+        Resource base = ResourceFactory.root().newResource(dir);
+        assertThat("base.filename", base.getFileName(), is(expected));
+    }
+
+    @Test
     public void testInputStream() throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
@@ -524,20 +535,18 @@ public class FileSystemResourceTest
         Files.createDirectories(dir.resolve("tick"));
         Files.createDirectories(dir.resolve("tock"));
 
-        List<String> expected = new ArrayList<>();
-        expected.add("foo");
-        expected.add("bar");
-        expected.add("tick/");
-        expected.add("tock/");
+        String[] expectedFileNames = {
+            "foo",
+            "bar",
+            "tick",
+            "tock"
+        };
 
         Resource base = ResourceFactory.root().newResource(dir);
-        List<String> actual = base.list();
+        List<Resource> listing = base.list();
+        List<String> actualFileNames = listing.stream().map(Resource::getFileName).toList();
 
-        assertEquals(expected.size(), actual.size());
-        for (String s : expected)
-        {
-            assertTrue(actual.contains(s));
-        }
+        assertThat(actualFileNames, containsInAnyOrder(expectedFileNames));
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
@@ -18,9 +18,7 @@ import java.nio.file.ClosedFileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.zip.ZipFile;
 
 import org.eclipse.jetty.toolchain.test.FS;
@@ -72,8 +70,8 @@ public class JarResourceTest
         {
             Resource r = resourceFactory.newResource(uri);
 
-            Set<String> entries = new HashSet<>(r.list());
-            assertThat(entries, containsInAnyOrder("alphabet", "numbers", "subsubdir/"));
+            List<String> entries = r.list().stream().map(Resource::getFileName).toList();
+            assertThat(entries, containsInAnyOrder("alphabet", "numbers", "subsubdir"));
 
             Path extract = workDir.getPathFile("extract");
             FS.ensureEmpty(extract);
@@ -82,13 +80,13 @@ public class JarResourceTest
 
             Resource e = resourceFactory.newResource(extract.toString());
 
-            entries = new HashSet<>(e.list());
-            assertThat(entries, containsInAnyOrder("alphabet", "numbers", "subsubdir/"));
+            entries = r.list().stream().map(Resource::getFileName).toList();
+            assertThat(entries, containsInAnyOrder("alphabet", "numbers", "subsubdir"));
 
             s = "jar:" + testZip.toUri().toASCIIString() + "!/subdir/subsubdir/";
             r = resourceFactory.newResource(s);
 
-            entries = new HashSet<>(r.list());
+            entries = r.list().stream().map(Resource::getFileName).toList();
             assertThat(entries, containsInAnyOrder("alphabet", "numbers"));
 
             Path extract2 = workDir.getPathFile("extract2");
@@ -98,7 +96,7 @@ public class JarResourceTest
 
             e = resourceFactory.newResource(extract2.toString());
 
-            entries = new HashSet<>(e.list());
+            entries = r.list().stream().map(Resource::getFileName).toList();
             assertThat(entries, containsInAnyOrder("alphabet", "numbers"));
         }
     }
@@ -242,15 +240,15 @@ public class JarResourceTest
 
             assertThat("path /rez/ is a dir", rez.isDirectory(), is(true));
 
-            List<String> actual = rez.list();
+            List<String> actual = rez.list().stream().map(Resource::getFileName).toList();
             String[] expected = new String[]{
                 "one",
                 "aaa",
                 "bbb",
-                "oddities/",
-                "another dir/",
+                "oddities",
+                "another dir",
                 "ccc",
-                "deep/",
+                "deep",
                 };
             assertThat("Dir contents", actual, containsInAnyOrder(expected));
         }
@@ -272,7 +270,7 @@ public class JarResourceTest
 
             assertThat("path /rez/oddities/ is a dir", rez.isDirectory(), is(true));
 
-            List<String> actual = rez.list();
+            List<String> actual = rez.list().stream().map(Resource::getFileName).toList();
             String[] expected = new String[]{
                 ";",
                 "#hashcode",
@@ -298,7 +296,7 @@ public class JarResourceTest
 
             assertThat("path /rez/another dir/ is a dir", anotherDir.isDirectory(), is(true));
 
-            List<String> actual = anotherDir.list();
+            List<String> actual = anotherDir.list().stream().map(Resource::getFileName).toList();
             String[] expected = new String[]{
                 "a file.txt",
                 "another file.txt",

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/JarResourceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.util.resource;
 
 import java.net.URI;
 import java.nio.file.ClosedFileSystemException;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -117,10 +117,10 @@ public class JarResourceTest
     }
 
     @Test
-    public void testJarFileDeleted(@TempDir Path tempDir) throws Exception
+    public void testJarFileDeleted(WorkDir workDir) throws Exception
     {
         Path originalTestZip = MavenTestingUtils.getTestResourcePathFile("TestData/test.zip");
-        Path testZip = Files.copy(originalTestZip, tempDir.resolve("test.zip"));
+        Path testZip = Files.copy(originalTestZip, workDir.getEmptyPathDir().resolve("test.zip"));
         String s = "jar:" + testZip.toUri().toASCIIString() + "!/subdir/";
         URI uri = URI.create(s);
         Resource resource;
@@ -129,16 +129,16 @@ public class JarResourceTest
             resource = resourceFactory.newResource(uri);
             assertTrue(resource.exists());
             Files.delete(testZip);
-            assertThrows(IllegalStateException.class, () -> resource.resolve("alphabet"));
+            assertThrows(FileSystemNotFoundException.class, () -> resource.resolve("alphabet"));
         }
         assertThrows(ClosedFileSystemException.class, resource::exists);
     }
 
     @Test
-    public void testDumpAndSweep(@TempDir Path tempDir) throws Exception
+    public void testDumpAndSweep(WorkDir workDir) throws Exception
     {
         Path originalTestZip = MavenTestingUtils.getTestResourcePathFile("TestData/test.zip");
-        Path testZip = Files.copy(originalTestZip, tempDir.resolve("test.zip"));
+        Path testZip = Files.copy(originalTestZip, workDir.getEmptyPathDir().resolve("test.zip"));
         String s = "jar:" + testZip.toUri().toASCIIString() + "!/subdir/";
         URI uri = URI.create(s);
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -119,6 +119,9 @@ public class PathResourceTest
             Resource resource = resourceFactory.newResource(manifestPath);
             Path path = resource.getPath();
             assertThat("Path should not be null even for non-default FileSystem", path, notNullValue());
+
+            assertThat("Resource.getName", resource.getName(), is(path.toAbsolutePath().toString()));
+            assertThat("Resource.getFileName", resource.getFileName(), is("MANIFEST.MF"));
         }
     }
 
@@ -130,6 +133,9 @@ public class PathResourceTest
 
         Path path = resource.getPath();
         assertThat("File for default FileSystem", path, is(exampleJar));
+
+        assertThat("Resource.getName", resource.getName(), is(exampleJar.toAbsolutePath().toString()));
+        assertThat("Resource.getFileName", resource.getFileName(), is("example.jar"));
     }
 
     @Test
@@ -158,16 +164,22 @@ public class PathResourceTest
             // Resolve to name, but different case
             testText = archiveResource.resolve("/TEST.TXT");
             assertFalse(testText.exists());
+            assertThat("Resource.getName", testText.getName(), is("/TEST.TXT"));
+            assertThat("Resource.getFileName", testText.getFileName(), is("TEST.TXT"));
 
             // Resolve using path navigation
             testText = archiveResource.resolve("/foo/../test.txt");
             assertTrue(testText.exists());
             assertTrue(testText.isAlias());
+            assertThat("Resource.getName", testText.getName(), is("/test.txt"));
+            assertThat("Resource.getFileName", testText.getFileName(), is("test.txt"));
 
             // Resolve using encoded characters
             testText = archiveResource.resolve("/test%2Etxt");
             assertTrue(testText.exists());
             assertFalse(testText.isAlias());
+            assertThat("Resource.getName", testText.getName(), is("/test.txt"));
+            assertThat("Resource.getFileName", testText.getFileName(), is("test.txt"));
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceCollectionTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceCollectionTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -35,13 +36,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
@@ -66,6 +72,7 @@ public class ResourceCollectionTest
     @Test
     public void testList() throws Exception
     {
+        Path testBaseDir = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource");
         Path one = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/one");
         Path two = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/two");
         Path three = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/three");
@@ -75,9 +82,36 @@ public class ResourceCollectionTest
             resourceFactory.newResource(two),
             resourceFactory.newResource(three)
         );
-        assertThat(rc.list(), contains("1.txt", "2.txt", "3.txt", "dir/"));
-        assertThat(rc.resolve("dir").list(), contains("1.txt", "2.txt", "3.txt"));
-        assertThat(rc.resolve("unknown").list(), nullValue());
+
+        Function<Resource, String> relativizeToTestResources = (r) -> testBaseDir.toUri().relativize(r.getURI()).toASCIIString();
+
+        List<Resource> listing = rc.list();
+        List<String> listingFilenames = listing.stream().map(relativizeToTestResources).toList();
+
+        String[] expected = new String[] {
+            "one/dir/",
+            "one/1.txt",
+            "two/2.txt",
+            "two/dir/",
+            "two/1.txt",
+            "three/3.txt",
+            "three/2.txt",
+            "three/dir/"
+        };
+
+        assertThat(listingFilenames, containsInAnyOrder(expected));
+
+        listingFilenames = rc.resolve("dir").list().stream().map(relativizeToTestResources).toList();
+
+        expected = new String[] {
+            "one/dir/1.txt",
+            "two/dir/2.txt",
+            "three/dir/3.txt"
+        };
+
+        assertThat(listingFilenames, containsInAnyOrder(expected));
+
+        assertThat(rc.resolve("unknown").list(), is(empty()));
 
         assertEquals(getContent(rc, "1.txt"), "1 - one");
         assertEquals(getContent(rc, "2.txt"), "2 - two");
@@ -214,6 +248,39 @@ public class ResourceCollectionTest
         };
 
         assertThat(actual, contains(expected));
+    }
+
+    /**
+     * Demonstrate behavior of ResourceCollection.resolve() when dealing with
+     * conflicting names between Directories and Files.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"foo", "/foo", "foo/", "/foo/"})
+    public void testResolveConflictDirAndFile(String input) throws IOException
+    {
+        Path base = workDir.getEmptyPathDir();
+        Path dirA = base.resolve("dirA");
+        FS.ensureDirExists(dirA);
+        Files.createDirectory(dirA.resolve("foo"));
+
+        Path dirB = base.resolve("dirB");
+        FS.ensureDirExists(dirB);
+        Files.createDirectory(dirB.resolve("foo"));
+
+        Path dirC = base.resolve("dirC");
+        FS.ensureDirExists(dirC);
+        Files.createFile(dirC.resolve("foo"));
+
+        Resource rc = Resource.combine(
+            ResourceFactory.root().newResource(dirA),
+            ResourceFactory.root().newResource(dirB),
+            ResourceFactory.root().newResource(dirC)
+        );
+
+        Resource result = rc.resolve(input);
+        assertThat(result, instanceOf(PathResource.class));
+        assertThat(result.getPath().toUri().toASCIIString(), endsWith("dirC/foo"));
+        assertFalse(result.isDirectory());
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/OverlayManager.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/OverlayManager.java
@@ -133,12 +133,7 @@ public class OverlayManager
 
         //Get the name of the overlayed war and unpack it to a dir of the
         //same name in the temporary directory
-        String name = overlay.getResource().getName();
-        if (name.endsWith("!/"))
-            name = name.substring(0, name.length() - 2);
-        int i = name.lastIndexOf('/');
-        if (i > 0)
-            name = name.substring(i + 1, name.length());
+        String name = overlay.getResource().getFileName();
         name = name.replace('.', '_');
  
         File overlaysDir = new File(warPlugin.getProject().getBuild().getDirectory(), "jetty_overlays");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/SelectiveJarResource.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/SelectiveJarResource.java
@@ -129,6 +129,12 @@ public class SelectiveJarResource extends Resource
     }
 
     @Override
+    public String getFileName()
+    {
+        return _delegate.getFileName();
+    }
+
+    @Override
     public void copyTo(Path directory) throws IOException
     {
         if (_includes == null)

--- a/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
+++ b/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.runner;
 
-import java.io.IOException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -107,7 +106,7 @@ public class Runner
     {
         private List<URI> _classpath = new ArrayList<>();
 
-        public void addJars(Resource lib) throws IOException
+        public void addJars(Resource lib)
         {
             if (lib == null || !lib.exists())
                 throw new IllegalStateException("No such lib: " + lib);
@@ -117,9 +116,7 @@ public class Runner
                 if (item.isDirectory())
                     addJars(item);
                 else if (FileID.isLibArchive(item.getFileName()))
-                {
                     _classpath.add(item.getURI());
-                }
             }
         }
 

--- a/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
+++ b/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
@@ -116,7 +116,7 @@ public class Runner
             {
                 if (item.isDirectory())
                     addJars(item);
-                else if (FileID.isArchive(item.getFileName()))
+                else if (FileID.isLibArchive(item.getFileName()))
                 {
                     _classpath.add(item.getURI());
                 }

--- a/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
+++ b/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.RolloverFileOutputStream;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -111,26 +112,13 @@ public class Runner
             if (lib == null || !lib.exists())
                 throw new IllegalStateException("No such lib: " + lib);
 
-            List<String> list = lib.list();
-            if (list == null)
-                return;
-
-            for (String path : list)
+            for (Resource item: lib.list())
             {
-                if (".".equals(path) || "..".equals(path))
-                    continue;
-
-                Resource item = lib.resolve(path);
                 if (item.isDirectory())
                     addJars(item);
-                else
+                else if (FileID.isArchive(item.getFileName()))
                 {
-                    String lowerCasePath = path.toLowerCase(Locale.ENGLISH);
-                    if (lowerCasePath.endsWith(".jar") ||
-                        lowerCasePath.endsWith(".zip"))
-                    {
-                        _classpath.add(item.getURI());
-                    }
+                    _classpath.add(item.getURI());
                 }
             }
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -834,13 +834,9 @@ public class ServletContextHandler extends ContextHandler implements Graceful
                 path = path + URIUtil.SLASH;
 
             HashSet<String> set = new HashSet<>();
-
-            for (Resource r: resource)
+            for (Resource item: resource.list())
             {
-                for (Resource item: r.list())
-                {
-                    set.add(path + item.getFileName());
-                }
+                set.add(path + item.getFileName());
             }
             return set;
         }
@@ -2933,9 +2929,22 @@ public class ServletContextHandler extends ContextHandler implements Graceful
             path = URIUtil.canonicalPath(path);
             if (path == null)
                 return null;
+
+            // Assumption is that the resource base has been properly setup.
+            // Spec requirement is that the WAR file is interrogated first.
+            // If a WAR file is mounted, or is extracted to a temp directory,
+            // then the first entry of the resource base must be the WAR file.
             Resource resource = ServletContextHandler.this.getResource(path);
-            if (resource != null && resource.exists())
-                return resource.getURI().toURL();
+            if (resource == null)
+                return null;
+
+            for (Resource r: resource)
+            {
+                if (r.exists())
+                    return r.getURI().toURL();
+            }
+
+            // Resource was returned, but none-existed
             return null;
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -830,22 +830,19 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         {
             Resource resource = getResource(path);
 
-            if (resource != null && resource.exists())
-            {
-                if (!path.endsWith(URIUtil.SLASH))
-                    path = path + URIUtil.SLASH;
+            if (!path.endsWith(URIUtil.SLASH))
+                path = path + URIUtil.SLASH;
 
-                List<String> l = resource.list();
-                if (l != null)
+            HashSet<String> set = new HashSet<>();
+
+            for (Resource r: resource)
+            {
+                for (Resource item: r.list())
                 {
-                    HashSet<String> set = new HashSet<>();
-                    for (int i = 0; i < l.size(); i++)
-                    {
-                        set.add(path + l.get(i));
-                    }
-                    return set;
+                    set.add(path + item.getFileName());
                 }
             }
+            return set;
         }
         catch (Exception e)
         {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -2944,7 +2944,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
                     return r.getURI().toURL();
             }
 
-            // Resource was returned, but none-existed
+            // A Resource was returned, but did not exist
             return null;
         }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -25,12 +25,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +42,7 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UriPatternPredicate;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceCollators;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.ResourceUriPatternPredicate;
 import org.slf4j.Logger;
@@ -693,37 +692,26 @@ public class MetaInfConfiguration extends AbstractConfiguration
         throws Exception
     {
         Resource webInf = context.getWebInf();
-        if (webInf == null || !webInf.exists())
+        if (webInf == null)
             return null;
 
-        List<Resource> jarResources = new ArrayList<Resource>();
+        List<Resource> jarResources = new ArrayList<>();
         Resource webInfLib = webInf.resolve("/lib");
-        if (webInfLib.exists() && webInfLib.isDirectory())
+        for (Resource lib: webInfLib) // walk all "lib" hits
         {
-            List<String> files = webInfLib.list();
-            if (files != null)
+            if (!lib.exists())
+                continue; // doesn't exist, skip entry
+
+            for (Resource entry: lib.list()) // get contents of "lib" entry
             {
-                files.sort(Comparator.naturalOrder());
-            }
-            for (int f = 0; files != null && f < files.size(); f++)
-            {
-                try
+                if (FileID.isArchive(entry.getFileName()))
                 {
-                    Resource file = webInfLib.resolve(files.get(f));
-                    String fnlc = file.getName().toLowerCase(Locale.ENGLISH);
-                    int dot = fnlc.lastIndexOf('.');
-                    String extension = (dot < 0 ? null : fnlc.substring(dot));
-                    if (extension != null && (extension.equals(".jar") || extension.equals(".zip")))
-                    {
-                        jarResources.add(file);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LOG.warn("Unable to load WEB-INF file {}", files.get(f), ex);
+                    jarResources.add(entry);
                 }
             }
         }
+
+        jarResources.sort(ResourceCollators.byName(true));
         return jarResources;
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -695,24 +695,12 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (webInf == null)
             return null;
 
-        List<Resource> jarResources = new ArrayList<>();
         Resource webInfLib = webInf.resolve("/lib");
-        for (Resource lib: webInfLib) // walk all "lib" hits
-        {
-            if (!lib.exists())
-                continue; // doesn't exist, skip entry
 
-            for (Resource entry: lib.list()) // get contents of "lib" entry
-            {
-                if (FileID.isLibArchive(entry.getFileName()))
-                {
-                    jarResources.add(entry);
-                }
-            }
-        }
-
-        jarResources.sort(ResourceCollators.byName(true));
-        return jarResources;
+        return webInfLib.list().stream()
+            .filter((lib) -> FileID.isLibArchive(lib.getFileName()))
+            .sorted(ResourceCollators.byName(true))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -704,7 +704,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
             for (Resource entry: lib.list()) // get contents of "lib" entry
             {
-                if (FileID.isArchive(entry.getFileName()))
+                if (FileID.isLibArchive(entry.getFileName()))
                 {
                     jarResources.add(entry);
                 }
@@ -781,6 +781,6 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
     private boolean isFileSupported(Resource resource)
     {
-        return FileID.isArchive(resource.getURI());
+        return FileID.isLibArchive(resource.getURI());
     }
 }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.ee10.servlet.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ExceptionUtil;
+import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -1449,13 +1450,11 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 return null;
 
             // Should we go to the original war?
-            if (resource.isDirectory() && resource instanceof ResourceCollection && !WebAppContext.this.isExtractWAR())
+            if (resource.isDirectory() && !WebAppContext.this.isExtractWAR())
             {
-                List<Resource> resources = ((ResourceCollection)resource).getResources();
-                for (int i = resources.size(); i-- > 0; )
+                for (Resource r: resource)
                 {
-                    Resource r = resources.get(i);
-                    if (r.getName().startsWith("jar:file"))
+                    if (FileID.isWebArchive(r.getFileName()))
                         return r.getURI().toURL();
                 }
             }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1458,7 +1458,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                     return r.getURI().toURL();
             }
 
-            // Resource was returned, but none-existed
+            // A Resource was returned, but did not exist
             return null;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.ee10.servlet.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ExceptionUtil;
-import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -1445,21 +1444,22 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             if (path == null)
                 return null;
 
+            // Assumption is that the resource base has been properly setup.
+            // Spec requirement is that the WAR file is interrogated first.
+            // If a WAR file is mounted, or is extracted to a temp directory,
+            // then the first entry of the resource base must be the WAR file.
             Resource resource = WebAppContext.this.getResource(path);
-            if (resource == null || !resource.exists())
+            if (resource == null)
                 return null;
 
-            // Should we go to the original war?
-            if (resource.isDirectory() && !WebAppContext.this.isExtractWAR())
+            for (Resource r: resource)
             {
-                for (Resource r: resource)
-                {
-                    if (FileID.isWebArchive(r.getFileName()))
-                        return r.getURI().toURL();
-                }
+                if (r.exists())
+                    return r.getURI().toURL();
             }
 
-            return resource.getURI().toURL();
+            // Resource was returned, but none-existed
+            return null;
         }
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
@@ -85,6 +85,12 @@ public class OrderingTest
         }
 
         @Override
+        public String getFileName()
+        {
+            return null;
+        }
+
+        @Override
         public URI getURI()
         {
             return null;
@@ -106,12 +112,6 @@ public class OrderingTest
         public long length()
         {
             return 0;
-        }
-
-        @Override
-        public List<String> list()
-        {
-            return null;
         }
     }
 

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/OverlayManager.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/OverlayManager.java
@@ -133,12 +133,7 @@ public class OverlayManager
 
         //Get the name of the overlayed war and unpack it to a dir of the
         //same name in the temporary directory
-        String name = overlay.getResource().getName();
-        if (name.endsWith("!/"))
-            name = name.substring(0, name.length() - 2);
-        int i = name.lastIndexOf('/');
-        if (i > 0)
-            name = name.substring(i + 1, name.length());
+        String name = overlay.getResource().getFileName();
         name = name.replace('.', '_');
  
         File overlaysDir = new File(warPlugin.getProject().getBuild().getDirectory(), "jetty_overlays");

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/SelectiveJarResource.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/SelectiveJarResource.java
@@ -129,6 +129,12 @@ public class SelectiveJarResource extends Resource
     }
 
     @Override
+    public String getFileName()
+    {
+        return _delegate.getFileName();
+    }
+
+    @Override
     public void copyTo(Path directory) throws IOException
     {
         if (_includes == null)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1463,22 +1463,19 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         {
             Resource resource = getResource(path);
 
-            if (resource != null && resource.exists())
-            {
-                if (!path.endsWith(URIUtil.SLASH))
-                    path = path + URIUtil.SLASH;
+            if (!path.endsWith(URIUtil.SLASH))
+                path = path + URIUtil.SLASH;
 
-                List<String> l = resource.list();
-                if (l != null)
+            HashSet<String> set = new HashSet<>();
+
+            for (Resource r: resource)
+            {
+                for (Resource item: r.list())
                 {
-                    HashSet<String> set = new HashSet<>();
-                    for (int i = 0; i < l.size(); i++)
-                    {
-                        set.add(path + l.get(i));
-                    }
-                    return set;
+                    set.add(path + item.getFileName());
                 }
             }
+            return set;
         }
         catch (Exception e)
         {

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -695,24 +695,12 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (webInf == null || !webInf.exists())
             return null;
 
-        List<Resource> jarResources = new ArrayList<>();
         Resource webInfLib = webInf.resolve("/lib");
-        for (Resource lib: webInfLib) // walk all "lib" hits
-        {
-            if (!lib.exists())
-                continue; // doesn't exist, skip entry
 
-            for (Resource entry: lib.list()) // get contents of "lib" entry
-            {
-                if (FileID.isLibArchive(entry.getFileName()))
-                {
-                    jarResources.add(entry);
-                }
-            }
-        }
-
-        jarResources.sort(ResourceCollators.byName(true));
-        return jarResources;
+        return webInfLib.list().stream()
+            .filter((lib) -> FileID.isLibArchive(lib.getFileName()))
+            .sorted(ResourceCollators.byName(true))
+            .collect(Collectors.toList());
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -25,12 +25,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +42,7 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UriPatternPredicate;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceCollators;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.ResourceUriPatternPredicate;
 import org.slf4j.Logger;
@@ -696,34 +695,23 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (webInf == null || !webInf.exists())
             return null;
 
-        List<Resource> jarResources = new ArrayList<Resource>();
+        List<Resource> jarResources = new ArrayList<>();
         Resource webInfLib = webInf.resolve("/lib");
-        if (webInfLib.exists() && webInfLib.isDirectory())
+        for (Resource lib: webInfLib) // walk all "lib" hits
         {
-            List<String> files = webInfLib.list();
-            if (files != null)
+            if (!lib.exists())
+                continue; // doesn't exist, skip entry
+
+            for (Resource entry: lib.list()) // get contents of "lib" entry
             {
-                files.sort(Comparator.naturalOrder());
-            }
-            for (int f = 0; files != null && f < files.size(); f++)
-            {
-                try
+                if (FileID.isArchive(entry.getFileName()))
                 {
-                    Resource file = webInfLib.resolve(files.get(f));
-                    String fnlc = file.getName().toLowerCase(Locale.ENGLISH);
-                    int dot = fnlc.lastIndexOf('.');
-                    String extension = (dot < 0 ? null : fnlc.substring(dot));
-                    if (extension != null && (extension.equals(".jar") || extension.equals(".zip")))
-                    {
-                        jarResources.add(file);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LOG.warn("Unable to load WEB-INF file {}", files.get(f), ex);
+                    jarResources.add(entry);
                 }
             }
         }
+
+        jarResources.sort(ResourceCollators.byName(true));
         return jarResources;
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -704,7 +704,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
             for (Resource entry: lib.list()) // get contents of "lib" entry
             {
-                if (FileID.isArchive(entry.getFileName()))
+                if (FileID.isLibArchive(entry.getFileName()))
                 {
                     jarResources.add(entry);
                 }
@@ -782,6 +782,6 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
     private boolean isFileSupported(Resource resource)
     {
-        return FileID.isArchive(resource.getURI());
+        return FileID.isLibArchive(resource.getURI());
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1447,7 +1447,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                     return r.getURI().toURL();
             }
 
-            // Resource was returned, but none-existed
+            // A Resource was returned, but did not exist
             return null;
         }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -55,6 +55,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.ExceptionUtil;
+import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -1438,13 +1439,11 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 return null;
 
             // Should we go to the original war?
-            if (resource.isDirectory() && resource instanceof ResourceCollection && !WebAppContext.this.isExtractWAR())
+            if (resource.isDirectory() && !WebAppContext.this.isExtractWAR())
             {
-                List<Resource> resources = ((ResourceCollection)resource).getResources();
-                for (int i = resources.size(); i-- > 0; )
+                for (Resource r: resource)
                 {
-                    Resource r = resources.get(i);
-                    if (r.getName().startsWith("jar:file"))
+                    if (FileID.isWebArchive(r.getFileName()))
                         return r.getURI().toURL();
                 }
             }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -55,7 +55,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.ExceptionUtil;
-import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -1434,21 +1433,22 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             if (path == null)
                 return null;
 
+            // Assumption is that the resource base has been properly setup.
+            // Spec requirement is that the WAR file is interrogated first.
+            // If a WAR file is mounted, or is extracted to a temp directory,
+            // then the first entry of the resource base must be the WAR file.
             Resource resource = WebAppContext.this.getResource(path);
-            if (resource == null || !resource.exists())
+            if (resource == null)
                 return null;
 
-            // Should we go to the original war?
-            if (resource.isDirectory() && !WebAppContext.this.isExtractWAR())
+            for (Resource r: resource)
             {
-                for (Resource r: resource)
-                {
-                    if (FileID.isWebArchive(r.getFileName()))
-                        return r.getURI().toURL();
-                }
+                if (r.exists())
+                    return r.getURI().toURL();
             }
 
-            return resource.getURI().toURL();
+            // Resource was returned, but none-existed
+            return null;
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
@@ -85,6 +85,12 @@ public class OrderingTest
         }
 
         @Override
+        public String getFileName()
+        {
+            return null;
+        }
+
+        @Override
         public URI getURI()
         {
             return null;
@@ -106,12 +112,6 @@ public class OrderingTest
         public long length()
         {
             return 0;
-        }
-
-        @Override
-        public List<String> list()
-        {
-            return null;
         }
     }
 


### PR DESCRIPTION
Per discussion around Issue #8474, the API of `Resource.list()` has changed.

* Signature of return has changed from `List<String>` to `List<Resource>`
* Always returns all hits, leaving unique behavior to caller of the API to do.

New API `Resource.getFileName()` has been implemented to make users of the above API easier to implement.

When it comes to uniqueness of the entries in the list, that's only relevant for the `ResourceListing` class.
All other callers don't need (or want) the uniqueness behaviors.

The uniqueness algorithm in `ResourceListing` for this PR is "first hit".
Other algorithms suggested (eg: "most recently updated" / "largest entry" / "last hit" / etc) are not implemented in this PR.
