### PR TITLE
Jetty 10.0.x: disable Foreign module tests on JDK18+

### DIFF
--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
@@ -70,4 +70,27 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <!--
+       This module can be built with JDK 17+ but can only be tested on JDK 17 as the Foreign module
+       changed both its API (18) and its name (19), so tests are disabled on JDKs over 17.
+       Eventually, new Foreign modules for JDKs 18 and 19 should be added.
+       -->
+      <id>jdk18+</id>
+      <activation>
+        <jdk>[18,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
JDK 18+ can build the Foreign module but cannot execute it.