### PR TITLE
Jetty 12 - Improving `URIUtil.addPathQuery` behavior + adding tests

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1068,13 +1068,13 @@ public final class URIUtil
     }
 
     /** Add a path and a query string
-     * @param path The path which may already contain contain a query
-     * @param query The query string or null if no query to be added
-     * @return The path with any non null query added after a '?' or '&amp;' as appropriate.
+     * @param path The path which may already contain a query
+     * @param query The query string to add (if blank, no query is added)
+     * @return The path with any non-blank query added after a '?' or '&amp;' as appropriate.
      */
     public static String addPathQuery(String path, String query)
     {
-        if (query == null)
+        if (StringUtil.isBlank(query))
             return path;
         if (path.indexOf('?') >= 0)
             return path + '&' + query;

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -546,6 +546,25 @@ public class URIUtilTest
         assertThat(actual.toASCIIString(), is("file:///opt/foo.txt/bar.dat"));
     }
 
+    public static Stream<Arguments> addPathQuerySource()
+    {
+        return Stream.of(
+            Arguments.of("/path", null, "/path"),
+            Arguments.of("/path", "", "/path"),
+            Arguments.of("/path", "    ", "/path"),
+            Arguments.of("/path", "a=b", "/path?a=b"),
+            Arguments.of("/path?a=b", "x=y", "/path?a=b&x=y")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("addPathQuerySource")
+    public void testAddPathQuery(String path, String query, String expected)
+    {
+        String actual = URIUtil.addPathQuery(path, query);
+        assertThat(actual, is(expected));
+    }
+
     public static Stream<Arguments> ensureSafeEncodingSource()
     {
         return Stream.of(


### PR DESCRIPTION
+ URIUtil.addPathQuery responds appropriately with blank query now as well
+ Adding tests for addPathQuery (they were missing)