### PR TITLE
expand jetty properties when generating dry-run command line

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -817,7 +817,7 @@ public class StartArgs
             {
                 for (Prop p : properties)
                 {
-                    cmd.addRawArg(CommandLineBuilder.quote(p.key) + "=" + CommandLineBuilder.quote(p.value));
+                    cmd.addRawArg(CommandLineBuilder.quote(p.key) + "=" + CommandLineBuilder.quote(properties.expand(p.value)));
                 }
             }
             else if (properties.size() > 0)


### PR DESCRIPTION
When using `--dry-run`, the command line printed was not resolving jetty properties.

For example using `logging-jetty` adds `${jetty.home.uri}/lib/logging/` to server classes. 

However this is never resolved with the value of the `jetty.home.uri` property, and this is what is what ends up in server classes of the webapp when Jetty is started:
```
|  |     +> Serverclasses XWiki@c05fddc size=22
|  |     |  +> ${jetty.home.uri}/lib/logging/
```

this results in the `ServiceConfigurationError` seen in https://github.com/eclipse/jetty.docker/issues/118.
