### PR TITLE
fix(sec): upgrade org.eclipse.jetty.http2:http2-server to 11.0.10

### DIFF
--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -170,7 +171,7 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-server</artifactId>
-        <version>10.0.13-SNAPSHOT</version>
+        <version>11.0.10</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty.http2:http2-server 10.0.13-SNAPSHOT
- [CVE-2022-2048](https://www.oscs1024.com/hd/CVE-2022-2048)


### What did I do？
Upgrade org.eclipse.jetty.http2:http2-server from 10.0.13-SNAPSHOT to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS