### PR TITLE
Issue #8822 - Fix NPE seen on `deflater.reset()` when called after `deflater.end()`

### DIFF
--- a/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipDefaultServletTest.java
+++ b/jetty-servlets/src/test/java/org/eclipse/jetty/servlets/GzipDefaultServletTest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.servlet.ServletException;
@@ -29,7 +30,9 @@ import org.eclipse.jetty.http.DateGenerator;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -53,6 +56,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the GzipHandler support when working with the {@link DefaultServlet}.
@@ -77,6 +81,17 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         server = new Server();
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        localConnector.addBean(new HttpChannel.Listener()
+        {
+            @Override
+            public void onComplete(Request request)
+            {
+                latch.countDown();
+            }
+        });
 
         Path contextDir = workDir.resolve("context");
         FS.ensureDirExists(contextDir);
@@ -122,6 +137,10 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         assertThat("Response[ETag]", response.get("ETag"), containsString(CompressedContentFormat.GZIP.getEtagSuffix()));
 
         assertThat("Response[Content-Length]", response.get("Content-Length"), is(nullValue()));
+
+        // allow server to finish sending body (for HEAD, server.stop() races with the gzip writing thread)
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+
         // A HEAD request should have similar headers, but no body
         if (!method.equals("HEAD"))
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
@@ -115,6 +115,7 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
     {
         private final T _value;
         private final Pool<Entry>.Entry _entry;
+        private boolean closed = false;
 
         Entry(T value)
         {
@@ -134,8 +135,11 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
 
         public void release()
         {
-            // Reset the value for the next usage.
-            reset(_value);
+            if (!closed)
+            {
+                // Reset the value for the next usage.
+                reset(_value);
+            }
 
             if (_entry != null)
             {
@@ -156,6 +160,7 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
         public void close()
         {
             end(_value);
+            closed = true;
         }
     }
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/compression/CompressionPool.java
@@ -115,7 +115,6 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
     {
         private final T _value;
         private final Pool<Entry>.Entry _entry;
-        private boolean closed = false;
 
         Entry(T value)
         {
@@ -135,11 +134,8 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
 
         public void release()
         {
-            if (!closed)
-            {
-                // Reset the value for the next usage.
-                reset(_value);
-            }
+            // Reset the value for the next usage.
+            reset(_value);
 
             if (_entry != null)
             {
@@ -160,7 +156,6 @@ public abstract class CompressionPool<T> extends ContainerLifeCycle
         public void close()
         {
             end(_value);
-            closed = true;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>