### PR TITLE
Jetty 12 : ResourceFactory.of(WebAppContext) to WebAppContext.getResourceFactory()

### DIFF
--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationIntrospector.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationIntrospector.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.ee10.servlet.BaseHolder;
 import org.eclipse.jetty.ee10.servlet.Source.Origin;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.webapp.WebDescriptor;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +168,7 @@ public class AnnotationIntrospector
                 String descriptorLocation = holder.getSource().getResource();
                 if (descriptorLocation == null)
                     return true; //no descriptor, can't be metadata-complete
-                return !WebDescriptor.isMetaDataComplete(_context.getMetaData().getFragmentDescriptor(ResourceFactory.of(_context).newResource(descriptorLocation)));
+                return !WebDescriptor.isMetaDataComplete(_context.getMetaData().getFragmentDescriptor(_context.getResourceFactory().newResource(descriptorLocation)));
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ServerWithJNDI.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ServerWithJNDI.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration;
 import org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * ServerWithJNDI
@@ -37,7 +36,7 @@ public class ServerWithJNDI
         WebAppContext webapp = new WebAppContext();
         webapp.setContextPath("/");
         Path testJndiWar = JettyDemos.find("jetty-ee10-demo-jndi-webapp/target/jetty-ee10-demo-jndi-webapp-@VER@.war");
-        webapp.setWarResource(ResourceFactory.of(webapp).newResource(testJndiWar));
+        webapp.setWarResource(webapp.getResourceFactory().newResource(testJndiWar));
         server.setHandler(webapp);
 
         // Enable parsing of jndi-related parts of web.xml and jetty-env.xml

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/test/java/org/eclipse/jetty/ee10/TestServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/test/java/org/eclipse/jetty/ee10/TestServer.java
@@ -115,7 +115,7 @@ public class TestServer
         Path webappBase = webappProjectRoot.resolve("jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/main/webapp");
         if (!Files.exists(webappBase))
             throw new FileNotFoundException(webappBase.toString());
-        webapp.setBaseResource(ResourceFactory.of(server).newResource(webappBase));
+        webapp.setBaseResource(webapp.getResourceFactory().newResource(webappBase));
         webapp.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN,
             ".*/test-jetty-webapp/target/classes.*$|" +
                 ".*/jakarta.servlet.api-[^/]*\\.jar$|.*/jakarta.servlet.jsp.jstl-.*\\.jar$|.*/org.apache.taglibs.taglibs-standard.*\\.jar$"

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
@@ -24,7 +24,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * Base class for all goals that operate on unassembled webapps.
@@ -131,7 +130,7 @@ public abstract class AbstractUnassembledWebAppMojo extends AbstractWebAppMojo
                 //Use the default static resource location
                 if (!webAppSourceDirectory.exists())
                     webAppSourceDirectory.mkdirs();
-                originalBaseResource = ResourceFactory.of(webApp).newResource(webAppSourceDirectory.getCanonicalPath());
+                originalBaseResource = webApp.getResourceFactory().newResource(webAppSourceDirectory.getCanonicalPath());
             }
             else
                 originalBaseResource = webApp.getBaseResource();
@@ -167,7 +166,7 @@ public abstract class AbstractUnassembledWebAppMojo extends AbstractWebAppMojo
             //Has an explicit web.xml file been configured to use?
             if (webXml != null)
             {
-                Resource r = ResourceFactory.of(webApp).newResource(webXml.toPath());
+                Resource r = webApp.getResourceFactory().newResource(webXml.toPath());
                 if (r.exists() && !r.isDirectory())
                 {
                     webApp.setDescriptor(r.toString());

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * JettyEmbedded
@@ -280,7 +279,7 @@ public class JettyEmbedder extends AbstractLifeCycle
             Path qs = webApp.getTempDirectory().toPath().resolve("quickstart-web.xml");
             if (Files.exists(qs) && Files.isRegularFile(qs))
             {
-                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(qs));
+                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webApp.getResourceFactory().newResource(qs));
                 webApp.addConfiguration(new MavenQuickStartConfiguration());
                 webApp.setAttribute(QuickStartConfiguration.MODE, Mode.QUICKSTART);
             }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyRunMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyRunMojo.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.util.IncludeExcludeSet;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.Scheduler;
 
 /**
@@ -220,7 +219,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
     {
         if (webApp.getDescriptor() != null)
         {
-            Resource r = ResourceFactory.of(webApp).newResource(webApp.getDescriptor());
+            Resource r = webApp.getResourceFactory().newResource(webApp.getDescriptor());
             scanner.addFile(r.getPath());
         }
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenMetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenMetaInfConfiguration.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.ee10.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +67,7 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                     try
                     {
                         LOG.debug(" add  resource to resources to examine {}", file);
-                        list.add(ResourceFactory.of(context).newResource(file.toURI()));
+                        list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)
                     {
@@ -102,7 +101,7 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                 {
                     try
                     {
-                        list.add(ResourceFactory.of(context).newResource(file.toURI()));
+                        list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)
                     {

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -41,7 +41,6 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -232,7 +231,7 @@ public class MavenWebAppContext extends WebAppContext
                 .map(URI::create)
                 .toList();
 
-            setBaseResource(ResourceFactory.of(this).newResource(uris));
+            setBaseResource(this.getResourceFactory().newResource(uris));
         }
         catch (Throwable t)
         {
@@ -319,7 +318,7 @@ public class MavenWebAppContext extends WebAppContext
             for (Configuration c : configurations)
             {
                 if (c instanceof EnvConfiguration)
-                    ((EnvConfiguration)c).setJettyEnvResource(ResourceFactory.of(this).newResource(getJettyEnvXml()));
+                    ((EnvConfiguration)c).setJettyEnvResource(this.getResourceFactory().newResource(getJettyEnvXml()));
             }
         }
 
@@ -383,9 +382,9 @@ public class MavenWebAppContext extends WebAppContext
                     // return the resource matching the web-inf classes
                     // rather than the test classes
                     if (_classes != null)
-                        return ResourceFactory.of(this).newResource(_classes.toPath());
+                        return this.getResourceFactory().newResource(_classes.toPath());
                     else if (_testClasses != null)
-                        return ResourceFactory.of(this).newResource(_testClasses.toPath());
+                        return this.getResourceFactory().newResource(_testClasses.toPath());
                 }
                 else
                 {
@@ -395,7 +394,7 @@ public class MavenWebAppContext extends WebAppContext
                     while (res == null && (i < _webInfClasses.size()))
                     {
                         String newPath = StringUtil.replace(uri, WEB_INF_CLASSES_PREFIX, _webInfClasses.get(i).getPath());
-                        res = ResourceFactory.of(this).newResource(newPath);
+                        res = this.getResourceFactory().newResource(newPath);
                         if (!res.exists())
                         {
                             res = null;
@@ -416,7 +415,7 @@ public class MavenWebAppContext extends WebAppContext
                     return null;
                 File jarFile = _webInfJarMap.get(jarName);
                 if (jarFile != null)
-                    return ResourceFactory.of(this).newResource(jarFile.getPath());
+                    return this.getResourceFactory().newResource(jarFile.getPath());
 
                 return null;
             }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration.Mode;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
@@ -121,7 +120,7 @@ public class QuickStartGenerator
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
         webApp.setAttribute(QuickStartConfiguration.MODE, Mode.GENERATE);
-        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(quickstartXml.toPath()));
+        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webApp.getResourceFactory().newResource(quickstartXml.toPath()));
         webApp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "o");
         webApp.setCopyWebDir(false);
         webApp.setCopyWebInf(false);

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
@@ -31,7 +31,6 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
 /**
@@ -174,7 +173,7 @@ public class WebAppPropertyConverter
         if (resource == null)
             throw new IllegalStateException("No resource");
 
-        fromProperties(webApp, ResourceFactory.of(webApp).newResource(resource).getPath(), server, jettyProperties);
+        fromProperties(webApp, webApp.getResourceFactory().newResource(resource).getPath(), server, jettyProperties);
     }
 
     /**
@@ -209,7 +208,7 @@ public class WebAppPropertyConverter
         str = webAppProperties.getProperty(QUICKSTART_WEB_XML);
         if (!StringUtil.isBlank(str))
         {
-            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(str));
+            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webApp.getResourceFactory().newResource(str));
         }
 
         // - the tmp directory
@@ -228,7 +227,7 @@ public class WebAppPropertyConverter
             // This is a use provided list of overlays, which could have mountable entries.
             List<URI> uris = URIUtil.split(str);
             webApp.setWar(null);
-            webApp.setBaseResource(ResourceFactory.of(webApp).newResource(uris));
+            webApp.setBaseResource(webApp.getResourceFactory().newResource(uris));
         }
 
         str = webAppProperties.getProperty(WAR_FILE);
@@ -290,7 +289,7 @@ public class WebAppPropertyConverter
         str = (String)webAppProperties.getProperty(CONTEXT_XML);
         if (!StringUtil.isBlank(str))
         {
-            XmlConfiguration xmlConfiguration = new XmlConfiguration(ResourceFactory.of(webApp).newResource(str));
+            XmlConfiguration xmlConfiguration = new XmlConfiguration(webApp.getResourceFactory().newResource(str));
             xmlConfiguration.getIdMap().put("Server", server);
             //add in any properties
             if (jettyProperties != null)

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/PlusDescriptorProcessorTest.java
@@ -154,20 +154,20 @@ public class PlusDescriptorProcessorTest
         doEnvConfiguration(envCtx, vacuumStringEnvEntry);
 
         URL webXml = Thread.currentThread().getContextClassLoader().getResource("web.xml");
-        webDescriptor = new WebDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(webXml));
+        webDescriptor = new WebDescriptor(context.getResourceFactory().newResource(webXml));
         webDescriptor.parse(WebDescriptor.getParser(false));
 
         URL frag1Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-1.xml");
-        fragDescriptor1 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag1Xml));
+        fragDescriptor1 = new FragmentDescriptor(context.getResourceFactory().newResource(frag1Xml));
         fragDescriptor1.parse(WebDescriptor.getParser(false));
         URL frag2Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-2.xml");
-        fragDescriptor2 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag2Xml));
+        fragDescriptor2 = new FragmentDescriptor(context.getResourceFactory().newResource(frag2Xml));
         fragDescriptor2.parse(WebDescriptor.getParser(false));
         URL frag3Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-3.xml");
-        fragDescriptor3 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag3Xml));
+        fragDescriptor3 = new FragmentDescriptor(context.getResourceFactory().newResource(frag3Xml));
         fragDescriptor3.parse(WebDescriptor.getParser(false));
         URL frag4Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-4.xml");
-        fragDescriptor4 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag4Xml));
+        fragDescriptor4 = new FragmentDescriptor(context.getResourceFactory().newResource(frag4Xml));
         fragDescriptor4.parse(WebDescriptor.getParser(false));
         Thread.currentThread().setContextClassLoader(oldLoader);
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/Quickstart.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/Quickstart.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
 public class Quickstart
@@ -37,7 +36,7 @@ public class Quickstart
         WebAppContext webapp = new WebAppContext();
         Resource contextXml = null;
         if (args.length > 1)
-            contextXml = ResourceFactory.of(webapp).newResource(args[1]);
+            contextXml = webapp.getResourceFactory().newResource(args[1]);
 
         Server server = new Server(8080);
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1253,7 +1253,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     public void setExtraClasspath(String extraClasspath)
     {
         List<URI> uris = URIUtil.split(extraClasspath);
-        setExtraClasspath(ResourceFactory.of(this).newResource(uris));
+        setExtraClasspath(this.getResourceFactory().newResource(uris));
     }
 
     public void setExtraClasspath(ResourceCollection extraClasspath)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -41,7 +41,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.webapp.tmpResourceBase";
 
     protected Resource _preUnpackBaseResource;
-    private ResourceFactory.Closeable _resourceFactory;
 
     public WebInfConfiguration()
     {
@@ -92,9 +91,6 @@ public class WebInfConfiguration extends AbstractConfiguration
         Boolean tmpdirConfigured = (Boolean)context.getAttribute(TEMPDIR_CONFIGURED);
         if (tmpdirConfigured != null && !tmpdirConfigured)
             context.setTempDirectory(null);
-
-        IO.close(_resourceFactory);
-        _resourceFactory = null;
 
         //reset the base resource back to what it was before we did any unpacking of resources
         //TODO there is something wrong with the config of the resource base as this should never be null
@@ -282,7 +278,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     public void unpack(WebAppContext context) throws IOException
     {
         Resource webApp = context.getBaseResource();
-        _resourceFactory = ResourceFactory.closeable();
         _preUnpackBaseResource = context.getBaseResource();
 
         if (webApp == null)
@@ -317,7 +312,7 @@ public class WebInfConfiguration extends AbstractConfiguration
             if (webApp.exists() && !webApp.isDirectory() && !webApp.toString().startsWith("jar:"))
             {
                 // No - then lets see if it can be turned into a jar URL.
-                webApp = _resourceFactory.newJarFileResource(webApp.getURI());
+                webApp = context.getResourceFactory().newJarFileResource(webApp.getURI());
             }
 
             // If we should extract or the URL is still not usable
@@ -334,7 +329,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 if (war != null)
                 {
                     // look for a sibling like "foo/" to a "foo.war"
-                    Path warfile = _resourceFactory.newResource(war).getPath();
+                    Path warfile = context.getResourceFactory().newResource(war).getPath();
                     if (warfile != null && warfile.getFileName().toString().toLowerCase(Locale.ENGLISH).endsWith(".war"))
                     {
                         Path sibling = warfile.getParent().resolve(warfile.getFileName().toString().substring(0, warfile.getFileName().toString().length() - 4));
@@ -397,7 +392,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                         }
                     }
                 }
-                webApp = _resourceFactory.newResource(extractedWebAppDir.normalize());
+                webApp = context.getResourceFactory().newResource(extractedWebAppDir.normalize());
             }
 
             // Now do we have something usable?
@@ -450,7 +445,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 webInfClasses.copyTo(webInfClassesDir.toPath());
             }
 
-            webInf = _resourceFactory.newResource(extractedWebInfDir.getCanonicalPath());
+            webInf = context.getResourceFactory().newResource(extractedWebInfDir.getCanonicalPath());
 
             Resource rc = Resource.combine(webInf, webApp);
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
@@ -49,7 +49,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String defaultsDescriptor = context.getDefaultsDescriptor();
         if (defaultsDescriptor != null && defaultsDescriptor.length() > 0)
         {
-            Resource dftResource = ResourceFactory.of(context).newSystemResource(defaultsDescriptor);
+            Resource dftResource = context.getResourceFactory().newSystemResource(defaultsDescriptor);
             if (dftResource == null)
             {
                 String pkg = WebXmlConfiguration.class.getPackageName().replace(".", "/") + "/";
@@ -83,7 +83,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         {
             if (overrideDescriptor != null && overrideDescriptor.length() > 0)
             {
-                Resource orideResource = ResourceFactory.of(context).newSystemResource(overrideDescriptor);
+                Resource orideResource = context.getResourceFactory().newSystemResource(overrideDescriptor);
                 if (orideResource == null)
                     orideResource = context.newResource(overrideDescriptor);
                 context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoaderTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoaderTest.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ public class WebAppClassLoaderTest
 
         _testWebappDir = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         _context = new WebAppContext();
-        Resource webapp = ResourceFactory.of(_context).newResource(_testWebappDir);
+        Resource webapp = _context.getResourceFactory().newResource(_testWebappDir);
         _context.setBaseResource(webapp);
         _context.setContextPath("/test");
         _context.setExtraClasspath("src/test/resources/ext/*");

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebAppTester.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebAppTester.java
@@ -44,7 +44,6 @@ import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +153,7 @@ public class WebAppTester extends ContainerLifeCycle
             // Configure the WebAppContext.
             _context = new WebAppContext();
             _context.setContextPath(contextPath);
-            _context.setBaseResource(ResourceFactory.of(_context).newResource(_contextDir).getPath());
+            _context.setBaseResource(_context.getResourceFactory().newResource(_contextDir).getPath());
 
             _context.setConfigurations(new Configuration[]
             {

--- a/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/AnnotationIntrospector.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/AnnotationIntrospector.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.ee9.servlet.BaseHolder;
 import org.eclipse.jetty.ee9.servlet.Source.Origin;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.ee9.webapp.WebDescriptor;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +168,7 @@ public class AnnotationIntrospector
                 String descriptorLocation = holder.getSource().getResource();
                 if (descriptorLocation == null)
                     return true; //no descriptor, can't be metadata-complete
-                return !WebDescriptor.isMetaDataComplete(_context.getMetaData().getFragmentDescriptor(ResourceFactory.of(_context).newResource(descriptorLocation)));
+                return !WebDescriptor.isMetaDataComplete(_context.getMetaData().getFragmentDescriptor(_context.getResourceFactory().newResource(descriptorLocation)));
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ServerWithJNDI.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ServerWithJNDI.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.ee9.plus.webapp.EnvConfiguration;
 import org.eclipse.jetty.ee9.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * ServerWithJNDI
@@ -37,7 +36,7 @@ public class ServerWithJNDI
         WebAppContext webapp = new WebAppContext();
         webapp.setContextPath("/");
         Path testJndiWar = JettyDemos.find("jetty-ee9-demo-jndi-webapp/target/jetty-ee9-demo-jndi-webapp-@VER@.war");
-        webapp.setWarResource(ResourceFactory.of(webapp).newResource(testJndiWar));
+        webapp.setWarResource(webapp.getResourceFactory().newResource(testJndiWar));
         server.setHandler(webapp);
 
         // Enable parsing of jndi-related parts of web.xml and jetty-env.xml

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyRunMojo.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyRunMojo.java
@@ -219,7 +219,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
     {
         if (webApp.getDescriptor() != null)
         {
-            Resource r = webapp.getResourceFactory().newResource(webApp.getDescriptor());
+            Resource r = webApp.getResourceFactory().newResource(webApp.getDescriptor());
             scanner.addFile(r.getPath());
         }
 

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyRunMojo.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyRunMojo.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.util.IncludeExcludeSet;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.Scheduler;
 
 /**
@@ -220,7 +219,7 @@ public class JettyRunMojo extends AbstractUnassembledWebAppMojo
     {
         if (webApp.getDescriptor() != null)
         {
-            Resource r = ResourceFactory.of(webApp).newResource(webApp.getDescriptor());
+            Resource r = webapp.getResourceFactory().newResource(webApp.getDescriptor());
             scanner.addFile(r.getPath());
         }
 

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenMetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenMetaInfConfiguration.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.ee9.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +67,7 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                     try
                     {
                         LOG.debug(" add  resource to resources to examine {}", file);
-                        list.add(ResourceFactory.of(context).newResource(file.toURI()));
+                        list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)
                     {
@@ -102,7 +101,7 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                 {
                     try
                     {
-                        list.add(ResourceFactory.of(context).newResource(file.toURI()));
+                        list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)
                     {

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/QuickStartGenerator.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.ee9.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee9.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.ee9.quickstart.QuickStartConfiguration.Mode;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
@@ -121,7 +120,7 @@ public class QuickStartGenerator
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
         webApp.setAttribute(QuickStartConfiguration.MODE, Mode.GENERATE);
-        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(quickstartXml.toPath()));
+        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webapp.getResourceFactory().newResource(quickstartXml.toPath()));
         webApp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "o");
         webApp.setCopyWebDir(false);
         webApp.setCopyWebInf(false);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/QuickStartGenerator.java
@@ -120,7 +120,7 @@ public class QuickStartGenerator
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
         webApp.setAttribute(QuickStartConfiguration.MODE, Mode.GENERATE);
-        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webapp.getResourceFactory().newResource(quickstartXml.toPath()));
+        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webApp.getResourceFactory().newResource(quickstartXml.toPath()));
         webApp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "o");
         webApp.setCopyWebDir(false);
         webApp.setCopyWebInf(false);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
@@ -31,7 +31,6 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
 /**
@@ -174,7 +173,7 @@ public class WebAppPropertyConverter
         if (resource == null)
             throw new IllegalStateException("No resource");
 
-        fromProperties(webApp, ResourceFactory.of(webApp).newResource(resource).getPath(), server, jettyProperties);
+        fromProperties(webApp, webapp.getResourceFactory().newResource(resource).getPath(), server, jettyProperties);
     }
 
     /**
@@ -209,7 +208,7 @@ public class WebAppPropertyConverter
         str = webAppProperties.getProperty(QUICKSTART_WEB_XML);
         if (!StringUtil.isBlank(str))
         {
-            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(str));
+            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webapp.getResourceFactory().newResource(str));
         }
 
         // - the tmp directory
@@ -228,7 +227,7 @@ public class WebAppPropertyConverter
             // This is a use provided list of overlays, which could have mountable entries.
             List<URI> uris = URIUtil.split(str);
             webApp.setWar(null);
-            webApp.setBaseResource(ResourceFactory.of(webApp).newResource(uris));
+            webApp.setBaseResource(webapp.getResourceFactory().newResource(uris));
         }
 
         str = webAppProperties.getProperty(WAR_FILE);
@@ -290,7 +289,7 @@ public class WebAppPropertyConverter
         str = (String)webAppProperties.getProperty(CONTEXT_XML);
         if (!StringUtil.isBlank(str))
         {
-            XmlConfiguration xmlConfiguration = new XmlConfiguration(ResourceFactory.of(webApp).newResource(str));
+            XmlConfiguration xmlConfiguration = new XmlConfiguration(webapp.getResourceFactory().newResource(str));
             xmlConfiguration.getIdMap().put("Server", server);
             //add in any properties
             if (jettyProperties != null)

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
@@ -173,7 +173,7 @@ public class WebAppPropertyConverter
         if (resource == null)
             throw new IllegalStateException("No resource");
 
-        fromProperties(webApp, webapp.getResourceFactory().newResource(resource).getPath(), server, jettyProperties);
+        fromProperties(webApp, webApp.getResourceFactory().newResource(resource).getPath(), server, jettyProperties);
     }
 
     /**
@@ -208,7 +208,7 @@ public class WebAppPropertyConverter
         str = webAppProperties.getProperty(QUICKSTART_WEB_XML);
         if (!StringUtil.isBlank(str))
         {
-            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webapp.getResourceFactory().newResource(str));
+            webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, webApp.getResourceFactory().newResource(str));
         }
 
         // - the tmp directory
@@ -227,7 +227,7 @@ public class WebAppPropertyConverter
             // This is a use provided list of overlays, which could have mountable entries.
             List<URI> uris = URIUtil.split(str);
             webApp.setWar(null);
-            webApp.setBaseResource(webapp.getResourceFactory().newResource(uris));
+            webApp.setBaseResource(webApp.getResourceFactory().newResource(uris));
         }
 
         str = webAppProperties.getProperty(WAR_FILE);
@@ -289,7 +289,7 @@ public class WebAppPropertyConverter
         str = (String)webAppProperties.getProperty(CONTEXT_XML);
         if (!StringUtil.isBlank(str))
         {
-            XmlConfiguration xmlConfiguration = new XmlConfiguration(webapp.getResourceFactory().newResource(str));
+            XmlConfiguration xmlConfiguration = new XmlConfiguration(webApp.getResourceFactory().newResource(str));
             xmlConfiguration.getIdMap().put("Server", server);
             //add in any properties
             if (jettyProperties != null)

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +44,7 @@ public class TestJettyEmbedder
     {
         Path baseResource = workDir.getEmptyPathDir();
         MavenWebAppContext webApp = new MavenWebAppContext();
-        webApp.setBaseResource(ResourceFactory.of(webApp).newResource(baseResource));
+        webApp.setBaseResource(webapp.getResourceFactory().newResource(baseResource));
         MavenServerConnector connector = new MavenServerConnector();
         connector.setPort(0);
 
@@ -83,14 +82,14 @@ public class TestJettyEmbedder
     {
         MavenWebAppContext webApp = new MavenWebAppContext();
         Path baseResource = workDir.getEmptyPathDir();
-        webApp.setBaseResource(ResourceFactory.of(webApp).newResource(baseResource));
+        webApp.setBaseResource(webapp.getResourceFactory().newResource(baseResource));
         Server server = new Server();
         Map<String, String> jettyProperties = new HashMap<>();
         jettyProperties.put("jetty.server.dumpAfterStart", "false");
 
         ContextHandler otherHandler = new ContextHandler();
         otherHandler.setContextPath("/other");
-        otherHandler.setBaseResource(ResourceFactory.of(webApp).newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
+        otherHandler.setBaseResource(webapp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
 
         MavenServerConnector connector = new MavenServerConnector();
         connector.setPort(0);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
@@ -44,7 +44,7 @@ public class TestJettyEmbedder
     {
         Path baseResource = workDir.getEmptyPathDir();
         MavenWebAppContext webApp = new MavenWebAppContext();
-        webApp.setBaseResource(webapp.getResourceFactory().newResource(baseResource));
+        webApp.setBaseResource(webApp.getResourceFactory().newResource(baseResource));
         MavenServerConnector connector = new MavenServerConnector();
         connector.setPort(0);
 
@@ -82,14 +82,14 @@ public class TestJettyEmbedder
     {
         MavenWebAppContext webApp = new MavenWebAppContext();
         Path baseResource = workDir.getEmptyPathDir();
-        webApp.setBaseResource(webapp.getResourceFactory().newResource(baseResource));
+        webApp.setBaseResource(webApp.getResourceFactory().newResource(baseResource));
         Server server = new Server();
         Map<String, String> jettyProperties = new HashMap<>();
         jettyProperties.put("jetty.server.dumpAfterStart", "false");
 
         ContextHandler otherHandler = new ContextHandler();
         otherHandler.setContextPath("/other");
-        otherHandler.setBaseResource(webapp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
+        otherHandler.setBaseResource(webApp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
 
         MavenServerConnector connector = new MavenServerConnector();
         connector.setPort(0);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestWebAppPropertyConverter.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestWebAppPropertyConverter.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -95,7 +94,7 @@ public class TestWebAppPropertyConverter
 
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/foo");
-        webApp.setBaseResource(ResourceFactory.of(webApp).newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
+        webApp.setBaseResource(webapp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
         webApp.setTempDirectory(tmpDir);
         webApp.setPersistTempDirectory(false);
         webApp.setClasses(classesDir);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestWebAppPropertyConverter.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestWebAppPropertyConverter.java
@@ -94,7 +94,7 @@ public class TestWebAppPropertyConverter
 
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/foo");
-        webApp.setBaseResource(webapp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
+        webApp.setBaseResource(webApp.getResourceFactory().newResource(MavenTestingUtils.getTargetPath("test-classes/root")));
         webApp.setTempDirectory(tmpDir);
         webApp.setPersistTempDirectory(false);
         webApp.setClasses(classesDir);

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
@@ -154,20 +154,20 @@ public class PlusDescriptorProcessorTest
         doEnvConfiguration(envCtx, vacuumStringEnvEntry);
 
         URL webXml = Thread.currentThread().getContextClassLoader().getResource("web.xml");
-        webDescriptor = new WebDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(webXml));
+        webDescriptor = new WebDescriptor(context.getResourceFactory().newResource(webXml));
         webDescriptor.parse(WebDescriptor.getParser(false));
 
         URL frag1Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-1.xml");
-        fragDescriptor1 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag1Xml));
+        fragDescriptor1 = new FragmentDescriptor(context.getResourceFactory().newResource(frag1Xml));
         fragDescriptor1.parse(WebDescriptor.getParser(false));
         URL frag2Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-2.xml");
-        fragDescriptor2 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag2Xml));
+        fragDescriptor2 = new FragmentDescriptor(context.getResourceFactory().newResource(frag2Xml));
         fragDescriptor2.parse(WebDescriptor.getParser(false));
         URL frag3Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-3.xml");
-        fragDescriptor3 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag3Xml));
+        fragDescriptor3 = new FragmentDescriptor(context.getResourceFactory().newResource(frag3Xml));
         fragDescriptor3.parse(WebDescriptor.getParser(false));
         URL frag4Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-4.xml");
-        fragDescriptor4 = new FragmentDescriptor(org.eclipse.jetty.util.resource.ResourceFactory.of(context).newResource(frag4Xml));
+        fragDescriptor4 = new FragmentDescriptor(context.getResourceFactory().newResource(frag4Xml));
         fragDescriptor4.parse(WebDescriptor.getParser(false));
         Thread.currentThread().setContextClassLoader(oldLoader);
     }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/Quickstart.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/Quickstart.java
@@ -37,7 +37,7 @@ public class Quickstart
         WebAppContext webapp = new WebAppContext();
         Resource contextXml = null;
         if (args.length > 1)
-            contextXml = ResourceFactory.of(webapp).newResource(args[1]);
+            contextXml = webapp.getResourceFactory().newResource(args[1]);
 
         Server server = new Server(8080);
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1252,7 +1252,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     public void setExtraClasspath(String extraClasspath) throws IOException
     {
         List<URI> uris = URIUtil.split(extraClasspath);
-        setExtraClasspath(ResourceFactory.of(this).newResource(uris));
+        setExtraClasspath(this.getResourceFactory().newResource(uris));
     }
 
     public void setExtraClasspath(ResourceCollection extraClasspath)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -40,7 +40,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.ee9.webapp.tmpResourceBase";
 
     protected Resource _preUnpackBaseResource;
-    private ResourceFactory.Closeable _resourceFactory;
 
     public WebInfConfiguration()
     {
@@ -91,9 +90,6 @@ public class WebInfConfiguration extends AbstractConfiguration
         Boolean tmpdirConfigured = (Boolean)context.getAttribute(TEMPDIR_CONFIGURED);
         if (tmpdirConfigured != null && !tmpdirConfigured)
             context.setTempDirectory(null);
-
-        IO.close(_resourceFactory);
-        _resourceFactory = null;
 
         //reset the base resource back to what it was before we did any unpacking of resources
         context.setBaseResource(_preUnpackBaseResource);
@@ -280,7 +276,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     public void unpack(WebAppContext context) throws IOException
     {
         Resource webApp = context.getBaseResource();
-        _resourceFactory = ResourceFactory.closeable();
         _preUnpackBaseResource = context.getBaseResource();
 
         if (webApp == null)
@@ -315,7 +310,7 @@ public class WebInfConfiguration extends AbstractConfiguration
             if (webApp.exists() && !webApp.isDirectory() && !webApp.toString().startsWith("jar:"))
             {
                 // No - then lets see if it can be turned into a jar URL.
-                webApp = _resourceFactory.newJarFileResource(webApp.getURI());
+                webApp = context.getResourceFactory().newJarFileResource(webApp.getURI());
             }
 
             // If we should extract or the URL is still not usable
@@ -332,7 +327,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 if (war != null)
                 {
                     // look for a sibling like "foo/" to a "foo.war"
-                    Path warfile = _resourceFactory.newResource(war).getPath();
+                    Path warfile = context.getResourceFactory().newResource(war).getPath();
                     if (warfile != null && warfile.getFileName().toString().toLowerCase(Locale.ENGLISH).endsWith(".war"))
                     {
                         Path sibling = warfile.getParent().resolve(warfile.getFileName().toString().substring(0, warfile.getFileName().toString().length() - 4));
@@ -395,7 +390,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                         }
                     }
                 }
-                webApp = _resourceFactory.newResource(extractedWebAppDir.normalize());
+                webApp = context.getResourceFactory().newResource(extractedWebAppDir.normalize());
             }
 
             // Now do we have something usable?
@@ -448,7 +443,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 webInfClasses.copyTo(webInfClassesDir.toPath());
             }
 
-            webInf = _resourceFactory.newResource(extractedWebInfDir.getCanonicalPath());
+            webInf = context.getResourceFactory().newResource(extractedWebInfDir.getCanonicalPath());
 
             Resource rc = Resource.combine(webInf, webApp);
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
@@ -49,7 +49,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String defaultsDescriptor = context.getDefaultsDescriptor();
         if (defaultsDescriptor != null && defaultsDescriptor.length() > 0)
         {
-            Resource dftResource = ResourceFactory.of(context).newSystemResource(defaultsDescriptor);
+            Resource dftResource = context.getResourceFactory().newSystemResource(defaultsDescriptor);
             if (dftResource == null)
             {
                 String pkg = WebXmlConfiguration.class.getPackageName().replace(".", "/") + "/";
@@ -83,7 +83,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         {
             if (overrideDescriptor != null && overrideDescriptor.length() > 0)
             {
-                Resource orideResource = ResourceFactory.of(context).newSystemResource(overrideDescriptor);
+                Resource orideResource = context.getResourceFactory().newSystemResource(overrideDescriptor);
                 if (orideResource == null)
                     orideResource = context.newResource(overrideDescriptor);
                 context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoaderTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoaderTest.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ public class WebAppClassLoaderTest
 
         _testWebappDir = MavenTestingUtils.getTargetPath("test-classes/webapp");
         _context = new WebAppContext();
-        Resource webapp = ResourceFactory.of(_context).newResource(_testWebappDir);
+        Resource webapp = _context.getResourceFactory().newResource(_testWebappDir);
         _context.setBaseResource(webapp);
         _context.setContextPath("/test");
         _context.setExtraClasspath("target/test-classes/ext/*");

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -519,7 +519,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         Path warPath = MavenTestingUtils.getTargetPath("test-classes/wars/dump.war");
-        context.setBaseResource(ResourceFactory.of(context).newResource(warPath));
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
         context.setExtraClasspath(extraClasspathGlobReference);
 
         server.setHandler(context);
@@ -593,7 +593,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         Path warPath = MavenTestingUtils.getTargetPath("test-classes/wars/dump.war");
-        context.setBaseResource(ResourceFactory.of(context).newResource(warPath));
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
 
         context.setExtraClasspath(extraClassPathReference);
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketWebApp.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketWebApp.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.TypeUtil;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,7 @@ public class JettyWebSocketWebApp extends WebAppContext
 
         // Configure the WebAppContext.
         setContextPath("/" + contextName);
-        setBaseResource(ResourceFactory.of(this).newResource(contextDir));
+        setBaseResource(this.getResourceFactory().newResource(contextDir));
         addConfiguration(new JettyWebSocketConfiguration());
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebAppTester.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebAppTester.java
@@ -44,7 +44,6 @@ import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +153,7 @@ public class WebAppTester extends ContainerLifeCycle
             // Configure the WebAppContext.
             _context = new WebAppContext();
             _context.setContextPath(contextPath);
-            _context.setBaseResource(ResourceFactory.of(_context).newResource(_contextDir));
+            _context.setBaseResource(_context.getResourceFactory().newResource(_contextDir));
 
             _context.setConfigurations(new Configuration[]
             {


### PR DESCRIPTION
Use `WebAppContext.getResourceFactory()` instead of `ResourceFactory.of(container)` where possible.

Taken from PR #8597