### PR TITLE
Jetty 12 - Example of using `TryPathsHandler` with PHP

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -83,19 +83,21 @@ public class TryPathsHandler extends Handler.Wrapper
         public TryPathsRequest(Request wrapped, String interpolated)
         {
             super(wrapped);
+
+            HttpURI.Mutable rewrittenUri = HttpURI.build(wrapped.getHttpURI());
+
             int queryIdx = interpolated.indexOf('?');
             if (queryIdx >= 0)
             {
                 String path = interpolated.substring(0, queryIdx);
-                _uri = HttpURI.build(wrapped.getHttpURI())
-                    .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
-                    .query(interpolated.substring(queryIdx + 1))
-                    .asImmutable();
+                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), path));
+                rewrittenUri.query(interpolated.substring(queryIdx + 1));
             }
             else
             {
-                _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(interpolated));
+                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), interpolated));
             }
+            _uri = rewrittenUri.asImmutable();
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -89,7 +89,7 @@ public class TryPathsHandler extends Handler.Wrapper
                 String path = interpolated.substring(0, queryIdx);
                 _uri = HttpURI.build(wrapped.getHttpURI())
                     .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
-                    .query(interpolated.substring(queryIdx+1))
+                    .query(interpolated.substring(queryIdx + 1))
                     .asImmutable();
             }
             else

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -87,10 +87,22 @@ public class TryPathsHandler extends Handler.Wrapper
     {
         private final HttpURI _uri;
 
-        public TryPathsRequest(Request wrapped, String pathInContext)
+        public TryPathsRequest(Request wrapped, String interpolated)
         {
             super(wrapped);
-            _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(pathInContext));
+            int queryIdx = interpolated.indexOf('?');
+            if (queryIdx >= 0)
+            {
+                String path = interpolated.substring(0, queryIdx);
+                _uri = HttpURI.build(wrapped.getHttpURI())
+                    .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
+                    .query(interpolated.substring(queryIdx+1))
+                    .asImmutable();
+            }
+            else
+            {
+                _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(interpolated));
+            }
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -70,13 +70,6 @@ public class TryPathsHandler extends Handler.Wrapper
         return result.wrapProcessor(super.handle(result));
     }
 
-    private Request.Processor fallback(Request request) throws Exception
-    {
-        String fallback = paths.isEmpty() ? "$path" : paths.get(paths.size() - 1);
-        String interpolated = interpolate(request, fallback);
-        return super.handle(new TryPathsRequest(request, interpolated));
-    }
-
     private String interpolate(Request request, String value)
     {
         String path = Request.getPathInContext(request);


### PR DESCRIPTION
+ This utilizes the matching logic of the `PathMappingsHandler`
+ Also fixed a paths entry with query string bug in `TryPathsRequest`