### PR TITLE
Issue #8330 - fix IllegalStateException from using OpenID with SessionDatastore

### DIFF
--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.security.openid;
 
+import java.io.File;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
@@ -28,7 +29,9 @@ import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.session.FileSessionDataStoreFactory;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,6 +110,11 @@ public class OpenIdAuthenticationTest
         securityHandler.setInitParameter(OpenIdAuthenticator.LOGOUT_REDIRECT_PATH, "/");
         context.setSecurityHandler(securityHandler);
 
+        File datastoreDir = MavenTestingUtils.getTargetTestingDir("datastore");
+        FileSessionDataStoreFactory fileSessionDataStoreFactory = new FileSessionDataStoreFactory();
+        fileSessionDataStoreFactory.setStoreDir(datastoreDir);
+        server.addBean(fileSessionDataStoreFactory);
+
         server.start();
         String redirectUri = "http://localhost:" + connector.getLocalPort() + "/redirect_path";
         openIdProvider.addRedirectUri(redirectUri);
@@ -152,6 +160,19 @@ public class OpenIdAuthenticationTest
         // Request to admin page gives 403 as we do not have admin role
         response = client.GET(appUriString + "/admin");
         assertThat(response.getStatus(), is(HttpStatus.FORBIDDEN_403));
+
+        // We can restart the server and still be logged in as we have persistent session datastore.
+        server.stop();
+        server.start();
+        appUriString = "http://localhost:" + connector.getLocalPort();
+
+        // After restarting server the authentication is saved as a session authentication.
+        response = client.GET(appUriString + "/");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        content = response.getContentAsString();
+        assertThat(content, containsString("userId: 123456789"));
+        assertThat(content, containsString("name: Alice"));
+        assertThat(content, containsString("email: Alice@example.com"));
 
         // We are no longer authenticated after logging out
         response = client.GET(appUriString + "/logout");

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.session.FileSessionDataStoreFactory;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,6 +112,7 @@ public class OpenIdAuthenticationTest
         context.setSecurityHandler(securityHandler);
 
         File datastoreDir = MavenTestingUtils.getTargetTestingDir("datastore");
+        IO.delete(datastoreDir);
         FileSessionDataStoreFactory fileSessionDataStoreFactory = new FileSessionDataStoreFactory();
         fileSessionDataStoreFactory.setStoreDir(datastoreDir);
         server.addBean(fileSessionDataStoreFactory);

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionActivationListener;
 import javax.servlet.http.HttpSessionBindingListener;
+import javax.servlet.http.HttpSessionEvent;
 
 import org.eclipse.jetty.security.AbstractUserAuthentication;
 import org.eclipse.jetty.security.Authenticator;
@@ -98,5 +99,19 @@ public class SessionAuthentication extends AbstractUserAuthentication
     public String toString()
     {
         return String.format("%s@%x{%s,%s}", this.getClass().getSimpleName(), hashCode(), _session == null ? "-" : _session.getId(), _userIdentity);
+    }
+
+    @Override
+    public void sessionWillPassivate(HttpSessionEvent se)
+    {
+    }
+
+    @Override
+    public void sessionDidActivate(HttpSessionEvent se)
+    {
+        if (_session == null)
+        {
+            _session = se.getSession();
+        }
     }
 }

--- a/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
+++ b/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
@@ -19,9 +19,9 @@ import java.io.Serializable;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionActivationListener;
 import javax.servlet.http.HttpSessionBindingListener;
-import javax.servlet.http.HttpSessionEvent;
 
 import org.eclipse.jetty.security.AbstractUserAuthentication;
+import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.UserIdentity;
@@ -76,7 +76,13 @@ public class SessionAuthentication extends AbstractUserAuthentication
             return;
         }
 
-        LoginService loginService = security.getLoginService();
+        LoginService loginService;
+        Authenticator authenticator = security.getAuthenticator();
+        if (authenticator instanceof LoginAuthenticator)
+            loginService = ((LoginAuthenticator)authenticator).getLoginService();
+        else
+            loginService = security.getLoginService();
+
         if (loginService == null)
         {
             if (LOG.isDebugEnabled())
@@ -92,19 +98,5 @@ public class SessionAuthentication extends AbstractUserAuthentication
     public String toString()
     {
         return String.format("%s@%x{%s,%s}", this.getClass().getSimpleName(), hashCode(), _session == null ? "-" : _session.getId(), _userIdentity);
-    }
-
-    @Override
-    public void sessionWillPassivate(HttpSessionEvent se)
-    {
-    }
-
-    @Override
-    public void sessionDidActivate(HttpSessionEvent se)
-    {
-        if (_session == null)
-        {
-            _session = se.getSession();
-        }
     }
 }


### PR DESCRIPTION
## Closes #8330 

`SessionAuthentication` did not know how to get `LoginService` from OpenID in some use cases.

Now we first try to get `LoginService` from `LoginAuthenticator` before trying from `SecurityHandler` directly.