### PR TITLE
Fix #8897 Ignore conditional headers as per RFC7232

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -596,10 +596,14 @@ public class ResourceService
                 }
 
                 long ifmsl = DateParser.parseDate(ifms);
-                if (ifmsl != -1 && content.getResource().lastModified() / 1000 <= ifmsl / 1000)
+                if (ifmsl != -1)
                 {
-                    sendStatus(response, HttpServletResponse.SC_NOT_MODIFIED, content::getETagValue);
-                    return false;
+                    long lm = content.getResource().lastModified();
+                    if (lm != -1 && lm / 1000 <= ifmsl / 1000)
+                    {
+                        sendStatus(response, HttpServletResponse.SC_NOT_MODIFIED, content::getETagValue);
+                        return false;
+                    }
                 }
             }
 
@@ -607,10 +611,14 @@ public class ResourceService
             if (ifums != null && ifm == null)
             {
                 long ifumsl = DateParser.parseDate(ifums);
-                if (ifumsl != -1 && content.getResource().lastModified() / 1000 > ifumsl / 1000)
+                if (ifumsl != -1)
                 {
-                    response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED);
-                    return false;
+                    long lm = content.getResource().lastModified();
+                    if (lm != -1 && lm / 1000 > ifumsl / 1000)
+                    {
+                        response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED);
+                        return false;
+                    }
                 }
             }
         }

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -200,6 +200,25 @@ public class ResourceHandlerTest
     }
 
     @Test
+    public void testIfModifiedSinceIgnored() throws Exception
+    {
+        HttpTester.Response response = HttpTester.parseResponse(
+            _local.getResponse("GET /resource/simple.txt HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.get(LAST_MODIFIED), Matchers.notNullValue());
+        assertThat(response.getContent(), containsString("simple text"));
+        String lastModified = response.get(LAST_MODIFIED);
+
+        response = HttpTester.parseResponse(_local.getResponse(
+            "GET /resource/simple.txt HTTP/1.0\r\n" +
+                "If-Modified-Since: " + lastModified + "\r\n" +
+                "If-None-Match: XYZ\r\n" +
+                "\r\n"));
+
+        assertThat(response.getStatus(), equalTo(200));
+    }
+
+    @Test
     public void testBigFile() throws Exception
     {
         _config.setOutputBufferSize(2048);


### PR DESCRIPTION
Ignore date based headers if etag ones are present. Also avoid parsing dates unless necessary.

Signed-off-by: Greg Wilkins <gregw@webtide.com>