### PR TITLE
Fixes the case where HTTP/2 readData() was returning EOF

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -416,18 +416,6 @@ public interface Stream
         }
 
         @Override
-        public void retain()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean release()
-        {
-            return true;
-        }
-
-        @Override
         public String toString()
         {
             return "%s@%x[%s]".formatted(getClass().getSimpleName(), hashCode(), frame());
@@ -438,6 +426,18 @@ public interface Stream
             public EOF(int streamId)
             {
                 super(new DataFrame(streamId, BufferUtil.EMPTY_BUFFER, true));
+            }
+
+            @Override
+            public void retain()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean release()
+            {
+                return true;
             }
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -234,9 +234,12 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
 
     private Content.Chunk createChunk(Stream.Data data)
     {
-        // As we are passing the ByteBuffer to the Chunk we need to retain.
-        data.retain();
         DataFrame frame = data.frame();
+        if (frame.isEndStream() && frame.remaining() == 0)
+            return Content.Chunk.EOF;
+
+        // We need to retain because we are passing the ByteBuffer to the Chunk.
+        data.retain();
         return Content.Chunk.from(frame.getData(), frame.isEndStream(), data);
     }
 


### PR DESCRIPTION
that could not be wrapped in a Chunk, because Data.EOF.retain() throws UnsupportedOperationException.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>