### PR TITLE
Jetty 12.0.x client serialized events

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpExchange.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpExchange.java
@@ -170,6 +170,14 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         return false;
     }
 
+    public boolean isResponseComplete()
+    {
+        try (AutoLock l = lock.lock())
+        {
+            return responseState == State.COMPLETED;
+        }
+    }
+
     public boolean responseComplete(Throwable failure)
     {
         try (AutoLock l = lock.lock())

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpReceiver.java
@@ -16,29 +16,22 @@ package org.eclipse.jetty.client;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.LongConsumer;
-import java.util.function.LongUnaryOperator;
 
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.content.ContentSourceTransformer;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.MathUtils;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.component.Destroyable;
-import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.util.thread.SerializedInvoker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +47,7 @@ import org.slf4j.LoggerFactory;
  * is available</li>
  * <li>{@link #responseHeader(HttpExchange, HttpField)}, when an HTTP field is available</li>
  * <li>{@link #responseHeaders(HttpExchange)}, when all HTTP headers are available</li>
- * <li>{@link #responseContent(HttpExchange, ByteBuffer, Callback)}, when HTTP content is available</li>
- * <li>{@link #responseSuccess(HttpExchange)}, when the response is successful</li>
+ * <li>{@link #responseSuccess(HttpExchange, Runnable)}, when the response is successful</li>
  * </ol>
  * At any time, subclasses may invoke {@link #responseFailure(Throwable, Promise)} to indicate that the response has failed
  * (for example, because of I/O exceptions).
@@ -71,72 +63,45 @@ public abstract class HttpReceiver
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpReceiver.class);
 
-    private final AutoLock lock = new AutoLock();
-    private final AtomicReference<ResponseState> responseState = new AtomicReference<>(ResponseState.IDLE);
-    private final ContentListeners contentListeners = new ContentListeners();
+    private final SerializedInvoker invoker = new SerializedInvoker();
     private final HttpChannel channel;
-    private Decoder decoder;
+    private ResponseState responseState = ResponseState.IDLE;
+    private NotifiableContentSource contentSource;
     private Throwable failure;
-    private long demand;
-    private boolean stalled;
 
     protected HttpReceiver(HttpChannel channel)
     {
         this.channel = channel;
     }
 
+    /**
+     * Reads a chunk of data.
+     * <p>
+     * If no data was read, {@code null} is returned and if {@code fillInterestIfNeeded}
+     * is {@code true} then fill interest is registered.
+     * <p>
+     * The returned chunk of data may be the last one or an error exactly like
+     * {@link Content.Source#read()} specifies.
+     *
+     * @param fillInterestIfNeeded true to register for fill interest when no data was read.
+     * @return the chunk of data that was read, or {@code null} if nothing was read.
+     */
+    protected abstract Content.Chunk read(boolean fillInterestIfNeeded);
+
+    /**
+     * Prepare for the next step after an interim response was read.
+     */
+    protected abstract void onInterim();
+
+    /**
+     * Fails the receiver and closes the underlying stream.
+     * @param failure the failure.
+     */
+    protected abstract void failAndClose(Throwable failure);
+
     protected HttpChannel getHttpChannel()
     {
         return channel;
-    }
-
-    void demand(long n)
-    {
-        if (n <= 0)
-            throw new IllegalArgumentException("Invalid demand " + n);
-
-        boolean resume = false;
-        try (AutoLock ignored = lock.lock())
-        {
-            demand = MathUtils.cappedAdd(demand, n);
-            if (stalled)
-            {
-                stalled = false;
-                resume = true;
-            }
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response demand={}/{}, resume={} on {}", n, demand, resume, this);
-        }
-
-        if (resume)
-        {
-            if (decoder != null)
-                decoder.resume();
-            else
-                receive();
-        }
-    }
-
-    protected long demand()
-    {
-        return demand(LongUnaryOperator.identity());
-    }
-
-    private long demand(LongUnaryOperator operator)
-    {
-        try (AutoLock ignored = lock.lock())
-        {
-            return demand = operator.applyAsLong(demand);
-        }
-    }
-
-    protected boolean hasDemandOrStall()
-    {
-        try (AutoLock ignored = lock.lock())
-        {
-            stalled = demand <= 0;
-            return !stalled;
-        }
     }
 
     protected HttpExchange getHttpExchange()
@@ -151,11 +116,12 @@ public abstract class HttpReceiver
 
     public boolean isFailed()
     {
-        return responseState.get() == ResponseState.FAILURE;
+        return responseState == ResponseState.FAILURE;
     }
 
-    protected void receive()
+    protected boolean hasContent()
     {
+        return contentSource != null;
     }
 
     /**
@@ -167,39 +133,40 @@ public abstract class HttpReceiver
      * This method takes case of notifying {@link org.eclipse.jetty.client.api.Response.BeginListener}s.
      *
      * @param exchange the HTTP exchange
-     * @return whether the processing should continue
      */
-    protected boolean responseBegin(HttpExchange exchange)
+    protected void responseBegin(HttpExchange exchange)
     {
-        if (!updateResponseState(ResponseState.IDLE, ResponseState.TRANSIENT))
-            return false;
-
-        HttpConversation conversation = exchange.getConversation();
-        HttpResponse response = exchange.getResponse();
-        // Probe the protocol handlers
-        HttpDestination destination = getHttpDestination();
-        HttpClient client = destination.getHttpClient();
-        ProtocolHandler protocolHandler = client.findProtocolHandler(exchange.getRequest(), response);
-        Response.Listener handlerListener = null;
-        if (protocolHandler != null)
-        {
-            handlerListener = protocolHandler.getResponseListener();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response {} found protocol handler {}", response, protocolHandler);
-        }
-        exchange.getConversation().updateResponseListeners(handlerListener);
-
         if (LOG.isDebugEnabled())
-            LOG.debug("Response begin {}", response);
-        ResponseNotifier notifier = destination.getResponseNotifier();
-        notifier.notifyBegin(conversation.getResponseListeners(), response);
+            LOG.debug("Invoking responseBegin for {} on {}", exchange, this);
 
-        if (updateResponseState(ResponseState.TRANSIENT, ResponseState.BEGIN))
-            return true;
+        invoker.run(() ->
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing responseBegin for {} on {}", exchange, this);
 
-        dispose();
-        terminateResponse(exchange);
-        return false;
+            if (exchange.isResponseComplete())
+                return;
+            responseState = ResponseState.BEGIN;
+            HttpConversation conversation = exchange.getConversation();
+            HttpResponse response = exchange.getResponse();
+            // Probe the protocol handlers
+            HttpDestination destination = getHttpDestination();
+            HttpClient client = destination.getHttpClient();
+            ProtocolHandler protocolHandler = client.findProtocolHandler(exchange.getRequest(), response);
+            Response.Listener handlerListener = null;
+            if (protocolHandler != null)
+            {
+                handlerListener = protocolHandler.getResponseListener();
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Response {} found protocol handler {}", response, protocolHandler);
+            }
+            exchange.getConversation().updateResponseListeners(handlerListener);
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Response begin {}", response);
+            ResponseNotifier notifier = destination.getResponseNotifier();
+            notifier.notifyBegin(conversation.getResponseListeners(), response);
+        });
     }
 
     /**
@@ -211,41 +178,46 @@ public abstract class HttpReceiver
      * This method takes case of notifying {@link org.eclipse.jetty.client.api.Response.HeaderListener}s and storing cookies.
      *
      * @param exchange the HTTP exchange
-     * @param field the response HTTP field
-     * @return whether the processing should continue
+     * @param field    the response HTTP field
      */
-    protected boolean responseHeader(HttpExchange exchange, HttpField field)
+    protected void responseHeader(HttpExchange exchange, HttpField field)
     {
-        if (!updateResponseState(ResponseState.BEGIN, ResponseState.HEADER, ResponseState.TRANSIENT))
-            return false;
+        if (LOG.isDebugEnabled())
+            LOG.debug("Invoking responseHeader for {} on {}", field, this);
 
-        HttpResponse response = exchange.getResponse();
-        ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-        boolean process = notifier.notifyHeader(exchange.getConversation().getResponseListeners(), response, field);
-        if (process)
+        invoker.run(() ->
         {
-            response.addHeader(field);
-            HttpHeader fieldHeader = field.getHeader();
-            if (fieldHeader != null)
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing responseHeader on {}", this);
+
+            if (exchange.isResponseComplete())
+                return;
+            responseState = ResponseState.HEADER;
+            HttpResponse response = exchange.getResponse();
+            ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Notifying header {}", field);
+            boolean process = notifier.notifyHeader(exchange.getConversation().getResponseListeners(), response, field);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Header {} notified, {}processing needed", field, (process ? "" : "no "));
+            if (process)
             {
-                switch (fieldHeader)
+                response.addHeader(field);
+                HttpHeader fieldHeader = field.getHeader();
+                if (fieldHeader != null)
                 {
-                    case SET_COOKIE, SET_COOKIE2 ->
+                    switch (fieldHeader)
                     {
-                        URI uri = exchange.getRequest().getURI();
-                        if (uri != null)
-                            storeCookie(uri, field);
+                        case SET_COOKIE, SET_COOKIE2 ->
+                        {
+                            URI uri = exchange.getRequest().getURI();
+                            if (uri != null)
+                                storeCookie(uri, field);
+                        }
                     }
                 }
             }
-        }
-
-        if (updateResponseState(ResponseState.TRANSIENT, ResponseState.HEADER))
-            return true;
-
-        dispose();
-        terminateResponse(exchange);
-        return false;
+        });
     }
 
     protected void storeCookie(URI uri, HttpField field)
@@ -270,151 +242,137 @@ public abstract class HttpReceiver
     /**
      * Method to be invoked after all response HTTP headers are available.
      * <p>
-     * This method takes case of notifying {@link org.eclipse.jetty.client.api.Response.HeadersListener}s.
+     * This method takes care of notifying {@link org.eclipse.jetty.client.api.Response.HeadersListener}s.
      *
      * @param exchange the HTTP exchange
-     * @return whether the processing should continue
      */
-    protected boolean responseHeaders(HttpExchange exchange)
+    protected void responseHeaders(HttpExchange exchange)
     {
-        if (!updateResponseState(ResponseState.BEGIN, ResponseState.HEADER, ResponseState.TRANSIENT))
-            return false;
-
-        HttpResponse response = exchange.getResponse();
         if (LOG.isDebugEnabled())
-            LOG.debug("Response headers {}{}{}", response, System.lineSeparator(), response.getHeaders().toString().trim());
-        ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-        List<Response.ResponseListener> responseListeners = exchange.getConversation().getResponseListeners();
-        notifier.notifyHeaders(responseListeners, response);
-        contentListeners.reset(responseListeners);
-        contentListeners.notifyBeforeContent(response);
+            LOG.debug("Invoking responseHeaders on {}", this);
 
-        if (!contentListeners.isEmpty())
+        invoker.run(() ->
         {
-            List<String> contentEncodings = response.getHeaders().getCSV(HttpHeader.CONTENT_ENCODING.asString(), false);
-            if (contentEncodings != null && !contentEncodings.isEmpty())
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing responseHeaders on {}", this);
+
+            if (exchange.isResponseComplete())
+                return;
+            responseState = ResponseState.HEADERS;
+            HttpResponse response = exchange.getResponse();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Response headers {}{}{}", response, System.lineSeparator(), response.getHeaders().toString().trim());
+            ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
+            List<Response.ResponseListener> responseListeners = exchange.getConversation().getResponseListeners();
+            notifier.notifyHeaders(responseListeners, response);
+
+            if (HttpStatus.isInterim(response.getStatus()))
             {
-                for (ContentDecoder.Factory factory : getHttpDestination().getHttpClient().getContentDecoderFactories())
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Interim response status {}, succeeding", response.getStatus());
+                responseSuccess(exchange, this::onInterim);
+                return;
+            }
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Switching to CONTENT state for {} on {}", response, this);
+            responseState = ResponseState.CONTENT;
+            if (contentSource != null)
+                throw new IllegalStateException();
+            contentSource = new ContentSource();
+
+            List<Response.ContentSourceListener> contentListeners = responseListeners.stream()
+                    .filter(l -> l instanceof Response.ContentSourceListener)
+                    .map(Response.ContentSourceListener.class::cast)
+                    .toList();
+
+            if (!contentListeners.isEmpty())
+            {
+                List<String> contentEncodings = response.getHeaders().getCSV(HttpHeader.CONTENT_ENCODING.asString(), false);
+                if (contentEncodings != null && !contentEncodings.isEmpty())
                 {
-                    for (String encoding : contentEncodings)
+                    both:
+                    for (ContentDecoder.Factory factory : getHttpDestination().getHttpClient().getContentDecoderFactories())
                     {
-                        if (factory.getEncoding().equalsIgnoreCase(encoding))
+                        for (String encoding : contentEncodings)
                         {
-                            decoder = new Decoder(exchange, factory.newContentDecoder());
-                            break;
+                            if (factory.getEncoding().equalsIgnoreCase(encoding))
+                            {
+                                contentSource = new DecodingContentSource(contentSource, factory.newContentDecoder());
+                                break both;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        if (updateResponseState(ResponseState.TRANSIENT, ResponseState.HEADERS))
-        {
-            boolean hasDemand = hasDemandOrStall();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response headers hasDemand={} {}", hasDemand, response);
-            return hasDemand;
-        }
-
-        dispose();
-        terminateResponse(exchange);
-        return false;
+            notifier.notifyContent(response, contentSource, contentListeners);
+        });
     }
 
     /**
-     * Method to be invoked when response HTTP content is available.
+     * Method to be invoked when response content is available to be read.
      * <p>
-     * This method takes case of decoding the content, if necessary, and notifying {@link org.eclipse.jetty.client.api.Response.ContentListener}s.
-     *
-     * @param exchange the HTTP exchange
-     * @param buffer the response HTTP content buffer
-     * @param callback the callback
-     * @return whether the processing should continue
+     * This method takes care of ensuring the {@link Content.Source} passed to
+     * {@link Response.ContentSourceListener#onContentSource(Response, Content.Source)} calls the
+     * demand callback.
      */
-    protected boolean responseContent(HttpExchange exchange, ByteBuffer buffer, Callback callback)
+    protected void responseContentAvailable()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Response content {}{}{}", exchange.getResponse(), System.lineSeparator(), BufferUtil.toDetailString(buffer));
-        if (demand() <= 0)
-        {
-            callback.failed(new IllegalStateException("No demand for response content"));
-            return false;
-        }
-        if (decoder == null)
-            return plainResponseContent(exchange, buffer, callback);
-        else
-            return decodeResponseContent(buffer, callback);
-    }
-
-    private boolean plainResponseContent(HttpExchange exchange, ByteBuffer buffer, Callback callback)
-    {
-        if (!updateResponseState(ResponseState.HEADERS, ResponseState.CONTENT, ResponseState.TRANSIENT))
-        {
-            callback.failed(new IllegalStateException("Invalid response state " + responseState));
-            return false;
-        }
-
-        HttpResponse response = exchange.getResponse();
-        if (contentListeners.isEmpty())
-            callback.succeeded();
-        else
-            contentListeners.notifyContent(response, buffer, callback);
-
-        if (updateResponseState(ResponseState.TRANSIENT, ResponseState.CONTENT))
-        {
-            boolean hasDemand = hasDemandOrStall();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response content {}, hasDemand={}", response, hasDemand);
-            return hasDemand;
-        }
-
-        dispose();
-        terminateResponse(exchange);
-        return false;
-    }
-
-    private boolean decodeResponseContent(ByteBuffer buffer, Callback callback)
-    {
-        return decoder.decode(buffer, callback);
+            LOG.debug("Response content available on {}", this);
+        contentSource.onDataAvailable();
     }
 
     /**
      * Method to be invoked when the response is successful.
      * <p>
-     * This method takes case of notifying {@link org.eclipse.jetty.client.api.Response.SuccessListener}s and possibly
+     * This method takes care of notifying {@link org.eclipse.jetty.client.api.Response.SuccessListener}s and possibly
      * {@link org.eclipse.jetty.client.api.Response.CompleteListener}s (if the exchange is completed).
      *
      * @param exchange the HTTP exchange
-     * @return whether the response was processed as successful
+     * @param afterSuccessTask an optional task to invoke afterwards
      */
-    protected boolean responseSuccess(HttpExchange exchange)
+    protected void responseSuccess(HttpExchange exchange, Runnable afterSuccessTask)
     {
-        // Mark atomically the response as completed, with respect
-        // to concurrency between response success and response failure.
-        if (!exchange.responseComplete(null))
-            return false;
-
-        responseState.set(ResponseState.IDLE);
-
-        // Reset to be ready for another response.
-        reset();
-
-        HttpResponse response = exchange.getResponse();
         if (LOG.isDebugEnabled())
-            LOG.debug("Response success {}", response);
-        List<Response.ResponseListener> listeners = exchange.getConversation().getResponseListeners();
-        ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-        notifier.notifySuccess(listeners, response);
+            LOG.debug("Invoking responseSuccess on {}", this);
 
-        // Interim responses do not terminate the exchange.
-        if (HttpStatus.isInterim(exchange.getResponse().getStatus()))
-            return true;
+        NotifiableContentSource contentSource = this.contentSource;
+        if (contentSource != null)
+        {
+            this.contentSource = null;
+            contentSource.eof();
+        }
 
-        // Mark atomically the response as terminated, with
-        // respect to concurrency between request and response.
-        terminateResponse(exchange);
+        invoker.run(() ->
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing responseSuccess on {}", this);
 
-        return true;
+            // Mark atomically the response as completed, with respect
+            // to concurrency between response success and response failure.
+            if (!exchange.responseComplete(null))
+                return;
+
+            responseState = ResponseState.IDLE;
+            reset();
+
+            HttpResponse response = exchange.getResponse();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Response success {}", response);
+            List<Response.ResponseListener> listeners = exchange.getConversation().getResponseListeners();
+            ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
+            notifier.notifySuccess(listeners, response);
+
+            // Interim responses do not terminate the exchange.
+            if (HttpStatus.isInterim(exchange.getResponse().getStatus()))
+                return;
+
+            // Mark atomically the response as terminated, with
+            // respect to concurrency between request and response.
+            terminateResponse(exchange);
+        }, afterSuccessTask);
     }
 
     /**
@@ -423,30 +381,38 @@ public abstract class HttpReceiver
      * This method takes care of notifying {@link org.eclipse.jetty.client.api.Response.FailureListener}s.
      *
      * @param failure the response failure
-     * @param promise the promise to complete with true if the response was processed as failed, false otherwise
      */
     protected void responseFailure(Throwable failure, Promise<Boolean> promise)
     {
-        HttpExchange exchange = getHttpExchange();
-        // In case of a response error, the failure has already been notified
-        // and it is possible that a further attempt to read in the receive
-        // loop throws an exception that reenters here but without exchange;
-        // or, the server could just have timed out the connection.
-        if (exchange == null)
-        {
-            promise.succeeded(false);
-            return;
-        }
-
         if (LOG.isDebugEnabled())
-            LOG.debug("Response failure {}", exchange.getResponse(), failure);
+            LOG.debug("Invoking responseFailure with {} on {}", failure, this);
 
-        // Mark atomically the response as completed, with respect
-        // to concurrency between response success and response failure.
-        if (exchange.responseComplete(failure))
-            abort(exchange, failure, promise);
-        else
-            promise.succeeded(false);
+        invoker.run(() ->
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing responseFailure on {}", this);
+
+            HttpExchange exchange = getHttpExchange();
+            // In case of a response error, the failure has already been notified
+            // and it is possible that a further attempt to read in the receive
+            // loop throws an exception that reenters here but without exchange;
+            // or, the server could just have timed out the connection.
+            if (exchange == null)
+            {
+                promise.succeeded(false);
+                return;
+            }
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Response failure {}", exchange.getResponse(), failure);
+
+            // Mark atomically the response as completed, with respect
+            // to concurrency between response success and response failure.
+            if (exchange.responseComplete(failure))
+                abort(exchange, failure, promise);
+            else
+                promise.succeeded(false);
+        });
     }
 
     private void terminateResponse(HttpExchange exchange)
@@ -487,6 +453,8 @@ public abstract class HttpReceiver
      */
     protected void reset()
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Resetting {}", this);
         cleanup();
     }
 
@@ -499,116 +467,61 @@ public abstract class HttpReceiver
      */
     protected void dispose()
     {
-        assert responseState.get() != ResponseState.TRANSIENT;
+        if (LOG.isDebugEnabled())
+            LOG.debug("Disposing {}", this);
         cleanup();
     }
 
     private void cleanup()
     {
-        contentListeners.clear();
-        if (decoder != null)
-            decoder.destroy();
-        decoder = null;
-        demand = 0;
-        stalled = false;
+        contentSource = null;
     }
 
     public void abort(HttpExchange exchange, Throwable failure, Promise<Boolean> promise)
     {
-        // Update the state to avoid more response processing.
-        boolean terminate;
-        while (true)
+        if (LOG.isDebugEnabled())
+            LOG.debug("Invoking abort with {} on {}", failure, this);
+
+        invoker.run(() ->
         {
-            ResponseState current = responseState.get();
-            if (current == ResponseState.FAILURE)
+            if (LOG.isDebugEnabled())
+                LOG.debug("Executing abort on {}", this);
+
+            if (responseState == ResponseState.FAILURE)
             {
                 promise.succeeded(false);
                 return;
             }
-            if (updateResponseState(current, ResponseState.FAILURE))
-            {
-                terminate = current != ResponseState.TRANSIENT;
-                break;
-            }
-        }
 
-        this.failure = failure;
-
-        if (terminate)
+            responseState = ResponseState.FAILURE;
+            this.failure = failure;
+            if (contentSource != null)
+                contentSource.fail(failure);
             dispose();
 
-        HttpResponse response = exchange.getResponse();
-        if (LOG.isDebugEnabled())
-            LOG.debug("Response abort {} {} on {}: {}", response, exchange, getHttpChannel(), failure);
-        List<Response.ResponseListener> listeners = exchange.getConversation().getResponseListeners();
-        ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-        notifier.notifyFailure(listeners, response, failure);
+            HttpResponse response = exchange.getResponse();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Response abort {} {} on {}: {}", response, exchange, getHttpChannel(), failure);
+            List<Response.ResponseListener> listeners = exchange.getConversation().getResponseListeners();
+            ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
+            notifier.notifyFailure(listeners, response, failure);
 
-        // We want to deliver the "complete" event as last,
-        // so we emit it here only if no event handlers are
-        // executing, otherwise they will emit it.
-        if (terminate)
-        {
             // Mark atomically the response as terminated, with
             // respect to concurrency between request and response.
             terminateResponse(exchange);
             promise.succeeded(true);
-        }
-        else
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Concurrent failure: response termination skipped, performed by helpers");
-            promise.succeeded(false);
-        }
-    }
-
-    private boolean updateResponseState(ResponseState from1, ResponseState from2, ResponseState to)
-    {
-        while (true)
-        {
-            ResponseState current = responseState.get();
-            if (current == from1 || current == from2)
-            {
-                if (updateResponseState(current, to))
-                    return true;
-            }
-            else
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("State update failed: [{},{}] -> {}: {}", from1, from2, to, current);
-                return false;
-            }
-        }
-    }
-
-    private boolean updateResponseState(ResponseState from, ResponseState to)
-    {
-        while (true)
-        {
-            ResponseState current = responseState.get();
-            if (current == from)
-            {
-                if (responseState.compareAndSet(current, to))
-                    return true;
-            }
-            else
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("State update failed: {} -> {}: {}", from, to, current);
-                return false;
-            }
-        }
+        });
     }
 
     @Override
     public String toString()
     {
-        return String.format("%s@%x(rsp=%s,demand=%d,failure=%s)",
-            getClass().getSimpleName(),
-            hashCode(),
-            responseState,
-            demand(),
-            failure);
+        return String.format("%s@%x(ex=%s,rsp=%s,failure=%s)",
+                getClass().getSimpleName(),
+                hashCode(),
+                getHttpExchange(),
+                responseState,
+                failure);
     }
 
     /**
@@ -616,10 +529,6 @@ public abstract class HttpReceiver
      */
     private enum ResponseState
     {
-        /**
-         * One of the response*() methods is being executed.
-         */
-        TRANSIENT,
         /**
          * The response is not yet received, the initial state
          */
@@ -646,237 +555,230 @@ public abstract class HttpReceiver
         FAILURE
     }
 
-    /**
-     * <p>Wraps a list of content listeners, notifies them about content events and
-     * tracks individual listener demand to produce a global demand for content.</p>
-     */
-    private class ContentListeners
+    private interface NotifiableContentSource extends Content.Source
     {
-        private final Map<Object, Long> demands = new ConcurrentHashMap<>();
-        private final LongConsumer demand = HttpReceiver.this::demand;
-        private final List<Response.DemandedContentListener> listeners = new ArrayList<>(2);
+        void eof();
 
-        private void clear()
-        {
-            demands.clear();
-            listeners.clear();
-        }
-
-        private void reset(List<Response.ResponseListener> responseListeners)
-        {
-            clear();
-            for (Response.ResponseListener listener : responseListeners)
-            {
-                if (listener instanceof Response.DemandedContentListener)
-                    listeners.add((Response.DemandedContentListener)listener);
-            }
-        }
-
-        private boolean isEmpty()
-        {
-            return listeners.isEmpty();
-        }
-
-        private void notifyBeforeContent(HttpResponse response)
-        {
-            if (isEmpty())
-            {
-                // If no listeners, we want to proceed and consume any content.
-                demand.accept(1);
-            }
-            else
-            {
-                ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-                notifier.notifyBeforeContent(response, this::demand, listeners);
-            }
-        }
-
-        private void notifyContent(HttpResponse response, ByteBuffer buffer, Callback callback)
-        {
-            HttpReceiver.this.demand(d -> d - 1);
-            ResponseNotifier notifier = getHttpDestination().getResponseNotifier();
-            notifier.notifyContent(response, this::demand, buffer, callback, listeners);
-        }
-
-        private void demand(Object context, long value)
-        {
-            if (listeners.size() > 1)
-                accept(context, value);
-            else
-                demand.accept(value);
-        }
-
-        private void accept(Object context, long value)
-        {
-            // Increment the demand for the given listener.
-            demands.merge(context, value, MathUtils::cappedAdd);
-
-            // Check if we have demand from all listeners.
-            if (demands.size() == listeners.size())
-            {
-                long minDemand = Long.MAX_VALUE;
-                for (Long demand : demands.values())
-                {
-                    if (demand < minDemand)
-                        minDemand = demand;
-                }
-                if (minDemand > 0)
-                {
-                    // We are going to demand for minDemand content
-                    // chunks, so decrement the listener's demand by
-                    // minDemand and remove those that have no demand left.
-                    Iterator<Map.Entry<Object, Long>> iterator = demands.entrySet().iterator();
-                    while (iterator.hasNext())
-                    {
-                        Map.Entry<Object, Long> entry = iterator.next();
-                        long newValue = entry.getValue() - minDemand;
-                        if (newValue == 0)
-                            iterator.remove();
-                        else
-                            entry.setValue(newValue);
-                    }
-
-                    // Demand more content chunks for all the listeners.
-                    demand.accept(minDemand);
-                }
-            }
-        }
+        void onDataAvailable();
     }
 
-    /**
-     * <p>Implements the decoding of content, producing decoded buffers only if there is demand for content.</p>
-     */
-    private class Decoder implements Destroyable
+    private static class DecodingContentSource extends ContentSourceTransformer implements NotifiableContentSource
     {
-        private final HttpExchange exchange;
-        private final ContentDecoder decoder;
-        private ByteBuffer encoded;
-        private Callback callback;
+        private static final Logger LOG = LoggerFactory.getLogger(DecodingContentSource.class);
 
-        private Decoder(HttpExchange exchange, ContentDecoder decoder)
+        private final NotifiableContentSource _rawSource;
+        private final ContentDecoder _decoder;
+        private Content.Chunk _chunk;
+
+        public DecodingContentSource(NotifiableContentSource rawSource, ContentDecoder decoder)
         {
-            this.exchange = exchange;
-            this.decoder = Objects.requireNonNull(decoder);
-        }
-
-        private boolean decode(ByteBuffer encoded, Callback callback)
-        {
-            // Store the buffer to decode in case the
-            // decoding produces multiple decoded buffers.
-            this.encoded = encoded;
-            this.callback = callback;
-
-            HttpResponse response = exchange.getResponse();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response content decoding {} with {}{}{}", response, decoder, System.lineSeparator(), BufferUtil.toDetailString(encoded));
-
-            boolean needInput = decode();
-            if (!needInput)
-                return false;
-
-            boolean hasDemand = hasDemandOrStall();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response content decoded, hasDemand={} {}", hasDemand, response);
-            return hasDemand;
-        }
-
-        private boolean decode()
-        {
-            while (true)
-            {
-                if (!updateResponseState(ResponseState.HEADERS, ResponseState.CONTENT, ResponseState.TRANSIENT))
-                {
-                    callback.failed(new IllegalStateException("Invalid response state " + responseState));
-                    return false;
-                }
-
-                DecodeResult result = decodeChunk();
-
-                if (updateResponseState(ResponseState.TRANSIENT, ResponseState.CONTENT))
-                {
-                    if (result == DecodeResult.NEED_INPUT)
-                        return true;
-                    if (result == DecodeResult.ABORT)
-                        return false;
-
-                    boolean hasDemand = hasDemandOrStall();
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Response content decoded chunk, hasDemand={} {}", hasDemand, exchange.getResponse());
-                    if (hasDemand)
-                        continue;
-                    else
-                        return false;
-                }
-
-                dispose();
-                terminateResponse(exchange);
-                return false;
-            }
-        }
-
-        private DecodeResult decodeChunk()
-        {
-            try
-            {
-                ByteBuffer buffer;
-                while (true)
-                {
-                    buffer = decoder.decode(encoded);
-                    if (buffer.hasRemaining())
-                        break;
-                    if (!encoded.hasRemaining())
-                    {
-                        callback.succeeded();
-                        encoded = null;
-                        callback = null;
-                        return DecodeResult.NEED_INPUT;
-                    }
-                }
-
-                ByteBuffer decoded = buffer;
-                HttpResponse response = exchange.getResponse();
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Response content decoded chunk {}{}{}", response, System.lineSeparator(), BufferUtil.toDetailString(decoded));
-
-                contentListeners.notifyContent(response, decoded, Callback.from(() -> decoder.release(decoded), callback::failed));
-
-                return DecodeResult.DECODE;
-            }
-            catch (Throwable x)
-            {
-                callback.failed(x);
-                return DecodeResult.ABORT;
-            }
-        }
-
-        private void resume()
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Response content resume decoding {} with {}", exchange.getResponse(), decoder);
-
-            // The content and callback may be null
-            // if there is no initial content demand.
-            if (callback == null)
-            {
-                receive();
-                return;
-            }
-
-            boolean needInput = decode();
-            if (needInput)
-                receive();
+            super(rawSource);
+            _rawSource = rawSource;
+            _decoder = decoder;
         }
 
         @Override
-        public void destroy()
+        public void eof()
         {
-            if (decoder instanceof Destroyable)
-                ((Destroyable)decoder).destroy();
+            _rawSource.eof();
+        }
+
+        @Override
+        public void onDataAvailable()
+        {
+            _rawSource.onDataAvailable();
+        }
+
+        @Override
+        protected Content.Chunk transform(Content.Chunk inputChunk)
+        {
+            while (true)
+            {
+                boolean retain = _chunk == null;
+                if (LOG.isDebugEnabled())
+                    LOG.debug("input: {}, chunk: {}, retain? {}", inputChunk, _chunk, retain);
+                if (_chunk == null)
+                    _chunk = inputChunk;
+                if (_chunk == null)
+                    return null;
+                if (_chunk instanceof Content.Chunk.Error)
+                    return _chunk;
+
+                // Retain the input chunk because its ByteBuffer will be referenced by the Inflater.
+                if (retain && _chunk.hasRemaining())
+                    _chunk.retain();
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decoding: {}", _chunk);
+                ByteBuffer decodedBuffer = _decoder.decode(_chunk.getByteBuffer());
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decoded: {}", BufferUtil.toDetailString(decodedBuffer));
+
+                if (BufferUtil.hasContent(decodedBuffer))
+                {
+                    // The decoded ByteBuffer is a transformed "copy" of the
+                    // compressed one, so it has its own reference counter.
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("returning decoded content");
+                    return Content.Chunk.from(decodedBuffer, false, _decoder::release);
+                }
+                else
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("decoding produced no content");
+
+                    if (!_chunk.hasRemaining())
+                    {
+                        Content.Chunk result = _chunk.isLast() ? Content.Chunk.EOF : null;
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Could not decode more from this chunk, releasing it, r={}", result);
+                        _chunk.release();
+                        _chunk = null;
+                        return result;
+                    }
+                    else
+                    {
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("retrying transformation");
+                    }
+                }
+            }
         }
     }
 
-    private enum DecodeResult
+    /**
+     * This Content.Source implementation guarantees that all {@link #read(boolean)} calls
+     * happening from a {@link #demand(Runnable)} callback must be serialized.
+     */
+    private class ContentSource implements NotifiableContentSource
     {
-        DECODE, NEED_INPUT, ABORT
+        private static final Logger LOG = LoggerFactory.getLogger(ContentSource.class);
+
+        private final AtomicReference<Runnable> demandCallbackRef = new AtomicReference<>();
+        private volatile Content.Chunk currentChunk;
+
+        @Override
+        public Content.Chunk read()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Reading from {}", this);
+            Content.Chunk chunk = consumeCurrentChunk();
+            if (chunk != null)
+                return chunk;
+            currentChunk = HttpReceiver.this.read(false);
+            return consumeCurrentChunk();
+        }
+
+        @Override
+        public void eof()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Setting EOF on {}", this);
+            if (currentChunk != null)
+                throw new IllegalStateException();
+            currentChunk = Content.Chunk.EOF;
+
+            Runnable demandCallback = demandCallbackRef.getAndSet(null);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Calling demand callback on {}", this);
+            if (demandCallback != null)
+            {
+                try
+                {
+                    demandCallback.run();
+                }
+                catch (Throwable x)
+                {
+                    fail(x);
+                }
+            }
+        }
+
+        @Override
+        public void onDataAvailable()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("onDataAvailable on {}", this);
+            // The demandCallback will call read() that will itself call
+            // HttpReceiver.read(boolean) so it must be called by the invoker.
+            invokeDemandCallback(true);
+        }
+
+        private Content.Chunk consumeCurrentChunk()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Consuming current chunk from {}", this);
+            Content.Chunk chunk = currentChunk;
+            currentChunk = Content.Chunk.next(chunk);
+            return chunk;
+        }
+
+        @Override
+        public void demand(Runnable demandCallback)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Registering demand on {}", this);
+            if (demandCallback == null)
+                throw new IllegalArgumentException();
+            if (!demandCallbackRef.compareAndSet(null, demandCallback))
+                throw new IllegalStateException();
+            // The processDemand method may call HttpReceiver.read(boolean)
+            // so it must be called by the invoker.
+            invoker.run(this::processDemand);
+        }
+
+        private void processDemand()
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Processing demand on {}", this);
+
+            if (currentChunk == null)
+            {
+                currentChunk = HttpReceiver.this.read(true);
+                if (currentChunk == null)
+                    return;
+            }
+            // The processDemand method is only ever called by the
+            // invoker so there is no need to use the latter here.
+            invokeDemandCallback(false);
+        }
+
+        private void invokeDemandCallback(boolean invoke)
+        {
+            Runnable demandCallback = demandCallbackRef.getAndSet(null);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Invoking demand callback on {}", this);
+            if (demandCallback != null)
+            {
+                try
+                {
+                    if (invoke)
+                        invoker.run(demandCallback);
+                    else
+                        demandCallback.run();
+                }
+                catch (Throwable x)
+                {
+                    fail(x);
+                }
+            }
+        }
+
+        @Override
+        public void fail(Throwable failure)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Failing {}", this);
+            if (currentChunk != null)
+                currentChunk.release();
+            if (currentChunk == null || !(currentChunk instanceof Content.Chunk.Error))
+                HttpReceiver.this.failAndClose(failure);
+            currentChunk = Content.Chunk.from(failure);
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s@%x{c=%s,d=%s}", getClass().getSimpleName(), hashCode(), currentChunk, demandCallbackRef);
+        }
     }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
@@ -574,6 +575,20 @@ public class HttpRequest implements Request
             public void onContent(Response response, LongConsumer demand, ByteBuffer content, Callback callback)
             {
                 listener.onContent(response, demand, content, callback);
+            }
+        });
+        return this;
+    }
+
+    @Override
+    public Request onResponseContentSource(Response.ContentSourceListener listener)
+    {
+        this.responseListeners.add(new Response.ContentSourceListener()
+        {
+            @Override
+            public void onContentSource(Response response, org.eclipse.jetty.io.Content.Source contentSource)
+            {
+                listener.onContentSource(response, contentSource);
             }
         });
         return this;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -422,6 +422,12 @@ public interface Request
     Request onResponseFailure(Response.FailureListener listener);
 
     /**
+     * @param listener a listener for driving {@link org.eclipse.jetty.io.Content.Source}
+     * @return this request object
+     */
+    Request onResponseContentSource(Response.ContentSourceListener listener);
+
+    /**
      * <p>Sets a handler for pushed resources.</p>
      * <p>When resources are pushed from the server, the given {@code pushHandler}
      * is invoked for every pushed resource.

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
@@ -18,7 +18,6 @@ import java.nio.channels.AsynchronousCloseException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTP.java
@@ -29,11 +29,11 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpParser;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.io.RetainableByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +51,8 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     private boolean unsolicited;
     private String method;
     private int status;
+    private Content.Chunk chunk;
+    private Runnable action;
 
     public HttpReceiverOverHTTP(HttpChannelOverHTTP channel)
     {
@@ -58,14 +60,99 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         HttpClient httpClient = channel.getHttpDestination().getHttpClient();
         parser = new HttpParser(this, -1, httpClient.getHttpCompliance());
         HttpClientTransport transport = httpClient.getTransport();
-        if (transport instanceof HttpClientTransportOverHTTP)
+        if (transport instanceof HttpClientTransportOverHTTP httpTransport)
         {
-            HttpClientTransportOverHTTP httpTransport = (HttpClientTransportOverHTTP)transport;
             parser.setHeaderCacheSize(httpTransport.getHeaderCacheSize());
             parser.setHeaderCacheCaseSensitive(httpTransport.isHeaderCacheCaseSensitive());
         }
+        retainableByteBufferPool = httpClient.getByteBufferPool().asRetainableByteBufferPool();
+    }
 
-        this.retainableByteBufferPool = httpClient.getByteBufferPool().asRetainableByteBufferPool();
+    void receive()
+    {
+        if (!hasContent())
+        {
+            boolean setFillInterest = parseAndFill();
+            if (!hasContent() && setFillInterest)
+                fillInterested();
+        }
+        else
+        {
+            responseContentAvailable();
+        }
+    }
+
+    @Override
+    protected void onInterim()
+    {
+        receive();
+    }
+
+    @Override
+    protected void reset()
+    {
+        super.reset();
+        parser.reset();
+        if (chunk != null)
+        {
+            chunk.release();
+            chunk = null;
+        }
+    }
+
+    @Override
+    protected void dispose()
+    {
+        super.dispose();
+        parser.close();
+        if (chunk != null)
+        {
+            chunk.release();
+            chunk = null;
+        }
+    }
+
+    @Override
+    public Content.Chunk read(boolean fillInterestIfNeeded)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Reading, fillInterestIfNeeded={} in {}", fillInterestIfNeeded, this);
+
+        Content.Chunk chunk = consumeChunk();
+        if (chunk != null)
+            return chunk;
+        boolean needFillInterest = parseAndFill();
+        if (LOG.isDebugEnabled())
+            LOG.debug("ParseAndFill needFillInterest {} in {}", needFillInterest, this);
+        chunk = consumeChunk();
+        if (chunk != null)
+            return chunk;
+        if (needFillInterest && fillInterestIfNeeded)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Read null, filled 0, fill interest requested -> call fillInterested in {}", this);
+            fillInterested();
+        }
+        return null;
+    }
+
+    private Content.Chunk consumeChunk()
+    {
+        Content.Chunk chunk = this.chunk;
+        this.chunk = null;
+        if (LOG.isDebugEnabled())
+            LOG.debug("Receiver consuming chunk {} in {}", chunk, this);
+        return chunk;
+    }
+
+    @Override
+    public void failAndClose(Throwable failure)
+    {
+        responseFailure(failure, Promise.from((failed) ->
+        {
+            if (failed)
+                getHttpConnection().close(failure);
+        }, x -> getHttpConnection().close(failure)));
     }
 
     @Override
@@ -84,19 +171,11 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         return networkBuffer == null ? null : networkBuffer.getBuffer();
     }
 
-    @Override
-    public void receive()
-    {
-        if (networkBuffer == null)
-            acquireNetworkBuffer();
-        process();
-    }
-
     private void acquireNetworkBuffer()
     {
         networkBuffer = newNetworkBuffer();
         if (LOG.isDebugEnabled())
-            LOG.debug("Acquired {}", networkBuffer);
+            LOG.debug("Acquired {} in {}", networkBuffer, this);
     }
 
     private void reacquireNetworkBuffer()
@@ -110,7 +189,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         currentBuffer.release();
         networkBuffer = newNetworkBuffer();
         if (LOG.isDebugEnabled())
-            LOG.debug("Reacquired {} <- {}", currentBuffer, networkBuffer);
+            LOG.debug("Reacquired {} <- {} in {}", currentBuffer, networkBuffer, this);
     }
 
     private RetainableByteBuffer newNetworkBuffer()
@@ -126,7 +205,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
             return;
         networkBuffer.release();
         if (LOG.isDebugEnabled())
-            LOG.debug("Released {}", networkBuffer);
+            LOG.debug("Released {} in {}", networkBuffer, this);
         networkBuffer = null;
     }
 
@@ -149,29 +228,40 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         return upgradeBuffer;
     }
 
-    private void process()
+    /**
+     * Parses the networkBuffer until the next content is generated or until the buffer is depleted.
+     * If this method depletes the buffer, it will always try to re-fill until fill generates 0 byte.
+     * @return true if no bytes were filled.
+     */
+    private boolean parseAndFill()
     {
         HttpConnectionOverHTTP connection = getHttpConnection();
         EndPoint endPoint = connection.getEndPoint();
         try
         {
+            if (networkBuffer == null)
+                acquireNetworkBuffer();
             while (true)
             {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Parsing {} in {}", BufferUtil.toDetailString(networkBuffer.getBuffer()), this);
                 // Always parse even empty buffers to advance the parser.
                 if (parse())
                 {
                     // Return immediately, as this thread may be in a race
                     // with e.g. another thread demanding more content.
-                    return;
+                    return false;
                 }
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Parser willing to advance in {}", this);
 
                 // Connection may be closed in a parser callback.
                 if (connection.isClosed())
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Closed {}", connection);
+                        LOG.debug("Closed {} in {}", connection, this);
                     releaseNetworkBuffer();
-                    return;
+                    return false;
                 }
 
                 if (networkBuffer.isRetained())
@@ -180,7 +270,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                 // The networkBuffer may have been reacquired.
                 int read = endPoint.fill(networkBuffer.getBuffer());
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Read {} bytes in {} from {}", read, networkBuffer, endPoint);
+                    LOG.debug("Read {} bytes in {} from {} in {}", read, networkBuffer, endPoint, this);
 
                 if (read > 0)
                 {
@@ -188,25 +278,24 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                 }
                 else if (read == 0)
                 {
-                    assert networkBuffer.isEmpty();
                     releaseNetworkBuffer();
-                    fillInterested();
-                    return;
+                    return true;
                 }
                 else
                 {
                     releaseNetworkBuffer();
                     shutdown();
-                    return;
+                    return false;
                 }
             }
         }
         catch (Throwable x)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Error processing {}", endPoint, x);
+                LOG.debug("Error processing {} in {}", endPoint, this, x);
             releaseNetworkBuffer();
             failAndClose(x);
+            return false;
         }
     }
 
@@ -220,20 +309,29 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         while (true)
         {
             boolean handle = parser.parseNext(networkBuffer.getBuffer());
-            boolean failed = isFailed();
             if (LOG.isDebugEnabled())
-                LOG.debug("Parse result={}, failed={}", handle, failed);
-            // When failed, it's safe to close the parser because there
-            // will be no races with other threads demanding more content.
-            if (failed)
-                parser.close();
+                LOG.debug("Parse result={} on {}", handle, this);
+            Runnable action = getAndSetAction(null);
+            if (action != null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Executing action after parser returned: {} on {}", action, this);
+                action.run();
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Action executed after Parse result={} on {}", handle, this);
+            }
             if (handle)
-                return !failed;
+            {
+                // When the receiver is aborted, the parser is closed in dispose() which changes
+                // its state to State.CLOSE; so checking parser.isClose() is just a way to check
+                // if the receiver was aborted or not.
+                return !parser.isClose();
+            }
 
             boolean complete = this.complete;
             this.complete = false;
             if (LOG.isDebugEnabled())
-                LOG.debug("Parse complete={}, {} {}", complete, networkBuffer, parser);
+                LOG.debug("Parse complete={}, {} {} in {}", complete, networkBuffer, parser, this);
 
             if (complete)
             {
@@ -254,7 +352,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                 if (!HttpStatus.isInformational(status))
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Discarding unexpected content after response {}: {}", status, networkBuffer);
+                        LOG.debug("Discarding unexpected content after response {}: {} in {}", status, networkBuffer, this);
                     networkBuffer.clear();
                 }
                 return false;
@@ -267,6 +365,8 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
 
     protected void fillInterested()
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Registering as fill interested in {}", this);
         getHttpConnection().fillInterested();
     }
 
@@ -329,24 +429,36 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         // Store the EndPoint is case of upgrades, tunnels, etc.
         exchange.getRequest().getConversation().setAttribute(EndPoint.class.getName(), getHttpConnection().getEndPoint());
         getHttpConnection().onResponseHeaders(exchange);
-        return !responseHeaders(exchange);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Setting action to responseHeaders(exchange, boolean) on {}", this);
+        if (getAndSetAction(() -> responseHeaders(exchange)) != null)
+            throw new IllegalStateException();
+        return true;
     }
 
     @Override
     public boolean content(ByteBuffer buffer)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Parser generated content {} in {}", BufferUtil.toDetailString(buffer), this);
         HttpExchange exchange = getHttpExchange();
         unsolicited |= exchange == null;
         if (unsolicited)
             return false;
 
+        if (chunk != null)
+            throw new IllegalStateException("Content generated with unconsumed content left");
+
         RetainableByteBuffer networkBuffer = this.networkBuffer;
         networkBuffer.retain();
-        return !responseContent(exchange, buffer, Callback.from(networkBuffer::release, failure ->
-        {
-            networkBuffer.release();
-            failAndClose(failure);
-        }));
+        chunk = Content.Chunk.from(buffer, false, networkBuffer);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Setting action to responseContentAvailable on {}", this);
+        if (getAndSetAction(this::responseContentAvailable) != null)
+            throw new IllegalStateException();
+        if (getHttpConnection().isFillInterested())
+            throw new IllegalStateException();
+        return true;
     }
 
     @Override
@@ -363,6 +475,8 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         if (unsolicited)
             return;
 
+        if (LOG.isDebugEnabled())
+            LOG.debug("Appending trailer '{}' to response in {}", trailer, this);
         exchange.getResponse().trailer(trailer);
     }
 
@@ -384,10 +498,31 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
             complete = true;
         }
 
-        boolean stopParsing = !responseSuccess(exchange);
-        if (status == HttpStatus.SWITCHING_PROTOCOLS_101)
-            stopParsing = true;
-        return stopParsing;
+        if (chunk != null)
+            throw new IllegalStateException();
+        chunk = Content.Chunk.EOF;
+
+        boolean isUpgrade = status == HttpStatus.SWITCHING_PROTOCOLS_101;
+        boolean isTunnel = getHttpChannel().isTunnel(method, status);
+        Runnable task = isUpgrade || isTunnel ? null : this::receiveNext;
+        if (LOG.isDebugEnabled())
+            LOG.debug("Message complete, calling response success with task {} in {}", task, this);
+        responseSuccess(exchange, task);
+        return false;
+    }
+
+    private void receiveNext()
+    {
+        if (hasContent())
+            throw new IllegalStateException();
+        if (chunk != null)
+            throw new IllegalStateException();
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Receiving next request in {}", this);
+        boolean setFillInterest = parseAndFill();
+        if (!hasContent() && setFillInterest)
+            fillInterested();
     }
 
     @Override
@@ -417,20 +552,11 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         }
     }
 
-    @Override
-    protected void reset()
+    private Runnable getAndSetAction(Runnable action)
     {
-        super.reset();
-        parser.reset();
-    }
-
-    private void failAndClose(Throwable failure)
-    {
-        responseFailure(failure, Promise.from(failed ->
-        {
-            if (failed)
-                getHttpConnection().close(failure);
-        }, f -> getHttpConnection().close(failure)));
+        Runnable r = this.action;
+        this.action = action;
+        return r;
     }
 
     long getMessagesIn()

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpResponseConcurrentAbortTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpResponseConcurrentAbortTest.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
@@ -25,6 +26,8 @@ import org.eclipse.jetty.server.Request;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTest
@@ -32,8 +35,9 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
     private final CountDownLatch callbackLatch = new CountDownLatch(1);
     private final CountDownLatch failureLatch = new CountDownLatch(1);
     private final CountDownLatch completeLatch = new CountDownLatch(1);
-    private final AtomicBoolean failureWasAsync = new AtomicBoolean();
+    private final AtomicBoolean failureWasSync = new AtomicBoolean();
     private final AtomicBoolean completeWasSync = new AtomicBoolean();
+    private final AtomicReference<Object> abortResult = new AtomicReference<>();
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
@@ -47,8 +51,9 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
             .send(new TestResponseListener());
         assertTrue(callbackLatch.await(5, TimeUnit.SECONDS));
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(failureWasAsync.get());
+        assertTrue(failureWasSync.get());
         assertTrue(completeWasSync.get());
+        await().atMost(5, TimeUnit.SECONDS).until(abortResult::get, is(Boolean.TRUE));
     }
 
     @ParameterizedTest
@@ -67,8 +72,9 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
             .send(new TestResponseListener());
         assertTrue(callbackLatch.await(5, TimeUnit.SECONDS));
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(failureWasAsync.get());
+        assertTrue(failureWasSync.get());
         assertTrue(completeWasSync.get());
+        await().atMost(5, TimeUnit.SECONDS).until(abortResult::get, is(Boolean.TRUE));
     }
 
     @ParameterizedTest
@@ -83,8 +89,9 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
             .send(new TestResponseListener());
         assertTrue(callbackLatch.await(5, TimeUnit.SECONDS));
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(failureWasAsync.get());
+        assertTrue(failureWasSync.get());
         assertTrue(completeWasSync.get());
+        await().atMost(5, TimeUnit.SECONDS).until(abortResult::get, is(Boolean.TRUE));
     }
 
     @ParameterizedTest
@@ -106,8 +113,9 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
             .send(new TestResponseListener());
         assertTrue(callbackLatch.await(5, TimeUnit.SECONDS));
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(failureWasAsync.get());
+        assertTrue(failureWasSync.get());
         assertTrue(completeWasSync.get());
+        await().atMost(5, TimeUnit.SECONDS).until(abortResult::get, is(Boolean.TRUE));
     }
 
     private void abort(final Response response)
@@ -117,17 +125,21 @@ public class HttpResponseConcurrentAbortTest extends AbstractHttpClientServerTes
             @Override
             public void run()
             {
-                response.abort(new Exception());
+                response.abort(new Exception()).whenComplete((aborted, x) ->
+                {
+                    if (x != null)
+                        abortResult.set(x);
+                    else
+                        abortResult.set(aborted);
+                });
             }
         }.start();
 
         try
         {
-            // The failure callback is executed asynchronously, but
-            // here we are within the context of another response
-            // callback, which should detect that a failure happened
-            // and therefore this thread should complete the response.
-            failureWasAsync.set(failureLatch.await(2, TimeUnit.SECONDS));
+            // The failure callback must be executed by this thread,
+            // after we return from this response callback.
+            failureWasSync.set(!failureLatch.await(1, TimeUnit.SECONDS));
 
             // The complete callback must be executed by this thread,
             // after we return from this response callback.

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.http2.client.transport.internal;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -29,19 +28,19 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.DataFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.internal.ErrorCode;
 import org.eclipse.jetty.http2.internal.HTTP2Channel;
 import org.eclipse.jetty.http2.internal.HTTP2Stream;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,23 +54,57 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
     }
 
     @Override
-    protected HttpChannelOverHTTP2 getHttpChannel()
+    protected void onInterim()
     {
-        return (HttpChannelOverHTTP2)super.getHttpChannel();
     }
 
     @Override
-    protected void receive()
+    protected void reset()
     {
-        // Called when the application resumes demand of content.
+        super.reset();
+    }
+
+    @Override
+    public Content.Chunk read(boolean fillInterestIfNeeded)
+    {
         if (LOG.isDebugEnabled())
-            LOG.debug("Resuming response processing on {}", this);
+            LOG.debug("Reading, fillInterestIfNeeded={} in {}", fillInterestIfNeeded, this);
+        Stream stream = getHttpChannel().getStream();
+        Stream.Data data = stream.readData();
+        if (LOG.isDebugEnabled())
+            LOG.debug("Read stream data {} in {}", data, this);
+        if (data == null)
+        {
+            if (fillInterestIfNeeded)
+                stream.demand();
+            return null;
+        }
+        DataFrame frame = data.frame();
+        boolean last = frame.remaining() == 0 && frame.isEndStream();
+        if (last)
+            responseSuccess(getHttpExchange(), null);
+        return Content.Chunk.from(frame.getData(), last, data);
+    }
 
-        HttpExchange exchange = getHttpExchange();
-        if (exchange == null)
-            return;
+    @Override
+    public void failAndClose(Throwable failure)
+    {
+        Stream stream = getHttpChannel().getStream();
+        responseFailure(failure, Promise.from(failed ->
+        {
+            stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+            getHttpChannel().getHttpConnection().close(failure);
+        }, x ->
+        {
+            stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+            getHttpChannel().getHttpConnection().close(failure);
+        }));
+    }
 
-        getHttpChannel().getStream().demand();
+    @Override
+    protected HttpChannelOverHTTP2 getHttpChannel()
+    {
+        return (HttpChannelOverHTTP2)super.getHttpChannel();
     }
 
     void onHeaders(Stream stream, HeadersFrame frame)
@@ -93,46 +126,36 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         HttpResponse httpResponse = exchange.getResponse();
         httpResponse.version(response.getHttpVersion()).status(response.getStatus()).reason(response.getReason());
 
-        if (responseBegin(exchange))
+        responseBegin(exchange);
+        if (exchange.isResponseComplete())
+            return;
+
+        HttpFields headers = response.getFields();
+        for (HttpField header : headers)
         {
-            HttpFields headers = response.getFields();
-            for (HttpField header : headers)
-            {
-                if (!responseHeader(exchange, header))
-                    return;
-            }
-
-            HttpRequest httpRequest = exchange.getRequest();
-            if (MetaData.isTunnel(httpRequest.getMethod(), httpResponse.getStatus()))
-            {
-                ClientHTTP2StreamEndPoint endPoint = new ClientHTTP2StreamEndPoint((HTTP2Stream)stream);
-                long idleTimeout = httpRequest.getIdleTimeout();
-                if (idleTimeout > 0)
-                    endPoint.setIdleTimeout(idleTimeout);
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Successful HTTP2 tunnel on {} via {}", stream, endPoint);
-                ((HTTP2Stream)stream).setAttachment(endPoint);
-                HttpConversation conversation = httpRequest.getConversation();
-                conversation.setAttribute(EndPoint.class.getName(), endPoint);
-                HttpUpgrader upgrader = (HttpUpgrader)conversation.getAttribute(HttpUpgrader.class.getName());
-                if (upgrader != null)
-                    upgrade(upgrader, httpResponse, endPoint);
-            }
-
-            if (responseHeaders(exchange))
-            {
-                int status = response.getStatus();
-                if (frame.isEndStream() || HttpStatus.isInterim(status))
-                    responseSuccess(exchange);
-                else
-                    stream.demand();
-            }
-            else
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Stalling response processing, no demand after headers on {}", this);
-            }
+            responseHeader(exchange, header);
+            if (exchange.isResponseComplete())
+                return;
         }
+
+        HttpRequest httpRequest = exchange.getRequest();
+        if (MetaData.isTunnel(httpRequest.getMethod(), httpResponse.getStatus()))
+        {
+            ClientHTTP2StreamEndPoint endPoint = new ClientHTTP2StreamEndPoint((HTTP2Stream)stream);
+            long idleTimeout = httpRequest.getIdleTimeout();
+            if (idleTimeout > 0)
+                endPoint.setIdleTimeout(idleTimeout);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Successful HTTP2 tunnel on {} via {} in {}", stream, endPoint, this);
+            ((HTTP2Stream)stream).setAttachment(endPoint);
+            HttpConversation conversation = httpRequest.getConversation();
+            conversation.setAttribute(EndPoint.class.getName(), endPoint);
+            HttpUpgrader upgrader = (HttpUpgrader)conversation.getAttribute(HttpUpgrader.class.getName());
+            if (upgrader != null)
+                upgrade(upgrader, httpResponse, endPoint);
+        }
+
+        responseHeaders(exchange);
     }
 
     private void onTrailer(HeadersFrame frame)
@@ -196,54 +219,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         if (exchange == null)
             return;
 
-        Stream stream = getHttpChannel().getStream();
-        if (stream == null)
-            return;
-
-        Stream.Data data = stream.readData();
-        if (data != null)
-        {
-            ByteBuffer byteBuffer = data.frame().getData();
-            boolean endStream = data.frame().isEndStream();
-            if (byteBuffer.hasRemaining())
-            {
-                Callback callback = Callback.from(Invocable.InvocationType.NON_BLOCKING, data::release, x ->
-                {
-                    data.release();
-                    responseFailure(x, Promise.from(failed ->
-                    {
-                        if (failed)
-                            stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
-                    }, f -> stream.reset(new ResetFrame(stream.getId(), ErrorCode.INTERNAL_ERROR.code), Callback.NOOP)));
-                });
-
-                boolean proceed = responseContent(exchange, byteBuffer, callback);
-                if (proceed)
-                {
-                    if (endStream)
-                        responseSuccess(exchange);
-                    else
-                        stream.demand();
-                }
-                else
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Stalling response processing, no demand after {} on {}", data, this);
-                }
-            }
-            else
-            {
-                data.release();
-                if (endStream)
-                    responseSuccess(exchange);
-                else
-                    stream.demand();
-            }
-        }
-        else
-        {
-            stream.demand();
-        }
+        responseContentAvailable();
     }
 
     void onReset(ResetFrame frame)

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpChannelOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpChannelOverHTTP3.java
@@ -40,6 +40,11 @@ public class HttpChannelOverHTTP3 extends HttpChannel
         receiver = new HttpReceiverOverHTTP3(this);
     }
 
+    public HttpConnectionOverHTTP3 getHttpConnection()
+    {
+        return connection;
+    }
+
     public HTTP3SessionClient getSession()
     {
         return session;

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -20,14 +20,11 @@ import org.eclipse.jetty.client.HttpReceiver;
 import org.eclipse.jetty.client.HttpResponse;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
-import org.eclipse.jetty.http3.internal.HTTP3ErrorCode;
-import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,23 +38,49 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     }
 
     @Override
-    protected HttpChannelOverHTTP3 getHttpChannel()
+    protected void onInterim()
     {
-        return (HttpChannelOverHTTP3)super.getHttpChannel();
     }
 
     @Override
-    protected void receive()
+    protected void reset()
     {
-        // Called when the application resumes demand of content.
+        super.reset();
+    }
+
+    @Override
+    public Content.Chunk read(boolean fillInterestIfNeeded)
+    {
         if (LOG.isDebugEnabled())
-            LOG.debug("resuming response processing on {}", this);
+            LOG.debug("Reading, fillInterestIfNeeded={} in {}", fillInterestIfNeeded, this);
+        Stream stream = getHttpChannel().getStream();
+        Stream.Data data = stream.readData();
+        if (LOG.isDebugEnabled())
+            LOG.debug("Read stream data {} in {}", data, this);
+        if (data == null)
+        {
+            if (fillInterestIfNeeded)
+                stream.demand();
+            return null;
+        }
+        ByteBuffer byteBuffer = data.getByteBuffer();
+        boolean last = !byteBuffer.hasRemaining() && data.isLast();
+        if (last)
+            responseSuccess(getHttpExchange(), null);
+        return Content.Chunk.from(byteBuffer, last, data);
+    }
 
-        HttpExchange exchange = getHttpExchange();
-        if (exchange == null)
-            return;
+    @Override
+    public void failAndClose(Throwable failure)
+    {
+        responseFailure(failure, Promise.from(failed -> getHttpChannel().getHttpConnection().close(failure),
+            x -> getHttpChannel().getHttpConnection().close(failure)));
+    }
 
-        getHttpChannel().getStream().demand();
+    @Override
+    protected HttpChannelOverHTTP3 getHttpChannel()
+    {
+        return (HttpChannelOverHTTP3)super.getHttpChannel();
     }
 
     @Override
@@ -71,82 +94,34 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
         MetaData.Response response = (MetaData.Response)frame.getMetaData();
         httpResponse.version(response.getHttpVersion()).status(response.getStatus()).reason(response.getReason());
 
-        if (responseBegin(exchange))
+        responseBegin(exchange);
+        if (exchange.isResponseComplete())
+            return;
+
+        HttpFields headers = response.getFields();
+        for (HttpField header : headers)
         {
-            HttpFields headers = response.getFields();
-            for (HttpField header : headers)
-            {
-                if (!responseHeader(exchange, header))
-                    return;
-            }
-
-            // TODO: add support for HttpMethod.CONNECT.
-
-            if (responseHeaders(exchange))
-            {
-                int status = response.getStatus();
-                if (frame.isLast() || HttpStatus.isInterim(status))
-                    responseSuccess(exchange);
-                else
-                    stream.demand();
-            }
-            else
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("stalling response processing, no demand after headers on {}", this);
-            }
+            responseHeader(exchange, header);
+            if (exchange.isResponseComplete())
+                return;
         }
+
+        // TODO: add support for HttpMethod.CONNECT.
+
+        responseHeaders(exchange);
     }
 
     @Override
     public void onDataAvailable(Stream.Client stream)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Data available notification in {}", this);
+
         HttpExchange exchange = getHttpExchange();
         if (exchange == null)
             return;
 
-        Stream.Data data = stream.readData();
-        if (data != null)
-        {
-            ByteBuffer byteBuffer = data.getByteBuffer();
-            if (byteBuffer.hasRemaining())
-            {
-                Callback callback = Callback.from(Invocable.InvocationType.NON_BLOCKING, data::release, x ->
-                {
-                    data.release();
-                    responseFailure(x, Promise.from(failed ->
-                    {
-                        if (failed)
-                            stream.reset(HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), x);
-                    }, f -> stream.reset(HTTP3ErrorCode.INTERNAL_ERROR.code(), x)));
-                });
-                boolean proceed = responseContent(exchange, byteBuffer, callback);
-                if (proceed)
-                {
-                    if (data.isLast())
-                        responseSuccess(exchange);
-                    else
-                        stream.demand();
-                }
-                else
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("stalling response processing, no demand after {} on {}", data, this);
-                }
-            }
-            else
-            {
-                data.release();
-                if (data.isLast())
-                    responseSuccess(exchange);
-                else
-                    stream.demand();
-            }
-        }
-        else
-        {
-            stream.demand();
-        }
+        responseContentAvailable();
     }
 
     @Override
@@ -159,7 +134,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
         HttpFields trailers = frame.getMetaData().getFields();
         trailers.forEach(exchange.getResponse()::trailer);
 
-        responseSuccess(exchange);
+        responseSuccess(exchange, null);
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -540,6 +540,28 @@ public class Content
         }
 
         /**
+         * <p>Creates a chunk that is a slice of the given chunk.</p>
+         * <p>
+         *  The chunk slice has a byte buffer that is a slice of the original chunk's byte buffer, the last flag
+         *  copied over and the original chunk used as the retainable of the chunk slice.
+         *  Note that after this method returns, an extra Chunk instance refers to the same byte buffer,
+         *  so the original chunk is retained and is used as the {@link Retainable} for the returned chunk.
+         * </p>
+         * <p>Passing a null chunk returns null.</p>
+         * <p>Passing a terminal chunk returns it.</p>
+         *
+         * @param chunk the chunk to slice.
+         * @return the chunk slice.
+         */
+        static Chunk slice(Chunk chunk)
+        {
+            if (chunk == null || chunk.isTerminal())
+                return chunk;
+            chunk.retain();
+            return Chunk.from(chunk.getByteBuffer().slice(), chunk.isLast(), chunk);
+        }
+
+        /**
          * @return the ByteBuffer of this Chunk
          */
         ByteBuffer getByteBuffer();
@@ -680,6 +702,12 @@ public class Content
             public boolean release()
             {
                 return true;
+            }
+
+            @Override
+            public String toString()
+            {
+                return String.format("%s@%x{c=%s}", getClass().getSimpleName(), hashCode(), cause);
             }
         }
 

--- a/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicStreamEndPoint.java
+++ b/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicStreamEndPoint.java
@@ -258,7 +258,8 @@ public class QuicStreamEndPoint extends AbstractEndPoint
     {
         if (LOG.isDebugEnabled())
             LOG.debug("setting fill interest on {}", this);
-        super.fillInterested(callback);
+        if (!isFillInterested())
+            super.fillInterested(callback);
 
         // TODO: see above
 //        getQuicSession().setFillInterested(getStreamId(), true);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
@@ -18,6 +18,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
       <scope>test</scope>

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -14,13 +14,12 @@
 package org.eclipse.jetty.test.client.transport;
 
 import java.io.InterruptedIOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.Random;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,16 +37,22 @@ import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientDemandTest extends AbstractTest
 {
@@ -166,21 +171,28 @@ public class HttpClientDemandTest extends AbstractTest
         assertEquals(1, contentQueue.size());
         assertEquals(1, callbackQueue.size());
 
-        // Demand more buffers.
-        int count = 2;
+        // Demand one more buffer.
         LongConsumer demand = demandQueue.poll();
         assertNotNull(demand);
-        demand.accept(count);
+        demand.accept(1);
         // The client should have received just `count` more buffers.
         Thread.sleep(1000);
-        assertEquals(count, demandQueue.size());
-        assertEquals(1 + count, contentQueue.size());
-        assertEquals(1 + count, callbackQueue.size());
+        assertEquals(1, demandQueue.size());
+        assertEquals(2, contentQueue.size());
+        assertEquals(2, callbackQueue.size());
 
         // Demand all the rest.
         demand = demandQueue.poll();
         assertNotNull(demand);
-        demand.accept(Long.MAX_VALUE);
+        long begin = NanoTime.now();
+        // Spin on demand until content.length bytes have been read.
+        while (content.length > contentQueue.stream().mapToInt(Buffer::remaining).sum())
+        {
+            if (NanoTime.millisSince(begin) > 5000L)
+                fail("Failed to demand all content");
+            demand.accept(1);
+        }
+        demand.accept(1); // Demand one last time to get EOF.
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
 
         byte[] received = new byte[content.length];
@@ -273,15 +285,15 @@ public class HttpClientDemandTest extends AbstractTest
     public void testTwoListenersWithDifferentDemand(Transport transport) throws Exception
     {
         int bufferSize = 1536;
-        byte[] content = new byte[10 * bufferSize];
-        new Random().nextBytes(content);
+        byte[] bytes = new byte[10 * bufferSize];
+        new Random().nextBytes(bytes);
         startServer(transport, new Handler.Processor()
         {
             @Override
             public void process(Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
-                response.getHeaders().putLongField(HttpHeader.CONTENT_LENGTH, content.length);
-                response.write(true, ByteBuffer.wrap(content), callback);
+                response.getHeaders().putLongField(HttpHeader.CONTENT_LENGTH, bytes.length);
+                response.write(true, ByteBuffer.wrap(bytes), callback);
             }
         });
         startClient(transport);
@@ -290,22 +302,25 @@ public class HttpClientDemandTest extends AbstractTest
         client.setResponseBufferSize(bufferSize);
         client.start();
 
-        AtomicInteger chunks = new AtomicInteger();
-        Response.DemandedContentListener listener1 = (response, demand, content1, callback) ->
+        AtomicInteger listener1Chunks = new AtomicInteger();
+        AtomicInteger listener1ContentSize = new AtomicInteger();
+        AtomicReference<LongConsumer> listener1DemandRef = new AtomicReference<>();
+        Response.DemandedContentListener listener1 = (response, demand, content, callback) ->
         {
+            listener1Chunks.incrementAndGet();
+            listener1ContentSize.addAndGet(content.remaining());
             callback.succeeded();
-            // The first time, demand infinitely.
-            if (chunks.incrementAndGet() == 1)
-                demand.accept(Long.MAX_VALUE);
+            listener1DemandRef.set(demand);
         };
-        BlockingQueue<ByteBuffer> contentQueue = new LinkedBlockingQueue<>();
-        AtomicReference<LongConsumer> demandRef = new AtomicReference<>();
-        AtomicReference<CountDownLatch> demandLatch = new AtomicReference<>(new CountDownLatch(1));
-        Response.DemandedContentListener listener2 = (response, demand, content12, callback) ->
+        AtomicInteger listener2Chunks = new AtomicInteger();
+        AtomicInteger listener2ContentSize = new AtomicInteger();
+        AtomicReference<LongConsumer> listener2DemandRef = new AtomicReference<>();
+        Response.DemandedContentListener listener2 = (response, demand, content, callback) ->
         {
-            assertTrue(contentQueue.offer(content12));
-            demandRef.set(demand);
-            demandLatch.get().countDown();
+            listener2Chunks.incrementAndGet();
+            listener2ContentSize.addAndGet(content.remaining());
+            callback.succeeded();
+            listener2DemandRef.set(demand);
         };
 
         CountDownLatch resultLatch = new CountDownLatch(1);
@@ -320,28 +335,27 @@ public class HttpClientDemandTest extends AbstractTest
                 resultLatch.countDown();
             });
 
-        assertTrue(demandLatch.get().await(5, TimeUnit.SECONDS));
-        LongConsumer demand = demandRef.get();
-        assertNotNull(demand);
-        assertEquals(1, contentQueue.size());
-        assertNotNull(contentQueue.poll());
+        await().atMost(5, TimeUnit.SECONDS).until(listener1DemandRef::get, not(nullValue()));
+        await().atMost(5, TimeUnit.SECONDS).until(listener2DemandRef::get, not(nullValue()));
 
-        // Must not get additional content because listener2 did not demand.
-        assertNull(contentQueue.poll(1, TimeUnit.SECONDS));
+        // Make both listeners progress in locksteps.
+        int i = 0;
+        while (resultLatch.getCount() > 0)
+        {
+            i++;
 
-        // Now demand, we should get content in both listeners.
-        demandLatch.set(new CountDownLatch(1));
-        demand.accept(1);
+            // Assert that no listener can progress for as long as both listeners did not demand.
+            assertThat(listener1Chunks.get(), is(i));
+            assertThat(listener2Chunks.get(), is(i));
+            listener2DemandRef.get().accept(1);
+            assertThat(listener1Chunks.get(), is(i));
+            assertThat(listener2Chunks.get(), is(i));
+            listener1DemandRef.get().accept(1);
+        }
 
-        assertNotNull(contentQueue.poll(5, TimeUnit.SECONDS));
-        assertEquals(2, chunks.get());
-
-        // Demand the rest and verify the result.
-        assertTrue(demandLatch.get().await(5, TimeUnit.SECONDS));
-        demand = demandRef.get();
-        assertNotNull(demand);
-        demand.accept(Long.MAX_VALUE);
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
+        assertThat(listener1ContentSize.get(), is(bytes.length));
+        assertThat(listener2ContentSize.get(), is(bytes.length));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Simplify the client's internals to use a `SerializedInvoker` to replace the FSM that was used to handle async `abort()` calls.

The goal is to refactor the internal engine to make use of `Content.Source` and its read/demand loop.

Requires https://github.com/eclipse/jetty.project/pull/8725 and https://github.com/eclipse/jetty.project/pull/8755