### PR TITLE
Jetty 12 : Correct appassembler error during `jetty-ee10-test-quickstart`

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
@@ -110,33 +110,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>appassembler-maven-plugin</artifactId>
-        <configuration>
-          <platforms>
-            <platform>unix</platform>
-          </platforms>
-          <programs>
-            <program>
-              <id>preconfigure</id>
-              <mainClass>org.eclipse.jetty.quickstart.PreconfigureQuickStartWar</mainClass>
-            </program>
-            <program>
-              <mainClass>org.eclipse.jetty.quickstart.QuickStartWar</mainClass>
-              <id>quickstart</id>
-            </program>
-          </programs>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
     <weld.version>4.0.2.Final</weld.version>
 
     <!-- some maven plugins versions -->
-    <appassembler.maven.plugin.version>2.1.0</appassembler.maven.plugin.version>
     <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
     <build-helper.maven.plugin.version>3.3.0</build-helper.maven.plugin.version>
     <buildnumber.maven.plugin.version>3.0.0</buildnumber.maven.plugin.version>
@@ -838,11 +837,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>appassembler-maven-plugin</artifactId>
-          <version>${appassembler.maven.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -841,6 +841,11 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
+          <artifactId>appassembler-maven-plugin</artifactId>
+          <version>${appassembler.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper.maven.plugin.version}</version>
         </plugin>


### PR DESCRIPTION
Corrects error during build ...

```
'build.plugins.plugin.version' for org.codehaus.mojo:appassembler-maven-plugin is missing. @ line 112, column 15
```