### PR TITLE
Fixes #8930 - NoSuchMethodException ofVirtual when building documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -32,8 +32,8 @@ This release process will produce releases:
   + [ ] Create and use branches `release/<ver>` to perform version specific release work from.
   + [ ] Ensure `VERSION.txt` additions for each release will be meaningful, descriptive, correct text.
   + [ ] Stage 9.4 release with Java 11.
-  + [ ] Stage 10 release with Java 17.
-  + [ ] Stage 11 release with Java 17.
+  + [ ] Stage 10 release with Java 19.
+  + [ ] Stage 11 release with Java 19.
   + [ ] Push release branches `release/<ver>` to to https://github.com/eclipse/jetty.project
   + [ ] Push release tags `jetty-<ver>` to https://github.com/eclipse/jetty.project
   + [ ] Edit a draft release (for each Jetty release) in GitHub (https://github.com/eclipse/jetty.project/releases). Content is generated with the "changelog tool".

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -14,6 +14,18 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <fail>false</fail>
+          <rules>
+            <requireJavaVersion>
+              <version>[19,)</version>
+              <message>[ERROR] OLD JDK [${java.version}] in use. Jetty documentation ${project.version} MUST use JDK 19 or newer</message>
+            </requireJavaVersion>
+          </rules>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2226,8 +2226,8 @@
                 <configuration>
                   <rules>
                     <requireJavaVersion>
-                      <version>[17,)</version>
-                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 17 or newer</message>
+                      <version>[19,)</version>
+                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 19 or newer</message>
                     </requireJavaVersion>
                   </rules>
                 </configuration>


### PR DESCRIPTION
Do not hard fail the documentation if Java < 19.
Require Java 19 to build the release.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>