### PR TITLE
Fixes #8938 - Improve API compatibility between Jetty 11 and Jetty 12…

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -242,6 +242,11 @@ public class Request implements HttpServletRequest
 
     public HttpFields getHttpFields()
     {
+        return getHeaders();
+    }
+
+    public HttpFields getHeaders()
+    {
         return _httpFields;
     }
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -1387,6 +1387,11 @@ public class Response implements HttpServletResponse
 
     public HttpFields.Mutable getHttpFields()
     {
+        return getHeaders();
+    }
+
+    public HttpFields.Mutable getHeaders()
+    {
         return _fields;
     }
 


### PR DESCRIPTION
… for Spring.

Introduced Request.getHeaders() and Response.getHeaders().

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>