### PR TITLE
Disable flaky test - `org.eclipse.jetty.quic.client.End2EndClientTest.testMultiThreadedHTTP1`

### DIFF
--- a/jetty-quic/quic-client/src/test/java/org/eclipse/jetty/quic/client/End2EndClientTest.java
+++ b/jetty-quic/quic-client/src/test/java/org/eclipse/jetty/quic/client/End2EndClientTest.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -101,6 +102,7 @@ public class End2EndClientTest
         LifeCycle.stop(server);
     }
 
+    @Disabled("Flaky test - see Issue #8815")
     @Test
     public void testSimpleHTTP1() throws Exception
     {


### PR DESCRIPTION
Disabling test until it can be properly fixed/addressed.