### PR TITLE
Fixes #8750 - AbstractProxyServlet.onServerResponseHeaders does not s…

### DIFF
--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/AbstractProxyServlet.java
@@ -663,7 +663,7 @@ public abstract class AbstractProxyServlet extends HttpServlet
                 continue;
 
             String newHeaderValue = filterServerResponseHeader(clientRequest, serverResponse, headerName, field.getValue());
-            if (newHeaderValue == null || newHeaderValue.trim().length() == 0)
+            if (newHeaderValue == null)
                 continue;
 
             proxyResponse.addHeader(headerName, newHeaderValue);

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ProxyServletTest.java
@@ -999,6 +999,36 @@ public class ProxyServletTest
         assertTrue(response.getHeaders().contains(PROXIED_HEADER));
     }
 
+    @ParameterizedTest
+    @MethodSource("transparentImpls")
+    public void testTransparentProxyEmptyHeaderValue(AbstractProxyServlet proxyServletClass) throws Exception
+    {
+        String emptyHeaderName = "X-Empty";
+        startServer(new EmptyHttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response)
+            {
+                assertEquals("", request.getHeader(emptyHeaderName));
+                response.setHeader(emptyHeaderName, "");
+            }
+        });
+        String proxyTo = "http://localhost:" + serverConnector.getLocalPort();
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("proxyTo", proxyTo);
+        startProxy(proxyServletClass, initParams);
+        startClient();
+
+        // Make the request to the proxy, it should transparently forward to the server.
+        ContentResponse response = client.newRequest("localhost", proxyConnector.getLocalPort())
+            .headers(headers -> headers.put(emptyHeaderName, ""))
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertEquals("", response.getHeaders().get(emptyHeaderName));
+    }
+
     /**
      * Only tests overridden ProxyServlet behavior, see CachingProxyServlet
      */


### PR DESCRIPTION
…upport headers with empty values

Fixed support for empty headers.
Added test case.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>