### PR TITLE
Issue #8779 - CompactPathRule should not drop query section from modified URI

### DIFF
--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -35,7 +35,7 @@ public class CompactPathRule extends Rule implements Rule.ApplyURI
     @Override
     public void applyURI(Request request, String oldURI, String newURI) throws IOException
     {
-        String uri = request.getRequestURI();
+        String uri = oldURI;
         if (uri.startsWith("/"))
             uri = URIUtil.compactPath(uri);
         request.setHttpURI(HttpURI.build(request.getHttpURI(), uri));

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -33,7 +33,7 @@ public class CompactPathRule extends Rule implements Rule.ApplyURI
     }
 
     @Override
-    public void applyURI(Request request, String oldURI, String newURI) throws IOException
+    public void applyURI(Request request, String oldURI, String newURI)
     {
         String uri = request.getHttpURI().getPathQuery();
         if (uri.startsWith("/"))

--- a/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -35,7 +35,7 @@ public class CompactPathRule extends Rule implements Rule.ApplyURI
     @Override
     public void applyURI(Request request, String oldURI, String newURI) throws IOException
     {
-        String uri = oldURI;
+        String uri = request.getHttpURI().getPathQuery();
         if (uri.startsWith("/"))
             uri = URIUtil.compactPath(uri);
         request.setHttpURI(HttpURI.build(request.getHttpURI(), uri));

--- a/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
+++ b/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
@@ -1,0 +1,64 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.rewrite.handler;
+
+import java.util.stream.Stream;
+
+import org.eclipse.jetty.http.HttpURI;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CompactPathRuleTest extends AbstractRuleTestCase
+{
+    public static Stream<Arguments> scenarios()
+    {
+        return Stream.of(
+            // shouldn't change anything
+            Arguments.of("/foo", null, "/foo", null),
+            Arguments.of("/", null, "/", null),
+            // simple compact path
+            Arguments.of("////foo", null, "/foo", null),
+            // with simple query
+            Arguments.of("//foo//bar", "a=b", "/foo/bar", "a=b"),
+            // with query that has double slashes (should preserve slashes in query)
+            Arguments.of("//foo//bar", "a=b//c", "/foo/bar", "a=b//c")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("scenarios")
+    public void testCompactPathRule(String inputPath, String inputQuery, String expectedPath, String expectedQuery) throws Exception
+    {
+        start(false);
+
+        CompactPathRule rule = new CompactPathRule();
+
+        reset();
+        _request.setHttpURI(HttpURI.build(_request.getHttpURI(), inputPath, null, inputQuery).asImmutable());
+
+        String result = rule.matchAndApply(_request.getHttpURI().getDecodedPath(), _request, _response);
+        assertEquals(expectedPath, result);
+
+        rule.applyURI(_request, _request.getHttpURI().getPathQuery(), result);
+
+        if (result != null)
+        {
+            assertEquals(expectedPath, _request.getRequestURI());
+            assertEquals(expectedQuery, _request.getQueryString());
+        }
+    }
+}


### PR DESCRIPTION
+ Simply use the original URI path+query when applying the rule.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>