### PR TITLE
Re-enable DefaultServletRangesTest and fix byte ranges for ee10

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -246,9 +246,10 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
     {
         private final PathContentSource content;
 
-        public Part(String contentType, Path path, ByteRange byteRange)
+        public Part(String contentType, Path path, ByteRange byteRange, long contentLength)
         {
-            this(HttpFields.build().put(HttpHeader.CONTENT_TYPE, contentType), path, byteRange);
+            this(HttpFields.build().put(HttpHeader.CONTENT_TYPE, contentType)
+                .put(HttpHeader.CONTENT_RANGE, byteRange.toHeaderValue(contentLength)), path, byteRange);
         }
 
         public Part(HttpFields headers, Path path, ByteRange byteRange)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -629,7 +629,7 @@ public class ResourceService
         String boundary = MultiPart.generateBoundary(null, 24);
         response.getHeaders().put(HttpHeader.CONTENT_TYPE, contentType + boundary);
         MultiPartByteRanges.ContentSource byteRanges = new MultiPartByteRanges.ContentSource(boundary);
-        ranges.forEach(range -> byteRanges.addPart(new MultiPartByteRanges.Part(content.getContentTypeValue(), content.getResource().getPath(), range)));
+        ranges.forEach(range -> byteRanges.addPart(new MultiPartByteRanges.Part(content.getContentTypeValue(), content.getResource().getPath(), range, contentLength)));
         byteRanges.close();
         Content.copy(byteRanges, response, callback);
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartByteRangesTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartByteRangesTest.java
@@ -86,7 +86,7 @@ public class MultiPartByteRangesTest
                 String boundary = "boundary";
                 try (MultiPartByteRanges.ContentSource content = new MultiPartByteRanges.ContentSource(boundary))
                 {
-                    ranges.forEach(range -> content.addPart(new MultiPartByteRanges.Part("text/plain", resourcePath, range)));
+                    ranges.forEach(range -> content.addPart(new MultiPartByteRanges.Part("text/plain", resourcePath, range, content.getLength())));
                     content.close();
 
                     response.setStatus(HttpStatus.PARTIAL_CONTENT_206);

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletRangesTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletRangesTest.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,7 +35,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled
 @ExtendWith(WorkDirExtension.class)
 public class DefaultServletRangesTest
 {
@@ -45,7 +43,6 @@ public class DefaultServletRangesTest
 
     private Server server;
     private LocalConnector connector;
-    private ServletContextHandler context;
 
     @BeforeEach
     public void init() throws Exception
@@ -55,7 +52,7 @@ public class DefaultServletRangesTest
         connector = new LocalConnector(server);
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
 
-        context = new ServletContextHandler();
+        ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/context");
         context.setWelcomeFiles(new String[]{"index.html", "index.jsp", "index.htm"});
 
@@ -142,7 +139,7 @@ public class DefaultServletRangesTest
                 "Connection: close\r\n" +
                 "Range: bytes=0-9,20-29,40-49\r\n" +
                 "\r\n");
-        int start = response.indexOf("--jetty");
+        int start = response.indexOf("--");
         String body = response.substring(start);
         String boundary = body.substring(0, body.indexOf("\r\n"));
         assertResponseContains("206 Partial", response);
@@ -186,9 +183,9 @@ public class DefaultServletRangesTest
             "GET /context/data.txt HTTP/1.1\r\n" +
                 "Host: localhost\r\n" +
                 "Connection: close\r\n" +
-                "Range: bytes=" + stringBuilder.toString() + "0-2\r\n" +
+                "Range: bytes=" + stringBuilder + "0-2\r\n" +
                 "\r\n");
-        int start = response.indexOf("--jetty");
+        int start = response.indexOf("--");
         String body = response.substring(start);
         String boundary = body.substring(0, body.indexOf("\r\n"));
         assertResponseContains("206 Partial", response);


### PR DESCRIPTION
Fixes to `MultiPartByteRanges` to pass tests in `DefaultServletRangesTest`