### PR TITLE
Jetty 12 - Remove start slash cleanup from `resolve(String)`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -285,17 +285,6 @@ public class PathResource extends Resource
         if (URIUtil.SLASH.equals(subUriPath))
             return this;
 
-        // Sub-paths are always resolved under the given URI,
-        // we compensate for input sub-paths like "/subdir"
-        // where default resolve behavior would be to treat
-        // that like an absolute path.
-        while (subUriPath.startsWith(URIUtil.SLASH))
-        {
-            // TODO XXX this appears entirely unnecessary and inefficient.  We already have utilities
-            //      to handle appending path strings with/without slashes.
-            subUriPath = subUriPath.substring(1);
-        }
-
         URI uri = getURI();
         URI resolvedUri = URIUtil.addPath(uri, subUriPath);
         Path path = Paths.get(resolvedUri);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -379,6 +379,19 @@ public class ResourceTest
     }
 
     @Test
+    public void testResolveStartsWithSlash(WorkDir workDir)
+    {
+        Path testdir = workDir.getEmptyPathDir();
+        Path foo = testdir.resolve("foo");
+        FS.ensureDirExists(foo);
+        Resource resourceBase = resourceFactory.newResource(testdir);
+        // test that a resolve starting with `/` works.
+        Resource resourceDir = resourceBase.resolve("/foo");
+        assertTrue(Resources.exists(resourceDir));
+        assertThat(resourceDir.getURI(), is(foo.toUri()));
+    }
+
+    @Test
     public void testNewResourcePathDoesNotExist(WorkDir workDir)
     {
         Path dir = workDir.getEmptyPathDir().resolve("foo/bar");


### PR DESCRIPTION
Cleanup PathResource.resolve(String) a bit.
Remove the code that removes the starting slash, as it seems to not be needed.