### PR TITLE
Add debug logging to `SerializedInvoker`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
@@ -59,18 +59,7 @@ public class SerializedInvoker
             {
                 // Wrap the given task with another one that's going to delegate run() to the wrapped task while the
                 // wrapper's toString() returns a description of the place in code where SerializedInvoker.run() was called.
-                StackTraceElement[] stackTrace = new Exception().getStackTrace();
-                for (StackTraceElement stackTraceElement : stackTrace)
-                {
-                    String className = stackTraceElement.getClassName();
-                    if (!className.equals(SerializedInvoker.class.getName()) && !className.equals(getClass().getName()))
-                    {
-                        String name = "Queued at " + className + "." + stackTraceElement.getMethodName() +
-                            "(" + stackTraceElement.getFileName() + ":" + stackTraceElement.getLineNumber() + ")";
-                        task = new NamedRunnable(task, name);
-                        break;
-                    }
-                }
+                task = new NamedRunnable(task, deriveTaskName(task));
             }
         }
         Link link = new Link(task);
@@ -81,6 +70,18 @@ public class SerializedInvoker
             return link;
         penultimate._next.lazySet(link);
         return null;
+    }
+
+    protected String deriveTaskName(Runnable task)
+    {
+        StackTraceElement[] stackTrace = new Exception().getStackTrace();
+        for (StackTraceElement stackTraceElement : stackTrace)
+        {
+            String className = stackTraceElement.getClassName();
+            if (!className.equals(SerializedInvoker.class.getName()) && !className.equals(getClass().getName()))
+                return "Queued at " + stackTraceElement;
+        }
+        return task.toString();
     }
 
     /**

--- a/jetty-core/jetty-util/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-util/src/test/resources/jetty-logging.properties
@@ -2,3 +2,4 @@
 #org.eclipse.jetty.util.PathWatcher.LEVEL=DEBUG
 #org.eclipse.jetty.util.thread.QueuedThreadPool.LEVEL=DEBUG
 #org.eclipse.jetty.util.thread.ReservedThreadExecutor.LEVEL=DEBUG
+#org.eclipse.jetty.util.thread.SerializedInvoker$NamedRunnable.LEVEL=DEBUG


### PR DESCRIPTION
Figuring out what tasks get executed and enqueued by the `SerializedInvoker` has proven invaluable  while chasing race conditions in the client's internal engine.

This is what the debug logs now look like:
```
Offering 3 tasks in SerializedInvoker@5ace1ed4
Offering link Link@2df9b86[Queued at org.eclipse.jetty.SampleTest.test(SampleTest.java:73)] -> null of SerializedInvoker@5ace1ed4
Offering task null, skipping it in SerializedInvoker@5ace1ed4
Offering link Link@37654521[Queued at org.eclipse.jetty.SampleTest.test(SampleTest.java:73)] -> null of SerializedInvoker@5ace1ed4
Running link Link@2df9b86[Queued at org.eclipse.jetty.SampleTest.test(SampleTest.java:73)] -> Link@37654521[Queued at org.eclipse.jetty.SampleTest.test(SampleTest.java:73)] -> null of SerializedInvoker@5ace1ed4
Offering link Link@50b5ac82[Queued at org.eclipse.jetty.SampleTest.lambda$test$0(SampleTest.java:74)] -> null of SerializedInvoker@5ace1ed4
Queued link in SerializedInvoker@5ace1ed4
Running link Link@37654521[Queued at org.eclipse.jetty.SampleTest.test(SampleTest.java:73)] -> Link@50b5ac82[Queued at org.eclipse.jetty.SampleTest.lambda$test$0(SampleTest.java:74)] -> null of SerializedInvoker@5ace1ed4
Offering link Link@101952da[Queued at org.eclipse.jetty.SampleTest.lambda$test$1(SampleTest.java:76)] -> null of SerializedInvoker@5ace1ed4
Queued link in SerializedInvoker@5ace1ed4
Running link Link@50b5ac82[Queued at org.eclipse.jetty.SampleTest.lambda$test$0(SampleTest.java:74)] -> Link@101952da[Queued at org.eclipse.jetty.SampleTest.lambda$test$1(SampleTest.java:76)] -> null of SerializedInvoker@5ace1ed4
Running link Link@101952da[Queued at org.eclipse.jetty.SampleTest.lambda$test$1(SampleTest.java:76)] -> null of SerializedInvoker@5ace1ed4
Next link is null, execution is over in SerializedInvoker@5ace1ed4
```
and this is what looking at a link using the debugger looks like:
```
Link@492c03d2[Queued at org.eclipse.jetty.client.HttpReceiver$ContentSource.demand(HttpReceiver.java:719)] -> Link@5b4071da[Queued at org.eclipse.jetty.client.HttpReceiver$ContentSource.onDataAvailable(HttpReceiver.java:694)] -> Link@688698c5[Queued at org.eclipse.jetty.client.HttpReceiver.responseSuccess(HttpReceiver.java:351)] -> null
```


I believe it's worth being considered outside the scope of the client rework.