### PR TITLE
Re-enable and fix loginservice tests ee10

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DataSourceLoginServiceTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DataSourceLoginServiceTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -44,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * DataSourceLoginServiceTest
  */
-@Disabled //TODO needs DefaultServlet
 @Testcontainers(disabledWithoutDocker = true)
 public class DataSourceLoginServiceTest
 {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DatabaseLoginServiceTestServer.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DatabaseLoginServiceTestServer.java
@@ -98,6 +98,26 @@ public class DatabaseLoginServiceTestServer
         }
     }
     
+    public static class ExtendedDefaultServlet extends DefaultServlet
+    {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            if (resp.getStatus() == HttpServletResponse.SC_OK)
+                return;
+            
+            super.doPost(req, resp);
+        }
+
+        @Override
+        protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            if (resp.getStatus() == HttpServletResponse.SC_CREATED)
+                return;
+            super.doPut(req, resp);
+        }
+    }
+    
     public static class TestFilter extends HttpFilter
     {
         private final Path _resourcePath;
@@ -119,8 +139,9 @@ public class DatabaseLoginServiceTestServer
             OutputStream out = null;
             if (req.getMethod().equals("PUT"))
             {
-                Path p = _resourcePath.resolve(URLDecoder.decode(req.getPathInfo(), "utf-8"));
-                
+                //remove leading slash from pathinfo
+                Path p = _resourcePath.resolve(URLDecoder.decode(req.getPathInfo().substring(1), "utf-8"));
+
                 File file = p.toFile();
                 FS.ensureDirExists(file.getParentFile());
 
@@ -224,12 +245,12 @@ public class DatabaseLoginServiceTestServer
         root.setSecurityHandler(security);
         root.setContextPath("/");
         root.setBaseResource(_resourceBase);
-        ServletHolder servletHolder = new ServletHolder(new DefaultServlet());
+        ServletHolder servletHolder = new ServletHolder(new ExtendedDefaultServlet());
         servletHolder.setInitParameter("gzip", "true");
         root.addServlet(servletHolder, "/*");
 
         _filter = new TestFilter(_resourceBase);
-        root.addFilter(_filter, "/", EnumSet.allOf(DispatcherType.class));
+        root.addFilter(_filter, "/*", EnumSet.allOf(DispatcherType.class));
         
         _server.setHandler(root);
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/JdbcLoginServiceTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/JdbcLoginServiceTest.java
@@ -39,14 +39,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled //TODO needs DefaultServlet
 @Testcontainers(disabledWithoutDocker = true)
 public class JdbcLoginServiceTest
 {


### PR DESCRIPTION
Undisable Datasource and JDBC LoginService tests for ee10. Also needed to convert from a Handler-based test to a Filter & Servlet based test.