### PR TITLE
Make Client's Request and Response `abort()` fully async

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
@@ -144,7 +144,7 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
         if (responseFailure != null)
             abortResponse(exchange, responseFailure, responsePromise);
         else
-            requestPromise.succeeded(false);
+            responsePromise.succeeded(false);
 
         requestPromise.thenAcceptBoth(responsePromise, (requestAborted, responseAborted) -> promise.succeeded(requestAborted || responseAborted));
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContentResponse.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpContentResponse.java
@@ -17,6 +17,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -82,7 +83,7 @@ public class HttpContentResponse implements ContentResponse
     }
 
     @Override
-    public boolean abort(Throwable cause)
+    public CompletableFuture<Boolean> abort(Throwable cause)
     {
         return response.abort(cause);
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConversation.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConversation.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.util.AttributesMap;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,10 +154,13 @@ public class HttpConversation extends AttributesMap
         return firstExchange == null ? 0 : firstExchange.getRequest().getTimeout();
     }
 
-    public boolean abort(Throwable cause)
+    public void abort(Throwable cause, Promise<Boolean> promise)
     {
         HttpExchange exchange = exchanges.peekLast();
-        return exchange != null && exchange.abort(cause);
+        if (exchange != null)
+            exchange.abort(cause, promise);
+        else
+            promise.succeeded(false);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -409,9 +409,7 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
                 // It may happen that the request is aborted before the exchange
                 // is created. Aborting the exchange a second time will result in
                 // a no-operation, so we just abort here to cover that edge case.
-                exchange.abort(cause, new Promise<>()
-                {
-                });
+                exchange.abort(cause, Promise.noop());
                 return getQueuedRequestCount() > 0;
             }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpDestination.java
@@ -409,7 +409,9 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
                 // It may happen that the request is aborted before the exchange
                 // is created. Aborting the exchange a second time will result in
                 // a no-operation, so we just abort here to cover that edge case.
-                exchange.abort(cause);
+                exchange.abort(cause, new Promise<>()
+                {
+                });
                 return getQueuedRequestCount() > 0;
             }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -444,15 +444,9 @@ public abstract class HttpReceiver
         // Mark atomically the response as completed, with respect
         // to concurrency between response success and response failure.
         if (exchange.responseComplete(failure))
-        {
-            // We can use a Promise.Completable and join it here only
-            // because the implementation of abort() is synchronous.
             abort(exchange, failure, promise);
-        }
         else
-        {
             promise.succeeded(false);
-        }
     }
 
     private void terminateResponse(HttpExchange exchange)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -54,6 +55,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.Promise;
 
 public class HttpRequest implements Request
 {
@@ -815,11 +817,15 @@ public class HttpRequest implements Request
     }
 
     @Override
-    public boolean abort(Throwable cause)
+    public CompletableFuture<Boolean> abort(Throwable cause)
     {
         if (aborted.compareAndSet(null, Objects.requireNonNull(cause)))
-            return conversation.abort(cause);
-        return false;
+        {
+            Promise.Completable<Boolean> promise = new Promise.Completable<>();
+            conversation.abort(cause, promise);
+            return promise;
+        }
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import org.eclipse.jetty.client.api.Request;
@@ -131,7 +132,7 @@ public class HttpResponse implements Response
     }
 
     @Override
-    public boolean abort(Throwable cause)
+    public CompletableFuture<Boolean> abort(Throwable cause)
     {
         return request.abort(cause);
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -463,7 +464,7 @@ public interface Request
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded
      */
-    boolean abort(Throwable cause);
+    CompletableFuture<Boolean> abort(Throwable cause);
 
     /**
      * @return the abort cause passed to {@link #abort(Throwable)},

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.client.api;
 import java.nio.ByteBuffer;
 import java.util.EventListener;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.function.LongConsumer;
 
@@ -80,7 +81,7 @@ public interface Response
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded
      */
-    boolean abort(Throwable cause);
+    CompletableFuture<Boolean> abort(Throwable cause);
 
     /**
      * Common, empty, super-interface for response listeners

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.io.RetainableByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -425,8 +426,11 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
 
     private void failAndClose(Throwable failure)
     {
-        if (responseFailure(failure))
-            getHttpConnection().close(failure);
+        responseFailure(failure, Promise.from(failed ->
+        {
+            if (failed)
+                getHttpConnection().close(failure);
+        }, f -> getHttpConnection().close(failure)));
     }
 
     long getMessagesIn()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/FutureResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/FutureResponseListener.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jetty.client.HttpContentResponse;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -44,7 +45,7 @@ public class FutureResponseListener extends BufferingResponseListener implements
     private final Request request;
     private ContentResponse response;
     private Throwable failure;
-    private volatile boolean cancelled;
+    private final AtomicBoolean cancelled = new AtomicBoolean();
 
     public FutureResponseListener(Request request)
     {
@@ -73,14 +74,18 @@ public class FutureResponseListener extends BufferingResponseListener implements
     @Override
     public boolean cancel(boolean mayInterruptIfRunning)
     {
-        cancelled = true;
-        return request.abort(new CancellationException());
+        if (cancelled.compareAndSet(false, true))
+        {
+            request.abort(new CancellationException());
+            return true;
+        }
+        return false;
     }
 
     @Override
     public boolean isCancelled()
     {
-        return cancelled;
+        return cancelled.get();
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/FutureResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/FutureResponseListener.java
@@ -41,11 +41,11 @@ import org.eclipse.jetty.client.api.Result;
  */
 public class FutureResponseListener extends BufferingResponseListener implements Future<ContentResponse>
 {
+    private final AtomicBoolean cancelled = new AtomicBoolean();
     private final CountDownLatch latch = new CountDownLatch(1);
     private final Request request;
     private ContentResponse response;
     private Throwable failure;
-    private final AtomicBoolean cancelled = new AtomicBoolean();
 
     public FutureResponseListener(Request request)
     {

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientUploadDuringServerShutdownTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientUploadDuringServerShutdownTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Test;
 
@@ -189,17 +190,17 @@ public class HttpClientUploadDuringServerShutdownTest
                     }
 
                     @Override
-                    protected boolean abort(Throwable failure)
+                    protected void abort(Throwable failure, Promise<Boolean> promise)
                     {
                         try
                         {
                             associateLatch.await(5, TimeUnit.SECONDS);
-                            return super.abort(failure);
+                            super.abort(failure, promise);
                         }
                         catch (InterruptedException x)
                         {
                             x.printStackTrace();
-                            return false;
+                            promise.failed(x);
                         }
                     }
                 };

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpRequestAbortTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpRequestAbortTest.java
@@ -87,8 +87,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
                 @Override
                 public void onQueued(Request request)
                 {
-                    aborted.set(request.abort(cause));
-                    latch.countDown();
+                    request.abort(cause).thenAccept(b ->
+                    {
+                        aborted.set(b);
+                        latch.countDown();
+                    });
                 }
 
                 @Override
@@ -130,8 +133,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
                 @Override
                 public void onBegin(Request request)
                 {
-                    aborted.set(request.abort(cause));
-                    latch.countDown();
+                    request.abort(cause).thenAccept(b ->
+                    {
+                        aborted.set(b);
+                        latch.countDown();
+                    });
                 }
 
                 @Override
@@ -172,8 +178,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
                 @Override
                 public void onHeaders(Request request)
                 {
-                    aborted.set(request.abort(cause));
-                    latch.countDown();
+                    request.abort(cause).thenAccept(b ->
+                    {
+                        aborted.set(b);
+                        latch.countDown();
+                    });
                 }
 
                 @Override
@@ -214,8 +223,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
         {
             request.onRequestCommit(r ->
             {
-                aborted.set(r.abort(cause));
-                latch.countDown();
+                r.abort(cause).thenAccept(b ->
+                {
+                    aborted.set(b);
+                    latch.countDown();
+                });
             }).timeout(5, TimeUnit.SECONDS).send();
         });
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -253,8 +265,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
         {
             request.onRequestCommit(r ->
             {
-                aborted.set(r.abort(cause));
-                latch.countDown();
+                r.abort(cause).thenAccept(b ->
+                {
+                    aborted.set(b);
+                    latch.countDown();
+                });
             }).body(new ByteBufferRequestContent(ByteBuffer.wrap(new byte[]{0}), ByteBuffer.wrap(new byte[]{1}))
             {
                 @Override
@@ -309,8 +324,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
             {
                 request.onRequestContent((r, c) ->
                 {
-                    aborted.set(r.abort(cause));
-                    latch.countDown();
+                    r.abort(cause).thenAccept(b ->
+                    {
+                        aborted.set(b);
+                        latch.countDown();
+                    });
                 }).body(new ByteBufferRequestContent(ByteBuffer.wrap(new byte[]{0}), ByteBuffer.wrap(new byte[]{1}))
                 {
                     @Override
@@ -395,8 +413,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
             try
             {
                 TimeUnit.MILLISECONDS.sleep(delay);
-                aborted.set(request.abort(cause));
-                latch.countDown();
+                request.abort(cause).thenAccept(b ->
+                {
+                    aborted.set(b);
+                    latch.countDown();
+                });
             }
             catch (InterruptedException x)
             {
@@ -488,8 +509,11 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
                 // Abort the request after the 3xx response but before issuing the next request
                 if (!result.isFailed())
                 {
-                    aborted.set(result.getRequest().abort(cause));
-                    latch.countDown();
+                    result.getRequest().abort(cause).thenAccept(b ->
+                    {
+                        aborted.set(b);
+                        latch.countDown();
+                    });
                 }
                 super.onComplete(result);
             }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpChannelOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpChannelOverFCGI.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.IdleTimeout;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,10 +139,13 @@ public class HttpChannelOverFCGI extends HttpChannel
         return exchange != null && receiver.responseSuccess(exchange);
     }
 
-    protected boolean responseFailure(Throwable failure)
+    protected void responseFailure(Throwable failure, Promise<Boolean> promise)
     {
         HttpExchange exchange = getHttpExchange();
-        return exchange != null && receiver.responseFailure(failure);
+        if (exchange != null)
+            receiver.responseFailure(failure, promise);
+        else
+            promise.succeeded(false);
     }
 
     @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpReceiverOverFCGI.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpReceiver;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 
 public class HttpReceiverOverFCGI extends HttpReceiver
 {
@@ -65,9 +66,9 @@ public class HttpReceiverOverFCGI extends HttpReceiver
     }
 
     @Override
-    protected boolean responseFailure(Throwable failure)
+    protected void responseFailure(Throwable failure, Promise<Boolean> promise)
     {
-        return super.responseFailure(failure);
+        super.responseFailure(failure, promise);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.http2.internal.HTTP2Stream;
 import org.eclipse.jetty.http2.internal.HTTP2StreamEndPoint;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +38,15 @@ public class ClientHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
     }
 
     @Override
-    public boolean onTimeout(Throwable failure)
+    public void onTimeout(Throwable failure, Promise<Boolean> promise)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("idle timeout on {}: {}", this, failure);
         Connection connection = getConnection();
         if (connection != null)
-            return connection.onIdleExpired();
-        return true;
+            promise.succeeded(connection.onIdleExpired());
+        else
+            promise.succeeded(true);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http2.internal.ErrorCode;
 import org.eclipse.jetty.http2.internal.HTTP2Channel;
 import org.eclipse.jetty.http2.internal.HTTP2Stream;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,10 +201,10 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         }
 
         @Override
-        public boolean onIdleTimeout(Stream stream, Throwable x)
+        public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            return channel.onTimeout(x);
+            channel.onTimeout(x, promise);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.http2.internal.HTTP2Channel;
 import org.eclipse.jetty.http2.internal.HTTP2Stream;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -252,12 +253,13 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
     }
 
     @Override
-    public boolean onTimeout(Throwable failure)
+    public void onTimeout(Throwable failure, Promise<Boolean> promise)
     {
         HttpExchange exchange = getHttpExchange();
-        if (exchange == null)
-            return false;
-        return !exchange.abort(failure);
+        if (exchange != null)
+            exchange.abort(failure, Promise.from(b -> promise.succeeded(!b), promise::failed));
+        else
+            promise.succeeded(false);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -257,7 +257,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
     {
         HttpExchange exchange = getHttpExchange();
         if (exchange != null)
-            exchange.abort(failure, Promise.from(b -> promise.succeeded(!b), promise::failed));
+            exchange.abort(failure, Promise.from(aborted -> promise.succeeded(!aborted), promise::failed));
         else
             promise.succeeded(false);
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -218,7 +218,7 @@ public interface Stream
     /**
      * @param idleTimeout the stream idle timeout
      * @see #getIdleTimeout()
-     * @see Stream.Listener#onIdleTimeout(Stream, Throwable)
+     * @see Stream.Listener#onIdleTimeout(Stream, Throwable, Promise)
      */
     public void setIdleTimeout(long idleTimeout);
 
@@ -364,14 +364,14 @@ public interface Stream
         /**
          * <p>Callback method invoked when the stream exceeds its idle timeout.</p>
          *
-         * @param stream the stream
-         * @param x the timeout failure
-         * @return true to reset the stream, false to ignore the idle timeout
+         * @param stream  the stream
+         * @param x       the timeout failure
+         * @param promise the promise to complete
          * @see #getIdleTimeout()
          */
-        public default boolean onIdleTimeout(Stream stream, Throwable x)
+        public default void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
         {
-            return true;
+            promise.succeeded(true);
         }
 
         /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Channel.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Channel.java
@@ -13,10 +13,11 @@
 
 package org.eclipse.jetty.http2.internal;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 
 /**
  * <p>A HTTP/2 specific handler of events for normal and tunneled exchanges.</p>
@@ -33,7 +34,7 @@ public interface HTTP2Channel
     {
         public void onDataAvailable();
 
-        public boolean onTimeout(Throwable failure);
+        public void onTimeout(Throwable failure, Promise<Boolean> promise);
 
         public void onFailure(Throwable failure, Callback callback);
     }
@@ -53,7 +54,7 @@ public interface HTTP2Channel
         // TODO: review the signature because the serialization done by HttpChannel.onError()
         //  is now failing the callback which fails the HttpStream, which should decide whether
         //  to reset the HTTP/2 stream, so we may not need the boolean return type.
-        public boolean onTimeout(Throwable failure, Consumer<Runnable> consumer);
+        public void onTimeout(Throwable failure, BiConsumer<Runnable, Boolean> consumer);
 
         // TODO: can it be simplified? The callback seems to only be succeeded, which
         //  means it can be converted into a Runnable which may just be the return type

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.NegotiatingServerConnection.CipherDiscriminator;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.Name;
 import org.slf4j.Logger;
@@ -167,9 +168,9 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         }
 
         @Override
-        public boolean onIdleTimeout(Stream stream, Throwable x)
+        public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
         {
-            return getConnection().onStreamTimeout(stream, x);
+            getConnection().onStreamTimeout(stream, x, promise);
         }
 
         private void close(Stream stream, String reason)

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -153,12 +153,16 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         HTTP2Channel.Server channel = (HTTP2Channel.Server)((HTTP2Stream)stream).getAttachment();
         if (channel != null)
         {
-            channel.onTimeout(failure, (task, b) ->
+            channel.onTimeout(failure, (task, timedOut) ->
             {
                 if (task != null)
                     offerTask(task, true);
-                promise.succeeded(b);
+                promise.succeeded(timedOut);
             });
+        }
+        else
+        {
+            promise.succeeded(false);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.HostPort;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.StringUtil;
 
 public class HTTP2ServerConnection extends HTTP2Connection implements ConnectionMetaData
@@ -145,13 +146,20 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         }
     }
 
-    public boolean onStreamTimeout(Stream stream, Throwable failure)
+    public void onStreamTimeout(Stream stream, Throwable failure, Promise<Boolean> promise)
     {
-        HTTP2Channel.Server channel = (HTTP2Channel.Server)((HTTP2Stream)stream).getAttachment();
-        boolean result = channel != null && channel.onTimeout(failure, task -> offerTask(task, true));
         if (LOG.isDebugEnabled())
-            LOG.debug("{} idle timeout on {}: {}", result ? "Processed" : "Ignored", stream, failure);
-        return result;
+            LOG.debug("Idle timeout on {}: {}", stream, failure);
+        HTTP2Channel.Server channel = (HTTP2Channel.Server)((HTTP2Stream)stream).getAttachment();
+        if (channel != null)
+        {
+            channel.onTimeout(failure, (task, b) ->
+            {
+                if (task != null)
+                    offerTask(task, true);
+                promise.succeeded(b);
+            });
+        }
     }
 
     public void onStreamFailure(Stream stream, Throwable failure, Callback callback)

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -14,7 +14,7 @@
 package org.eclipse.jetty.http2.server.internal;
 
 import java.nio.ByteBuffer;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.BadMessageException;
@@ -545,12 +545,11 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     }
 
     @Override
-    public boolean onTimeout(Throwable failure, Consumer<Runnable> consumer)
+    public void onTimeout(Throwable failure, BiConsumer<Runnable, Boolean> consumer)
     {
-        Runnable runnable = _httpChannel.onFailure(failure);
-        if (runnable != null)
-            consumer.accept(runnable);
-        return !_httpChannel.isRequestHandled();
+        Runnable task = _httpChannel.onFailure(failure);
+        boolean idle = !_httpChannel.isRequestHandled();
+        consumer.accept(task, idle);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/ServerHTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/ServerHTTP2StreamEndPoint.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.http2.server.internal;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.internal.HTTP2Channel;
@@ -48,7 +48,7 @@ public class ServerHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
     }
 
     @Override
-    public boolean onTimeout(Throwable failure, Consumer<Runnable> consumer)
+    public void onTimeout(Throwable failure, BiConsumer<Runnable, Boolean> consumer)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("idle timeout on {}: {}", this, failure);
@@ -56,12 +56,13 @@ public class ServerHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
         Connection connection = getConnection();
         if (connection != null)
             result = connection.onIdleExpired();
+        Runnable r = null;
         if (result)
         {
             processFailure(failure);
-            consumer.accept(() -> close(failure));
+            r = () -> close(failure);
         }
-        return result;
+        consumer.accept(r, result);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -388,11 +388,11 @@ public class IdleTimeoutTest extends AbstractTest
             }
 
             @Override
-            public boolean onIdleTimeout(Stream stream, Throwable x)
+            public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
             {
                 assertThat(x, Matchers.instanceOf(TimeoutException.class));
                 timeoutLatch.countDown();
-                return true;
+                promise.succeeded(true);
             }
         });
 
@@ -425,10 +425,10 @@ public class IdleTimeoutTest extends AbstractTest
                 return new Stream.Listener()
                 {
                     @Override
-                    public boolean onIdleTimeout(Stream stream, Throwable x)
+                    public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
                     {
                         timeoutLatch.countDown();
-                        return true;
+                        promise.succeeded(true);
                     }
                 };
             }
@@ -472,10 +472,10 @@ public class IdleTimeoutTest extends AbstractTest
                 return new Stream.Listener()
                 {
                     @Override
-                    public boolean onIdleTimeout(Stream stream, Throwable x)
+                    public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
                     {
                         timeoutLatch.countDown();
-                        return true;
+                        promise.succeeded(true);
                     }
                 };
             }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RawHTTP2ProxyTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RawHTTP2ProxyTest.java
@@ -521,12 +521,12 @@ public class RawHTTP2ProxyTest
         }
 
         @Override
-        public boolean onIdleTimeout(Stream stream, Throwable x)
+        public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
         {
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug("CPS idle timeout for {}", stream);
             // TODO: drain the queue for that stream, reset stream, and notify server.
-            return true;
+            promise.succeeded(true);
         }
     }
 
@@ -684,12 +684,12 @@ public class RawHTTP2ProxyTest
         }
 
         @Override
-        public boolean onIdleTimeout(Stream stream, Throwable x)
+        public void onIdleTimeout(Stream stream, Throwable x, Promise<Boolean> promise)
         {
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug("SPC idle timeout for {}", stream);
             // TODO:
-            return true;
+            promise.succeeded(true);
         }
 
         private void link(Stream proxyToServerStream, Stream clientToProxyStream)

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.internal.HTTP3ErrorCode;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,13 +160,13 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     }
 
     @Override
-    public boolean onIdleTimeout(Stream.Client stream, Throwable failure)
+    public void onIdleTimeout(Stream.Client stream, Throwable failure, Promise<Boolean> promise)
     {
         HttpExchange exchange = getHttpExchange();
-        if (exchange == null)
-            return false;
-
-        return !exchange.abort(failure);
+        if (exchange != null)
+            exchange.abort(failure, Promise.from(b -> promise.succeeded(!b), promise::failed));
+        else
+            promise.succeeded(false);
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -164,7 +164,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     {
         HttpExchange exchange = getHttpExchange();
         if (exchange != null)
-            exchange.abort(failure, Promise.from(b -> promise.succeeded(!b), promise::failed));
+            exchange.abort(failure, Promise.from(aborted -> promise.succeeded(!aborted), promise::failed));
         else
             promise.succeeded(false);
     }

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.internal.HTTP3Session;
 import org.eclipse.jetty.http3.internal.HTTP3Stream;
 import org.eclipse.jetty.quic.common.QuicStreamEndPoint;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,19 +111,20 @@ public class HTTP3StreamClient extends HTTP3Stream implements Stream.Client
     }
 
     @Override
-    protected boolean notifyIdleTimeout(TimeoutException timeout)
+    protected void notifyIdleTimeout(TimeoutException timeout, Promise<Boolean> promise)
     {
         Listener listener = getListener();
         try
         {
             if (listener != null)
-                return listener.onIdleTimeout(this, timeout);
-            return true;
+                listener.onIdleTimeout(this, timeout, promise);
+            else
+                promise.succeeded(true);
         }
         catch (Throwable x)
         {
             LOG.info("failure notifying listener {}", listener, x);
-            return true;
+            promise.failed(x);
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -226,7 +226,6 @@ public interface Stream
              * @param stream  the stream
              * @param failure the timeout failure
              * @param promise
-             * @return true to reset the stream, false to ignore the idle timeout
              */
             public default void onIdleTimeout(Client stream, Throwable failure, Promise<Boolean> promise)
             {
@@ -342,7 +341,6 @@ public interface Stream
              * @param stream  the stream
              * @param failure the timeout failure
              * @param promise
-             * @return true to reset the stream, false to ignore the idle timeout
              */
             public default void onIdleTimeout(Server stream, Throwable failure, Promise<Boolean> promise)
             {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.http3.frames.DataFrame;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.io.Retainable;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Promise;
 
 /**
  * <p>A {@link Stream} represents a bidirectional exchange of data within a {@link Session}.</p>
@@ -222,13 +223,14 @@ public interface Stream
             /**
              * <p>Callback method invoked when the stream idle timeout elapses.</p>
              *
-             * @param stream the stream
+             * @param stream  the stream
              * @param failure the timeout failure
+             * @param promise
              * @return true to reset the stream, false to ignore the idle timeout
              */
-            public default boolean onIdleTimeout(Stream.Client stream, Throwable failure)
+            public default void onIdleTimeout(Client stream, Throwable failure, Promise<Boolean> promise)
             {
-                return true;
+                promise.succeeded(true);
             }
 
             /**
@@ -337,13 +339,14 @@ public interface Stream
             /**
              * <p>Callback method invoked when the stream idle timeout elapses.</p>
              *
-             * @param stream the stream
+             * @param stream  the stream
              * @param failure the timeout failure
+             * @param promise
              * @return true to reset the stream, false to ignore the idle timeout
              */
-            public default boolean onIdleTimeout(Stream.Server stream, Throwable failure)
+            public default void onIdleTimeout(Server stream, Throwable failure, Promise<Boolean> promise)
             {
-                return true;
+                promise.succeeded(true);
             }
 
             /**

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -225,7 +225,8 @@ public interface Stream
              *
              * @param stream  the stream
              * @param failure the timeout failure
-             * @param promise
+             * @param promise the promise to complete with true to reset the stream,
+             *                false to ignore the idle timeout
              */
             public default void onIdleTimeout(Client stream, Throwable failure, Promise<Boolean> promise)
             {
@@ -340,7 +341,8 @@ public interface Stream
              *
              * @param stream  the stream
              * @param failure the timeout failure
-             * @param promise
+             * @param promise the promise to complete with true to reset the stream,
+             *                false to ignore the idle timeout
              */
             public default void onIdleTimeout(Server stream, Throwable failure, Promise<Boolean> promise)
             {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http3.server.internal.ServerHTTP3StreamConnection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,16 +142,17 @@ public class HTTP3ServerConnectionFactory extends AbstractHTTP3ServerConnectionF
         }
 
         @Override
-        public boolean onIdleTimeout(Stream.Server stream, Throwable failure)
+        public void onIdleTimeout(Stream.Server stream, Throwable failure, Promise<Boolean> promise)
         {
             HTTP3Stream http3Stream = (HTTP3Stream)stream;
-            return getConnection().onIdleTimeout((HTTP3Stream)stream, failure, task ->
+            getConnection().onIdleTimeout((HTTP3Stream)stream, failure, (task, timedOut) ->
             {
                 if (task != null)
                 {
                     ServerHTTP3Session protocolSession = (ServerHTTP3Session)http3Stream.getSession().getProtocolSession();
                     protocolSession.offer(task, true);
                 }
+                promise.succeeded(timedOut);
             });
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http3.internal.HTTP3Stream;
 import org.eclipse.jetty.http3.internal.MessageFlusher;
 import org.eclipse.jetty.quic.common.QuicStreamEndPoint;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,19 +108,20 @@ public class HTTP3StreamServer extends HTTP3Stream implements Stream.Server
     }
 
     @Override
-    protected boolean notifyIdleTimeout(TimeoutException timeout)
+    protected void notifyIdleTimeout(TimeoutException timeout, Promise<Boolean> promise)
     {
         Listener listener = this.listener;
         try
         {
             if (listener != null)
-                return listener.onIdleTimeout(this, timeout);
-            return true;
+                listener.onIdleTimeout(this, timeout, promise);
+            else
+                promise.succeeded(true);
         }
         catch (Throwable x)
         {
             LOG.info("failure notifying listener {}", listener, x);
-            return true;
+            promise.failed(x);
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -16,7 +16,7 @@ package org.eclipse.jetty.http3.server.internal;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.BadMessageException;
@@ -503,12 +503,11 @@ public class HttpStreamOverHTTP3 implements HttpStream
         stream.reset(HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), x);
     }
 
-    public boolean onIdleTimeout(Throwable failure, Consumer<Runnable> consumer)
+    public void onIdleTimeout(Throwable failure, BiConsumer<Runnable, Boolean> consumer)
     {
         Runnable runnable = httpChannel.onFailure(failure);
-        if (runnable != null)
-            consumer.accept(runnable);
-        return !httpChannel.isRequestHandled();
+        boolean idle = !httpChannel.isRequestHandled();
+        consumer.accept(runnable, idle);
     }
 
     public Runnable onFailure(Throwable failure)

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
@@ -16,7 +16,7 @@ package org.eclipse.jetty.http3.server.internal;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
@@ -69,10 +69,10 @@ public class ServerHTTP3StreamConnection extends HTTP3StreamConnection implement
         return httpStream.onTrailer(frame);
     }
 
-    public boolean onIdleTimeout(HTTP3Stream stream, Throwable failure, Consumer<Runnable> consumer)
+    public void onIdleTimeout(HTTP3Stream stream, Throwable failure, BiConsumer<Runnable, Boolean> consumer)
     {
         HttpStreamOverHTTP3 httpStream = (HttpStreamOverHTTP3)stream.getAttachment();
-        return httpStream.onIdleTimeout(failure, consumer);
+        httpStream.onIdleTimeout(failure, consumer);
     }
 
     public Runnable onFailure(HTTP3Stream stream, Throwable failure)

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/StreamIdleTimeoutTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/StreamIdleTimeoutTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http3.api.Session;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.server.AbstractHTTP3ServerConnectionFactory;
+import org.eclipse.jetty.util.Promise;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
@@ -83,11 +84,11 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
         clientSession.newRequest(new HeadersFrame(newRequest("/idle"), false), new Stream.Client.Listener()
         {
             @Override
-            public boolean onIdleTimeout(Stream.Client stream, Throwable failure)
+            public void onIdleTimeout(Stream.Client stream, Throwable failure, Promise<Boolean> promise)
             {
                 clientIdleLatch.countDown();
                 // Signal to close the stream.
-                return true;
+                promise.succeeded(true);
             }
         }).get(5, TimeUnit.SECONDS);
 
@@ -138,10 +139,10 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
                     return new Stream.Server.Listener()
                     {
                         @Override
-                        public boolean onIdleTimeout(Stream.Server stream, Throwable failure)
+                        public void onIdleTimeout(Stream.Server stream, Throwable failure, Promise<Boolean> promise)
                         {
                             serverIdleLatch.countDown();
-                            return true;
+                            promise.succeeded(true);
                         }
                     };
                 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Promise.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Promise.java
@@ -26,6 +26,16 @@ import org.slf4j.LoggerFactory;
  */
 public interface Promise<C>
 {
+    Promise<Object> NOOP = new Promise<>()
+    {
+    };
+
+    @SuppressWarnings("unchecked")
+    static <T> Promise<T> noop()
+    {
+        return (Promise<T>)NOOP;
+    }
+
     /**
      * <p>Callback invoked when the operation completes.</p>
      *
@@ -43,6 +53,24 @@ public interface Promise<C>
      */
     default void failed(Throwable x)
     {
+    }
+
+    /**
+     * <p>Completes this promise with the given {@link CompletableFuture}.</p>
+     * <p>When the CompletableFuture completes normally, this promise is succeeded;
+     * when the CompletableFuture completes exceptionally, this promise is failed.</p>
+     *
+     * @param completable the CompletableFuture that completes this promise
+     */
+    default void completeWith(CompletableFuture<C> completable)
+    {
+        completable.whenComplete((o, x) ->
+        {
+            if (x == null)
+                succeeded(o);
+            else
+                failed(x);
+        });
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
@@ -638,12 +638,15 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected void onClientRequestFailure(HttpServletRequest clientRequest, Request proxyRequest, HttpServletResponse proxyResponse, Throwable failure)
     {
-        boolean aborted = proxyRequest.abort(failure);
-        if (!aborted)
+        proxyRequest.abort(failure).whenComplete((aborted, x) ->
         {
-            int status = clientRequestStatus(failure);
-            sendProxyResponseError(clientRequest, proxyResponse, status);
-        }
+            // The variable 'aborted' could be null.
+            if (aborted == Boolean.FALSE)
+            {
+                int status = clientRequestStatus(failure);
+                sendProxyResponseError(clientRequest, proxyResponse, status);
+            }
+        });
     }
 
     protected int clientRequestStatus(Throwable failure)

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
@@ -638,12 +638,15 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected void onClientRequestFailure(HttpServletRequest clientRequest, Request proxyRequest, HttpServletResponse proxyResponse, Throwable failure)
     {
-        boolean aborted = proxyRequest.abort(failure);
-        if (!aborted)
+        proxyRequest.abort(failure).whenComplete((aborted, x) ->
         {
-            int status = clientRequestStatus(failure);
-            sendProxyResponseError(clientRequest, proxyResponse, status);
-        }
+            // The variable 'aborted' could be null.
+            if (aborted == Boolean.FALSE)
+            {
+                int status = clientRequestStatus(failure);
+                sendProxyResponseError(clientRequest, proxyResponse, status);
+            }
+        });
     }
 
     protected int clientRequestStatus(Throwable failure)


### PR DESCRIPTION
The client's `Request` and `Response` interfaces contain the following method:
```java
boolean abort(Throwable cause);
```
The contract of that `abort()` method is to asynchronously notify a running request that it has to be aborted.

That `abort()` method is meant to run concurrently with the servicing of the request, meaning that the request may be aborted, or it may finish before the abort takes effect, and some actions must happen depending on the outcome of this race condition: either `abort()` won the race and -for instance in H2- a reset needs to be sent, or `abort()` lost the race and it basically must be treated as a no-op.

The problem of the current method signature is that it returns a boolean that is returned immediately while that boolean is supposed to be computed during the async execution. This has hard implications on how `abort()` can be implemented, and prevents some refactorings of the client's internals.

The solution is to change the contract such as the `boolean` is delivered asynchronously:
```java
CompletableFuture<Boolean> abort(Throwable cause);
```
