### PR TITLE
Jetty 12 : QuickStart Generation uses Path instead of Resource

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
@@ -76,7 +76,7 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
     {
         try
         {
-            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml, webApp);
+            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml.toPath(), webApp);
             generator.generate();
         }
         catch (Exception e)

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * JettyEmbedded
@@ -280,7 +279,7 @@ public class JettyEmbedder extends AbstractLifeCycle
             Path qs = webApp.getTempDirectory().toPath().resolve("quickstart-web.xml");
             if (Files.exists(qs) && Files.isRegularFile(qs))
             {
-                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(qs));
+                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, qs);
                 webApp.addConfiguration(new MavenQuickStartConfiguration());
                 webApp.setAttribute(QuickStartConfiguration.MODE, Mode.QUICKSTART);
             }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
@@ -112,9 +112,9 @@ public class JettyForker extends AbstractForker
         throws Exception
     {
         //Run the webapp to create the quickstart file and properties file
-        generator = new QuickStartGenerator(forkWebXml, webApp);
+        generator = new QuickStartGenerator(forkWebXml.toPath(), webApp);
         generator.setContextXml(contextXml);
-        generator.setWebAppPropsFile(webAppPropsFile);
+        generator.setWebAppPropsFile(webAppPropsFile.toPath());
         generator.setServer(server);
         generator.generate();
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
@@ -13,13 +13,12 @@
 
 package org.eclipse.jetty.ee10.maven.plugin;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration.Mode;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
@@ -31,9 +30,9 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
  */
 public class QuickStartGenerator
 {
-    private File quickstartXml;
-    private MavenWebAppContext webApp;
-    private File webAppPropsFile;
+    private final Path quickstartXml;
+    private final MavenWebAppContext webApp;
+    private Path webAppPropsFile;
     private String contextXml;
     private boolean prepared = false;
     private Server server;
@@ -43,10 +42,10 @@ public class QuickStartGenerator
      * @param quickstartXml the file to generate quickstart into
      * @param webApp the webapp for which to generate quickstart
      */
-    public QuickStartGenerator(File quickstartXml, MavenWebAppContext webApp)
+    public QuickStartGenerator(Path quickstartXml, MavenWebAppContext webApp) throws Exception
     {
         this.quickstartXml = quickstartXml;
-        this.webApp = webApp;
+        this.webApp = webApp == null ? new MavenWebAppContext() : webApp;
     }
 
     /**
@@ -60,7 +59,7 @@ public class QuickStartGenerator
     /**
      * @return the quickstartXml
      */
-    public File getQuickstartXml()
+    public Path getQuickstartXml()
     {
         return quickstartXml;
     }
@@ -81,7 +80,7 @@ public class QuickStartGenerator
         this.server = server;
     }
 
-    public File getWebAppPropsFile()
+    public Path getWebAppPropsFile()
     {
         return webAppPropsFile;
     }
@@ -89,7 +88,7 @@ public class QuickStartGenerator
     /**
      * @param webAppPropsFile properties file describing the webapp
      */
-    public void setWebAppPropsFile(File webAppPropsFile)
+    public void setWebAppPropsFile(Path webAppPropsFile)
     {
         this.webAppPropsFile = webAppPropsFile;
     }
@@ -115,13 +114,10 @@ public class QuickStartGenerator
     private void prepareWebApp()
         throws Exception
     {
-        if (webApp == null)
-            webApp = new MavenWebAppContext();
-
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
         webApp.setAttribute(QuickStartConfiguration.MODE, Mode.GENERATE);
-        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(quickstartXml.toPath()));
+        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, quickstartXml);
         webApp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "o");
         webApp.setCopyWebDir(false);
         webApp.setCopyWebInf(false);
@@ -175,7 +171,7 @@ public class QuickStartGenerator
 
             //save config of the webapp BEFORE we stop
             if (webAppPropsFile != null)
-                WebAppPropertyConverter.toProperties(webApp, webAppPropsFile, contextXml);
+                WebAppPropertyConverter.toProperties(webApp, webAppPropsFile.toFile(), contextXml);
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
@@ -13,12 +13,17 @@
 
 package org.eclipse.jetty.ee10.maven.plugin;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -27,24 +32,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestQuickStartGenerator
 {
+    public WorkDir workDir;
+
     @Test
     public void testGenerator() throws Exception
     {
+        Path tmpDir = workDir.getEmptyPathDir();
+
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/shouldbeoverridden");
-        webApp.setBaseResource(MavenTestingUtils.getTestResourcePathDir("root"));
-        File quickstartFile = new File(MavenTestingUtils.getTargetTestingDir(), "quickstart-web.xml");
+        Path rootDir = MavenTestingUtils.getTargetPath("test-classes/root");
+        assertTrue(Files.exists(rootDir));
+        assertTrue(Files.isDirectory(rootDir));
+        webApp.setBaseResource(ResourceFactory.root().newResource(rootDir));
+
+        Path quickstartFile = tmpDir.resolve("quickstart-web.xml");
         QuickStartGenerator generator = new QuickStartGenerator(quickstartFile, webApp);
-        generator.setContextXml(MavenTestingUtils.getTestResourceFile("embedder-context.xml").getAbsolutePath());
+        generator.setContextXml(MavenTestingUtils.getTargetFile("test-classes/embedder-context.xml").getAbsolutePath());
         generator.setServer(new Server());
-        MavenTestingUtils.getTargetTestingDir().mkdirs();
-        File propsFile = new File(MavenTestingUtils.getTargetTestingDir(), "webapp.props");
-        propsFile.createNewFile();
+
+        Path propsFile = tmpDir.resolve("webapp.props");
+        Files.createFile(propsFile);
         generator.setWebAppPropsFile(propsFile);
         generator.generate();
-        assertTrue(propsFile.exists());
-        assertTrue(propsFile.length() > 0);
-        assertTrue(quickstartFile.exists());
-        assertTrue(quickstartFile.length() > 0);
+        assertTrue(Files.exists(propsFile));
+        assertThat(Files.size(propsFile), greaterThan(0L));
+        assertTrue(Files.exists(quickstartFile));
+        assertThat(Files.size(quickstartFile), greaterThan(0L));
     }
 }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.quickstart;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -99,8 +100,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
             throw new IllegalStateException("Bad Quickstart location");
 
         //look for quickstart-web.xml in WEB-INF of webapp
-        Resource quickStartWebXml = getQuickStartWebXml(context);
-        LOG.debug("quickStartWebXml={} exists={}", quickStartWebXml, quickStartWebXml.exists());
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        LOG.debug("quickStartWebXml={}", quickStartWebXml);
 
         //Get the mode
         Object o = context.getAttribute(MODE);
@@ -114,7 +115,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
         {
             case GENERATE:
             {
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                     LOG.info("Regenerating {}", quickStartWebXml);
                 else
                     LOG.info("Generating {}", quickStartWebXml);
@@ -128,7 +129,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
             }
             case AUTO:
             {
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                 {
                     quickStart(context);
                 }
@@ -141,7 +142,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
                 break;
             }
             case QUICKSTART:
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                     quickStart(context);
                 else
                     throw new IllegalStateException("No " + quickStartWebXml);
@@ -159,7 +160,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
         if (attr != null)
             generator.setOriginAttribute(attr.toString());
 
-        generator.setQuickStartWebXml((Resource)context.getAttribute(QUICKSTART_WEB_XML));
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        generator.setQuickStartWebXml(quickStartWebXml);
     }
 
     @Override
@@ -211,7 +213,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
             .filter(c -> !__replacedConfigurations.contains(c.replaces()) && !__replacedConfigurations.contains(c.getClass())).toList().toArray(new Configuration[]{}));
-        context.getMetaData().setWebDescriptor(new WebDescriptor((Resource)context.getAttribute(QUICKSTART_WEB_XML)));
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        context.getMetaData().setWebDescriptor(new WebDescriptor(quickStartWebXml));
         context.getContext().getServletContext().setEffectiveMajorVersion(context.getMetaData().getWebDescriptor().getMajorVersion());
         context.getContext().getServletContext().setEffectiveMinorVersion(context.getMetaData().getWebDescriptor().getMinorVersion());
     }
@@ -223,41 +226,66 @@ public class QuickStartConfiguration extends AbstractConfiguration
      * @return the Resource for the quickstart-web.xml
      * @throws Exception if unable to find the quickstart xml
      */
-    public Resource getQuickStartWebXml(WebAppContext context) throws Exception
+    public static Path getQuickStartWebXml(WebAppContext context) throws IOException
     {
         Object attr = context.getAttribute(QUICKSTART_WEB_XML);
-        if (attr instanceof Resource)
-            return (Resource)attr;
+        if (attr instanceof Path)
+            return (Path)attr;
 
-        Resource webInf = context.getWebInf();
-        if (webInf == null || !webInf.exists())
-        {
-            Files.createDirectories(context.getBaseResource().getPath().resolve("WEB-INF"));
-            webInf = context.getWebInf();
-        }
+        Path webInfDir = getWebInfPath(context);
+        Path qstartFile = webInfDir.resolve("quickstart-web.xml");
 
-        Resource qstart;
-        if (attr == null || StringUtil.isBlank(attr.toString()))
+        if (attr != null && StringUtil.isNotBlank(attr.toString()))
         {
-            // TODO: should never return from WEB-INF/lib/foo.jar!/WEB-INF/quickstart-web.xml
-            // TODO: should also never return from a META-INF/versions/#/WEB-INF/quickstart-web.xml location
-            qstart = webInf.resolve("quickstart-web.xml");
-        }
-        else
-        {
+            Resource resource;
+            String attrValue = attr.toString();
             try
             {
                 // Try a relative resolution
-                qstart = _resourceFactory.newResource(webInf.getPath().resolve(attr.toString()));
+                resource = context.getResourceFactory().newResource(webInfDir.resolve(attrValue));
             }
             catch (Throwable th)
             {
                 // try as a resource
-                qstart = _resourceFactory.newResource(attr.toString());
+                resource = context.getResourceFactory().newResource(attrValue);
             }
-            context.setAttribute(QUICKSTART_WEB_XML, qstart);
+            if (resource != null)
+            {
+                Path attrPath = resource.getPath();
+                if (attrPath != null)
+                {
+                    if (LOG.isDebugEnabled())
+                    {
+                        LOG.debug("Using quickstart attribute {} value of {}", attr, attrValue);
+                    }
+                    qstartFile = attrPath;
+                }
+            }
         }
-        context.setAttribute(QUICKSTART_WEB_XML, qstart);
-        return  qstart;
+        if (LOG.isDebugEnabled())
+        {
+            LOG.debug("Using quickstart location: {}", qstartFile);
+        }
+        context.setAttribute(QUICKSTART_WEB_XML, qstartFile);
+        return qstartFile;
+    }
+
+    private static Path getWebInfPath(WebAppContext context) throws IOException
+    {
+        Path webInfDir = null;
+        Resource webInf = context.getWebInf();
+        if (webInf != null)
+        {
+            webInfDir = webInf.getPath();
+        }
+
+        if (webInfDir == null)
+        {
+            Path baseResourcePath = context.getBaseResource().getPath();
+            webInfDir = baseResourcePath.resolve("WEB-INF");
+            if (!Files.exists(webInfDir))
+                Files.createDirectories(webInfDir);
+        }
+        return webInfDir;
     }
 }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -101,7 +101,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
 
         //look for quickstart-web.xml in WEB-INF of webapp
         Path quickStartWebXml = getQuickStartWebXml(context);
-        LOG.debug("quickStartWebXml={}", quickStartWebXml);
+        if (LOG.isDebugEnabled())
+            LOG.debug("quickStartWebXml={}", quickStartWebXml);
 
         //Get the mode
         Object o = context.getAttribute(MODE);
@@ -183,7 +184,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
             //add a decorator that will find introspectable annotations
             context.getObjectFactory().addDecorator(new AnnotationDecorator(context)); //this must be the last Decorator because they are run in reverse order!
 
-            LOG.debug("configured {}", this);
+            if (LOG.isDebugEnabled())
+                LOG.debug("configured {}", this);
         }
     }
 
@@ -214,7 +216,10 @@ public class QuickStartConfiguration extends AbstractConfiguration
         context.setConfigurations(context.getConfigurations().stream()
             .filter(c -> !__replacedConfigurations.contains(c.replaces()) && !__replacedConfigurations.contains(c.getClass())).toList().toArray(new Configuration[]{}));
         Path quickStartWebXml = getQuickStartWebXml(context);
-        context.getMetaData().setWebDescriptor(new WebDescriptor(quickStartWebXml));
+        if (!Files.exists(quickStartWebXml))
+            throw new IllegalStateException("Quickstart doesn't exist: " + quickStartWebXml);
+        Resource quickStartWebResource = context.getResourceFactory().newResource(quickStartWebXml);
+        context.getMetaData().setWebDescriptor(new WebDescriptor(quickStartWebResource));
         context.getContext().getServletContext().setEffectiveMajorVersion(context.getMetaData().getWebDescriptor().getMajorVersion());
         context.getContext().getServletContext().setEffectiveMinorVersion(context.getMetaData().getWebDescriptor().getMinorVersion());
     }
@@ -255,17 +260,13 @@ public class QuickStartConfiguration extends AbstractConfiguration
                 if (attrPath != null)
                 {
                     if (LOG.isDebugEnabled())
-                    {
                         LOG.debug("Using quickstart attribute {} value of {}", attr, attrValue);
-                    }
                     qstartFile = attrPath;
                 }
             }
         }
         if (LOG.isDebugEnabled())
-        {
             LOG.debug("Using quickstart location: {}", qstartFile);
-        }
         context.setAttribute(QUICKSTART_WEB_XML, qstartFile);
         return qstartFile;
     }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
@@ -17,6 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,6 @@ import org.eclipse.jetty.ee10.webapp.WebInfConfiguration;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.xml.XmlAppendable;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     protected final boolean _abort;
     protected String _originAttribute;
     protected int _count;
-    protected Resource _quickStartWebXml;
+    protected Path _quickStartWebXml;
    
     public QuickStartGeneratorConfiguration()
     {
@@ -114,12 +114,12 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         return _originAttribute;
     }
 
-    public Resource getQuickStartWebXml()
+    public Path getQuickStartWebXml()
     {
         return _quickStartWebXml;
     }
 
-    public void setQuickStartWebXml(Resource quickStartWebXml)
+    public void setQuickStartWebXml(Path quickStartWebXml)
     {
         _quickStartWebXml = quickStartWebXml;
     }
@@ -812,7 +812,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     {
         MetaData metadata = context.getMetaData();
         metadata.resolve(context);
-        try (OutputStream os = Files.newOutputStream(_quickStartWebXml.getPath()))
+        try (OutputStream os = Files.newOutputStream(_quickStartWebXml))
         {
             generateQuickStartWebXml(context, os);
             LOG.info("Generated {}", _quickStartWebXml);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEffectiveWebXml.java
@@ -76,7 +76,7 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
     {
         try
         {
-            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml, webApp);
+            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml.toPath(), webApp);
             generator.generate();
         }
         catch (Exception e)

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * JettyEmbedded
@@ -280,8 +279,8 @@ public class JettyEmbedder extends ContainerLifeCycle
             Path qs = webApp.getTempDirectory().toPath().resolve("quickstart-web.xml");
             if (Files.exists(qs) && Files.isRegularFile(qs))
             {
-                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(this).newResource(qs));
                 webApp.addConfiguration(new MavenQuickStartConfiguration());
+                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, qs);
                 webApp.setAttribute(QuickStartConfiguration.MODE, Mode.QUICKSTART);
             }
         }

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyForker.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyForker.java
@@ -112,9 +112,9 @@ public class JettyForker extends AbstractForker
         throws Exception
     {
         //Run the webapp to create the quickstart file and properties file
-        generator = new QuickStartGenerator(forkWebXml, webApp);
+        generator = new QuickStartGenerator(forkWebXml.toPath(), webApp);
         generator.setContextXml(contextXml);
-        generator.setWebAppPropsFile(webAppPropsFile);
+        generator.setWebAppPropsFile(webAppPropsFile.toPath());
         generator.setServer(server);
         generator.generate();
 

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -17,6 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,6 @@ import org.eclipse.jetty.ee9.webapp.WebInfConfiguration;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.xml.XmlAppendable;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     protected final boolean _abort;
     protected String _originAttribute;
     protected int _count;
-    protected Resource _quickStartWebXml;
+    protected Path _quickStartWebXml;
    
     public QuickStartGeneratorConfiguration()
     {
@@ -114,12 +114,12 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         return _originAttribute;
     }
 
-    public Resource getQuickStartWebXml()
+    public Path getQuickStartWebXml()
     {
         return _quickStartWebXml;
     }
 
-    public void setQuickStartWebXml(Resource quickStartWebXml)
+    public void setQuickStartWebXml(Path quickStartWebXml)
     {
         _quickStartWebXml = quickStartWebXml;
     }
@@ -812,7 +812,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     {
         MetaData metadata = context.getMetaData();
         metadata.resolve(context);
-        try (OutputStream os = Files.newOutputStream(_quickStartWebXml.getPath()))
+        try (OutputStream os = Files.newOutputStream(_quickStartWebXml))
         {
             generateQuickStartWebXml(context, os);
             LOG.info("Generated {}", _quickStartWebXml);


### PR DESCRIPTION
This change is in preparation for the resolve() returning null if doesn't exist PR #8597 

+ QuickStart will use a Path object to handle creation / regeneration of the quickstart-web.xml
+ Updated maven plugin usage as well.
+ Depends on path based Descriptor impl

Note: this PR based on PR #8611 (and will require it to function)

Taken from PR #8597