### PR TITLE
Jetty 12 - Reworking ResourceService.dirAllowed to DirBehavior

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -176,11 +176,13 @@ public class ResourceHandler extends Handler.Wrapper
     }
 
     /**
-     * @return If true, directory listings are returned if no welcome file is found. Else 403 Forbidden.
+     * Get the Directory Behavior mode.
+     *
+     * @return the mode of operation for handling requests for directories
      */
-    public boolean isDirAllowed()
+    public ResourceService.DirectoryBehavior getDirectoryBehavior()
     {
-        return _resourceService.isDirAllowed();
+        return _resourceService.getDirectoryBehavior();
     }
 
     /**
@@ -246,11 +248,13 @@ public class ResourceHandler extends Handler.Wrapper
     }
 
     /**
-     * @param dirAllowed If true, directory listings are returned if no welcome file is found. Else 403 Forbidden.
+     * Set the Directory serving behavior mode
+     *
+     * @param mode the behavior of ResourceHandler when being asked to serve a directory.
      */
-    public void setDirAllowed(boolean dirAllowed)
+    public void setDirectoryBehavior(ResourceService.DirectoryBehavior mode)
     {
-        _resourceService.setDirAllowed(dirAllowed);
+        _resourceService.setDirectoryBehavior(mode);
     }
 
     /**

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasCheckerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/AllowSymLinkAliasCheckerTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -169,7 +170,7 @@ public class AllowSymLinkAliasCheckerTest
         server.addConnector(localConnector);
 
         ResourceHandler fileResourceHandler = new ResourceHandler();
-        fileResourceHandler.setDirAllowed(true);
+        fileResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING);
         fileResourceHandler.setWelcomeFiles(List.of("index.html"));
         fileResourceHandler.setEtags(true);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -755,7 +755,7 @@ public class ResourceHandlerTest
         Files.writeString(docRoot.resolve("data0.txt"), "Hello Text 0", UTF_8);
         Files.writeString(docRoot.resolve("data0.txt.br"), "fake brotli", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.BR);
         _rootResourceHandler.setEtags(true);
@@ -783,7 +783,7 @@ public class ResourceHandlerTest
         Files.writeString(docRoot.resolve("data0.txt"), "Hello Text 0", UTF_8);
         Files.writeString(docRoot.resolve("data0.txt.br"), "fake brotli", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.BR);
         _rootResourceHandler.setEtags(true);
@@ -920,7 +920,7 @@ public class ResourceHandlerTest
         Files.writeString(docRoot.resolve("data0.txt"), "Hello Text 0", UTF_8);
         Files.writeString(docRoot.resolve("data0.txt.br"), "fake brotli", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.BR);
         _rootResourceHandler.setEtags(true);
@@ -1041,7 +1041,7 @@ public class ResourceHandlerTest
         Path file0gz = docRoot.resolve("data0.txt.gz");
         Files.writeString(file0gz, "fake gzip", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
         _rootResourceHandler.setEtags(true);
@@ -1740,7 +1740,7 @@ public class ResourceHandlerTest
             Arguments.of("""
                 GET /context/directory;JSESSIONID=12345678 HTTP/1.1\r
                 Host: local\r
-                Connection: close\r              
+                Connection: close\r             
                 \r
                 """, "/context/directory/;JSESSIONID=12345678"),
             Arguments.of("""
@@ -2115,7 +2115,7 @@ public class ResourceHandlerTest
         Path file0gz = docRoot.resolve("data0.txt.gz");
         Files.writeString(file0gz, "fake gzip", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
         _rootResourceHandler.setEtags(true);
@@ -2636,7 +2636,7 @@ public class ResourceHandlerTest
     @MethodSource("contextBreakoutScenarios")
     public void testListingContextBreakout(ResourceHandlerTest.Scenario scenario) throws Exception
     {
-        _rootResourceHandler.setDirAllowed(true);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING);
         _rootResourceHandler.setWelcomeFiles("index.html");
 
         /* create some content in the docroot */
@@ -3089,7 +3089,7 @@ public class ResourceHandlerTest
         Path nofilesuffix = docRoot.resolve("nofilesuffix");
         Files.writeString(nofilesuffix, "01234567890123456789012345678901234567890123456789012345678901234567890123456789", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setAcceptRanges(true);
 
@@ -3111,7 +3111,7 @@ public class ResourceHandlerTest
         getLocalConnectorConfig().setRelativeRedirectAllowed(true);
 
         _rootResourceHandler.setRedirectWelcome(true);
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setWelcomeFiles("index.html");
 
         String rawResponse;
@@ -3302,7 +3302,7 @@ public class ResourceHandlerTest
     @MethodSource("welcomeScenarios")
     public void testWelcome(ResourceHandlerTest.Scenario scenario) throws Exception
     {
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
         _rootResourceHandler.setWelcomeFiles("index.html", "index.htm");
 
@@ -3389,7 +3389,7 @@ public class ResourceHandlerTest
 
         ResourceHandler altResourceHandler = new ResourceHandler();
         altResourceHandler.setBaseResource(ResourceFactory.root().newResource(altRoot));
-        altResourceHandler.setDirAllowed(false); // Cannot see listings
+        altResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE); // Cannot see listings
         altResourceHandler.setRedirectWelcome(false);
         altResourceHandler.setWelcomeFiles("index.html", "index.htm");
         ContextHandler altContext = new ContextHandler("/context/alt");
@@ -3399,7 +3399,7 @@ public class ResourceHandlerTest
 
         ResourceHandler otherResourceHandler = new ResourceHandler();
         otherResourceHandler.setBaseResource(ResourceFactory.root().newResource(altRoot));
-        otherResourceHandler.setDirAllowed(true); // Can see listings
+        otherResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING); // Can see listings
         otherResourceHandler.setRedirectWelcome(false);
         otherResourceHandler.setWelcomeFiles("index.html", "index.htm");
         ContextHandler otherContext = new ContextHandler("/context/other");
@@ -3407,7 +3407,7 @@ public class ResourceHandlerTest
         _contextHandlerCollection.addHandler(otherContext);
         otherContext.start(); // Correct behavior, after ContextHandlerCollection is started, it's on us to start the handler.
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(false);
 
         String rawResponse;
@@ -3586,7 +3586,7 @@ public class ResourceHandlerTest
         Path inde = dir.resolve("index.htm");
         Path index = dir.resolve("index.html");
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(true);
         _rootResourceHandler.setWelcomeFiles("index.html", "index.htm");
 
@@ -3672,7 +3672,7 @@ public class ResourceHandlerTest
         Path index = dir.resolve("index.html");
         Files.writeString(index, "<h1>Hello Index</h1>", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(true);
         _rootResourceHandler.setWelcomeFiles("index.html");
 
@@ -3721,7 +3721,7 @@ public class ResourceHandlerTest
         Path index = dir.resolve("index.html");
         Files.writeString(index, "<h1>Hello Index</h1>", UTF_8);
 
-        _rootResourceHandler.setDirAllowed(false);
+        _rootResourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
         _rootResourceHandler.setRedirectWelcome(true);
         _rootResourceHandler.setWelcomeFiles("index.html");
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -81,7 +82,6 @@ public class TryPathsHandlerTest
         tryPaths.setPaths(paths);
         tryPaths.setHandler(handler);
 
-        server.setDumpAfterStart(true);
         server.start();
     }
 
@@ -95,7 +95,7 @@ public class TryPathsHandlerTest
     public void testTryPaths() throws Exception
     {
         ResourceHandler resourceHandler = new ResourceHandler();
-        resourceHandler.setDirAllowed(false);
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SKIP);
         resourceHandler.setHandler(new Handler.Abstract()
         {
             @Override
@@ -161,7 +161,7 @@ public class TryPathsHandlerTest
     public void testTryPathsWithPathMappings() throws Exception
     {
         ResourceHandler resourceHandler = new ResourceHandler();
-        resourceHandler.setDirAllowed(false);
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SKIP);
 
         PathMappingsHandler pathMappingsHandler = new PathMappingsHandler();
         pathMappingsHandler.addMapping(new ServletPathSpec("/"), resourceHandler);

--- a/jetty-core/jetty-tests/jetty-test-core-integration/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-core-integration/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.eclipse.jetty</groupId>
+    <artifactId>jetty-tests</artifactId>
+    <version>12.0.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jetty-test-core-integration</artifactId>
+  <name>Jetty Core :: Tests :: Integration</name>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.test.core.integration</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/jetty-core/jetty-tests/jetty-test-core-integration/src/test/java/org/eclipse/jetty/test/core/integration/ResourceHandlerAndPhpTest.java
+++ b/jetty-core/jetty-tests/jetty-test-core-integration/src/test/java/org/eclipse/jetty/test/core/integration/ResourceHandlerAndPhpTest.java
@@ -1,0 +1,283 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.core.integration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.pathmap.ServletPathSpec;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.ResourceService;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.PathMappingsHandler;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.server.handler.TryPathsHandler;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResourceHandlerAndPhpTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceHandlerAndPhpTest.class);
+    private static final String ATTR_ORIGINAL_PATH = "test.originalPath";
+    private static final String ATTR_ORIGINAL_QUERY = "test.originalQuery";
+
+    private static Server server;
+    private static LocalConnector localConnector;
+
+    @BeforeAll
+    public static void setup(WorkDir workDir) throws Exception
+    {
+        // Build docroot
+        Path docroot = workDir.getEmptyPathDir();
+
+        Files.writeString(docroot.resolve("index.php"), "This is /index.php");
+        Path cssDir = docroot.resolve("css");
+        Files.createDirectory(cssDir);
+        Files.writeString(cssDir.resolve("main.css"), "This is the /css/main.css");
+        Path wpAdminDir = docroot.resolve("wp-admin");
+        Files.createDirectory(wpAdminDir);
+        Files.writeString(wpAdminDir.resolve("index.php"), "This is the /wp-admin/index.php");
+
+        // Setup Handler Tree
+        ContextHandler contextHandler = new ContextHandler();
+        contextHandler.setContextPath("/");
+        contextHandler.setBaseResource(ResourceFactory.of(contextHandler).newResource(docroot));
+
+        TryPathsHandler tryPathsHandler = new TryPathsHandler();
+        tryPathsHandler.setOriginalPathAttribute(ATTR_ORIGINAL_PATH);
+        tryPathsHandler.setOriginalQueryAttribute(ATTR_ORIGINAL_QUERY);
+        tryPathsHandler.setPaths(List.of("/maintenance.txt", "$path", "$pathindex.php", "/index.php?p=$path"));
+        contextHandler.setHandler(tryPathsHandler);
+
+        ResourceHandler resourceHandler = new ResourceHandler();
+        // configure ResourceHandler to skip attempts at directories it cannot serve
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.SKIP);
+
+        PhpHandler phpHandler = new PhpHandler();
+        phpHandler.addVirtualPath("/messaging/");
+
+        PathMappingsHandler pathMappingsHandler = new PathMappingsHandler();
+        pathMappingsHandler.addMapping(new ServletPathSpec("/"), resourceHandler);
+        pathMappingsHandler.addMapping(new ServletPathSpec("*.php"), phpHandler);
+
+        tryPathsHandler.setHandler(pathMappingsHandler);
+
+        server = new Server();
+        localConnector = new LocalConnector(server);
+        server.addConnector(localConnector);
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+        contextHandlerCollection.setHandlers(contextHandler);
+        server.setHandler(contextHandlerCollection);
+        server.start();
+    }
+
+    @AfterAll
+    public static void teardown()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testRequestNotExists() throws Exception
+    {
+        HttpTester.Response response = issueRequest(
+            """
+                GET /not-exists HTTP/1.1
+                Host: local
+                Connection: close
+                                
+                """
+        );
+        assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void testRequestRoot() throws Exception
+    {
+        HttpTester.Response response = issueRequest(
+            """
+                GET / HTTP/1.1
+                Host: local
+                Connection: close
+                                
+                """
+        );
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.get("X-Php"), is("/index.php"));
+    }
+
+    @Test
+    public void testRequestMainCss() throws Exception
+    {
+        HttpTester.Response response = issueRequest(
+            """
+                GET /css/main.css?v=1.23 HTTP/1.1
+                Host: local
+                Connection: close
+                                
+                """
+        );
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.getContent(), is("This is the /css/main.css"));
+    }
+
+    @Test
+    public void testRequestWpAdmin() throws Exception
+    {
+        HttpTester.Response response = issueRequest(
+            """
+                GET /wp-admin/ HTTP/1.1
+                Host: local
+                Connection: close
+                                
+                """
+        );
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.get("X-Php"), is("/wp-admin/index.php"));
+        assertThat(response.getContent(), containsString("originalPath=[/wp-admin/]"));
+    }
+
+    @Test
+    public void testRequestMessaging() throws Exception
+    {
+        HttpTester.Response response = issueRequest(
+            """
+                GET /messaging/ HTTP/1.1
+                Host: local
+                Connection: close
+                                
+                """
+        );
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.get("X-Php"), is("/messaging/index.php"));
+        assertThat(response.getContent(), containsString("originalPath=[/messaging/]"));
+    }
+
+    private HttpTester.Response issueRequest(String rawRequest) throws Exception
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Raw Request: " + rawRequest);
+
+        String rawResponse = localConnector.getResponse(rawRequest);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Raw Response: " + rawResponse);
+
+        return HttpTester.parseResponse(rawResponse);
+    }
+
+    private static class PhpHandler extends Handler.Abstract
+    {
+        private Resource resourceBase;
+        private List<String> virtualPaths = new ArrayList<>();
+
+        public void addVirtualPath(String path)
+        {
+            virtualPaths.add(path);
+        }
+
+        @Override
+        protected void doStart()
+        {
+            if (resourceBase == null)
+            {
+                Context context = ContextHandler.getCurrentContext();
+                if (context != null)
+                    resourceBase = context.getBaseResource();
+            }
+
+            if (resourceBase == null)
+                throw new IllegalStateException("Cannot have a null resourceBase");
+        }
+
+        private boolean canServeRequest(String path)
+        {
+            if (virtualPaths.contains(path))
+                return true;
+
+            Resource resolvedInBase = resourceBase.resolve(path);
+            return Resources.exists(resolvedInBase);
+        }
+
+        @Override
+        public Request.Processor handle(Request request)
+        {
+            final String originalPath = (String)request.getAttribute(ATTR_ORIGINAL_PATH);
+            // mimic the PHP behavior.
+            if (!canServeRequest(originalPath))
+            {
+                // cannot serve it, have this "php" handler return a 404
+                return new Handler.Processor()
+                {
+                    @Override
+                    public void process(Request request, Response response, Callback callback)
+                    {
+                        Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
+                    }
+                };
+            }
+
+            return new Handler.Processor()
+            {
+                @Override
+                public void process(Request request, Response response, Callback callback)
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=utf-8");
+                    response.getHeaders().put("X-Php", request.getHttpURI().getPathQuery());
+                    String originalQuery = (String)request.getAttribute(ATTR_ORIGINAL_QUERY);
+                    String message = """
+                        PHP:
+                        pathInContext=[%s]
+                        httpUri.query=[%s]
+                        originalPath=[%s]
+                        originalQuery=[%s]
+                        """
+                        .formatted(
+                            Request.getPathInContext(request),
+                            request.getHttpURI().getQuery(),
+                            originalPath,
+                            originalQuery
+                        );
+                    Content.Sink.write(response, true, message, callback);
+                }
+            };
+        }
+    }
+}

--- a/jetty-core/jetty-tests/jetty-test-core-integration/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-tests/jetty-test-core-integration/src/test/resources/jetty-logging.properties
@@ -1,0 +1,3 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+org.eclipse.jetty.test.LEVEL=DEBUG
+org.eclipse.jetty.server.handler.LEVEL=DEBUG

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -18,6 +18,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
@@ -942,6 +943,20 @@ public class StringUtil
         if (started)
             return minus ? (-val) : val;
         throw new NumberFormatException(string);
+    }
+
+    /**
+     * Return the lowercase version of the input.
+     *
+     * @param input the input String (can be null or blank)
+     * @return the lowercase version of the input string, or empty string if input is blank.
+     * @see #isBlank(String)
+     */
+    public static String toLowerCase(String input)
+    {
+        if (isBlank(input))
+            return "";
+        return input.toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServer.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -43,7 +44,7 @@ public class FileServer
 
         // Configure the ResourceHandler. Setting the resource base indicates where the files should be served out of.
         // In this example it is the current directory but it can be configured to anything that the jvm has access to.
-        resourceHandler.setDirAllowed(true);
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING);
         resourceHandler.setWelcomeFiles(List.of("index.html"));
         resourceHandler.setBaseResource(baseResource);
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/SplitFileServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/SplitFileServer.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.demos;
 
 import java.nio.file.Paths;
 
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -49,7 +50,7 @@ public class SplitFileServer
         // directory, you needn't use these, you simply need to supply the paths
         // you are looking to serve content from.
         ResourceHandler rh0 = new ResourceHandler();
-        rh0.setDirAllowed(false);
+        rh0.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
 
         ContextHandler context0 = new ContextHandler();
         context0.setContextPath("/");
@@ -59,7 +60,7 @@ public class SplitFileServer
         // Rinse and repeat the previous item, only specifying a different
         // resource base.
         ResourceHandler rh1 = new ResourceHandler();
-        rh1.setDirAllowed(false);
+        rh1.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
 
         ContextHandler context1 = new ContextHandler();
         context1.setContextPath("/");

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -66,6 +66,7 @@ import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -155,10 +156,22 @@ public class DefaultServlet extends HttpServlet
             servletContextHandler.setWelcomeFiles(new String[]{"index.html", "index.jsp"});
 
         _resourceService.setAcceptRanges(getInitBoolean("acceptRanges", _resourceService.isAcceptRanges()));
-        _resourceService.setDirAllowed(getInitBoolean("dirAllowed", _resourceService.isDirAllowed()));
         _resourceService.setRedirectWelcome(getInitBoolean("redirectWelcome", _resourceService.isRedirectWelcome()));
         _resourceService.setPrecompressedFormats(precompressedFormats);
         _resourceService.setEtags(getInitBoolean("etags", _resourceService.isEtags()));
+
+        if (getInitParameter("dirAllowed") != null)
+            LOG.warn("init-param 'dirAllowed' has been replaced by 'dirBehavior'");
+
+        String directoryMode = getInitParameter("dirBehavior", _resourceService.getDirectoryBehavior().name());
+        ResourceService.DirectoryBehavior mode = switch (StringUtil.toLowerCase(directoryMode))
+        {
+            case "skip" -> ResourceService.DirectoryBehavior.SKIP;
+            case "listing" -> ResourceService.DirectoryBehavior.LISTING;
+            default -> ResourceService.DirectoryBehavior.SERVE;
+        };
+
+        _resourceService.setDirectoryBehavior(mode);
 
         _isPathInfoOnly = getInitBoolean("pathInfoOnly", _isPathInfoOnly);
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServer.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServer.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -42,7 +43,7 @@ public class FileServer
 
         // Configure the ResourceHandler. Setting the resource base indicates where the files should be served out of.
         // In this example it is the current directory but it can be configured to anything that the jvm has access to.
-        resourceHandler.setDirAllowed(true);
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING);
         resourceHandler.setWelcomeFiles("index.html");
         resourceHandler.setBaseResource(baseResource);
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/SplitFileServer.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/SplitFileServer.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee9.demos;
 
 import java.nio.file.Paths;
 
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -49,7 +50,7 @@ public class SplitFileServer
         // directory, you needn't use these, you simply need to supply the paths
         // you are looking to serve content from.
         ResourceHandler rh0 = new ResourceHandler();
-        rh0.setDirAllowed(false);
+        rh0.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
 
         ContextHandler context0 = new ContextHandler();
         context0.setContextPath("/");
@@ -59,7 +60,7 @@ public class SplitFileServer
         // Rinse and repeat the previous item, only specifying a different
         // resource base.
         ResourceHandler rh1 = new ResourceHandler();
-        rh1.setDirAllowed(false);
+        rh1.setDirectoryBehavior(ResourceService.DirectoryBehavior.SERVE);
 
         ContextHandler context1 = new ContextHandler();
         context1.setContextPath("/");

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -83,7 +84,7 @@ public class GzipHandlerIsHandledTest
 
         ResourceHandler resourceHandler = new ResourceHandler();
         resourceHandler.setBaseResource(ResourceFactory.root().newResource(workDir.getPath()));
-        resourceHandler.setDirAllowed(true);
+        resourceHandler.setDirectoryBehavior(ResourceService.DirectoryBehavior.LISTING);
         resourceHandler.setHandler(new EventHandler(events, "ResourceHandler"));
 
         GzipHandler gzipHandler = new GzipHandler();

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@
     <module>tests</module>
     <!-- <module>jetty-p2</module> -->
      <module>documentation</module>
+    <module>jetty-core/jetty-tests/jetty-test-core-integration</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Experiment to see what a ResourceService would look like if Directory serving had an option to SKIP serving if not possible to serve as a Welcome File.
This will skip the creation of the Directory Listing, and also the Forbidden Response.

This is to see if we can integrate TryPathsHandler + PathMappingsHandler + ResourceHandler in the same series of requests.