### PR TITLE
Fixes #8863 - Provide a possibility to name virtual threads

### DIFF
--- a/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/DelegatingThreadPool.java
+++ b/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/DelegatingThreadPool.java
@@ -63,16 +63,16 @@ public class DelegatingThreadPool extends ContainerLifeCycle implements ThreadPo
     }
 
     @Override
-    public boolean isUseVirtualThreads()
+    public Executor getVirtualThreadsExecutor()
     {
-        return VirtualThreads.isUseVirtualThreads(_executor);
+        return VirtualThreads.getVirtualThreadsExecutor(_executor);
     }
 
     @Override
-    public void setUseVirtualThreads(boolean useVirtualThreads)
+    public void setVirtualThreadsExecutor(Executor executor)
     {
         if (_executor instanceof VirtualThreads.Configurable)
-            ((VirtualThreads.Configurable)_executor).setUseVirtualThreads(useVirtualThreads);
+            ((VirtualThreads.Configurable)_executor).setVirtualThreadsExecutor(executor);
     }
 
     @Override

--- a/jetty-server/src/main/config/etc/jetty-threadpool-virtual-preview.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool-virtual-preview.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<Configure>
+  <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+    <Set name="name" property="jetty.threadPool.namePrefix" />
+    <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+    <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+    <Set name="reservedThreads" type="int"><Property name="jetty.threadPool.reservedThreads" default="-1"/></Set>
+    <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+    <Set name="detailedDump" type="boolean"><Property name="jetty.threadPool.detailedDump" default="false"/></Set>
+    <Get id="namePrefix" name="name" />
+    <Call class="java.lang.Thread" name="ofVirtual">
+      <Call class="java.lang.Thread$Builder" name="name">
+        <Arg>
+          <Property name="jetty.threadPool.virtual.namePrefix">
+            <Default><Ref refid="namePrefix" />-virtual-</Default>
+          </Property>
+        </Arg>
+        <Arg type="long">0</Arg>
+        <Call class="java.lang.Thread$Builder" name="allowSetThreadLocals">
+          <Arg type="boolean"><Property name="jetty.threadPool.virtual.allowSetThreadLocals" default="true" /></Arg>
+          <Call class="java.lang.Thread$Builder" name="inheritInheritableThreadLocals">
+            <Arg type="boolean"><Property name="jetty.threadPool.virtual.inheritInheritableThreadLocals" default="false" /></Arg>
+            <Call id="virtualThreadFactory" class="java.lang.Thread$Builder" name="factory" />
+          </Call>
+        </Call>
+      </Call>
+    </Call>
+    <Call name="setVirtualThreadsExecutor">
+      <Arg>
+        <Call class="java.util.concurrent.Executors" name="newThreadPerTaskExecutor">
+          <Arg><Ref refid="virtualThreadFactory" /></Arg>
+        </Call>
+      </Arg>
+    </Call>
+  </New>
+
+  <Call class="org.slf4j.LoggerFactory" name="getLogger">
+    <Arg>org.eclipse.jetty</Arg>
+    <Call name="warn">
+      <Arg>Virtual threads are a Java Preview Feature, support may be limited.</Arg>
+    </Call>
+  </Call>
+</Configure>

--- a/jetty-server/src/main/config/etc/jetty-threadpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool.xml
@@ -20,10 +20,11 @@
   <!-- for all configuration that may be set here.                 -->
   <!-- =========================================================== -->
   <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+    <Set name="name" property="jetty.threadPool.namePrefix" />
     <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
     <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
     <Set name="reservedThreads" type="int"><Property name="jetty.threadPool.reservedThreads" default="-1"/></Set>
-    <Set name="useVirtualThreads" type="boolean"><Property name="jetty.threadPool.useVirtualThreads" default="false"/></Set>
+    <Set name="useVirtualThreads" type="boolean"><Property deprecated="jetty.threadPool.useVirtualThreads" default="false"/></Set>
     <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
     <Set name="detailedDump" type="boolean"><Property name="jetty.threadPool.detailedDump" default="false"/></Set>
   </New>

--- a/jetty-server/src/main/config/modules/threadpool-virtual-preview.mod
+++ b/jetty-server/src/main/config/modules/threadpool-virtual-preview.mod
@@ -1,0 +1,42 @@
+[description]
+Enables and configures the Server ThreadPool with support for virtual threads.
+
+[exec]
+--enable-preview
+
+[depends]
+logging
+
+[provides]
+threadpool
+
+[xml]
+etc/jetty-threadpool-virtual-preview.xml
+
+[ini-template]
+## Platform threads name prefix.
+#jetty.threadPool.namePrefix=qtp<hashCode>
+
+## Minimum number of pooled threads.
+#jetty.threadPool.minThreads=10
+
+## Maximum number of pooled threads.
+#jetty.threadPool.maxThreads=200
+
+## Number of reserved threads (-1 for heuristic).
+#jetty.threadPool.reservedThreads=-1
+
+## Thread idle timeout (in milliseconds).
+#jetty.threadPool.idleTimeout=60000
+
+## Whether to output a detailed dump.
+#jetty.threadPool.detailedDump=false
+
+## Virtual threads name prefix.
+#jetty.threadPool.virtual.namePrefix=qtp<hashCode>-virtual-
+
+## Whether virtual threads are allowed to set thread locals.
+#jetty.threadPool.virtual.allowSetThreadLocals=true
+
+## Whether virtual threads inherits the values of inheritable thread locals.
+#jetty.threadPool.virtual.allowSetThreadLocals=true

--- a/jetty-server/src/main/config/modules/threadpool.mod
+++ b/jetty-server/src/main/config/modules/threadpool.mod
@@ -4,10 +4,16 @@ Enables and configures the Server ThreadPool.
 [depends]
 logging
 
+[provides]
+threadpool|default
+
 [xml]
 etc/jetty-threadpool.xml
 
 [ini-template]
+## Thread name prefix.
+#jetty.threadPool.namePrefix=qtp<hashCode>
+
 ## Minimum number of pooled threads.
 #jetty.threadPool.minThreads=10
 
@@ -18,6 +24,7 @@ etc/jetty-threadpool.xml
 #jetty.threadPool.reservedThreads=-1
 
 ## Whether to use virtual threads, if the runtime supports them.
+## Deprecated, use Jetty module 'threadpool-virtual-preview' instead.
 #jetty.threadPool.useVirtualThreads=false
 
 ## Thread idle timeout (in milliseconds).

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +48,7 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
     private int _priority = Thread.NORM_PRIORITY;
     private boolean _daemon;
     private boolean _detailedDump;
-    private boolean _useVirtualThreads;
+    private Executor _virtualThreadsExecutor;
 
     public ExecutorThreadPool()
     {
@@ -271,18 +272,18 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
     }
 
     @Override
-    public boolean isUseVirtualThreads()
+    public Executor getVirtualThreadsExecutor()
     {
-        return _useVirtualThreads;
+        return _virtualThreadsExecutor;
     }
 
     @Override
-    public void setUseVirtualThreads(boolean useVirtualThreads)
+    public void setVirtualThreadsExecutor(Executor executor)
     {
         try
         {
-            VirtualThreads.Configurable.super.setUseVirtualThreads(useVirtualThreads);
-            _useVirtualThreads = useVirtualThreads;
+            VirtualThreads.Configurable.super.setVirtualThreadsExecutor(executor);
+            _virtualThreadsExecutor = executor;
         }
         catch (UnsupportedOperationException ignored)
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -111,7 +112,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     private int _lowThreadsThreshold = 1;
     private ThreadPoolBudget _budget;
     private long _stopTimeout;
-    private boolean _useVirtualThreads;
+    private Executor _virtualThreadsExecutor;
 
     public QueuedThreadPool()
     {
@@ -515,18 +516,18 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     }
 
     @Override
-    public boolean isUseVirtualThreads()
+    public Executor getVirtualThreadsExecutor()
     {
-        return _useVirtualThreads;
+        return _virtualThreadsExecutor;
     }
 
     @Override
-    public void setUseVirtualThreads(boolean useVirtualThreads)
+    public void setVirtualThreadsExecutor(Executor executor)
     {
         try
         {
-            VirtualThreads.Configurable.super.setUseVirtualThreads(useVirtualThreads);
-            _useVirtualThreads = useVirtualThreads;
+            VirtualThreads.Configurable.super.setVirtualThreadsExecutor(executor);
+            _virtualThreadsExecutor = executor;
         }
         catch (UnsupportedOperationException ignored)
         {

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -36,8 +36,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLSocketFactory;
 
-import javax.net.ssl.SSLSocketFactory;
-
 import org.eclipse.jetty.logging.JettyLevel;
 import org.eclipse.jetty.logging.JettyLogger;
 import org.eclipse.jetty.logging.StdErrAppender;

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLSocketFactory;
 
+import javax.net.ssl.SSLSocketFactory;
+
 import org.eclipse.jetty.logging.JettyLevel;
 import org.eclipse.jetty.logging.JettyLogger;
 import org.eclipse.jetty.logging.StdErrAppender;

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1277,7 +1277,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             assertEquals(0, run1.getExitValue());
 
             int httpPort = distribution.freePort();
-            try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort, "-Dorg.eclipse.jetty.LEVEL=DEBUG")))
+            try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort)))
             {
                 assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
 

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -55,6 +55,7 @@ import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -1256,6 +1257,35 @@ public class DistributionTests extends AbstractJettyHomeTest
                 Queue<String> logs = run2.getLogs();
                 assertThat(logs.size(), equalTo(1));
                 assertThat(logs.poll(), not(containsString("${jetty.home.uri}")));
+            }
+        }
+    }
+
+    @Test
+    @DisabledForJreRange(max = JRE.JAVA_18)
+    public void testVirtualThreadPool() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .mavenLocalRepository(System.getProperty("mavenRepoPath"))
+            .build();
+
+        try (JettyHomeTester.Run run1 = distribution.start("--add-modules=threadpool-virtual-preview,http"))
+        {
+            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertEquals(0, run1.getExitValue());
+
+            int httpPort = distribution.freePort();
+            try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort, "-Dorg.eclipse.jetty.LEVEL=DEBUG")))
+            {
+                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+
+                startHttpClient();
+                ContentResponse response = client.newRequest("localhost", httpPort)
+                    .timeout(15, TimeUnit.SECONDS)
+                    .send();
+                assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
             }
         }
     }

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/VirtualThreadsTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/VirtualThreadsTest.java
@@ -14,7 +14,11 @@
 package org.eclipse.jetty.http.client;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.AsyncContext;
@@ -58,6 +62,7 @@ public class VirtualThreadsTest extends AbstractTest<TransportScenario>
         // No virtual thread support in FCGI server-side.
         Assumptions.assumeTrue(transport != Transport.FCGI);
 
+        String virtualThreadsName = "green-";
         init(transport);
         scenario.prepareServer(new EmptyServerHandler()
         {
@@ -66,11 +71,21 @@ public class VirtualThreadsTest extends AbstractTest<TransportScenario>
             {
                 if (!VirtualThreads.isVirtualThread())
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
+                if (!Thread.currentThread().getName().startsWith(virtualThreadsName))
+                    response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
             }
         });
         ThreadPool threadPool = scenario.server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
-            ((VirtualThreads.Configurable)threadPool).setUseVirtualThreads(true);
+        {
+            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
+            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
+            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
+            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
+            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
+            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
+        }
         scenario.server.start();
         scenario.startClient();
 
@@ -151,7 +166,7 @@ public class VirtualThreadsTest extends AbstractTest<TransportScenario>
         });
         ThreadPool threadPool = scenario.server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
-            ((VirtualThreads.Configurable)threadPool).setUseVirtualThreads(true);
+            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         scenario.server.start();
         scenario.startClient();
 


### PR DESCRIPTION
Reworked the VirtualThreads APIs to be based on Executor rather than just boolean.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>