### PR TITLE
Fixes #7993 - HttpClient idleTimeout configuration being ignored/over…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -106,6 +106,7 @@ public abstract class HttpConnection implements IConnection, Attachable
             SendFailure result;
             if (channel.associate(exchange))
             {
+                request.sent();
                 requestTimeouts.schedule(channel);
                 channel.send();
                 result = null;

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -311,6 +311,7 @@ public abstract class HttpDestination extends ContainerLifeCycle implements Dest
         {
             if (enqueue(exchanges, exchange))
             {
+                request.sent();
                 requestTimeouts.schedule(exchange);
                 if (!client.isRunning() && exchanges.remove(exchange))
                 {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Destination;
@@ -195,10 +196,14 @@ public class HttpProxy extends ProxyConfiguration.Proxy
             String target = destination.getOrigin().getAddress().asString();
             Origin.Address proxyAddress = destination.getConnectAddress();
             HttpClient httpClient = destination.getHttpClient();
+            long connectTimeout = httpClient.getConnectTimeout();
             Request connect = new TunnelRequest(httpClient, proxyAddress)
                 .method(HttpMethod.CONNECT)
                 .path(target)
-                .headers(headers -> headers.put(HttpHeader.HOST, target));
+                .headers(headers -> headers.put(HttpHeader.HOST, target))
+                // Use the connect timeout as a total timeout,
+                // since this request is to "connect" to the server.
+                .timeout(connectTimeout, TimeUnit.MILLISECONDS);
             ProxyConfiguration.Proxy proxy = destination.getProxy();
             if (proxy.isSecure())
                 connect.scheme(HttpScheme.HTTPS.asString());

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -234,7 +234,7 @@ public class HttpProxy extends ProxyConfiguration.Proxy
 
         private void tunnelFailed(EndPoint endPoint, Throwable failure)
         {
-            endPoint.close();
+            endPoint.close(failure);
             promise.failed(failure);
         }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -816,15 +816,17 @@ public class HttpRequest implements Request
     {
         if (listener != null)
             responseListeners.add(listener);
-        sent();
         sender.accept(this, responseListeners);
     }
 
     void sent()
     {
-        long timeout = getTimeout();
-        if (timeout > 0)
-            timeoutNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(timeout);
+        if (timeoutNanoTime == Long.MAX_VALUE)
+        {
+            long timeout = getTimeout();
+            if (timeout > 0)
+                timeoutNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(timeout);
+        }
     }
 
     /**

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
@@ -131,7 +131,10 @@ public class HttpChannelOverHTTP extends HttpChannel
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Closing, reason: {} - {}", closeReason, connection);
-            connection.close();
+            if (result.isFailed())
+                connection.close(result.getFailure());
+            else
+                connection.close();
         }
         else
         {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -327,6 +327,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
 
         // Store the EndPoint is case of upgrades, tunnels, etc.
         exchange.getRequest().getConversation().setAttribute(EndPoint.class.getName(), getHttpConnection().getEndPoint());
+        getHttpConnection().onResponseHeaders(exchange);
         return !responseHeaders(exchange);
     }
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/IdleTimeout.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/IdleTimeout.java
@@ -80,6 +80,9 @@ public abstract class IdleTimeout
         long old = _idleTimeout;
         _idleTimeout = idleTimeout;
 
+        if (LOG.isDebugEnabled())
+            LOG.debug("Setting idle timeout {} -> {} on {}", old, idleTimeout, this);
+
         // Do we have an old timeout
         if (old > 0)
         {

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
@@ -166,7 +166,8 @@ public abstract class SelectorManager extends ContainerLifeCycle implements Dump
     public void connect(SelectableChannel channel, Object attachment)
     {
         ManagedSelector set = chooseSelector();
-        set.submit(set.new Connect(channel, attachment));
+        if (set != null)
+            set.submit(set.new Connect(channel, attachment));
     }
 
     /**

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
@@ -24,6 +24,7 @@ import java.security.Principal;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.net.ssl.KeyManager;
@@ -40,6 +41,7 @@ import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Destination;
+import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.FutureResponseListener;
@@ -61,7 +63,6 @@ import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
@@ -71,6 +72,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -413,7 +415,7 @@ public class ForwardProxyTLSServerTest
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
         });
-        assertThat(x.getCause(), Matchers.instanceOf(ConnectException.class));
+        assertThat(x.getCause(), instanceOf(ConnectException.class));
 
         httpClient.stop();
     }
@@ -822,6 +824,96 @@ public class ForwardProxyTLSServerTest
             assertEquals(HttpStatus.OK_200, response.getStatus());
             String content = response.getContentAsString();
             assertEquals(body, content);
+        }
+        finally
+        {
+            httpClient.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("proxyTLS")
+    public void testServerLongProcessing(SslContextFactory.Server proxyTLS) throws Exception
+    {
+        long timeout = 500;
+        startTLSServer(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                sleep(3 * timeout);
+                baseRequest.setHandled(true);
+            }
+        });
+        startProxy(proxyTLS);
+        HttpClient httpClient = newHttpClient();
+        httpClient.getProxyConfiguration().getProxies().add(newHttpProxy());
+        httpClient.setConnectTimeout(timeout);
+        httpClient.setIdleTimeout(4 * timeout);
+        httpClient.start();
+
+        try
+        {
+            // The idle timeout is larger than the server processing time, request should succeed.
+            ContentResponse response = httpClient.newRequest("localhost", serverConnector.getLocalPort())
+                .scheme(HttpScheme.HTTPS.asString())
+                .send();
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
+        finally
+        {
+            httpClient.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("proxyTLS")
+    public void testProxyLongProcessing(SslContextFactory.Server proxyTLS) throws Exception
+    {
+        long timeout = 500;
+        startTLSServer(new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                baseRequest.setHandled(true);
+            }
+        });
+        startProxy(proxyTLS, new ConnectHandler()
+        {
+            @Override
+            protected void handleConnect(Request baseRequest, HttpServletRequest request, HttpServletResponse response, String serverAddress)
+            {
+                sleep(3 * timeout);
+                super.handleConnect(baseRequest, request, response, serverAddress);
+            }
+        });
+        HttpClient httpClient = newHttpClient();
+        httpClient.getProxyConfiguration().getProxies().add(newHttpProxy());
+        httpClient.setConnectTimeout(timeout);
+        httpClient.setIdleTimeout(10 * timeout);
+        httpClient.start();
+
+        try
+        {
+            // Connecting to the server through the proxy involves a CONNECT + 200
+            // so if the proxy delays the response, the client request interprets
+            // it as a "connect" timeout (rather than an idle timeout).
+            AtomicReference<Result> resultRef = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            httpClient.newRequest("localhost", serverConnector.getLocalPort())
+                .scheme(HttpScheme.HTTPS.asString())
+                .send(result ->
+                {
+                    resultRef.set(result);
+                    latch.countDown();
+                });
+
+            assertTrue(latch.await(2 * timeout, TimeUnit.MILLISECONDS));
+            Result result = resultRef.get();
+            assertTrue(result.isFailed());
+            assertThat(result.getFailure(), instanceOf(TimeoutException.class));
         }
         finally
         {

--- a/jetty-proxy/src/test/resources/jetty-logging.properties
+++ b/jetty-proxy/src/test/resources/jetty-logging.properties
@@ -1,4 +1,3 @@
-# Jetty Logging using jetty-slf4j-impl
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.client.LEVEL=DEBUG
 #org.eclipse.jetty.proxy.LEVEL=DEBUG


### PR DESCRIPTION
…ridden

The problem was that the timeout scheduling was not happening, because for TunnelRequest the timeouts were set in normalizeRequest(), which runs after the scheduling.

Now a call to request.sent() is made also after normalizeRequest() so that the timeouts is scheduled (if it was not scheduled before).

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>