### PR TITLE
Jetty 10 - Flag flaky tests to be skipped on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
         configFileProvider(
                 [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS')]) {
-          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -DexcludedGroups=\"external, large-disk-resource, stress, slow\" -V -B -e -Djetty.testtracker.log=true $cmdline"
+          sh "mvn --no-transfer-progress -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -DexcludedGroups=\"external, large-disk-resource, stress, slow, flaky\" -V -B -e -Djetty.testtracker.log=true $cmdline"
         }
       }
     }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -1501,14 +1501,15 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
     /**
      * <p>The HTTP/2 specification requires that stream ids are monotonically increasing,
-     * see https://tools.ietf.org/html/rfc7540#section-5.1.1.</p>
+     * see <a href="https://tools.ietf.org/html/rfc7540#section-5.1.1">RFC 7540, 5.1.1</a>.</p>
      * <p>This implementation uses a queue to atomically reserve a stream id and claim
      * a slot in the queue; the slot is then assigned the entries to write.</p>
      * <p>Concurrent threads push slots in the queue but only one thread flushes
      * the slots, up to the slot that has a non-null entries to write, therefore
      * guaranteeing that frames are sent strictly in their stream id order.</p>
      * <p>This class also coordinates the creation of streams with the close of
-     * the session, see https://tools.ietf.org/html/rfc7540#section-6.8.</p>
+     * the session, see
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">RFC 7540, 6.8</a>.</p>
      */
     private class StreamsState
     {
@@ -1527,7 +1528,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
         private CloseState getCloseState()
         {
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 return closed;
             }
@@ -1536,7 +1537,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         private CompletableFuture<Void> shutdown()
         {
             CompletableFuture<Void> future;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 if (shutdownCallback != null)
                     return shutdownCallback;
@@ -1550,7 +1551,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         {
             boolean sendGoAway = false;
             boolean tryRunZeroStreamsAction = false;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1661,7 +1662,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
                 LOG.debug("Halting ({}) for {}", reason, HTTP2Session.this);
             GoAwayFrame goAwayFrame = null;
             GoAwayFrame goAwayFrameEvent;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1696,7 +1697,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         {
             boolean failStreams = false;
             boolean tryRunZeroStreamsAction = false;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1806,7 +1807,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             String reason = "input_shutdown";
             Throwable cause = null;
             boolean failStreams = false;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1866,7 +1867,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             boolean sendGoAway = false;
             GoAwayFrame goAwayFrame = null;
             Throwable cause = null;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1933,7 +1934,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         {
             GoAwayFrame goAwayFrame;
             Throwable cause;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -1970,7 +1971,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         private void onWriteFailure(Throwable x)
         {
             String reason = "write_failure";
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -2028,7 +2029,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             // but only one moves to CLOSED and runs the action.
             Runnable action = null;
             CompletableFuture<Void> future;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 long count = streamCount.get();
                 if (count > 0)
@@ -2133,7 +2134,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         private Stream newUpgradeStream(HeadersFrame frame, Stream.Listener listener, Consumer<Throwable> failFn)
         {
             int streamId;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 streamId = localStreamIds.getAndAdd(2);
                 HTTP2Session.this.onStreamCreated(streamId);
@@ -2153,7 +2154,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
         private boolean newRemoteStream(int streamId)
         {
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 switch (closed)
                 {
@@ -2237,7 +2238,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         private int reserveSlot(Slot slot, int streamId, Consumer<Throwable> fail)
         {
             Throwable failure = null;
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 if (closed == CloseState.NOT_CLOSED)
                 {
@@ -2263,7 +2264,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
 
         private void freeSlot(Slot slot, int streamId)
         {
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 slots.remove(slot);
             }
@@ -2292,7 +2293,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
             while (true)
             {
                 List<HTTP2Flusher.Entry> entries;
-                try (AutoLock l = lock.lock())
+                try (AutoLock ignored = lock.lock())
                 {
                     if (flushing == null)
                         flushing = thread;
@@ -2320,7 +2321,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements ISessio
         @Override
         public String toString()
         {
-            try (AutoLock l = lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
                 return String.format("state=[streams=%d,%s,goAwayRecv=%s,goAwaySent=%s,failure=%s]",
                     streamCount.get(),

--- a/jetty-quic/quic-client/src/test/java/org/eclipse/jetty/quic/client/End2EndClientTest.java
+++ b/jetty-quic/quic-client/src/test/java/org/eclipse/jetty/quic/client/End2EndClientTest.java
@@ -40,7 +40,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -102,8 +102,8 @@ public class End2EndClientTest
         LifeCycle.stop(server);
     }
 
-    @Disabled("Flaky test - see Issue #8815")
     @Test
+    @Tag("flaky") // Issue #8815
     public void testSimpleHTTP1() throws Exception
     {
         ContentResponse response = client.newRequest("https://localhost:" + connector.getLocalPort())
@@ -141,6 +141,7 @@ public class End2EndClientTest
     }
 
     @Test
+    @Tag("flaky") // Issue #8815
     public void testMultiThreadedHTTP1()
     {
         int count = 1000;

--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CloseableDoSFilterTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/CloseableDoSFilterTest.java
@@ -16,6 +16,8 @@ package org.eclipse.jetty.servlets;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(WorkDirExtension.class)
@@ -27,5 +29,13 @@ public class CloseableDoSFilterTest extends AbstractDoSFilterTest
     public void setUp() throws Exception
     {
         startServer(workDir, CloseableDoSFilter.class);
+    }
+
+    @Override
+    @Test
+    @Tag("flaky")
+    public void testUnavailableIP() throws Exception
+    {
+        super.testUnavailableIP();
     }
 }

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -251,7 +251,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(5, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitFor(20, TimeUnit.SECONDS));
             assertEquals(0, runConfig.getExitValue());
 
             int httpPort = distribution.freePort();

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -264,7 +264,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started Server@", 20, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse helloResponse = client.GET("http://localhost:" + httpPort + "/test/hello");

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -43,7 +43,6 @@ import org.eclipse.jetty.http3.client.http.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.start.FS;
 import org.eclipse.jetty.tests.distribution.openid.OpenIdProvider;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.eclipse.jetty.unixsocket.client.HttpClientTransportOverUnixSockets;
 import org.eclipse.jetty.unixsocket.server.UnixSocketConnector;
 import org.eclipse.jetty.util.BlockingArrayQueue;
@@ -1001,15 +1000,15 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-module=https,test-keystore,ssl-ini"))
         {
-            assertTrue(run1.awaitFor(5, TimeUnit.SECONDS));
+            assertTrue(run1.awaitFor(20, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());
 
             // Override the property on the command line with the correct password.
             try (JettyHomeTester.Run run2 = distribution.start(pathProperty + "=cmdline"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 5, TimeUnit.SECONDS));
-                PathAssert.assertFileExists("${jetty.base}/cmdline", jettyBase.resolve("cmdline"));
-                PathAssert.assertNotPathExists("${jetty.base}/modbased", jettyBase.resolve("modbased"));
+                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 20, TimeUnit.SECONDS));
+                assertTrue(Files.exists(jettyBase.resolve("cmdline")));
+                assertFalse(Files.exists(jettyBase.resolve("modbased")));
             }
         }
     }


### PR DESCRIPTION
Using `@Tag("flaky")` instead of `@Disabled`