### PR TITLE
Fixes #8913 - Review Jetty XML syntax to allow calling JDK methods

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
@@ -74,6 +74,8 @@ var mystring = new String();
 
 If an object with the id `mystring` already exists, then it is not created again but rather just referenced.
 
+Within element `<Configure>`, the created object (if any) is in xref:og-xml-syntax-scope[scope] and may be the implicit target of other, nested, elements.
+
 Typically the `<Configure>` element is used to configure a `Server` instance or `ContextHandler` subclasses such as `WebAppContext` that represent web applications.
 
 [[og-xml-syntax-arg]]
@@ -187,12 +189,38 @@ This is equivalent to the following Java code:
 var myhost = InetAddress.getByName("jdk.java.net");
 ----
 
+The `class` attribute can also be used to specify the Java class or interface to use to lookup the non-``static`` method name.
+This is necessary when the object in scope, onto which the `<Call>` would be applied, is an instance of a class that is not visible to Jetty classes, or not accessible because it is not `public`.
+For example:
+
+[source,xml,subs=normal]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<Configure>
+  <Call class="java.util.concurrent.Executors" name="newSingleThreadScheduledExecutor">
+    #<Call class="java.util.concurrent.ExecutorService" name="shutdown" />#
+  </Call>
+</Configure>
+----
+
+In the example above, `Executors.newSingleThreadScheduledExecutor()` returns an object whose class is a private JDK implementation class.
+Without an explicit `class` attribute, it is not possible to invoke the method `shutdown()` when it is obtained via reflection from the private JDK implementation class, because while the method is `public`, the private JDK implementation class is not, therefore this exception is thrown:
+
+[source]
+----
+java.lang.IllegalAccessException: class org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration (in module org.eclipse.jetty.xml) cannot access a member of class java.util.concurrent.Executors$DelegatedExecutorService (in module java.base) with modifiers "public"
+----
+
+The solution is to explicitly use the `class` attribute of the `<Call>` element that is invoking the `shutdown()` method, specifying a publicly accessible class or interface that the object in scope extends or implements (in the example above `java.util.concurrent.ExecutorService`).
+
 [[og-xml-syntax-get]]
 ===== `<Get>`
 
 Element `<Get>` retrieves the value of a JavaBean property specified by the mandatory `name` attribute.
 
-If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _method_ `getFoo()`; failing that, attempts to retrieve the value from _field_ `foo` (or `Foo`).
+If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _method_ `getFoo()` or _method_ `isFoo()`; failing that, attempts to retrieve the value from _field_ `foo` (or `Foo`).
 
 [source,xml]
 ----
@@ -211,6 +239,8 @@ If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _
   </Get>
 </Configure>
 ----
+
+The `class` attribute allows to perform `static` calls, or to lookup the getter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
 
 [[og-xml-syntax-set]]
 ===== `<Set>`
@@ -234,6 +264,8 @@ If the JavaBean property is `foo` (or `Foo`), `<Set>` first attempts to invoke _
   </Set>
 </Configure>
 ----
+
+The `class` attribute allows to perform `static` calls, or to lookup the setter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
 
 [[og-xml-syntax-map]]
 ===== `<Map>` and `<Entry>`

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
@@ -189,7 +189,7 @@ This is equivalent to the following Java code:
 var myhost = InetAddress.getByName("jdk.java.net");
 ----
 
-The `class` attribute can also be used to specify the Java class or interface to use to lookup the non-``static`` method name.
+The `class` attribute (or `<Class>` element) can also be used to specify the Java class or interface to use to lookup the non-``static`` method name.
 This is necessary when the object in scope, onto which the `<Call>` would be applied, is an instance of a class that is not visible to Jetty classes, or not accessible because it is not `public`.
 For example:
 
@@ -206,14 +206,14 @@ For example:
 ----
 
 In the example above, `Executors.newSingleThreadScheduledExecutor()` returns an object whose class is a private JDK implementation class.
-Without an explicit `class` attribute, it is not possible to invoke the method `shutdown()` when it is obtained via reflection from the private JDK implementation class, because while the method is `public`, the private JDK implementation class is not, therefore this exception is thrown:
+Without an explicit `class` attribute (or `<Class>` element), it is not possible to invoke the method `shutdown()` when it is obtained via reflection from the private JDK implementation class, because while the method is `public`, the private JDK implementation class is not, therefore this exception is thrown:
 
 [source]
 ----
 java.lang.IllegalAccessException: class org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration (in module org.eclipse.jetty.xml) cannot access a member of class java.util.concurrent.Executors$DelegatedExecutorService (in module java.base) with modifiers "public"
 ----
 
-The solution is to explicitly use the `class` attribute of the `<Call>` element that is invoking the `shutdown()` method, specifying a publicly accessible class or interface that the object in scope extends or implements (in the example above `java.util.concurrent.ExecutorService`).
+The solution is to explicitly use the `class` attribute (or `<Class>` element) of the `<Call>` element that is invoking the `shutdown()` method, specifying a publicly accessible class or interface that the object in scope extends or implements (in the example above `java.util.concurrent.ExecutorService`).
 
 [[og-xml-syntax-get]]
 ===== `<Get>`
@@ -240,7 +240,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _
 </Configure>
 ----
 
-The `class` attribute allows to perform `static` calls, or to lookup the getter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
+The `class` attribute (or `<Class>` element) allows to perform `static` calls, or to lookup the getter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
 
 [[og-xml-syntax-set]]
 ===== `<Set>`
@@ -265,7 +265,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Set>` first attempts to invoke _
 </Configure>
 ----
 
-The `class` attribute allows to perform `static` calls, or to lookup the setter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
+The `class` attribute (or `<Class>` element) allows to perform `static` calls, or to lookup the setter method from the specified class, as described in the xref:og-xml-syntax-call[`<Call>` section].
 
 [[og-xml-syntax-map]]
 ===== `<Map>` and `<Entry>`

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1180,7 +1180,7 @@ public class XmlConfiguration
                         if (value == null)
                         {
                             if (name == null)
-                                LOG.warn("Property '{}' is deprecated, do not use it", d);
+                                LOG.warn("Property '{}' is deprecated, no replacement available", d);
                             else
                                 LOG.warn("Property '{}' is deprecated, use '{}' instead", d, name);
                         }
@@ -1242,7 +1242,7 @@ public class XmlConfiguration
                         if (value == null)
                         {
                             if (name == null)
-                                LOG.warn("SystemProperty '{}' is deprecated, do not use it", d);
+                                LOG.warn("SystemProperty '{}' is deprecated, no replacement available", d);
                             else
                                 LOG.warn("SystemProperty '{}' is deprecated, use '{}' instead", d, name);
                         }
@@ -1302,7 +1302,7 @@ public class XmlConfiguration
                     if (value != null)
                     {
                         if (name == null)
-                            LOG.warn("Property '{}' is deprecated, do not use it", d);
+                            LOG.warn("Property '{}' is deprecated, no replacement available", d);
                         else
                             LOG.warn("Property '{}' is deprecated, use '{}' instead", d, name);
                         break;

--- a/jetty-xml/src/main/resources/org/eclipse/jetty/xml/configure_10_0.dtd
+++ b/jetty-xml/src/main/resources/org/eclipse/jetty/xml/configure_10_0.dtd
@@ -286,7 +286,7 @@ System Property Element.
 This element allows JVM System properties to be retrieved as
 part of the value of elements such as Set, Put, Arg, etc.
 The name attribute specifies the property name and the optional
-default argument provides a default value.
+default attribute provides a default value.
 
  <SystemProperty name="Test" default="value" />
 
@@ -303,7 +303,7 @@ Environment variable Element.
 This element allows OS Environment variables to be retrieved as
 part of the value of elements such as Set, Put, Arg, etc.
 The name attribute specifies the env variable name and the optional
-default argument provides a default value.
+default attribute provides a default value.
 
  <Env name="Test" default="value" />
 
@@ -311,7 +311,6 @@ This is equivalent to:
 
  String v=System.getEnv("Test");
  if (v==null) v="value";
-
 -->
 <!ELEMENT Env (Id?,Name?,Deprecated*,Default?) >
 <!ATTLIST Env %ID_ATTR; %NAME_ATTR; %DEPRECATED_ATTR; %DEFAULT_ATTR; >
@@ -321,7 +320,7 @@ This is equivalent to:
 Property Element.
 This element allows arbitrary properties to be retrieved by name.
 The name attribute specifies the property name and the optional
-default argument provides a default value.
+default attribute provides a default value.
 -->
 <!ELEMENT Property (Id?,Name?,Deprecated*,Default?) >
 <!ATTLIST Property %ID_ATTR; %NAME_ATTR; %DEPRECATED_ATTR; %DEFAULT_ATTR; >

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -20,6 +20,7 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -29,9 +30,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import javax.net.ssl.SSLSocketFactory;
 
 import org.eclipse.jetty.logging.JettyLevel;
 import org.eclipse.jetty.logging.JettyLogger;
@@ -39,7 +43,6 @@ import org.eclipse.jetty.logging.StdErrAppender;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
@@ -48,7 +51,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,19 +76,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(WorkDirExtension.class)
 public class XmlConfigurationTest
 {
-    public WorkDir workDir;
-
     private static final String STRING_ARRAY_XML = "<Array type=\"String\"><Item type=\"String\">String1</Item><Item type=\"String\">String2</Item></Array>";
     private static final String INT_ARRAY_XML = "<Array type=\"int\"><Item type=\"int\">1</Item><Item type=\"int\">2</Item></Array>";
+
+    public WorkDir workDir;
 
     @Test
     public void testMortBay() throws Exception
     {
         URL url = XmlConfigurationTest.class.getResource("mortbay.xml");
         Resource resource = Resource.newResource(url);
+        assertNotNull(resource);
         XmlConfiguration configuration = new XmlConfiguration(resource);
         configuration.configure();
     }
@@ -269,7 +271,7 @@ public class XmlConfigurationTest
 
     public XmlConfiguration asXmlConfiguration(String rawXml) throws IOException, SAXException
     {
-        if (rawXml.indexOf("!DOCTYPE") < 0)
+        if (!rawXml.contains("!DOCTYPE"))
             rawXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">\n" +
                 rawXml;
@@ -278,7 +280,7 @@ public class XmlConfigurationTest
 
     public XmlConfiguration asXmlConfiguration(String filename, String rawXml) throws IOException, SAXException
     {
-        if (rawXml.indexOf("!DOCTYPE") < 0)
+        if (!rawXml.contains("!DOCTYPE"))
             rawXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">\n" +
                 rawXml;
@@ -348,7 +350,7 @@ public class XmlConfigurationTest
         tc.testField1 = -1;
         configuration.configure(tc);
         assertEquals(-1, tc.testField1);
-        assertEquals(configuration.getIdMap().get("test"), null);
+        assertNull(configuration.getIdMap().get("test"));
     }
 
     @Test
@@ -745,7 +747,7 @@ public class XmlConfigurationTest
     {
         List<Method> methods = Arrays.stream(TestOrder.class.getMethods()).filter(m -> "call".equals(m.getName())).collect(Collectors.toList());
         Collections.shuffle(methods);
-        Collections.sort(methods, XmlConfiguration.EXECUTABLE_COMPARATOR);
+        methods.sort(XmlConfiguration.EXECUTABLE_COMPARATOR);
         assertThat(methods, Matchers.contains(
             TestOrder.class.getMethod("call"),
             TestOrder.class.getMethod("call", int.class),
@@ -1465,7 +1467,7 @@ public class XmlConfigurationTest
             assertThat("BarNamed has foo", bar.getFoo(), is("foozball"));
         });
 
-        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8.name()).split(System.lineSeparator()))
+        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8).split(System.lineSeparator()))
             .filter(line -> line.contains(":WARN"))
             .collect(Collectors.toList());
 
@@ -1495,7 +1497,7 @@ public class XmlConfigurationTest
             assertThat("BarNamed has foo", bar.getFoo(), is("foozball"));
         });
 
-        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8.name()).split(System.lineSeparator()))
+        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8).split(System.lineSeparator()))
             .filter(line -> line.contains(":WARN :"))
             .collect(Collectors.toList());
 
@@ -1564,7 +1566,7 @@ public class XmlConfigurationTest
             assertThat("Zeds[0]", zeds.get(0), is("plain-zero"));
         });
 
-        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8.name()).split(System.lineSeparator()))
+        List<String> warnings = Arrays.stream(logBytes.toString(UTF_8).split(System.lineSeparator()))
             .filter(line -> line.contains(":WARN :"))
             .collect(Collectors.toList());
 
@@ -1590,6 +1592,7 @@ public class XmlConfigurationTest
             configuration.configure();
             last = configuration;
         }
+        assertNotNull(last);
         return last.getIdMap();
     }
 
@@ -1628,7 +1631,7 @@ public class XmlConfigurationTest
 
         ByteArrayOutputStream logBytes = captureLoggingBytes(xmlConfiguration::configure);
 
-        String[] lines = logBytes.toString(UTF_8.name()).split(System.lineSeparator());
+        String[] lines = logBytes.toString(UTF_8).split(System.lineSeparator());
         List<String> warnings = Arrays.stream(lines)
             .filter(line -> line.contains(":WARN :"))
             .filter(line -> line.contains(testClass.getSimpleName()))
@@ -1763,6 +1766,94 @@ public class XmlConfigurationTest
         Path baseDir = testPath.resolve("bogus");
         String resolved = XmlConfiguration.resolvePath(baseDir.toString(), "etc/keystore");
         assertEquals(baseDir.resolve("etc/keystore").toString(), resolved);
+    }
+
+    @Test
+    public void testPropertyNoNameAttributeWithDeprecatedAttribute() throws Exception
+    {
+        XmlConfiguration configuration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+            "  <Set name=\"TestString\">" +
+            "    <Property deprecated=\"jetty.deprecated\" />" +
+            "  </Set>" +
+            "</Configure>"
+        );
+
+        String value = "deprecated";
+        configuration.getProperties().put("jetty.deprecated", value);
+
+        TestConfiguration tc = new TestConfiguration();
+        configuration.configure(tc);
+
+        assertThat(tc.getTestString(), is(value));
+    }
+
+    @Test
+    public void testVirtualGetWithClassAttribute() throws Exception
+    {
+        // SocketChannel.open() returns an internal class
+        // that cannot be accessed, so <Get> must specify the
+        // class to use to lookup the 'getLocalAddress' method.
+        XmlConfiguration configuration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+            "  <Set name=\"Test\">" +
+            "    <Call class=\"java.nio.channels.SocketChannel\" name=\"open\">" +
+            "      <Get class=\"java.nio.channels.SocketChannel\" name=\"localAddress\" />" +
+            "    </Call>" +
+            "  </Set>" +
+            "</Configure>"
+        );
+
+        TestConfiguration tc = new TestConfiguration();
+        configuration.configure(tc);
+
+        assertThat(tc.testObject, instanceOf(SocketChannel.class));
+    }
+
+    @Test
+    public void testVirtualSetWithClassAttribute() throws Exception
+    {
+        // SSLSocketFactory.getDefault().createSocket() returns an internal
+        // class that cannot be accessed, so <Set> must specify the
+        // class to use to lookup the 'setNeedClientAuth' method.
+        XmlConfiguration configuration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+            "  <Set name=\"Test\">" +
+            "    <Call class=\"javax.net.ssl.SSLSocketFactory\" name=\"getDefault\">" +
+            "      <Call class=\"javax.net.ssl.SSLSocketFactory\" name=\"createSocket\">" +
+            "        <Set class=\"javax.net.ssl.SSLSocket\" name=\"needClientAuth\">true</Set>" +
+            "      </Call>" +
+            "    </Call>" +
+            "  </Set>" +
+            "</Configure>"
+        );
+
+        TestConfiguration tc = new TestConfiguration();
+        configuration.configure(tc);
+
+        assertThat(tc.testObject, instanceOf(SSLSocketFactory.class));
+    }
+
+    @Test
+    public void testVirtualCallWithClassAttribute() throws Exception
+    {
+        // Executors.newSingleThreadScheduledExecutor() returns an
+        // internal class that cannot be accessed, so <Call> must
+        // specify the class to use to lookup the 'shutdown' method.
+        XmlConfiguration configuration = asXmlConfiguration(
+            "<Configure class=\"org.eclipse.jetty.xml.TestConfiguration\">" +
+            "  <Set name=\"Test\">" +
+            "    <Call class=\"java.util.concurrent.Executors\" name=\"newSingleThreadScheduledExecutor\">" +
+            "      <Call class=\"java.util.concurrent.ExecutorService\" name=\"shutdown\" />" +
+            "    </Call>" +
+            "  </Set>" +
+            "</Configure>"
+        );
+
+        TestConfiguration tc = new TestConfiguration();
+        configuration.configure(tc);
+
+        assertThat(tc.testObject, instanceOf(ScheduledExecutorService.class));
     }
 
     private ByteArrayOutputStream captureLoggingBytes(ThrowableAction action) throws Exception

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.net.ssl.SSLSocketFactory;
 
 import org.eclipse.jetty.logging.JettyLevel;


### PR DESCRIPTION
Now <Call>, <Get> and <Set> elements can use the "class" attribute to specify the exact class to perform method lookup.

Improved support for <Property>, <SystemProperty> and <Env> so that attribute "name" is now optional (as specified in the DTD), and a "deprecated" attribute may be present instead.
This is necessary to terminally deprecate properties that have no replacement.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>