### PR TITLE
Jetty 12 : QuickStart generation based on Path, usage based on Resource

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -104,18 +106,25 @@ public abstract class AbstractUnassembledWebAppMojo extends AbstractWebAppMojo
     }
     
     @Override
-    protected void configureWebApp() throws Exception
+    protected void configureWebApp() throws AbstractMojoExecutionException
     {
         super.configureWebApp();
-        configureUnassembledWebApp();
+        try
+        {
+            configureUnassembledWebApp();
+        }
+        catch (IOException e)
+        {
+            throw new MojoFailureException("Unable to configure unassembled webapp", e);
+        }
     }
     
     /**
      * Configure a webapp that has not been assembled into a war. 
      * 
-     * @throws Exception
+     * @throws IOException
      */
-    protected void configureUnassembledWebApp() throws Exception
+    protected void configureUnassembledWebApp() throws IOException
     {   
         //Set up the location of the webapp.
         //There are 2 parts to this: setWar() and setBaseResource(). On standalone jetty,

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractWebAppMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractWebAppMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -781,7 +782,7 @@ public abstract class AbstractWebAppMojo extends AbstractMojo
      * @throws Exception
      */
     protected void configureWebApp()
-        throws Exception
+        throws AbstractMojoExecutionException
     {
         if (webApp == null)
             webApp = new MavenWebAppContext();

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
@@ -14,8 +14,11 @@
 package org.eclipse.jetty.ee10.maven.plugin;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -36,21 +39,30 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
     protected File effectiveWebXml;
     
     @Override
-    public void configureWebApp() throws Exception
+    public void configureWebApp() throws AbstractMojoExecutionException
     {
         //Use a nominated war file for which to generate the effective web.xml, or
         //if that is not set, try to use the details of the current project's 
         //unassembled webapp
         super.configureWebApp();
-        if (StringUtil.isBlank(webApp.getWar()))
+        try
+        {
+            if (StringUtil.isBlank(webApp.getWar()))
+            {
             super.configureUnassembledWebApp();
+            }
+        }
+        catch (IOException e)
+        {
+            throw new MojoFailureException("Unable to configure unassembled webapp", e);
+        }
     }
     
     /**
      * Override so we can call the parent's method in a different order.
      */
     @Override
-    protected void configureUnassembledWebApp() throws Exception
+    protected void configureUnassembledWebApp()
     {
     }
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEffectiveWebXml.java
@@ -76,7 +76,7 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
     {
         try
         {
-            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml, webApp);
+            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml.toPath(), webApp);
             generator.generate();
         }
         catch (Exception e)

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * JettyEmbedded
@@ -280,7 +279,7 @@ public class JettyEmbedder extends AbstractLifeCycle
             Path qs = webApp.getTempDirectory().toPath().resolve("quickstart-web.xml");
             if (Files.exists(qs) && Files.isRegularFile(qs))
             {
-                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(qs));
+                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, qs);
                 webApp.addConfiguration(new MavenQuickStartConfiguration());
                 webApp.setAttribute(QuickStartConfiguration.MODE, Mode.QUICKSTART);
             }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyEmbedder.java
@@ -184,7 +184,7 @@ public class JettyEmbedder extends AbstractLifeCycle
         this.stopKey = stopKey;
     }
     
-    public void setWebApp(MavenWebAppContext app) throws Exception
+    public void setWebApp(MavenWebAppContext app)
     {
         webApp = app;
     }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForkedChild.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForkedChild.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.maven.plugin;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -51,10 +50,10 @@ public class JettyForkedChild extends ContainerLifeCycle
 
     /**
      * @param args arguments that were passed to main
-     * @throws Exception
+     * @throws IOException if unable to configure
      */
     public JettyForkedChild(String[] args)
-        throws Exception
+        throws IOException
     {
         jetty = new JettyEmbedder();
         configure(args);
@@ -64,10 +63,10 @@ public class JettyForkedChild extends ContainerLifeCycle
      * Based on the args passed to the program, configure jetty.
      * 
      * @param args args that were passed to the program.
-     * @throws Exception
+     * @throws IOException if unable to load webprops
      */
     public void configure(String[] args)
-        throws Exception
+        throws IOException
     {
         Map<String, String> jettyProperties = new HashMap<>();
         
@@ -171,10 +170,9 @@ public class JettyForkedChild extends ContainerLifeCycle
      * present.
      * 
      * @return file contents as properties
-     * @throws FileNotFoundException
      * @throws IOException
      */
-    private Properties loadWebAppProps() throws FileNotFoundException, IOException
+    private Properties loadWebAppProps() throws IOException
     {
         Properties props = new Properties();
         if (Objects.nonNull(webAppPropsFile))

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
@@ -112,9 +112,9 @@ public class JettyForker extends AbstractForker
         throws Exception
     {
         //Run the webapp to create the quickstart file and properties file
-        generator = new QuickStartGenerator(forkWebXml, webApp);
+        generator = new QuickStartGenerator(forkWebXml.toPath(), webApp);
         generator.setContextXml(contextXml);
-        generator.setWebAppPropsFile(webAppPropsFile);
+        generator.setWebAppPropsFile(webAppPropsFile.toPath());
         generator.setServer(server);
         generator.generate();
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyForker.java
@@ -114,7 +114,7 @@ public class JettyForker extends AbstractForker
         //Run the webapp to create the quickstart file and properties file
         generator = new QuickStartGenerator(forkWebXml.toPath(), webApp);
         generator.setContextXml(contextXml);
-        generator.setWebAppPropsFile(webAppPropsFile.toPath());
+        generator.setWebAppProps(webAppPropsFile.toPath());
         generator.setServer(server);
         generator.generate();
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyRunWarMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyRunWarMojo.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.util.Date;
 import java.util.Set;
 
+import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -67,7 +68,7 @@ public class JettyRunWarMojo extends AbstractWebAppMojo
     protected Path war;
     
     @Override
-    public void configureWebApp() throws Exception
+    public void configureWebApp() throws AbstractMojoExecutionException
     {
         super.configureWebApp();
         //if no war has been explicitly configured, use the one from the webapp project

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyStartWarMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/JettyStartWarMojo.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee10.maven.plugin;
 import java.io.File;
 import java.nio.file.Path;
 
+import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -59,7 +60,7 @@ public class JettyStartWarMojo extends AbstractWebAppMojo
     protected JettyHomeForker homeForker;
 
     @Override
-    public void configureWebApp() throws Exception
+    public void configureWebApp() throws AbstractMojoExecutionException
     {
         super.configureWebApp();
         //if a war has not been explicitly configured, use the one from the project

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -100,7 +100,7 @@ public class MavenWebAppContext extends WebAppContext
      */
     private boolean _baseAppFirst = true;
 
-    public MavenWebAppContext() throws Exception
+    public MavenWebAppContext()
     {
         super();
         // Turn off copyWebInf option as it is not applicable for plugin.

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/OverlayManager.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/OverlayManager.java
@@ -39,8 +39,7 @@ public class OverlayManager
         this.warPlugin = warPlugin;
     }
 
-    public void applyOverlays(MavenWebAppContext webApp)
-        throws Exception
+    public void applyOverlays(MavenWebAppContext webApp) throws IOException
     {
         List<Resource> resourceBases = new ArrayList<Resource>();
 
@@ -71,8 +70,7 @@ public class OverlayManager
      * Generate an ordered list of overlays
      */
     protected List<Overlay> getOverlays()
-        throws Exception
-    {        
+    {
         Set<Artifact> matchedWarArtifacts = new HashSet<Artifact>();
         List<Overlay> overlays = new ArrayList<Overlay>();
         
@@ -127,7 +125,7 @@ public class OverlayManager
      */
     protected  Resource unpackOverlay(Overlay overlay)
         throws IOException
-    {        
+    {
         if (overlay.getResource() == null)
             return null; //nothing to unpack
 

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
@@ -13,13 +13,12 @@
 
 package org.eclipse.jetty.ee10.maven.plugin;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration.Mode;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**
@@ -31,9 +30,9 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
  */
 public class QuickStartGenerator
 {
-    private File quickstartXml;
-    private MavenWebAppContext webApp;
-    private File webAppPropsFile;
+    private final Path quickstartXml;
+    private final MavenWebAppContext webApp;
+    private Path webAppPropsFile;
     private String contextXml;
     private boolean prepared = false;
     private Server server;
@@ -43,10 +42,10 @@ public class QuickStartGenerator
      * @param quickstartXml the file to generate quickstart into
      * @param webApp the webapp for which to generate quickstart
      */
-    public QuickStartGenerator(File quickstartXml, MavenWebAppContext webApp)
+    public QuickStartGenerator(Path quickstartXml, MavenWebAppContext webApp) throws Exception
     {
         this.quickstartXml = quickstartXml;
-        this.webApp = webApp;
+        this.webApp = webApp == null ? new MavenWebAppContext() : webApp;
     }
 
     /**
@@ -60,7 +59,7 @@ public class QuickStartGenerator
     /**
      * @return the quickstartXml
      */
-    public File getQuickstartXml()
+    public Path getQuickstartXml()
     {
         return quickstartXml;
     }
@@ -81,7 +80,7 @@ public class QuickStartGenerator
         this.server = server;
     }
 
-    public File getWebAppPropsFile()
+    public Path getWebAppPropsFile()
     {
         return webAppPropsFile;
     }
@@ -89,7 +88,7 @@ public class QuickStartGenerator
     /**
      * @param webAppPropsFile properties file describing the webapp
      */
-    public void setWebAppPropsFile(File webAppPropsFile)
+    public void setWebAppPropsFile(Path webAppPropsFile)
     {
         this.webAppPropsFile = webAppPropsFile;
     }
@@ -115,13 +114,10 @@ public class QuickStartGenerator
     private void prepareWebApp()
         throws Exception
     {
-        if (webApp == null)
-            webApp = new MavenWebAppContext();
-
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
         webApp.setAttribute(QuickStartConfiguration.MODE, Mode.GENERATE);
-        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(webApp).newResource(quickstartXml.toPath()));
+        webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, quickstartXml);
         webApp.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "o");
         webApp.setCopyWebDir(false);
         webApp.setCopyWebInf(false);
@@ -175,7 +171,7 @@ public class QuickStartGenerator
 
             //save config of the webapp BEFORE we stop
             if (webAppPropsFile != null)
-                WebAppPropertyConverter.toProperties(webApp, webAppPropsFile, contextXml);
+                WebAppPropertyConverter.toProperties(webApp, webAppPropsFile.toFile(), contextXml);
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
@@ -32,7 +32,7 @@ public class QuickStartGenerator
 {
     private final Path quickstartXml;
     private final MavenWebAppContext webApp;
-    private Path webAppPropsFile;
+    private Path webAppProps;
     private String contextXml;
     private boolean prepared = false;
     private Server server;
@@ -80,17 +80,17 @@ public class QuickStartGenerator
         this.server = server;
     }
 
-    public Path getWebAppPropsFile()
+    public Path getWebAppProps()
     {
-        return webAppPropsFile;
+        return webAppProps;
     }
 
     /**
-     * @param webAppPropsFile properties file describing the webapp
+     * @param webAppProps properties file describing the webapp
      */
-    public void setWebAppPropsFile(Path webAppPropsFile)
+    public void setWebAppProps(Path webAppProps)
     {
-        this.webAppPropsFile = webAppPropsFile;
+        this.webAppProps = webAppProps;
     }
     
     public String getContextXml()
@@ -170,8 +170,8 @@ public class QuickStartGenerator
             webApp.start(); //just enough to generate the quickstart
 
             //save config of the webapp BEFORE we stop
-            if (webAppPropsFile != null)
-                WebAppPropertyConverter.toProperties(webApp, webAppPropsFile.toFile(), contextXml);
+            if (webAppProps != null)
+                WebAppPropertyConverter.toProperties(webApp, webAppProps.toFile(), contextXml);
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/QuickStartGenerator.java
@@ -42,7 +42,7 @@ public class QuickStartGenerator
      * @param quickstartXml the file to generate quickstart into
      * @param webApp the webapp for which to generate quickstart
      */
-    public QuickStartGenerator(Path quickstartXml, MavenWebAppContext webApp) throws Exception
+    public QuickStartGenerator(Path quickstartXml, MavenWebAppContext webApp)
     {
         this.quickstartXml = quickstartXml;
         this.webApp = webApp == null ? new MavenWebAppContext() : webApp;
@@ -108,11 +108,8 @@ public class QuickStartGenerator
     
     /**
      * Configure the webapp in preparation for quickstart generation.
-     * 
-     * @throws Exception
      */
     private void prepareWebApp()
-        throws Exception
     {
         //set the webapp up to do very little other than generate the quickstart-web.xml
         webApp.addConfiguration(new MavenQuickStartConfiguration());
@@ -129,8 +126,7 @@ public class QuickStartGenerator
      * 
      * @throws Exception
      */
-    public void generate()
-        throws Exception
+    public void generate() throws Exception
     {
         if (quickstartXml == null)
             throw new IllegalStateException("No quickstart xml output file");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/ServerSupport.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/ServerSupport.java
@@ -54,9 +54,8 @@ public class ServerSupport
      * @param server the server to use
      * @param contextHandlers the context handlers to include
      * @param requestLog a request log to use
-     * @throws Exception
      */
-    public static void configureHandlers(Server server, List<ContextHandler> contextHandlers, RequestLog requestLog) throws Exception 
+    public static void configureHandlers(Server server, List<ContextHandler> contextHandlers, RequestLog requestLog)
     {
         if (server == null)
             throw new IllegalArgumentException("Server is null");
@@ -148,9 +147,8 @@ public class ServerSupport
      * Add a WebAppContext to a Server
      * @param server the server to use
      * @param webapp the webapp to add
-     * @throws Exception
      */
-    public static void addWebApplication(Server server, WebAppContext webapp) throws Exception
+    public static void addWebApplication(Server server, WebAppContext webapp)
     {
         if (server == null)
             throw new IllegalArgumentException("Server is null");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.maven.plugin;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -64,10 +65,10 @@ public class WebAppPropertyConverter
      * @param webApp the webapp to convert
      * @param propsFile the file to put the properties into
      * @param contextXml the optional context xml file related to the webApp
-     * @throws Exception if any I/O exception occurs
+     * @throws IOException if any I/O exception occurs
      */
     public static void toProperties(MavenWebAppContext webApp, File propsFile, String contextXml)
-        throws Exception
+        throws IOException
     {
         if (webApp == null)
             throw new IllegalArgumentException("No webapp");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
@@ -53,7 +53,7 @@ public class TestQuickStartGenerator
 
         Path propsFile = tmpDir.resolve("webapp.props");
         Files.createFile(propsFile);
-        generator.setWebAppPropsFile(propsFile);
+        generator.setWebAppProps(propsFile);
         generator.generate();
         assertTrue(Files.exists(propsFile));
         assertThat(Files.size(propsFile), greaterThan(0L));

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
@@ -13,12 +13,17 @@
 
 package org.eclipse.jetty.ee10.maven.plugin;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -27,24 +32,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestQuickStartGenerator
 {
+    public WorkDir workDir;
+
     @Test
     public void testGenerator() throws Exception
     {
+        Path tmpDir = workDir.getEmptyPathDir();
+
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/shouldbeoverridden");
-        webApp.setBaseResource(MavenTestingUtils.getTestResourcePathDir("root"));
-        File quickstartFile = new File(MavenTestingUtils.getTargetTestingDir(), "quickstart-web.xml");
+        Path rootDir = MavenTestingUtils.getTargetPath("test-classes/root");
+        assertTrue(Files.exists(rootDir));
+        assertTrue(Files.isDirectory(rootDir));
+        webApp.setBaseResource(ResourceFactory.root().newResource(rootDir));
+
+        Path quickstartFile = tmpDir.resolve("quickstart-web.xml");
         QuickStartGenerator generator = new QuickStartGenerator(quickstartFile, webApp);
-        generator.setContextXml(MavenTestingUtils.getTestResourceFile("embedder-context.xml").getAbsolutePath());
+        generator.setContextXml(MavenTestingUtils.getTargetFile("test-classes/embedder-context.xml").getAbsolutePath());
         generator.setServer(new Server());
-        MavenTestingUtils.getTargetTestingDir().mkdirs();
-        File propsFile = new File(MavenTestingUtils.getTargetTestingDir(), "webapp.props");
-        propsFile.createNewFile();
+
+        Path propsFile = tmpDir.resolve("webapp.props");
+        Files.createFile(propsFile);
         generator.setWebAppPropsFile(propsFile);
         generator.generate();
-        assertTrue(propsFile.exists());
-        assertTrue(propsFile.length() > 0);
-        assertTrue(quickstartFile.exists());
-        assertTrue(quickstartFile.length() > 0);
+        assertTrue(Files.exists(propsFile));
+        assertThat(Files.size(propsFile), greaterThan(0L));
+        assertTrue(Files.exists(quickstartFile));
+        assertThat(Files.size(quickstartFile), greaterThan(0L));
     }
 }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -102,7 +102,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
         //look for quickstart-web.xml in WEB-INF of webapp
         Path quickStartWebXml = getQuickStartWebXml(context);
         if (LOG.isDebugEnabled())
-            LOG.debug("quickStartWebXml={}", quickStartWebXml);
+            LOG.debug("quickStartWebXml={} exists={}", quickStartWebXml, Files.exists(quickStartWebXml));
 
         //Get the mode
         Object o = context.getAttribute(MODE);
@@ -211,7 +211,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
     protected void quickStart(WebAppContext context)
         throws Exception
     {
-        LOG.info("Quickstarting {}", context);
+        if (LOG.isDebugEnabled())
+            LOG.info("Quickstarting {}", context);
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
             .filter(c -> !__replacedConfigurations.contains(c.replaces()))

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -214,9 +214,9 @@ public class QuickStartConfiguration extends AbstractConfiguration
         LOG.info("Quickstarting {}", context);
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
-            .filter(c -> !__replacedConfigurations.contains(c.replaces()) && !__replacedConfigurations.contains(c.getClass()))
-            .toList()
-            .toArray(new Configuration[]{}));
+            .filter(c -> !__replacedConfigurations.contains(c.replaces()))
+            .filter(c -> !__replacedConfigurations.contains(c.getClass()))
+            .toArray(Configuration[]::new));
         Path quickStartWebXml = getQuickStartWebXml(context);
         if (!Files.exists(quickStartWebXml))
             throw new IllegalStateException("Quickstart doesn't exist: " + quickStartWebXml);

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartGeneratorConfiguration.java
@@ -17,6 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,6 @@ import org.eclipse.jetty.ee10.webapp.WebInfConfiguration;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.xml.XmlAppendable;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     protected final boolean _abort;
     protected String _originAttribute;
     protected int _count;
-    protected Resource _quickStartWebXml;
+    protected Path _quickStartWebXml;
    
     public QuickStartGeneratorConfiguration()
     {
@@ -114,12 +114,12 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         return _originAttribute;
     }
 
-    public Resource getQuickStartWebXml()
+    public Path getQuickStartWebXml()
     {
         return _quickStartWebXml;
     }
 
-    public void setQuickStartWebXml(Resource quickStartWebXml)
+    public void setQuickStartWebXml(Path quickStartWebXml)
     {
         _quickStartWebXml = quickStartWebXml;
     }
@@ -812,7 +812,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     {
         MetaData metadata = context.getMetaData();
         metadata.resolve(context);
-        try (OutputStream os = Files.newOutputStream(_quickStartWebXml.getPath()))
+        try (OutputStream os = Files.newOutputStream(_quickStartWebXml))
         {
             generateQuickStartWebXml(context, os);
             LOG.info("Generated {}", _quickStartWebXml);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEffectiveWebXml.java
@@ -76,7 +76,7 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
     {
         try
         {
-            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml, webApp);
+            QuickStartGenerator generator = new QuickStartGenerator(effectiveWebXml.toPath(), webApp);
             generator.generate();
         }
         catch (Exception e)

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyEmbedder.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ShutdownMonitor;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * JettyEmbedded
@@ -280,8 +279,8 @@ public class JettyEmbedder extends ContainerLifeCycle
             Path qs = webApp.getTempDirectory().toPath().resolve("quickstart-web.xml");
             if (Files.exists(qs) && Files.isRegularFile(qs))
             {
-                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, ResourceFactory.of(this).newResource(qs));
                 webApp.addConfiguration(new MavenQuickStartConfiguration());
+                webApp.setAttribute(QuickStartConfiguration.QUICKSTART_WEB_XML, qs);
                 webApp.setAttribute(QuickStartConfiguration.MODE, Mode.QUICKSTART);
             }
         }

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyForker.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/JettyForker.java
@@ -112,9 +112,9 @@ public class JettyForker extends AbstractForker
         throws Exception
     {
         //Run the webapp to create the quickstart file and properties file
-        generator = new QuickStartGenerator(forkWebXml, webApp);
+        generator = new QuickStartGenerator(forkWebXml.toPath(), webApp);
         generator.setContextXml(contextXml);
-        generator.setWebAppPropsFile(webAppPropsFile);
+        generator.setWebAppPropsFile(webAppPropsFile.toPath());
         generator.setServer(server);
         generator.generate();
 

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
@@ -102,7 +102,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
         //look for quickstart-web.xml in WEB-INF of webapp
         Path quickStartWebXml = getQuickStartWebXml(context);
         if (LOG.isDebugEnabled())
-            LOG.debug("quickStartWebXml={}", quickStartWebXml);
+            LOG.debug("quickStartWebXml={} exists={}", quickStartWebXml, Files.exists(quickStartWebXml));
 
         //Get the mode
         Object o = context.getAttribute(MODE);
@@ -211,7 +211,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
     protected void quickStart(WebAppContext context)
         throws Exception
     {
-        LOG.info("Quickstarting {}", context);
+        if (LOG.isDebugEnabled())
+            LOG.info("Quickstarting {}", context);
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
             .filter(c -> !__replacedConfigurations.contains(c.replaces()))

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
@@ -214,9 +214,9 @@ public class QuickStartConfiguration extends AbstractConfiguration
         LOG.info("Quickstarting {}", context);
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
-            .filter(c -> !__replacedConfigurations.contains(c.replaces()) && !__replacedConfigurations.contains(c.getClass()))
-            .toList()
-            .toArray(new Configuration[]{}));
+            .filter(c -> !__replacedConfigurations.contains(c.replaces()))
+            .filter(c -> !__replacedConfigurations.contains(c.getClass()))
+            .toArray(Configuration[]::new));
         Path quickStartWebXml = getQuickStartWebXml(context);
         if (!Files.exists(quickStartWebXml))
             throw new IllegalStateException("Quickstart doesn't exist: " + quickStartWebXml);

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartConfiguration.java
@@ -15,11 +15,10 @@ package org.eclipse.jetty.ee9.quickstart;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.eclipse.jetty.ee9.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee9.annotations.AnnotationDecorator;
 import org.eclipse.jetty.ee9.webapp.AbstractConfiguration;
 import org.eclipse.jetty.ee9.webapp.Configuration;
@@ -101,22 +100,23 @@ public class QuickStartConfiguration extends AbstractConfiguration
             throw new IllegalStateException("Bad Quickstart location");
 
         //look for quickstart-web.xml in WEB-INF of webapp
-        Resource quickStartWebXml = getQuickStartWebXml(context);
-        LOG.debug("quickStartWebXml={} exists={}", quickStartWebXml, quickStartWebXml.exists());
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        if (LOG.isDebugEnabled())
+            LOG.debug("quickStartWebXml={}", quickStartWebXml);
 
         //Get the mode
         Object o = context.getAttribute(MODE);
         _mode = (o instanceof Mode m) 
             ? m 
             : (o instanceof String s) ? Mode.valueOf(s) : _mode;
-        
+
         _quickStart = false;
-        
+
         switch (_mode)
         {
             case GENERATE:
             {
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                     LOG.info("Regenerating {}", quickStartWebXml);
                 else
                     LOG.info("Generating {}", quickStartWebXml);
@@ -130,7 +130,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
             }
             case AUTO:
             {
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                 {
                     quickStart(context);
                 }
@@ -143,7 +143,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
                 break;
             }
             case QUICKSTART:
-                if (quickStartWebXml.exists())
+                if (Files.exists(quickStartWebXml))
                     quickStart(context);
                 else
                     throw new IllegalStateException("No " + quickStartWebXml);
@@ -161,7 +161,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
         if (attr != null)
             generator.setOriginAttribute(attr.toString());
 
-        generator.setQuickStartWebXml((Resource)context.getAttribute(QUICKSTART_WEB_XML));
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        generator.setQuickStartWebXml(quickStartWebXml);
     }
 
     @Override
@@ -183,7 +184,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
             //add a decorator that will find introspectable annotations
             context.getObjectFactory().addDecorator(new AnnotationDecorator(context)); //this must be the last Decorator because they are run in reverse order!
 
-            LOG.debug("configured {}", this);
+            if (LOG.isDebugEnabled())
+                LOG.debug("configured {}", this);
         }
     }
 
@@ -213,52 +215,80 @@ public class QuickStartConfiguration extends AbstractConfiguration
         _quickStart = true;
         context.setConfigurations(context.getConfigurations().stream()
             .filter(c -> !__replacedConfigurations.contains(c.replaces()) && !__replacedConfigurations.contains(c.getClass()))
-            .collect(Collectors.toList()).toArray(new Configuration[]{}));
-        context.getMetaData().setWebDescriptor(new WebDescriptor((Resource)context.getAttribute(QUICKSTART_WEB_XML)));
+            .toList()
+            .toArray(new Configuration[]{}));
+        Path quickStartWebXml = getQuickStartWebXml(context);
+        if (!Files.exists(quickStartWebXml))
+            throw new IllegalStateException("Quickstart doesn't exist: " + quickStartWebXml);
+        Resource quickStartWebResource = context.getResourceFactory().newResource(quickStartWebXml);
+        context.getMetaData().setWebDescriptor(new WebDescriptor(quickStartWebResource));
         context.getServletContext().setEffectiveMajorVersion(context.getMetaData().getWebDescriptor().getMajorVersion());
         context.getServletContext().setEffectiveMinorVersion(context.getMetaData().getWebDescriptor().getMinorVersion());
     }
 
     /**
-     * Get the quickstart-web.xml file as a Resource.
+     * Get the quickstart-web.xml Path from the webapp (from attributes if present, or built from the context's {@link WebAppContext#getWebInf()}).
      *
      * @param context the web app context
-     * @return the Resource for the quickstart-web.xml
-     * @throws Exception if unable to find the quickstart xml
+     * @return the Path for the quickstart-web.xml
+     * @throws IOException if unable to build the quickstart xml
      */
-    public Resource getQuickStartWebXml(WebAppContext context) throws Exception
+    public static Path getQuickStartWebXml(WebAppContext context) throws IOException
     {
         Object attr = context.getAttribute(QUICKSTART_WEB_XML);
-        if (attr instanceof Resource)
-            return (Resource)attr;
+        if (attr instanceof Path)
+            return (Path)attr;
 
-        Resource webInf = context.getWebInf();
-        if (webInf == null || !webInf.exists())
-        {
-            Files.createDirectories(context.getBaseResource().getPath().resolve("WEB-INF"));
-            webInf = context.getWebInf();
-        }
+        Path webInfDir = getWebInfPath(context);
+        Path qstartFile = webInfDir.resolve("quickstart-web.xml");
 
-        Resource qstart;
-        if (attr == null || StringUtil.isBlank(attr.toString()))
+        if (attr != null && StringUtil.isNotBlank(attr.toString()))
         {
-            qstart = webInf.resolve("quickstart-web.xml");
-        }
-        else
-        {
+            Resource resource;
+            String attrValue = attr.toString();
             try
             {
                 // Try a relative resolution
-                qstart = _resourceFactory.newResource(webInf.getPath().resolve(attr.toString()));
+                resource = context.getResourceFactory().newResource(webInfDir.resolve(attrValue));
             }
             catch (Throwable th)
             {
                 // try as a resource
-                qstart = _resourceFactory.newResource(attr.toString());
+                resource = context.getResourceFactory().newResource(attrValue);
             }
-            context.setAttribute(QUICKSTART_WEB_XML, qstart);
+            if (resource != null)
+            {
+                Path attrPath = resource.getPath();
+                if (attrPath != null)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Using quickstart attribute {} value of {}", attr, attrValue);
+                    qstartFile = attrPath;
+                }
+            }
         }
-        context.setAttribute(QUICKSTART_WEB_XML, qstart);
-        return  qstart;
+        if (LOG.isDebugEnabled())
+            LOG.debug("Using quickstart location: {}", qstartFile);
+        context.setAttribute(QUICKSTART_WEB_XML, qstartFile);
+        return qstartFile;
+    }
+
+    private static Path getWebInfPath(WebAppContext context) throws IOException
+    {
+        Path webInfDir = null;
+        Resource webInf = context.getWebInf();
+        if (webInf != null)
+        {
+            webInfDir = webInf.getPath();
+        }
+
+        if (webInfDir == null)
+        {
+            Path baseResourcePath = context.getBaseResource().getPath();
+            webInfDir = baseResourcePath.resolve("WEB-INF");
+            if (!Files.exists(webInfDir))
+                Files.createDirectories(webInfDir);
+        }
+        return webInfDir;
     }
 }

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -17,6 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,6 @@ import org.eclipse.jetty.ee9.webapp.WebInfConfiguration;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.xml.XmlAppendable;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     protected final boolean _abort;
     protected String _originAttribute;
     protected int _count;
-    protected Resource _quickStartWebXml;
+    protected Path _quickStartWebXml;
    
     public QuickStartGeneratorConfiguration()
     {
@@ -114,12 +114,12 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         return _originAttribute;
     }
 
-    public Resource getQuickStartWebXml()
+    public Path getQuickStartWebXml()
     {
         return _quickStartWebXml;
     }
 
-    public void setQuickStartWebXml(Resource quickStartWebXml)
+    public void setQuickStartWebXml(Path quickStartWebXml)
     {
         _quickStartWebXml = quickStartWebXml;
     }
@@ -812,7 +812,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
     {
         MetaData metadata = context.getMetaData();
         metadata.resolve(context);
-        try (OutputStream os = Files.newOutputStream(_quickStartWebXml.getPath()))
+        try (OutputStream os = Files.newOutputStream(_quickStartWebXml))
         {
             generateQuickStartWebXml(context, os);
             LOG.info("Generated {}", _quickStartWebXml);


### PR DESCRIPTION
This change is in preparation for the resolve() returning null if doesn't exist PR #8597 

+ QuickStart will use a Path object to handle creation / regeneration of the quickstart-web.xml, but Resource when starting / running it.
+ Updated maven plugin usage as well.

Taken from PR #8597