### PR TITLE
Jetty-12 Rewrite RuleProcessor

### DIFF
--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
@@ -35,7 +35,7 @@ public class RewriteCustomizer extends RuleContainer implements Customizer
         try
         {
             // TODO: rule are able to complete the request/response, but customizers cannot.
-            Request.WrapperProcessor input = new Request.WrapperProcessor(request);
+            RuleProcessor input = new RuleProcessor(request);
             return matchAndApply(input);
         }
         catch (IOException e)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
@@ -35,7 +35,7 @@ public class RewriteCustomizer extends RuleContainer implements Customizer
         try
         {
             // TODO: rule are able to complete the request/response, but customizers cannot.
-            RuleProcessor input = new RuleProcessor(request);
+            Processor input = new Processor(request);
             return matchAndApply(input);
         }
         catch (IOException e)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -26,23 +26,16 @@ import org.eclipse.jetty.util.URIUtil;
 public class CompactPathRule extends Rule
 {
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor request) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
-        String path = request.getHttpURI().getCanonicalPath();
+        String path = input.getHttpURI().getCanonicalPath();
         String compacted = URIUtil.compactPath(path);
 
         if (path.equals(compacted))
             return null;
 
-        HttpURI uri = Request.newHttpURIFrom(request, compacted);
+        HttpURI uri = Request.newHttpURIFrom(input, compacted);
 
-        return new Request.WrapperProcessor(request)
-        {
-            @Override
-            public HttpURI getHttpURI()
-            {
-                return uri;
-            }
-        };
+        return new UriRuleProcessor(input, uri);
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -26,7 +26,7 @@ import org.eclipse.jetty.util.URIUtil;
 public class CompactPathRule extends Rule
 {
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         String path = input.getHttpURI().getCanonicalPath();
         String compacted = URIUtil.compactPath(path);
@@ -36,6 +36,6 @@ public class CompactPathRule extends Rule
 
         HttpURI uri = Request.newHttpURIFrom(input, compacted);
 
-        return new UriRuleProcessor(input, uri);
+        return new HttpURIProcessor(input, uri);
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
@@ -76,7 +76,7 @@ public class CookiePatternRule extends PatternRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor apply(RuleProcessor input) throws IOException
     {
         // TODO: fix once Request.getCookies() is implemented (currently always returns null)
         // Check that cookie is not already set
@@ -90,13 +90,13 @@ public class CookiePatternRule extends PatternRule
             }
         }
 
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback) throws Exception
+            public void process(Response response, Callback callback) throws Exception
             {
                 Response.addCookie(response, new HttpCookie(_name, _value));
-                super.process(this, response, callback);
+                super.process(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
@@ -76,9 +76,8 @@ public class CookiePatternRule extends PatternRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input) throws IOException
+    public Processor apply(Processor input) throws IOException
     {
-        // TODO: fix once Request.getCookies() is implemented (currently always returns null)
         // Check that cookie is not already set
         List<HttpCookie> cookies = Request.getCookies(input);
         if (cookies != null)
@@ -90,7 +89,7 @@ public class CookiePatternRule extends PatternRule
             }
         }
 
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForceRequestHeaderValueRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForceRequestHeaderValueRule.java
@@ -43,7 +43,7 @@ public class ForceRequestHeaderValueRule extends Rule
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         HttpFields headers = input.getHeaders();
         String existingValue = headers.get(headerName);
@@ -59,7 +59,7 @@ public class ForceRequestHeaderValueRule extends Rule
         HttpFields.Mutable newHeaders = HttpFields.build(headers);
         newHeaders.remove(headerName);
         newHeaders.add(headerName, headerValue);
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public HttpFields getHeaders()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForceRequestHeaderValueRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForceRequestHeaderValueRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.server.Request;
 
 public class ForceRequestHeaderValueRule extends Rule
 {
@@ -44,7 +43,7 @@ public class ForceRequestHeaderValueRule extends Rule
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         HttpFields headers = input.getHeaders();
         String existingValue = headers.get(headerName);
@@ -60,7 +59,7 @@ public class ForceRequestHeaderValueRule extends Rule
         HttpFields.Mutable newHeaders = HttpFields.build(headers);
         newHeaders.remove(headerName);
         newHeaders.add(headerName, headerValue);
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
             public HttpFields getHeaders()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
@@ -33,9 +33,9 @@ public class ForwardedSchemeHeaderRule extends HeaderRule
     }
 
     @Override
-    protected RuleProcessor apply(RuleProcessor input, String value)
+    protected Processor apply(Processor input, String value)
     {
         HttpURI newURI = HttpURI.build(input.getHttpURI()).scheme(getScheme());
-        return new UriRuleProcessor(input, newURI);
+        return new HttpURIProcessor(input, newURI);
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.rewrite.handler;
 
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Request;
 
 /**
  * <p>Sets the request URI scheme, by default {@code https}.</p>
@@ -34,16 +33,9 @@ public class ForwardedSchemeHeaderRule extends HeaderRule
     }
 
     @Override
-    protected Request.WrapperProcessor apply(Request.WrapperProcessor input, String value)
+    protected RuleProcessor apply(RuleProcessor input, String value)
     {
         HttpURI newURI = HttpURI.build(input.getHttpURI()).scheme(getScheme());
-        return new Request.WrapperProcessor(input)
-        {
-            @Override
-            public HttpURI getHttpURI()
-            {
-                return newURI;
-            }
-        };
+        return new UriRuleProcessor(input, newURI);
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
@@ -73,9 +73,9 @@ public class HeaderPatternRule extends PatternRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input) throws IOException
+    public Processor apply(Processor input) throws IOException
     {
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -74,18 +73,18 @@ public class HeaderPatternRule extends PatternRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor apply(RuleProcessor input) throws IOException
     {
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback) throws Exception
+            public void process(Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), getHeaderValue());
                 else
                     response.getHeaders().put(getHeaderName(), getHeaderValue());
-                super.process(ignored, response, callback);
+                super.process(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
@@ -74,9 +74,9 @@ public class HeaderRegexRule extends RegexRule
     }
 
     @Override
-    protected RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
+    protected Processor apply(Processor input, Matcher matcher) throws IOException
     {
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 import java.util.regex.Matcher;
 
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -75,18 +74,18 @@ public class HeaderRegexRule extends RegexRule
     }
 
     @Override
-    protected Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher) throws IOException
+    protected RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
     {
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback) throws Exception
+            public void process(Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), matcher.replaceAll(getHeaderValue()));
                 else
                     response.getHeaders().put(getHeaderName(), matcher.replaceAll(getHeaderValue()));
-                super.process(ignored, response, callback);
+                super.process(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRule.java
@@ -48,7 +48,7 @@ public abstract class HeaderRule extends Rule
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         String value = input.getHeaders().get(getHeaderName());
         if (value == null)
@@ -67,7 +67,7 @@ public abstract class HeaderRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract RuleProcessor apply(RuleProcessor input, String value) throws IOException;
+    protected abstract Processor apply(Processor input, String value) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRule.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
-import org.eclipse.jetty.server.Request;
-
 /**
  * <p>Abstract rule that matches against request headers.</p>
  */
@@ -50,7 +48,7 @@ public abstract class HeaderRule extends Rule
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         String value = input.getHeaders().get(getHeaderName());
         if (value == null)
@@ -69,7 +67,7 @@ public abstract class HeaderRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract Request.WrapperProcessor apply(Request.WrapperProcessor input, String value) throws IOException;
+    protected abstract RuleProcessor apply(RuleProcessor input, String value) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
@@ -74,7 +74,7 @@ public class InvalidURIRule extends Rule
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         String path = input.getHttpURI().getDecodedPath();
 
@@ -90,9 +90,9 @@ public class InvalidURIRule extends Rule
         return null;
     }
 
-    private RuleProcessor apply(RuleProcessor input)
+    private Processor apply(Processor input)
     {
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -75,7 +74,7 @@ public class InvalidURIRule extends Rule
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         String path = input.getHttpURI().getDecodedPath();
 
@@ -91,12 +90,12 @@ public class InvalidURIRule extends Rule
         return null;
     }
 
-    private Request.WrapperProcessor apply(Request.WrapperProcessor input)
+    private RuleProcessor apply(RuleProcessor input)
     {
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback)
+            public void process(Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/PatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/PatternRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
-import org.eclipse.jetty.server.Request;
 
 /**
  * <p>Abstract rule that uses the Servlet pattern syntax via
@@ -46,7 +45,7 @@ public abstract class PatternRule extends Rule
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         if (ServletPathSpec.match(_pattern, input.getHttpURI().getPath()))
             return apply(input);
@@ -60,7 +59,7 @@ public abstract class PatternRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException;
+    protected abstract RuleProcessor apply(RuleProcessor input) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/PatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/PatternRule.java
@@ -45,7 +45,7 @@ public abstract class PatternRule extends Rule
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         if (ServletPathSpec.match(_pattern, input.getHttpURI().getPath()))
             return apply(input);
@@ -59,7 +59,7 @@ public abstract class PatternRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract RuleProcessor apply(RuleProcessor input) throws IOException;
+    protected abstract Processor apply(Processor input) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
@@ -77,9 +77,9 @@ public class RedirectPatternRule extends PatternRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input) throws IOException
+    public Processor apply(Processor input) throws IOException
     {
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
@@ -77,12 +77,12 @@ public class RedirectPatternRule extends PatternRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor apply(RuleProcessor input) throws IOException
     {
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback)
+            public void process(Response response, Callback callback)
             {
                 String location = getLocation();
                 response.setStatus(getStatusCode());

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
@@ -76,9 +76,9 @@ public class RedirectRegexRule extends RegexRule
     }
 
     @Override
-    protected RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
+    protected Processor apply(Processor input, Matcher matcher) throws IOException
     {
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
@@ -76,12 +76,12 @@ public class RedirectRegexRule extends RegexRule
     }
 
     @Override
-    protected Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher) throws IOException
+    protected RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
     {
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback)
+            public void process(Response response, Callback callback)
             {
                 String target = matcher.replaceAll(getLocation());
                 response.setStatus(_statusCode);

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RegexRule.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.jetty.server.Request;
-
 /**
  * <p>Abstract rule that uses the regular expression syntax for path pattern matching.</p>
  */
@@ -54,7 +52,7 @@ public abstract class RegexRule extends Rule
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         String target = input.getHttpURI().getPathQuery();
         Matcher matcher = _regex.matcher(target);
@@ -71,7 +69,7 @@ public abstract class RegexRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher) throws IOException;
+    protected abstract RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RegexRule.java
@@ -52,7 +52,7 @@ public abstract class RegexRule extends Rule
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         String target = input.getHttpURI().getPathQuery();
         Matcher matcher = _regex.matcher(target);
@@ -69,7 +69,7 @@ public abstract class RegexRule extends Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}
      * @throws IOException if applying the rule failed
      */
-    protected abstract RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException;
+    protected abstract Processor apply(Processor input, Matcher matcher) throws IOException;
 
     @Override
     public String toString()

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
@@ -75,12 +75,12 @@ public class ResponsePatternRule extends PatternRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input) throws IOException
+    public Processor apply(Processor input) throws IOException
     {
         if (getCode() < HttpStatus.CONTINUE_100)
             return null;
 
-        return new RuleProcessor(input)
+        return new Processor(input)
         {
             @Override
             public void process(Response response, Callback callback)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -76,15 +75,15 @@ public class ResponsePatternRule extends PatternRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor apply(RuleProcessor input) throws IOException
     {
         if (getCode() < HttpStatus.CONTINUE_100)
             return null;
 
-        return new Request.WrapperProcessor(input)
+        return new RuleProcessor(input)
         {
             @Override
-            public void process(Request ignored, Response response, Callback callback)
+            public void process(Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -108,8 +108,8 @@ public class RewriteHandler extends Handler.Wrapper
         if (!isStarted())
             return null;
 
-        Request.WrapperProcessor input = new Request.WrapperProcessor(request);
-        Request.WrapperProcessor output = _rules.matchAndApply(input);
+        Rule.RuleProcessor input = new Rule.RuleProcessor(request);
+        Rule.RuleProcessor output = _rules.matchAndApply(input);
 
         // No rule matched, call super with the original request.
         if (output == null)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -108,8 +108,8 @@ public class RewriteHandler extends Handler.Wrapper
         if (!isStarted())
             return null;
 
-        Rule.RuleProcessor input = new Rule.RuleProcessor(request);
-        Rule.RuleProcessor output = _rules.matchAndApply(input);
+        Rule.Processor input = new Rule.Processor(request);
+        Rule.Processor output = _rules.matchAndApply(input);
 
         // No rule matched, call super with the original request.
         if (output == null)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewritePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewritePatternRule.java
@@ -63,7 +63,7 @@ public class RewritePatternRule extends PatternRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input) throws IOException
+    public Processor apply(Processor input) throws IOException
     {
         HttpURI httpURI = input.getHttpURI();
         String newQuery = URIUtil.addQueries(httpURI.getQuery(), _query);
@@ -71,7 +71,7 @@ public class RewritePatternRule extends PatternRule
         HttpURI newURI = HttpURI.build(httpURI, newPath, httpURI.getParam(), newQuery);
         if (LOG.isDebugEnabled())
             LOG.debug("rewriting {} to {}", httpURI, newURI);
-        return new UriRuleProcessor(input, newURI);
+        return new HttpURIProcessor(input, newURI);
     }
 
     @Override

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewritePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewritePatternRule.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.Name;
 import org.slf4j.Logger;
@@ -64,7 +63,7 @@ public class RewritePatternRule extends PatternRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor apply(RuleProcessor input) throws IOException
     {
         HttpURI httpURI = input.getHttpURI();
         String newQuery = URIUtil.addQueries(httpURI.getQuery(), _query);
@@ -72,14 +71,7 @@ public class RewritePatternRule extends PatternRule
         HttpURI newURI = HttpURI.build(httpURI, newPath, httpURI.getParam(), newQuery);
         if (LOG.isDebugEnabled())
             LOG.debug("rewriting {} to {}", httpURI, newURI);
-        return new Request.WrapperProcessor(input)
-        {
-            @Override
-            public HttpURI getHttpURI()
-            {
-                return newURI;
-            }
-        };
+        return new UriRuleProcessor(input, newURI);
     }
 
     @Override

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteRegexRule.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.annotation.Name;
 
 /**
@@ -50,20 +49,13 @@ public class RewriteRegexRule extends RegexRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher) throws IOException
+    public RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
     {
         HttpURI httpURI = input.getHttpURI();
         String replacedPath = matcher.replaceAll(replacement);
 
         HttpURI newURI = HttpURI.build(httpURI, replacedPath);
-        return new Request.WrapperProcessor(input)
-        {
-            @Override
-            public HttpURI getHttpURI()
-            {
-                return newURI;
-            }
-        };
+        return new UriRuleProcessor(input, newURI);
     }
 
     @Override

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteRegexRule.java
@@ -49,13 +49,13 @@ public class RewriteRegexRule extends RegexRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
+    public Processor apply(Processor input, Matcher matcher) throws IOException
     {
         HttpURI httpURI = input.getHttpURI();
         String replacedPath = matcher.replaceAll(replacement);
 
         HttpURI newURI = HttpURI.build(httpURI, replacedPath);
-        return new UriRuleProcessor(input, newURI);
+        return new HttpURIProcessor(input, newURI);
     }
 
     @Override

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
@@ -80,7 +80,6 @@ public abstract class Rule
         @Override
         public void process(Request request, Response response, Callback callback) throws Exception
         {
-            assert getWrapped() == request;
             process(response, callback);
         }
 
@@ -110,12 +109,7 @@ public abstract class Rule
         public Processor wrapProcessor(Processor processor)
         {
             _processor = processor;
-            return processor == null ? null : this::processWithWrappers;
-        }
-
-        protected void processWithWrappers(Request ignored, Response response, Callback callback) throws Exception
-        {
-            process(response, callback);
+            return processor == null ? null : this;
         }
     }
 

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
@@ -91,7 +91,7 @@ public abstract class Rule
          * @param response The response
          * @param callback The callback
          * @throws Exception If there is a problem processing
-         * @see #wrapProcessor(Processor).
+         * @see #wrapProcessor(Processor)
          */
         protected void process(Response response, Callback callback) throws Exception
         {

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
@@ -15,7 +15,10 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
 
 /**
  * <p>An abstract rule that, upon matching a certain condition, may wrap
@@ -32,7 +35,7 @@ public abstract class Rule
      * @return the possibly wrapped {@code Request} and {@code Processor}, or {@code null} if the rule did not match
      * @throws IOException if applying the rule failed
      */
-    public abstract Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException;
+    public abstract RuleProcessor matchAndApply(RuleProcessor input) throws IOException;
 
     /**
      * @return when {@code true}, rules after this one are not processed
@@ -54,5 +57,117 @@ public abstract class Rule
     public String toString()
     {
         return "%s@%x[terminating=%b]".formatted(getClass().getSimpleName(), hashCode(), isTerminating());
+    }
+
+    /**
+     * A tuple of a {@link Request.Wrapper} and is also a {@link org.eclipse.jetty.server.Request.Processor},
+     * that is used to chain a sequence of {@link Rule}s together.
+     * The tuple is initialized with only the request, then the processor is
+     * then passed to a chain of rules before the ultimate processor is
+     * passed in {@link #wrapProcessor(Processor)}. Finally, the response
+     * and callback are provided in a call to {@link #process(Request, Response, Callback)},
+     * which calls the {@link #process(Response, Callback)}.
+     */
+    public static class RuleProcessor extends Request.Wrapper implements Request.Processor
+    {
+        private volatile Processor _processor;
+
+        public RuleProcessor(Request request)
+        {
+            super(request);
+        }
+
+        @Override
+        public void process(Request request, Response response, Callback callback) throws Exception
+        {
+            assert getWrapped() == request;
+            process(response, callback);
+        }
+
+        /** Process this wrapped request together with the passed response and
+         * callback, using the processor set in {@link #wrapProcessor(Processor)}.
+         * This method should be extended if additional processing of the wrapped
+         * request is required.
+         * @param response The response
+         * @param callback The callback
+         * @throws Exception If there is a problem processing
+         * @see #wrapProcessor(Processor).
+         */
+        protected void process(Response response, Callback callback) throws Exception
+        {
+            Processor processor = _processor;
+            if (processor != null)
+                processor.process(this, response, callback);
+        }
+
+        /**
+         * <p>Wraps the given {@code Processor} within this instance and returns this instance.</p>
+         *
+         * @param processor the {@code Processor} to wrap
+         * @return this instance
+         */
+        public Processor wrapProcessor(Processor processor)
+        {
+            _processor = processor;
+            return processor == null ? null : this::wrappedProcess;
+        }
+
+        protected Request wrapRequest(Request request)
+        {
+            return request;
+        }
+
+        protected Response wrapResponse(Request request, Response response)
+        {
+            return response;
+        }
+
+        private void wrappedProcess(Request request, Response response, Callback callback) throws Exception
+        {
+            Request wrapped = this.getWrapped();
+            while (wrapped != null)
+            {
+                if (request == wrapped)
+                {
+                    process(wrapResponse(this, response), callback);
+                    return;
+                }
+                wrapped = wrapped instanceof Request.Wrapper w ? w.getWrapped() : null;
+            }
+
+            // We need a new instance of the wrapper
+            Request wrapper = wrapRequest(request);
+            process(wrapResponse(wrapper, response), callback);
+        }
+    }
+
+    public static class UriRuleProcessor extends RuleProcessor
+    {
+        private final HttpURI _uri;
+
+        public UriRuleProcessor(Request request, HttpURI uri)
+        {
+            super(request);
+            _uri = uri;
+        }
+
+        @Override
+        public HttpURI getHttpURI()
+        {
+            return _uri;
+        }
+
+        @Override
+        protected Request wrapRequest(Request request)
+        {
+            return new Request.Wrapper(request)
+            {
+                @Override
+                public HttpURI getHttpURI()
+                {
+                    return _uri;
+                }
+            };
+        }
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
@@ -103,7 +103,7 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
      * or {@code null} if no rule matched
      */
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         String originalPathAttribute = getOriginalPathAttribute();
         if (originalPathAttribute != null)
@@ -120,7 +120,7 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("applying {}", rule);
-            RuleProcessor output = rule.matchAndApply(input);
+            Processor output = rule.matchAndApply(input);
             if (output == null)
             {
                 if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +103,7 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
      * or {@code null} if no rule matched
      */
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         String originalPathAttribute = getOriginalPathAttribute();
         if (originalPathAttribute != null)
@@ -121,7 +120,7 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("applying {}", rule);
-            Request.WrapperProcessor output = rule.matchAndApply(input);
+            RuleProcessor output = rule.matchAndApply(input);
             if (output == null)
             {
                 if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingPatternRule.java
@@ -37,7 +37,7 @@ public class TerminatingPatternRule extends PatternRule
     }
 
     @Override
-    protected RuleProcessor apply(RuleProcessor input) throws IOException
+    protected Processor apply(Processor input) throws IOException
     {
         return input;
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingPatternRule.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
-import org.eclipse.jetty.server.Request;
-
 /**
  * <p>If this rule matches, terminates the processing of other rules, allowing
  * the request to be processed by the handlers after the {@link RewriteHandler}.</p>
@@ -39,7 +37,7 @@ public class TerminatingPatternRule extends PatternRule
     }
 
     @Override
-    protected Request.WrapperProcessor apply(Request.WrapperProcessor input) throws IOException
+    protected RuleProcessor apply(RuleProcessor input) throws IOException
     {
         return input;
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingRegexRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 import java.util.regex.Matcher;
 
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.annotation.Name;
 
 /**
@@ -41,7 +40,7 @@ public class TerminatingRegexRule extends RegexRule
     }
 
     @Override
-    public Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher) throws IOException
+    public RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
     {
         return input;
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/TerminatingRegexRule.java
@@ -40,7 +40,7 @@ public class TerminatingRegexRule extends RegexRule
     }
 
     @Override
-    public RuleProcessor apply(RuleProcessor input, Matcher matcher) throws IOException
+    public Processor apply(Processor input, Matcher matcher) throws IOException
     {
         return input;
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/VirtualHostRuleContainer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/VirtualHostRuleContainer.java
@@ -55,7 +55,7 @@ public class VirtualHostRuleContainer extends RuleContainer
     }
 
     @Override
-    public Request.WrapperProcessor matchAndApply(Request.WrapperProcessor input) throws IOException
+    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
     {
         if (_virtualHosts.isEmpty())
             return super.matchAndApply(input);

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/VirtualHostRuleContainer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/VirtualHostRuleContainer.java
@@ -55,7 +55,7 @@ public class VirtualHostRuleContainer extends RuleContainer
     }
 
     @Override
-    public RuleProcessor matchAndApply(RuleProcessor input) throws IOException
+    public Processor matchAndApply(Processor input) throws IOException
     {
         if (_virtualHosts.isEmpty())
             return super.matchAndApply(input);

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/PatternRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/PatternRuleTest.java
@@ -157,7 +157,7 @@ public class PatternRuleTest extends AbstractRuleTest
         }
 
         @Override
-        public RuleProcessor apply(RuleProcessor input)
+        public Processor apply(Processor input)
         {
             _applied = true;
             return input;

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/PatternRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/PatternRuleTest.java
@@ -157,7 +157,7 @@ public class PatternRuleTest extends AbstractRuleTest
         }
 
         @Override
-        public Request.WrapperProcessor apply(Request.WrapperProcessor input)
+        public RuleProcessor apply(RuleProcessor input)
         {
             _applied = true;
             return input;

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RegexRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RegexRuleTest.java
@@ -124,7 +124,7 @@ public class RegexRuleTest extends AbstractRuleTest
         }
 
         @Override
-        public RuleProcessor apply(RuleProcessor input, Matcher matcher)
+        public Processor apply(Processor input, Matcher matcher)
         {
             _applied = true;
             return input;

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RegexRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RegexRuleTest.java
@@ -124,7 +124,7 @@ public class RegexRuleTest extends AbstractRuleTest
         }
 
         @Override
-        public Request.WrapperProcessor apply(Request.WrapperProcessor input, Matcher matcher)
+        public RuleProcessor apply(RuleProcessor input, Matcher matcher)
         {
             _applied = true;
             return input;


### PR DESCRIPTION
This extracts some goodness from the closed  #8793.
This PR decouples the rewrite module from the `WrapperProcessor` class, which is being considered for significant refactoring or removal. Having a module specific version of that class allows better code readability and a more appropriate API that avoids duplication request instances.