### PR TITLE
Issue #8905 - GzipHandler should include `Vary` header on 304 (Not Modified) responses (per RFC9110)

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -147,6 +147,8 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
                     String responseEtagGzip = etagGzip(responseEtag);
                     if (requestEtags.contains(responseEtagGzip))
                         response.getHttpFields().put(HttpHeader.ETAG, responseEtagGzip);
+                    if (_vary != null)
+                        response.getHttpFields().ensureField(_vary);
                 }
             }
 


### PR DESCRIPTION


Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>