### PR TITLE
Fixes #8558 - Idle timeout occurs on HTTP/2 with InputStreamResponseL…

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -285,6 +285,15 @@ public class HTTP2Stream implements IStream, Callback, Dumpable, CyclicTimeouts.
         return committed;
     }
 
+    @Override
+    public int dataSize()
+    {
+        try (AutoLock l = lock.lock())
+        {
+            return dataQueue == null ? 0 : dataQueue.size();
+        }
+    }
+
     public boolean isOpen()
     {
         return !isClosed();
@@ -921,13 +930,14 @@ public class HTTP2Stream implements IStream, Callback, Dumpable, CyclicTimeouts.
     @Override
     public String toString()
     {
-        return String.format("%s@%x#%d@%x{sendWindow=%s,recvWindow=%s,demand=%d,reset=%b/%b,%s,age=%d,attachment=%s}",
+        return String.format("%s@%x#%d@%x{sendWindow=%s,recvWindow=%s,queue=%d,demand=%d,reset=%b/%b,%s,age=%d,attachment=%s}",
             getClass().getSimpleName(),
             hashCode(),
             getId(),
             session.hashCode(),
             sendWindow,
             recvWindow,
+            dataSize(),
             demand(),
             localReset,
             remoteReset,

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/IStream.java
@@ -143,6 +143,11 @@ public interface IStream extends Stream, Attachable, Closeable
     boolean isCommitted();
 
     /**
+     * @return the size of the DATA frame queue
+     */
+    int dataSize();
+
+    /**
      * <p>An ordered list of frames belonging to the same stream.</p>
      */
     public static class FrameList

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
@@ -186,7 +186,14 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         }
 
         @Override
-        public void onData(Stream stream, DataFrame frame, Callback callback)
+        public void onBeforeData(Stream stream)
+        {
+            // Don't demand here, as the initial demand is controlled by
+            // the application via DemandedContentListener.onBeforeContent().
+        }
+
+        @Override
+        public void onDataDemanded(Stream stream, DataFrame frame, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((IStream)stream).getAttachment();
             channel.onData(frame, callback);

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
@@ -85,7 +85,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientTransportOverHTTP2Test extends AbstractTest
 {
@@ -634,13 +633,10 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         });
 
         var requestCount = 10_000;
-        var progress = new AtomicInteger(0);
         IntStream.range(0, requestCount).forEach(i ->
         {
             try
             {
-                if (progress.incrementAndGet() % 1000 == 0)
-                    System.err.printf("progress %d/%d%n", progress.get(), requestCount);
                 InputStreamResponseListener listener = new InputStreamResponseListener();
                 client.newRequest("localhost", connector.getLocalPort()).headers(httpFields -> httpFields.put("X-Request-Id", Integer.toString(i))).send(listener);
                 Response response = listener.get(15, TimeUnit.SECONDS);
@@ -649,7 +645,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             }
             catch (Exception e)
             {
-                fail(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/HttpClientTransportOverHTTP2Test.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -40,6 +41,8 @@ import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -82,6 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientTransportOverHTTP2Test extends AbstractTest
 {
@@ -608,6 +612,46 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             });
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testInputStreamResponseListener() throws Exception
+    {
+        var bytes = 100_000;
+        start(new ServerSessionListener.Adapter()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                int streamId = stream.getId();
+                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                HeadersFrame responseFrame = new HeadersFrame(streamId, response, null, false);
+                Callback.Completable callback = new Callback.Completable();
+                stream.headers(responseFrame, callback);
+                callback.thenRun(() -> stream.data(new DataFrame(streamId, ByteBuffer.wrap(new byte[bytes]), true), Callback.NOOP));
+                return null;
+            }
+        });
+
+        var requestCount = 10_000;
+        var progress = new AtomicInteger(0);
+        IntStream.range(0, requestCount).forEach(i ->
+        {
+            try
+            {
+                if (progress.incrementAndGet() % 1000 == 0)
+                    System.err.printf("progress %d/%d%n", progress.get(), requestCount);
+                InputStreamResponseListener listener = new InputStreamResponseListener();
+                client.newRequest("localhost", connector.getLocalPort()).headers(httpFields -> httpFields.put("X-Request-Id", Integer.toString(i))).send(listener);
+                Response response = listener.get(15, TimeUnit.SECONDS);
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(bytes, listener.getInputStream().readAllBytes().length);
+            }
+            catch (Exception e)
+            {
+                fail(e);
+            }
+        });
     }
 
     @Disabled


### PR DESCRIPTION
…istener.

The issue was that HttpReceiverOverHTTP2.ContentNotifier.offer() was racy, as a network thread could have offered a DATA frame, but not yet called process() -- yet an application thread could have stolen the DATA frame completed the response and started another response, causing the network thread to interact with the wrong response.

The implementation has been changed so that HttpReceiverOverHTTP2.ContentNotifier does not have a queue anymore and it demands DATA frames to the Stream only when the application demands more -- a simpler model that just forwards the demand.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>