### PR TITLE
Jetty 9.4.x - Build + Dependency Roll-Up

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
@@ -297,10 +297,10 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
         InputStreamResponseListener listener = new InputStreamResponseListener();
         client.newRequest("localhost", connector.getLocalPort())
             .scheme(scenario.getScheme())
-            .timeout(5, TimeUnit.SECONDS)
+            .timeout(15, TimeUnit.SECONDS)
             .send(listener);
 
-        Response response = listener.get(5, TimeUnit.SECONDS);
+        Response response = listener.get(15, TimeUnit.SECONDS);
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
@@ -39,8 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ShutdownMonitorTest
 {
     @AfterEach
-    public void dispose()
+    public void shutdown()
     {
+        // clear out system properties set in individual test cases
+        System.getProperties().remove("STOP.EXIT");
         ShutdownMonitor.reset();
     }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ShutdownMonitorTest.java
@@ -25,9 +25,11 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Properties;
 
 import org.eclipse.jetty.util.thread.ShutdownThread;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -38,12 +40,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShutdownMonitorTest
 {
+    @BeforeEach
+    public void reset()
+    {
+        clearShutdownMonitorSystemProperties();
+    }
+
     @AfterEach
     public void shutdown()
     {
-        // clear out system properties set in individual test cases
-        System.getProperties().remove("STOP.EXIT");
+        clearShutdownMonitorSystemProperties();
         ShutdownMonitor.reset();
+    }
+
+    private void clearShutdownMonitorSystemProperties()
+    {
+        // clear out system properties set in individual test cases
+        Properties systemProperties = System.getProperties();
+        systemProperties.remove("STOP.EXIT");
+        systemProperties.remove("DEBUG");
+        systemProperties.remove("STOP.HOST");
+        systemProperties.remove("STOP.PORT");
+        systemProperties.remove("STOP.KEY");
     }
 
     @Test
@@ -127,6 +145,7 @@ public class ShutdownMonitorTest
     public void testNoExitSystemProperty() throws Exception
     {
         System.setProperty("STOP.EXIT", "false");
+        ShutdownMonitor.reset(); // this creates a new ShutdownMonitor singleton, so we do this now to get the System Property set properly
         ShutdownMonitor monitor = ShutdownMonitor.getInstance();
         monitor.setPort(0);
         assertFalse(monitor.isExitVm());
@@ -180,6 +199,7 @@ public class ShutdownMonitorTest
     {
         //Test setting exit true
         System.setProperty("STOP.EXIT", "true");
+        ShutdownMonitor.reset(); // this creates a new ShutdownMonitor singleton, so we do this now to get the System Property set properly
         ShutdownMonitor monitor = ShutdownMonitor.getInstance();
         monitor.setPort(0);
         assertTrue(monitor.isExitVm());
@@ -191,6 +211,7 @@ public class ShutdownMonitorTest
     {
         //Test setting exit false
         System.setProperty("STOP.EXIT", "false");
+        ShutdownMonitor.reset(); // this creates a new ShutdownMonitor singleton, so we do this now to get the System Property set properly
         ShutdownMonitor monitor = ShutdownMonitor.getInstance();
         monitor.setPort(0);
         assertFalse(monitor.isExitVm());

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
-    <maven.deploy.plugin.version>3.0.0-M2</maven.deploy.plugin.version>
+    <maven.deploy.plugin.version>3.0.0</maven.deploy.plugin.version>
     <servicemix-depends.plugin.version>1.4.0</servicemix-depends.plugin.version>
     <versions.plugin.version>2.11.0</versions.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <maven.site.plugin.version>3.12.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
-    <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
+    <maven.install.plugin.version>3.0.1</maven.install.plugin.version>
     <maven.deploy.plugin.version>3.0.0-M2</maven.deploy.plugin.version>
     <servicemix-depends.plugin.version>1.4.0</servicemix-depends.plugin.version>
     <versions.plugin.version>2.11.0</versions.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <logback.version>1.2.11</logback.version>
     <maven.plugin-tools.version>3.6.4</maven.plugin-tools.version>
-    <maven.resolver.version>1.8.0</maven.resolver.version>
+    <maven.resolver.version>1.8.2</maven.resolver.version>
     <maven.version>3.8.6</maven.version>
     <mongodb.version>2.14.3</mongodb.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <maven.jxr.plugin.version>3.3.1</maven.jxr.plugin.version>
     <maven.plugin.plugin.version>3.6.4</maven.plugin.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-    <maven.remote-resources.plugin.version>1.7.0</maven.remote-resources.plugin.version>
+    <maven.remote-resources.plugin.version>3.0.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
     <maven.site.plugin.version>3.12.0</maven.site.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <jetty-version-txt.plugin.version>2.7</jetty-version-txt.plugin.version>
     <license.plugin.version>4.1</license.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
-    <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
+    <maven.assembly.plugin.version>3.4.2</maven.assembly.plugin.version>
     <maven.invoker.plugin.version>3.3.0</maven.invoker.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <maven.remote-resources.plugin.version>1.7.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
-    <maven.site.plugin.version>3.12.0</maven.site.plugin.version>
+    <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
     <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
-    <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+    <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
     <maven.jxr.plugin.version>3.3.1</maven.jxr.plugin.version>
     <maven.plugin.plugin.version>3.6.4</maven.plugin.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.remote-resources.plugin.version>1.7.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-    <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
+    <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.site.plugin.version>3.12.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>


### PR DESCRIPTION
This is a rollup PR consisting of many other existing PRs + build related fixes so that we can get a stable `jetty-9.4.x` build for the rest of the dependabot PRs.

Once this is stable + green + merged, many other PRs will automatically close as merged as well.