### PR TITLE
Fixes #7117 - Timeout with Expect 100 continue when using ProxyServlet.

### DIFF
--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.net.ConnectException;
 import java.net.HttpCookie;
 import java.nio.ByteBuffer;
@@ -1636,5 +1637,37 @@ public class ProxyServletTest
         // The client should not send the content.
         assertFalse(contentLatch.await(1, TimeUnit.SECONDS));
         assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("impls")
+    public void testExpect100ContinueWithReader(Class<? extends ProxyServlet> proxyServletClass) throws Exception
+    {
+        startServer(new EmptyHttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                // Calling getReader() should trigger the send of 100 Continue.
+                IO.copy(request.getReader(), Writer.nullWriter());
+            }
+        });
+        startProxy(proxyServletClass);
+        startClient();
+        client.setMaxConnectionsPerDestination(1);
+
+        // Perform consecutive requests to test whether recycling of
+        // the Request on server side messes up 100 Continue handling.
+        int count = 8;
+        for (int i = 0; i < count; ++i)
+        {
+            ContentResponse response = client.newRequest("localhost", serverConnector.getLocalPort())
+                .path("/" + i)
+                .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
+                .body(new BytesRequestContent(new byte[]{'h', 'e', 'l', 'l', 'o'}))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1161,16 +1161,13 @@ public class Request implements HttpServletRequest
 
         if (_reader == null || !encoding.equalsIgnoreCase(_readerEncoding))
         {
-            final ServletInputStream in = getInputStream();
+            ServletInputStream in = getInputStream();
             _readerEncoding = encoding;
-            _reader = new BufferedReader(new InputStreamReader(in, encoding))
-            {
-                @Override
-                public void close() throws IOException
-                {
-                    in.close();
-                }
-            };
+            _reader = new BufferedReader(new InputStreamReader(in, encoding));
+        }
+        else if (_channel.isExpecting100Continue())
+        {
+            _channel.continue100(_input.available());
         }
         _inputState = INPUT_READER;
         return _reader;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1163,7 +1163,16 @@ public class Request implements HttpServletRequest
         {
             ServletInputStream in = getInputStream();
             _readerEncoding = encoding;
-            _reader = new BufferedReader(new InputStreamReader(in, encoding));
+            _reader = new BufferedReader(new InputStreamReader(in, encoding))
+            {
+                @Override
+                public void close() throws IOException
+                {
+                    // Do not call super to avoid marking this reader as closed,
+                    // but do close the ServletInputStream that can be reopened.
+                    in.close();
+                }
+            };
         }
         else if (_channel.isExpecting100Continue())
         {


### PR DESCRIPTION
Now getReader() tests whether it has to send a 100 continue in case getInputStream() is not called.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>