### PR TITLE
Jetty 12 : XmlAppendable use Charset, not String

### DIFF
--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java
@@ -17,6 +17,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Stack;
 
@@ -30,9 +33,9 @@ public class XmlAppendable
     private final Stack<String> _tags = new Stack<>();
     private String _space = "";
 
-    public XmlAppendable(OutputStream out, String encoding) throws IOException
+    public XmlAppendable(OutputStream out, Charset charset) throws IOException
     {
-        this(new OutputStreamWriter(out, encoding), encoding);
+        this(new OutputStreamWriter(out, charset), charset);
     }
 
     public XmlAppendable(Appendable out) throws IOException
@@ -40,21 +43,21 @@ public class XmlAppendable
         this(out, 2);
     }
 
-    public XmlAppendable(Appendable out, String encoding) throws IOException
+    public XmlAppendable(Appendable out, Charset charset) throws IOException
     {
-        this(out, 2, encoding);
+        this(out, 2, charset);
     }
 
     public XmlAppendable(Appendable out, int indent) throws IOException
     {
-        this(out, indent, "utf-8");
+        this(out, indent, StandardCharsets.UTF_8);
     }
 
-    public XmlAppendable(Appendable out, int indent, String encoding) throws IOException
+    public XmlAppendable(Appendable out, int indent, Charset charset) throws IOException
     {
         _out = out;
         _indent = indent;
-        _out.append("<?xml version=\"1.0\" encoding=\"").append(encoding).append("\"?>\n");
+        _out.append("<?xml version=\"1.0\" encoding=\"").append(charset.name().toLowerCase(Locale.ENGLISH)).append("\"?>\n");
     }
 
     public XmlAppendable openTag(String tag, Map<String, String> attributes) throws IOException

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java
@@ -33,31 +33,12 @@ public class XmlAppendable
     private final Stack<String> _tags = new Stack<>();
     private String _space = "";
 
-    public XmlAppendable(OutputStream out, Charset charset) throws IOException
+    public XmlAppendable(OutputStream out) throws IOException
     {
-        this(new OutputStreamWriter(out, charset), charset);
-    }
-
-    public XmlAppendable(Appendable out) throws IOException
-    {
-        this(out, 2);
-    }
-
-    public XmlAppendable(Appendable out, Charset charset) throws IOException
-    {
-        this(out, 2, charset);
-    }
-
-    public XmlAppendable(Appendable out, int indent) throws IOException
-    {
-        this(out, indent, StandardCharsets.UTF_8);
-    }
-
-    public XmlAppendable(Appendable out, int indent, Charset charset) throws IOException
-    {
-        _out = out;
-        _indent = indent;
-        _out.append("<?xml version=\"1.0\" encoding=\"").append(charset.name().toLowerCase(Locale.ENGLISH)).append("\"?>\n");
+        Charset utf8 = StandardCharsets.UTF_8;
+        _out = new OutputStreamWriter(out, utf8);
+        _indent = 2;
+        _out.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
     }
 
     public XmlAppendable openTag(String tag, Map<String, String> attributes) throws IOException

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlAppendableTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlAppendableTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.xml;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -25,8 +27,8 @@ public class XmlAppendableTest
     @Test
     public void test() throws Exception
     {
-        StringBuilder b = new StringBuilder();
-        XmlAppendable out = new XmlAppendable(b);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XmlAppendable out = new XmlAppendable(outputStream);
         Map<String, String> attr = new LinkedHashMap<>();
 
         out.openTag("test");
@@ -45,22 +47,26 @@ public class XmlAppendableTest
         out.closeTag();
 
         String expected =
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                "<test>\n" +
-                "  <tag/>\n" +
-                "  <tag name=\"attr value\" noval=\"\" quotes=\"&apos;&quot;\"/>\n" +
-                "  <tag name=\"attr value\" noval=\"\" quotes=\"&apos;&quot;\">content</tag>\n" +
-                "  <level1>\n" +
-                "    <tag>content</tag>\n" +
-                "    <tag>content</tag>\n" +
-                "  </level1>\n" +
-                "  <level1 name=\"attr value\" noval=\"\" quotes=\"&apos;&quot;\">\n" +
-                "    <level2>\n" +
-                "      <tag>content</tag>\n" +
-                "      <tag>content</tag>\n" +
-                "    </level2>\n" +
-                "  </level1>\n" +
-                "</test>\n";
-        assertEquals(expected, b.toString());
+            """
+                <?xml version="1.0" encoding="utf-8"?>
+                <test>
+                  <tag/>
+                  <tag name="attr value" noval="" quotes="&apos;&quot;"/>
+                  <tag name="attr value" noval="" quotes="&apos;&quot;">content</tag>
+                  <level1>
+                    <tag>content</tag>
+                    <tag>content</tag>
+                  </level1>
+                  <level1 name="attr value" noval="" quotes="&apos;&quot;">
+                    <level2>
+                      <tag>content</tag>
+                      <tag>content</tag>
+                    </level2>
+                  </level1>
+                </test>
+                """;
+
+        String result = outputStream.toString(StandardCharsets.UTF_8);
+        assertEquals(expected, result);
     }
 }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
@@ -159,7 +159,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("metadata-complete", Boolean.toString(context.getMetaData().isMetaDataComplete()));
         webappAttr.put("version", major + "." + minor);
 
-        XmlAppendable out = new XmlAppendable(stream, StandardCharsets.UTF_8);
+        XmlAppendable out = new XmlAppendable(stream);
         out.openTag("web-app", webappAttr);
         if (context.getDisplayName() != null)
             out.tag("display-name", context.getDisplayName());

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee10.quickstart;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
@@ -158,7 +159,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("metadata-complete", Boolean.toString(context.getMetaData().isMetaDataComplete()));
         webappAttr.put("version", major + "." + minor);
 
-        XmlAppendable out = new XmlAppendable(stream, "UTF-8");
+        XmlAppendable out = new XmlAppendable(stream, StandardCharsets.UTF_8);
         out.openTag("web-app", webappAttr);
         if (context.getDisplayName() != null)
             out.tag("display-name", context.getDisplayName());

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee10.quickstart;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee9.quickstart;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
@@ -158,7 +159,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("metadata-complete", Boolean.toString(context.getMetaData().isMetaDataComplete()));
         webappAttr.put("version", major + "." + minor);
 
-        XmlAppendable out = new XmlAppendable(stream, "UTF-8");
+        XmlAppendable out = new XmlAppendable(stream, StandardCharsets.UTF_8);
         out.openTag("web-app", webappAttr);
         if (context.getDisplayName() != null)
             out.tag("display-name", context.getDisplayName());

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee9.quickstart;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -159,7 +159,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         webappAttr.put("metadata-complete", Boolean.toString(context.getMetaData().isMetaDataComplete()));
         webappAttr.put("version", major + "." + minor);
 
-        XmlAppendable out = new XmlAppendable(stream, StandardCharsets.UTF_8);
+        XmlAppendable out = new XmlAppendable(stream);
         out.openTag("web-app", webappAttr);
         if (context.getDisplayName() != null)
             out.tag("display-name", context.getDisplayName());


### PR DESCRIPTION
Change to have XmlAppendable use Charset not String to create outputstream and whatnot.

Taken from PR #8597 