### PR TITLE
Fixes #8810 - ArrayRetainableByteBufferPool inefficiently calculates …

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/LogarithmicArrayByteBufferPool.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/LogarithmicArrayByteBufferPool.java
@@ -152,10 +152,11 @@ public class LogarithmicArrayByteBufferPool extends ArrayByteBufferPool
                 -1,
                 maxCapacity,
                 maxBucketSize,
-                maxHeapMemory,
-                maxDirectMemory,
                 c -> 32 - Integer.numberOfLeadingZeros(c - 1),
-                i -> 1 << i);
+                i -> 1 << i,
+                maxHeapMemory,
+                maxDirectMemory
+            );
         }
     }
 }

--- a/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPoolTest.java
+++ b/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayRetainableByteBufferPoolTest.java
@@ -377,10 +377,11 @@ public class ArrayRetainableByteBufferPoolTest
                 -1,
                 maxCapacity,
                 maxBucketSize,
-                maxHeapMemory,
-                maxDirectMemory,
                 c -> 32 - Integer.numberOfLeadingZeros(c - 1),
-                i -> 1 << i);
+                i -> 1 << i,
+                maxHeapMemory,
+                maxDirectMemory
+            );
         }
     }
 


### PR DESCRIPTION
…bucket indices

Added constructor that uses IntUnaryOperator to avoid boxing. Deprecated constructor that uses Function<Integer, Integer>.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>