### PR TITLE
Jetty 12 - Alternate `TryPathsHandler` based on `Request.Processor` existence

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -83,19 +83,21 @@ public class TryPathsHandler extends Handler.Wrapper
         public TryPathsRequest(Request wrapped, String interpolated)
         {
             super(wrapped);
+
+            HttpURI.Mutable rewrittenUri = HttpURI.build(wrapped.getHttpURI());
+
             int queryIdx = interpolated.indexOf('?');
             if (queryIdx >= 0)
             {
                 String path = interpolated.substring(0, queryIdx);
-                _uri = HttpURI.build(wrapped.getHttpURI())
-                    .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
-                    .query(interpolated.substring(queryIdx + 1))
-                    .asImmutable();
+                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), path));
+                rewrittenUri.query(interpolated.substring(queryIdx + 1));
             }
             else
             {
-                _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(interpolated));
+                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), interpolated));
             }
+            _uri = rewrittenUri.asImmutable();
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -89,7 +89,7 @@ public class TryPathsHandler extends Handler.Wrapper
                 String path = interpolated.substring(0, queryIdx);
                 _uri = HttpURI.build(wrapped.getHttpURI())
                     .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
-                    .query(interpolated.substring(queryIdx+1))
+                    .query(interpolated.substring(queryIdx + 1))
                     .asImmutable();
             }
             else

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -16,35 +16,110 @@ package org.eclipse.jetty.server.handler;
 import java.util.List;
 
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.URIUtil;
 
 /**
  * <p>Inspired by nginx's {@code try_files} functionality.</p>
- * <p> This handler can be configured with a list of URI paths.
- * The special token {@code $path} represents the current request URI
- * path (the portion after the context path).</p>
+ *
+ * <p> This handler can be configured with a list of rewrite URI paths.
+ * The special token {@code $path} represents the current request
+ * {@code pathInContext} (the portion after the context path).</p>
+ *
  * <p>Typical example of how this handler can be configured is the following:</p>
  * <pre>{@code
- * TryPathsHandler tryPaths = new TryPathsHandler();
- * tryPaths.setPaths("/maintenance.html", "$path", "/index.php?p=$path");
+ * TryPathsHandler tryPathsHandler = new TryPathsHandler();
+ * tryPathsHandler.setPaths("/maintenance.html", "$path", "/index.php?p=$path");
+ *
+ * PathMappingsHandler pathMappingsHandler = new PathMappingsHandler();
+ * tryPathsHandler.setHandler(pathMappingsHandler);
+ *
+ * pathMappingsHandler.addMapping(new ServletPathSpec("*.php"), new PHPHandler());
+ * pathMappingsHandler.addMapping(new ServletPathSpec("/"), new ResourceHandler());
  * }</pre>
- * <p>For a request such as {@code /context/path/to/resource.ext}, this
- * handler will try to serve the {@code /maintenance.html} file if it finds
- * it; failing that, it will try to serve the {@code /path/to/resource.ext}
- * file if it finds it; failing that it will forward the request to
- * {@code /index.php?p=/path/to/resource.ext} to the next handler.</p>
- * <p>The last URI path specified in the list is therefore the "fallback" to
- * which the request is forwarded to in case no previous files can be found.</p>
- * <p>The file paths are resolved against {@link Context#getBaseResource()}
- * to make sure that only files visible to the application are served.</p>
+ *
+ * <p>For a request such as {@code /context/path/to/resource.ext}:</p>
+ * <ul>
+ * <li>This handler rewrites the request {@code pathInContext} to
+ * {@code /maintenance.html} and forwards the request to the next handler,
+ * where it matches the {@code /} mapping, hitting the {@code ResourceHandler}
+ * that serves the file if it exists.</li>
+ * <li>Otherwise, this handler rewrites the request {@code pathInContext} to
+ * {@code /path/to/resource.ext} and forwards the request to the next handler,
+ * where it matches the {@code /} mapping, hitting the {@code ResourceHandler}
+ * that serves the file if it exists.</li>
+ * <li>Otherwise, this handler rewrites the request {@code pathInContext} to
+ * {@code /index.php?p=/path/to/resource.ext} and forwards the request to
+ * the next handler, where it matches the {@code *.php} mapping, hitting
+ * the {@code PHPHandler}.</li>
+ * </ul>
+ *
+ * <p>The original path and query may be stored as request attributes,
+ * under the names specified by {@link #setOriginalPathAttribute(String)}
+ * and {@link #setOriginalQueryAttribute(String)}.</p>
  */
 public class TryPathsHandler extends Handler.Wrapper
 {
+    private String originalPathAttribute;
+    private String originalQueryAttribute;
     private List<String> paths;
 
+    /**
+     * @return the attribute name of the original request path
+     */
+    public String getOriginalPathAttribute()
+    {
+        return originalPathAttribute;
+    }
+
+    /**
+     * <p>Sets the request attribute name to use to
+     * retrieve the original request path.</p>
+     *
+     * @param originalPathAttribute the attribute name of the original
+     * request path
+     */
+    public void setOriginalPathAttribute(String originalPathAttribute)
+    {
+        this.originalPathAttribute = originalPathAttribute;
+    }
+
+    /**
+     * @return the attribute name of the original request query
+     */
+    public String getOriginalQueryAttribute()
+    {
+        return originalQueryAttribute;
+    }
+
+    /**
+     * <p>Sets the request attribute name to use to
+     * retrieve the original request query.</p>
+     *
+     * @param originalQueryAttribute the attribute name of the original
+     * request query
+     */
+    public void setOriginalQueryAttribute(String originalQueryAttribute)
+    {
+        this.originalQueryAttribute = originalQueryAttribute;
+    }
+
+    /**
+     * @return the rewrite URI paths
+     */
+    public List<String> getPaths()
+    {
+        return paths;
+    }
+
+    /**
+     * <p>Sets a list of rewrite URI paths.</p>
+     * The special token {@code $path} represents the current request
+     * {@code pathInContext} (the portion after the context path).</p>
+     *
+     * @param paths the rewrite URI paths
+     */
     public void setPaths(List<String> paths)
     {
         this.paths = paths;
@@ -70,28 +145,37 @@ public class TryPathsHandler extends Handler.Wrapper
         return value.replace("$path", path);
     }
 
-    private static class TryPathsRequest extends Request.Wrapper
+    private class TryPathsRequest extends Request.Wrapper
     {
         private final HttpURI _uri;
 
-        public TryPathsRequest(Request wrapped, String interpolated)
+        public TryPathsRequest(Request wrapped, String newPathQuery)
         {
             super(wrapped);
 
-            HttpURI.Mutable rewrittenUri = HttpURI.build(wrapped.getHttpURI());
+            HttpURI originalURI = wrapped.getHttpURI();
 
-            int queryIdx = interpolated.indexOf('?');
+            String originalPathAttribute = getOriginalPathAttribute();
+            if (originalPathAttribute != null)
+                setAttribute(originalPathAttribute, Request.getPathInContext(wrapped));
+            String originalQueryAttribute = getOriginalQueryAttribute();
+            if (originalQueryAttribute != null)
+                setAttribute(originalQueryAttribute, originalURI.getQuery());
+
+            String originalContextPath = Request.getContextPath(wrapped);
+            HttpURI.Mutable rewrittenURI = HttpURI.build(originalURI);
+            int queryIdx = newPathQuery.indexOf('?');
             if (queryIdx >= 0)
             {
-                String path = interpolated.substring(0, queryIdx);
-                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), path));
-                rewrittenUri.query(interpolated.substring(queryIdx + 1));
+                String path = newPathQuery.substring(0, queryIdx);
+                rewrittenURI.path(URIUtil.addPaths(originalContextPath, path));
+                rewrittenURI.query(newPathQuery.substring(queryIdx + 1));
             }
             else
             {
-                rewrittenUri.path(URIUtil.addPaths(Request.getContextPath(wrapped), interpolated));
+                rewrittenURI.path(URIUtil.addPaths(originalContextPath, newPathQuery));
             }
-            _uri = rewrittenUri.asImmutable();
+            _uri = rewrittenURI.asImmutable();
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -87,10 +87,22 @@ public class TryPathsHandler extends Handler.Wrapper
     {
         private final HttpURI _uri;
 
-        public TryPathsRequest(Request wrapped, String pathInContext)
+        public TryPathsRequest(Request wrapped, String interpolated)
         {
             super(wrapped);
-            _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(pathInContext));
+            int queryIdx = interpolated.indexOf('?');
+            if (queryIdx >= 0)
+            {
+                String path = interpolated.substring(0, queryIdx);
+                _uri = HttpURI.build(wrapped.getHttpURI())
+                    .path(URIUtil.addPaths(Request.getContextPath(wrapped), path))
+                    .query(interpolated.substring(queryIdx+1))
+                    .asImmutable();
+            }
+            else
+            {
+                _uri = Request.newHttpURIFrom(wrapped, URIUtil.canonicalPath(interpolated));
+            }
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -70,13 +70,6 @@ public class TryPathsHandler extends Handler.Wrapper
         return result.wrapProcessor(super.handle(result));
     }
 
-    private Request.Processor fallback(Request request) throws Exception
-    {
-        String fallback = paths.isEmpty() ? "$path" : paths.get(paths.size() - 1);
-        String interpolated = interpolate(request, fallback);
-        return super.handle(new TryPathsRequest(request, interpolated));
-    }
-
     private String interpolate(Request request, String value)
     {
         String path = Request.getPathInContext(request);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.jetty.util.URIUtil;
 /**
  * <p>Inspired by nginx's {@code try_files} functionality.</p>
  *
- * <p> This handler can be configured with a list of rewrite URI paths.
+ * <p>This handler can be configured with a list of rewrite URI paths.
  * The special token {@code $path} represents the current request
  * {@code pathInContext} (the portion after the context path).</p>
  *
@@ -115,7 +115,7 @@ public class TryPathsHandler extends Handler.Wrapper
 
     /**
      * <p>Sets a list of rewrite URI paths.</p>
-     * The special token {@code $path} represents the current request
+     * <p>The special token {@code $path} represents the current request
      * {@code pathInContext} (the portion after the context path).</p>
      *
      * @param paths the rewrite URI paths


### PR DESCRIPTION
... instead of ResourceBase existence.

This is an alternative approach to PR #8777