### PR TITLE
Issue #8712 Deprecate ELContextCleaner

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/listener/ELContextCleaner.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/listener/ELContextCleaner.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * See http://java.net/jira/browse/GLASSFISH-1649
  * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=353095
  */
+@Deprecated
 public class ELContextCleaner implements ServletContextListener
 {
     private static final Logger LOG = LoggerFactory.getLogger(ELContextCleaner.class);

--- a/jetty-webapp/src/main/config/etc/webdefault.xml
+++ b/jetty-webapp/src/main/config/etc/webdefault.xml
@@ -28,14 +28,6 @@
     Default web.xml file.  
     This file is applied to a Web application before its own WEB_INF/web.xml file
   </description>
-
-  <!-- ==================================================================== -->
-  <!-- Removes static references to beans from javax.el.BeanELResolver to   -->
-  <!-- ensure webapp classloader can be released on undeploy                -->
-  <!-- ==================================================================== -->
-  <listener>
-   <listener-class>org.eclipse.jetty.servlet.listener.ELContextCleaner</listener-class>
-  </listener>
   
   <!-- ==================================================================== -->
   <!-- Removes static cache of Methods from java.beans.Introspector to      -->


### PR DESCRIPTION
Deprecate ELContextCleaner class as it is no longer needed, and remove it from `webdefault.xml`.