### PR TITLE
Disable building quiche foreign incubator binding builds on JDKs > 17

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
@@ -20,7 +20,7 @@
     <profile>
       <id>jdk17</id>
       <activation>
-        <jdk>[17,)</jdk>
+        <jdk>17</jdk>
       </activation>
       <modules>
         <module>jetty-quic-quiche-foreign-incubator</module>


### PR DESCRIPTION
The current quiche-foreign-incubator implementation only works with JDK 17, so disable it on other JDKs. See #8613.

This is a quick stopgap measure to allow building Jetty 12 with JDKs > 17. A proper rework of this quiche binding will be done at a latter stage.