### PR TITLE
Issue #8895 - delete javadoc sources

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -53,7 +53,7 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>init-jetty-sources-dir</id>
+            <id>create-sources-dir</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>run</goal>
@@ -61,6 +61,18 @@
             <configuration>
               <target>
                 <mkdir dir="${sources-directory}" />
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>delete-sources-dir</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <delete dir="${sources-directory}" />
               </target>
             </configuration>
           </execution>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -72,7 +72,7 @@
             </goals>
             <configuration>
               <target>
-                <delete dir="${sources-directory}" />
+                <delete dir="${sources-directory}" failonerror="false" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
Delete java source files used to generate javadocs, so that IDEs do not report duplicate sources.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>