### PR TITLE
Fixed tests that fail when localhost resolves to more than one address.

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/Socks4ProxyTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/Socks4ProxyTest.java
@@ -54,7 +54,7 @@ public class Socks4ProxyTest
     public void prepare() throws Exception
     {
         proxy = ServerSocketChannel.open();
-        proxy.bind(new InetSocketAddress("localhost", 0));
+        proxy.bind(new InetSocketAddress("127.0.0.1", 0));
 
         ClientConnector connector = new ClientConnector();
         QueuedThreadPool clientThreads = new QueuedThreadPool();
@@ -77,7 +77,7 @@ public class Socks4ProxyTest
     public void testSocks4Proxy() throws Exception
     {
         int proxyPort = proxy.socket().getLocalPort();
-        client.getProxyConfiguration().addProxy(new Socks4Proxy("localhost", proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -139,7 +139,7 @@ public class Socks4ProxyTest
     public void testSocks4ProxyWithSplitResponse() throws Exception
     {
         int proxyPort = proxy.socket().getLocalPort();
-        client.getProxyConfiguration().addProxy(new Socks4Proxy("localhost", proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -196,7 +196,6 @@ public class Socks4ProxyTest
     @Test
     public void testSocks4ProxyWithTLSServer() throws Exception
     {
-        String proxyHost = "localhost";
         int proxyPort = proxy.socket().getLocalPort();
 
         String serverHost = "127.0.0.13"; // Server host different from proxy host.
@@ -215,7 +214,7 @@ public class Socks4ProxyTest
             // The hostname must be that of the server, not of the proxy.
             ssl.setHostnameVerifier((hostname, session) -> serverHost.equals(hostname));
         });
-        client.getProxyConfiguration().addProxy(new Socks4Proxy(proxyHost, proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
 
         CountDownLatch latch = new CountDownLatch(1);
         client.newRequest(serverHost, serverPort)
@@ -281,12 +280,15 @@ public class Socks4ProxyTest
     @Test
     public void testRequestTimeoutWhenSocksProxyDoesNotRespond() throws Exception
     {
-        String proxyHost = "localhost";
         int proxyPort = proxy.socket().getLocalPort();
-        client.getProxyConfiguration().addProxy(new Socks4Proxy(proxyHost, proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
 
         long timeout = 1000;
-        Request request = client.newRequest("localhost", proxyPort + 1)
+
+        // Use an address to avoid resolution of "localhost" to multiple addresses.
+        String serverHost = "127.0.0.13";
+        int serverPort = proxyPort + 1; // Any port will do
+        Request request = client.newRequest(serverHost, serverPort)
             .timeout(timeout, TimeUnit.MILLISECONDS);
         FutureResponseListener listener = new FutureResponseListener(request);
         request.send(listener);
@@ -303,13 +305,15 @@ public class Socks4ProxyTest
     @Test
     public void testIdleTimeoutWhenSocksProxyDoesNotRespond() throws Exception
     {
-        String proxyHost = "localhost";
         int proxyPort = proxy.socket().getLocalPort();
-        client.getProxyConfiguration().addProxy(new Socks4Proxy(proxyHost, proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
         long idleTimeout = 1000;
         client.setIdleTimeout(idleTimeout);
 
-        Request request = client.newRequest("localhost", proxyPort + 1);
+        // Use an address to avoid resolution of "localhost" to multiple addresses.
+        String serverHost = "127.0.0.13";
+        int serverPort = proxyPort + 1; // Any port will do
+        Request request = client.newRequest(serverHost, serverPort);
         FutureResponseListener listener = new FutureResponseListener(request);
         request.send(listener);
 
@@ -325,11 +329,13 @@ public class Socks4ProxyTest
     @Test
     public void testSocksProxyClosesConnectionImmediately() throws Exception
     {
-        String proxyHost = "localhost";
         int proxyPort = proxy.socket().getLocalPort();
-        client.getProxyConfiguration().addProxy(new Socks4Proxy(proxyHost, proxyPort));
+        client.getProxyConfiguration().addProxy(new Socks4Proxy("127.0.0.1", proxyPort));
 
-        Request request = client.newRequest("localhost", proxyPort + 1);
+        // Use an address to avoid resolution of "localhost" to multiple addresses.
+        String serverHost = "127.0.0.13";
+        int serverPort = proxyPort + 1; // Any port will do
+        Request request = client.newRequest(serverHost, serverPort);
         FutureResponseListener listener = new FutureResponseListener(request);
         request.send(listener);
 

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ForwardProxyTLSServerTest.java
@@ -130,7 +130,8 @@ public class ForwardProxyTLSServerTest
 
     protected HttpProxy newHttpProxy()
     {
-        return new HttpProxy(new Origin.Address("localhost", proxyConnector.getLocalPort()), proxySslContextFactory != null);
+        // Use an address to avoid resolution of "localhost" to multiple addresses.
+        return new HttpProxy(new Origin.Address("127.0.0.1", proxyConnector.getLocalPort()), proxySslContextFactory != null);
     }
 
     private HttpClient newHttpClient()
@@ -615,7 +616,7 @@ public class ForwardProxyTLSServerTest
         if (includeAddress)
             httpProxy.getIncludedAddresses().add("localhost:" + serverConnector.getLocalPort());
         httpClient.getProxyConfiguration().addProxy(httpProxy);
-        URI uri = URI.create((proxySslContextFactory == null ? "http" : "https") + "://localhost:" + proxyConnector.getLocalPort());
+        URI uri = URI.create((proxySslContextFactory == null ? "http" : "https") + "://127.0.0.1:" + proxyConnector.getLocalPort());
         httpClient.getAuthenticationStore().addAuthentication(new BasicAuthentication(uri, realm, "proxyUser", "proxyPassword"));
         httpClient.start();
 


### PR DESCRIPTION
On Windows, Mac, OpenSolaris (verified) and probably Docker (did not verify, but likely), DNS resolution of "localhost" yields [127.0.0.1, ::1], while on Linux only [127.0.0.1].

HttpClient will try the first address, and in case of failure will try the second address. For those tests that want to explicitly fail the connection attempt, we don't want them to try the second address, which likely yields test failures because of unexpected results (for example, a different exception type).

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>