### PR TITLE
Bump Logback to version 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <junit.version>5.9.0</junit.version>
     <kerb-simplekdc.version>2.0.2</kerb-simplekdc.version>
     <log4j2.version>2.18.0</log4j2.version>
-    <logback.version>1.4.0</logback.version>
+    <logback.version>1.4.1</logback.version>
     <mariadb.version>3.0.7</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.resolver.version>1.8.2</maven.resolver.version>


### PR DESCRIPTION
> # 2022-09-14 Release of logback versions 1.3.1 and 1.4.1
> Logback components written for logback 1.2 should work without change in version 1.3. However, Joran, logback's configuration system, has been rewritten to use an internal representation model which can be processed separately. Thus, code depending on Joran needs to be adapted to changes in Joran (logback's internal configuration mechanism).
> 
> As a result of enhancements to Joran, logback configuration scripts are now largely order-free. For example, appenders can now be defined after they are first referenced in a logger. Moreover, unreferenced appenders are no longer instantiated.
> 
> - Logback-classic now correctly invokes DefaultJoranConfigurator when running in a (JPMS) modular environment. This fixes LOGBACK-1670 reported by Alexey Gavrilov who also provided the relevant test case.
> - Logback will now correctly retrieve its own version information when running in a (JPMS) modular environment. This fixes LOGBACK-1677.
> - Logback version 1.3.1 now correctly declares javax.servlet.ServletContainerInitializer as a provided service. This fixes LOGBACK-1671 as reported by Chad Wilson.