### PR TITLE
Bump SLF4J to version 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <org.osgi.util.promise.version>1.2.0</org.osgi.util.promise.version>
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>3.4.2</plexus-utils.version>
-    <slf4j.version>2.0.0</slf4j.version>
+    <slf4j.version>2.0.2</slf4j.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>


### PR DESCRIPTION
SLF4J 2.0.0, 2.0.1, and 2.0.2 have been released recently.

https://www.slf4j.org/news.html

> # 2022-09-20 - Release of SLF4J 2.0.2
> - Fixed bug in the setContextMap() method of Reload4jMDCAdapter. This issue was reported in [SLF4J-563](https://jira.qos.ch/browse/SLF4J-563) by Michael Wartes.
> - The binary of this version can be reproduced by checking out the tag v_2.0.2 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.
> # 2022-09-14 - Release of SLF4J 2.0.1
> - The Logger.makeLoggingEventBuilder method semantics has changed so that overriding implementations should now always build a new LoggingEventBuilder instance as appropraiate for the implementation, i.e the logging backend. For more details see [SLF4J-560](https://jira.qos.ch/browse/SLF4J-560).
> - Deprecated unused LoggerFactoryBinder and MarkerFactoryBinder classes. This issue was raised in [SLF4J-555](https://jira.qos.ch/browse/SLF4J-555) by Witalij Berdinskich who provided the relevant patch.
> - The binary of this version can be reproduced by checking out the tag v_2.0.1 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.
> 
> # 2022-08-20 - Release of SLF4J 2.0.0
> The the 2.0.x series requires Java 8 and adds a backward-compatible [fluent logging api](https://www.slf4j.org/manual.html#fluent).
> 
> Moreover, SLF4J has been modularized per [JPMS/Jigsaw](http://openjdk.java.net/projects/jigsaw/spec/) specification. The resulting internal changes are [detailed](https://www.slf4j.org/faq.html#changesInVersion200) in the FAQ page.
SLF4J 2.0.x series requires Java 8. It builds upon the 1.8.x series and adds a backward-compatible [fluent logging api](https://www.slf4j.org/manual.html#fluent). By backward-compatible, we mean that existing logging frameworks do not have to be changed for the user to benefit from the fluent logging API. However, existing frameworks must migrate to the ServiceLoader mechanism. The resulting internal changes are [detailed](https://www.slf4j.org/faq.html#changesInVersion200) in the FAQ page.
> - Except minor javadoc changes, this release is identical to 2.0.0-beta1 released earlier this month.
> - The binary of this version can be reproduced by checking out the tag v_2.0.0 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.