### PR TITLE
Rework client content listeners

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
@@ -219,22 +219,21 @@ The response content is provided by the `HttpClient` implementation to applicati
 The listener that follows this model is `Response.ContentSourceListener`.
 
 After the response headers have been processed by the `HttpClient` implementation, `Response.ContentSourceListener.onContentSource(response, contentSource)` is invoked once and only once.
-This allows the application to control precisely the read/demand loop: when to read a chunk, how to handle it and when to demand the next one.
+This allows the application to control precisely the read/demand loop: when to read a chunk, how to process it and when to demand the next one.
 
-A `org.eclipse.jetty.io.Content.Source` read/demand implementation akin to the idiomatic one must be provided: reading a `Content.Chunk` from the `contentSource`, demanding the next one if it is null, reporting if it is an error, processing its `buffer` then releasing it, and finally demanding the next one again if it is not terminal.
+You must provide a `org.eclipse.jetty.io.Content.Source` read/demand implementation that reads a `Content.Chunk` from the provided `Content.Source`; if the read chunk is `null`, `Content.Source.demand(Runnable)` should be called so that the demand callback is called back when more chunks are available; if the chunk is an instance of `Content.Chunk.Error` then the error should be processed; otherwise the chunk should be processed by consuming and then releasing the chunk's `ByteBuffer`; and finally either trying to read another chunk, or demanding for another chunk (unless the current chunk is the last).
 
-IMPORTANT: releasing the `Content.Chunk` must be done only after the bytes in the `buffer` returned by `getByteBuffer()` have been consumed.
+IMPORTANT: Calling `Content.Chunk.release()` must be done only after the bytes in the `ByteBuffer` returned by `Content.Chunk.getByteBuffer()` have been consumed.
 When the `Content.Chunk` is released, the `HttpClient` implementation may reuse the `buffer` and overwrite the bytes with different bytes; if the application looks at the `buffer` _after_ having released the `Content.Chunk` is may see other, unrelated, bytes.
 
-Applications will typically read just one `Content.Chunk` via `contentSource.read()` then demand the next one via `contentSource.demand(() -> onContentSource(request, contentSource))`, but may decide to call `contentSource.read()` until it returns `null`.
-The application uses the `demand` object to demand more content chunks.
-Applications will typically demand for just one more content via `demand.accept(1)`, but may decide to demand for more via `demand.accept(2)` or demand "infinitely" once via `demand.accept(Long.MAX_VALUE)`.
+// TODO: add example code snippet
 
-Applications that call `contentSource.read()` more than once must remember that the request will not be aborted (in case of a timeout or an async call to `request.abort(Throwable)`) for as long as `onContentSource(request, contentSource)` or the callback passed to `contentSource.demand(Runnable callback)` has not returned.
+The invocation of `onContentSource(Request, Content.Source)` and of the demand callback passed to `contentSource.demand(Runnable)` are serialized with respect to asynchronous events such as timeouts or an asynchronous call to `Request.abort(Throwable)`.
+This means that these asynchronous events are not processed until the invocation of `onContentSource(Request, Content.Source)` returns, or until the invocation of the demand callback returns.
 
 Demanding for content and consuming the content are orthogonal activities.
 
-An application can read/demand and store aside the `Content.Chunk` objects to consume them later.
+An application can read, store aside the `Content.Chunk` objects without releasing them (to consume them later), and demand for more chunks.
 If not done carefully, this may lead to excessive memory consumption, since the ``buffer``s are not consumed.
 Releasing the `Content.Chunk`s will result in the ``buffer``s to be disposed/recycled and may be performed at any time.
 

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
@@ -221,10 +221,10 @@ The listener that follows this model is `Response.ContentSourceListener`.
 After the response headers have been processed by the `HttpClient` implementation, `Response.ContentSourceListener.onContentSource(response, contentSource)` is invoked once and only once.
 This allows the application to control precisely the read/demand loop: when to read a chunk, how to process it and when to demand the next one.
 
-You must provide a `org.eclipse.jetty.io.Content.Source` read/demand implementation that reads a `Content.Chunk` from the provided `Content.Source`; if the read chunk is `null`, `Content.Source.demand(Runnable)` should be called so that the demand callback is called back when more chunks are available; if the chunk is an instance of `Content.Chunk.Error` then the error should be processed; otherwise the chunk should be processed by consuming and then releasing the chunk's `ByteBuffer`; and finally either trying to read another chunk, or demanding for another chunk (unless the current chunk is the last).
+You must provide a `ContentSourceListener` whose implementation reads a `Content.Chunk` from the provided `Content.Source`; if the read chunk is `null`, `Content.Source.demand(Runnable)` should be called so that the demand callback is called back when more chunks are available; if the chunk is an instance of `Content.Chunk.Error` then the error should be processed; otherwise the chunk should be processed by consuming and then releasing the chunk; and finally either trying to read another chunk, or demanding for another chunk (unless the current chunk is the last).
 
 IMPORTANT: Calling `Content.Chunk.release()` must be done only after the bytes in the `ByteBuffer` returned by `Content.Chunk.getByteBuffer()` have been consumed.
-When the `Content.Chunk` is released, the `HttpClient` implementation may reuse the `buffer` and overwrite the bytes with different bytes; if the application looks at the `buffer` _after_ having released the `Content.Chunk` is may see other, unrelated, bytes.
+When the `Content.Chunk` is released, the `HttpClient` implementation may reuse the `ByteBuffer` and overwrite the bytes with different bytes; if the application looks at the `ByteBuffer` _after_ having released the `Content.Chunk` is may see other, unrelated, bytes.
 
 // TODO: add example code snippet
 
@@ -233,13 +233,14 @@ This means that these asynchronous events are not processed until the invocation
 
 Demanding for content and consuming the content are orthogonal activities.
 
-An application can read, store aside the `Content.Chunk` objects without releasing them (to consume them later), and demand for more chunks.
+An application can read, store aside the `Content.Chunk` objects without releasing them (to consume them later), and demand for more chunks, but it must call `Chunk.retain()` on the stored chunks, and arrange to release them after they have been consumed later.
+
 If not done carefully, this may lead to excessive memory consumption, since the ``buffer``s are not consumed.
 Releasing the `Content.Chunk`s will result in the ``buffer``s to be disposed/recycled and may be performed at any time.
 
-An application can also read one chunk of content, consume it (by releasing it) and then _not_ demand for more content until a later time.
+An application can also read one chunk of content, consume it, release it, and then _not_ demand for more content until a later time.
 
-Subclass `Response.AsyncContentListener` overrides the behavior of `Response.ContentSourceListener`; when an application implements `onContent(response, chunk, demander)`, it can control the disposing/recycling the `buffer` by releasing the `chunk` _and_ it can control when to demand one more chunk of content by calling `demander.run()`.
+Subclass `Response.AsyncContentListener` overrides the behavior of `Response.ContentSourceListener`; when an application implements `AsyncContentListener.onContent(response, chunk, demander)`, it can control the disposing/recycling of the `ByteBuffer` by releasing the chunk _and_ it can control when to demand one more chunk by calling `demander.run()`.
 
 Subclass `Response.ContentListener` overrides the behavior of `Response.AsyncContentListener`; when an application implementing its `onContent(response, buffer)` returns from the method itself, it will _both_ the effect of disposing/recycling the `buffer` _and_ the effect of demanding one more chunk of content.
 

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-api.adoc
@@ -214,36 +214,33 @@ include::../../{doc_code}/org/eclipse/jetty/docs/programming/client/http/HTTPCli
 
 Finally, let's look at the advanced usage of the response content handling.
 
-The response content is provided by the `HttpClient` implementation to application listeners following a reactive model similar to that of `java.util.concurrent.Flow`.
+The response content is provided by the `HttpClient` implementation to application listeners following the read/demand model of `org.eclipse.jetty.io.Content.Source`.
 
-The listener that follows this model is `Response.DemandedContentListener`.
+The listener that follows this model is `Response.ContentSourceListener`.
 
-After the response headers have been processed by the `HttpClient` implementation, `Response.DemandedContentListener.onBeforeContent(response, demand)` is invoked.
-This allows the application to control whether to demand the first content or not.
-The default implementation of this method calls `demand.accept(1)`, which demands one chunk of content to the implementation.
-The implementation will deliver the chunk of content as soon as it is available.
+After the response headers have been processed by the `HttpClient` implementation, `Response.ContentSourceListener.onContentSource(response, contentSource)` is invoked once and only once.
+This allows the application to control precisely the read/demand loop: when to read a chunk, how to handle it and when to demand the next one.
 
-The chunks of content are delivered to the application by invoking `Response.DemandedContentListener.onContent(response, demand, buffer, callback)`.
-Applications implement this method to process the content bytes in the `buffer`.
-Succeeding the `callback` signals to the implementation that the application has consumed the `buffer` so that the implementation can dispose/recycle the `buffer`.
-Failing the `callback` signals to the implementation to fail the response (no more content will be delivered, and the _response failed_ event will be emitted).
+A `org.eclipse.jetty.io.Content.Source` read/demand implementation akin to the idiomatic one must be provided: reading a `Content.Chunk` from the `contentSource`, demanding the next one if it is null, reporting if it is an error, processing its `buffer` then releasing it, and finally demanding the next one again if it is not terminal.
 
-IMPORTANT: Succeeding the `callback` must be done only after the `buffer` bytes have been consumed.
-When the `callback` is succeeded, the `HttpClient` implementation may reuse the `buffer` and overwrite the bytes with different bytes; if the application looks at the `buffer` _after_ having succeeded the `callback` is may see other, unrelated, bytes.
+IMPORTANT: releasing the `Content.Chunk` must be done only after the bytes in the `buffer` returned by `getByteBuffer()` have been consumed.
+When the `Content.Chunk` is released, the `HttpClient` implementation may reuse the `buffer` and overwrite the bytes with different bytes; if the application looks at the `buffer` _after_ having released the `Content.Chunk` is may see other, unrelated, bytes.
 
+Applications will typically read just one `Content.Chunk` via `contentSource.read()` then demand the next one via `contentSource.demand(() -> onContentSource(request, contentSource))`, but may decide to call `contentSource.read()` until it returns `null`.
 The application uses the `demand` object to demand more content chunks.
 Applications will typically demand for just one more content via `demand.accept(1)`, but may decide to demand for more via `demand.accept(2)` or demand "infinitely" once via `demand.accept(Long.MAX_VALUE)`.
-Applications that demand for more than 1 chunk of content must be prepared to receive all the content that they have demanded.
+
+Applications that call `contentSource.read()` more than once must remember that the request will not be aborted (in case of a timeout or an async call to `request.abort(Throwable)`) for as long as `onContentSource(request, contentSource)` or the callback passed to `contentSource.demand(Runnable callback)` has not returned.
 
 Demanding for content and consuming the content are orthogonal activities.
 
-An application can demand "infinitely" and store aside the pairs `(buffer, callback)` to consume them later.
+An application can read/demand and store aside the `Content.Chunk` objects to consume them later.
 If not done carefully, this may lead to excessive memory consumption, since the ``buffer``s are not consumed.
-Succeeding the ``callback``s will result in the ``buffer``s to be disposed/recycled and may be performed at any time.
+Releasing the `Content.Chunk`s will result in the ``buffer``s to be disposed/recycled and may be performed at any time.
 
-An application can also demand one chunk of content, consume it (by succeeding the associated `callback`) and then _not_ demand for more content until a later time.
+An application can also read one chunk of content, consume it (by releasing it) and then _not_ demand for more content until a later time.
 
-Subclass `Response.AsyncContentListener` overrides the behavior of `Response.DemandedContentListener`; when an application implementing its `onContent(response, buffer, callback)` succeeds the `callback`, it will have _both_ the effect of disposing/recycling the `buffer` _and_ the effect of demanding one more chunk of content.
+Subclass `Response.AsyncContentListener` overrides the behavior of `Response.ContentSourceListener`; when an application implements `onContent(response, chunk, demander)`, it can control the disposing/recycling the `buffer` by releasing the `chunk` _and_ it can control when to demand one more chunk of content by calling `demander.run()`.
 
 Subclass `Response.ContentListener` overrides the behavior of `Response.AsyncContentListener`; when an application implementing its `onContent(response, buffer)` returns from the method itself, it will _both_ the effect of disposing/recycling the `buffer` _and_ the effect of demanding one more chunk of content.
 
@@ -253,5 +250,5 @@ An application that implements a forwarder between two servers can be implemente
 
 [source,java,indent=0]
 ----
-include::../../{doc_code}/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tags=demandedContentListener]
+include::../../{doc_code}/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tag=contentSourceListener]
 ----

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -265,7 +265,11 @@ public class HTTPClientDocs
             .onResponseBegin(response -> { /* ... */ })
             .onResponseHeader((response, field) -> true)
             .onResponseHeaders(response -> { /* ... */ })
-            .onResponseContentAsync((response, buffer, callback) -> callback.succeeded())
+            .onResponseContentAsync((response, chunk, demand) ->
+            {
+                chunk.release();
+                demand.run();
+            })
             .onResponseFailure((response, failure) -> { /* ... */ })
             .onResponseSuccess(response -> { /* ... */ })
             // Result hook.

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -265,10 +265,10 @@ public class HTTPClientDocs
             .onResponseBegin(response -> { /* ... */ })
             .onResponseHeader((response, field) -> true)
             .onResponseHeaders(response -> { /* ... */ })
-            .onResponseContentAsync((response, chunk, demand) ->
+            .onResponseContentAsync((response, chunk, demander) ->
             {
                 chunk.release();
-                demand.run();
+                demander.run();
             })
             .onResponseFailure((response, failure) -> { /* ... */ })
             .onResponseSuccess(response -> { /* ... */ })
@@ -516,10 +516,10 @@ public class HTTPClientDocs
                     return;
                 }
 
-                // When response content is received from server1, forward it to server2.
+                // When a response chunk is received from server1, forward it to server2.
                 content2.write(chunk.getByteBuffer(), Callback.from(() ->
                 {
-                    // When the request content to server2 is sent,
+                    // When the request chunk is successfully sent to server2,
                     // release the chunk to recycle the buffer.
                     chunk.release();
                     // Then demand more response content from server1.

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
@@ -552,9 +551,9 @@ public class HttpRequest implements Request
         this.responseListeners.add(new Response.AsyncContentListener()
         {
             @Override
-            public void onContent(Response response, ByteBuffer content, Callback callback)
+            public void onContent(Response response, org.eclipse.jetty.io.Content.Chunk chunk, Runnable demander)
             {
-                listener.onContent(response, content, callback);
+                listener.onContent(response, chunk, demander);
             }
         });
         return this;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -52,7 +51,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
@@ -554,26 +552,6 @@ public class HttpRequest implements Request
             public void onContent(Response response, org.eclipse.jetty.io.Content.Chunk chunk, Runnable demander)
             {
                 listener.onContent(response, chunk, demander);
-            }
-        });
-        return this;
-    }
-
-    @Override
-    public Request onResponseContentDemanded(Response.DemandedContentListener listener)
-    {
-        this.responseListeners.add(new Response.DemandedContentListener()
-        {
-            @Override
-            public void onBeforeContent(Response response, LongConsumer demand)
-            {
-                listener.onBeforeContent(response, demand);
-            }
-
-            @Override
-            public void onContent(Response response, LongConsumer demand, ByteBuffer content, Callback callback)
-            {
-                listener.onContent(response, demand, content, callback);
             }
         });
         return this;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -404,12 +404,6 @@ public interface Request
     Request onResponseContentAsync(Response.AsyncContentListener listener);
 
     /**
-     * @param listener an asynchronous listener for response content events
-     * @return this request object
-     */
-    Request onResponseContentDemanded(Response.DemandedContentListener listener);
-
-    /**
      * @param listener a listener for response success event
      * @return this request object
      */

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
@@ -153,20 +153,17 @@ public interface Response
         @Override
         default void onContent(Response response, Content.Chunk chunk, Runnable demander)
         {
-            boolean demand = false;
             try
             {
                 onContent(response, chunk.getByteBuffer());
                 chunk.release();
-                demand = true;
+                demander.run();
             }
             catch (Throwable x)
             {
                 chunk.release();
                 response.abort(x);
             }
-            if (demand)
-                demander.run();
         }
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/InputStreamResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/InputStreamResponseListener.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
 public class InputStreamResponseListener extends Listener.Adapter
 {
     private static final Logger LOG = LoggerFactory.getLogger(InputStreamResponseListener.class);
-    private static final ChunkCallback EOF = new ChunkCallback(Content.Chunk.EOF, () -> {}, (x) -> {});
+    private static final ChunkCallback EOF = new ChunkCallback(Content.Chunk.EOF, () -> {}, x -> {});
 
     private final AutoLock.WithCondition lock = new AutoLock.WithCondition();
     private final CountDownLatch responseLatch = new CountDownLatch(1);
@@ -104,7 +104,7 @@ public class InputStreamResponseListener extends Listener.Adapter
         if (!chunk.hasRemaining())
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Skipped empty content {}", chunk);
+                LOG.debug("Skipped empty chunk {}", chunk);
             chunk.release();
             demander.run();
             return;
@@ -117,7 +117,7 @@ public class InputStreamResponseListener extends Listener.Adapter
             if (!closed)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Queueing content {}", chunk);
+                    LOG.debug("Queueing chunk {}", chunk);
                 chunkCallbacks.add(new ChunkCallback(chunk, demander, response::abort));
                 l.signalAll();
             }
@@ -126,7 +126,7 @@ public class InputStreamResponseListener extends Listener.Adapter
         if (closed)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("InputStream closed, ignored content {}", chunk);
+                LOG.debug("InputStream closed, ignored chunk {}", chunk);
             chunk.release();
             response.abort(new AsynchronousCloseException());
         }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/InputStreamResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/util/InputStreamResponseListener.java
@@ -22,7 +22,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -34,7 +33,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Response.Listener;
 import org.eclipse.jetty.client.api.Result;
-import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -73,13 +72,13 @@ import org.slf4j.LoggerFactory;
 public class InputStreamResponseListener extends Listener.Adapter
 {
     private static final Logger LOG = LoggerFactory.getLogger(InputStreamResponseListener.class);
-    private static final Chunk EOF = new Chunk(BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+    private static final Tuple EOF = new Tuple(Content.Chunk.EOF, Callback.NOOP);
 
     private final AutoLock.WithCondition lock = new AutoLock.WithCondition();
     private final CountDownLatch responseLatch = new CountDownLatch(1);
     private final CountDownLatch resultLatch = new CountDownLatch(1);
     private final AtomicReference<InputStream> stream = new AtomicReference<>();
-    private final Queue<Chunk> chunks = new ArrayDeque<>();
+    private final Queue<Tuple> tuples = new ArrayDeque<>();
     private Response response;
     private Result result;
     private Throwable failure;
@@ -100,13 +99,14 @@ public class InputStreamResponseListener extends Listener.Adapter
     }
 
     @Override
-    public void onContent(Response response, ByteBuffer content, Callback callback)
+    public void onContent(Response response, Content.Chunk chunk, Runnable demander)
     {
-        if (content.remaining() == 0)
+        if (!chunk.hasRemaining())
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Skipped empty content {}", content);
-            callback.succeeded();
+                LOG.debug("Skipped empty content {}", chunk);
+            chunk.release();
+            demander.run();
             return;
         }
 
@@ -117,8 +117,8 @@ public class InputStreamResponseListener extends Listener.Adapter
             if (!closed)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Queueing content {}", content);
-                chunks.add(new Chunk(content, callback));
+                    LOG.debug("Queueing content {}", chunk);
+                tuples.add(new Tuple(chunk, Callback.from(demander, response::abort)));
                 l.signalAll();
             }
         }
@@ -126,8 +126,9 @@ public class InputStreamResponseListener extends Listener.Adapter
         if (closed)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("InputStream closed, ignored content {}", content);
-            callback.failed(new AsynchronousCloseException());
+                LOG.debug("InputStream closed, ignored content {}", chunk);
+            chunk.release();
+            response.abort(new AsynchronousCloseException());
         }
     }
 
@@ -137,7 +138,7 @@ public class InputStreamResponseListener extends Listener.Adapter
         try (AutoLock.WithCondition l = lock.lock())
         {
             if (!closed)
-                chunks.add(EOF);
+                tuples.add(EOF);
             l.signalAll();
         }
 
@@ -148,34 +149,34 @@ public class InputStreamResponseListener extends Listener.Adapter
     @Override
     public void onFailure(Response response, Throwable failure)
     {
-        List<Callback> callbacks;
+        List<Tuple> tuples;
         try (AutoLock.WithCondition l = lock.lock())
         {
             if (this.failure != null)
                 return;
             this.failure = failure;
-            callbacks = drain();
+            tuples = drain();
             l.signalAll();
         }
 
         if (LOG.isDebugEnabled())
             LOG.debug("Content failure", failure);
 
-        callbacks.forEach(callback -> callback.failed(failure));
+        tuples.forEach(tuple -> tuple.failed(failure));
     }
 
     @Override
     public void onComplete(Result result)
     {
         Throwable failure = result.getFailure();
-        List<Callback> callbacks = Collections.emptyList();
+        List<Tuple> tuples = Collections.emptyList();
         try (AutoLock.WithCondition l = lock.lock())
         {
             this.result = result;
             if (result.isFailed() && this.failure == null)
             {
                 this.failure = failure;
-                callbacks = drain();
+                tuples = drain();
             }
             // Notify the response latch in case of request failures.
             responseLatch.countDown();
@@ -191,7 +192,7 @@ public class InputStreamResponseListener extends Listener.Adapter
                 LOG.debug("Result failure", failure);
         }
 
-        callbacks.forEach(callback -> callback.failed(failure));
+        tuples.forEach(t -> t.failed(failure));
     }
 
     /**
@@ -261,21 +262,21 @@ public class InputStreamResponseListener extends Listener.Adapter
         return result;
     }
 
-    private List<Callback> drain()
+    private List<Tuple> drain()
     {
-        List<Callback> callbacks = new ArrayList<>();
+        List<Tuple> failures = new ArrayList<>();
         try (AutoLock ignored = lock.lock())
         {
             while (true)
             {
-                Chunk chunk = chunks.peek();
-                if (chunk == null || chunk == EOF)
+                Tuple tuple = tuples.peek();
+                if (tuple == null || tuple == EOF)
                     break;
-                callbacks.add(chunk.callback);
-                chunks.poll();
+                failures.add(tuple);
+                tuples.poll();
             }
         }
-        return callbacks;
+        return failures;
     }
 
     private class Input extends InputStream
@@ -296,17 +297,16 @@ public class InputStreamResponseListener extends Listener.Adapter
             try
             {
                 int result;
-                Callback callback = null;
+                Tuple tuple;
                 try (AutoLock.WithCondition l = lock.lock())
                 {
-                    Chunk chunk;
                     while (true)
                     {
-                        chunk = chunks.peek();
-                        if (chunk == EOF)
+                        tuple = tuples.peek();
+                        if (tuple == EOF)
                             return -1;
 
-                        if (chunk != null)
+                        if (tuple != null)
                             break;
 
                         if (failure != null)
@@ -318,17 +318,16 @@ public class InputStreamResponseListener extends Listener.Adapter
                         l.await();
                     }
 
-                    ByteBuffer buffer = chunk.buffer;
+                    ByteBuffer buffer = tuple.chunk().getByteBuffer();
                     result = Math.min(buffer.remaining(), length);
                     buffer.get(b, offset, result);
                     if (!buffer.hasRemaining())
-                    {
-                        callback = chunk.callback;
-                        chunks.poll();
-                    }
+                        tuples.poll();
+                    else
+                        tuple = null;
                 }
-                if (callback != null)
-                    callback.succeeded();
+                if (tuple != null)
+                    tuple.succeeded();
                 return result;
             }
             catch (InterruptedException x)
@@ -348,13 +347,13 @@ public class InputStreamResponseListener extends Listener.Adapter
         @Override
         public void close() throws IOException
         {
-            List<Callback> callbacks;
+            List<Tuple> tuples;
             try (AutoLock.WithCondition l = lock.lock())
             {
                 if (closed)
                     return;
                 closed = true;
-                callbacks = drain();
+                tuples = drain();
                 l.signalAll();
             }
 
@@ -362,21 +361,26 @@ public class InputStreamResponseListener extends Listener.Adapter
                 LOG.debug("InputStream close");
 
             Throwable failure = new AsynchronousCloseException();
-            callbacks.forEach(callback -> callback.failed(failure));
+            tuples.forEach(t -> t.failed(failure));
 
             super.close();
         }
     }
 
-    private static class Chunk
+    private record Tuple(Content.Chunk chunk, Callback callback) implements Callback
     {
-        private final ByteBuffer buffer;
-        private final Callback callback;
-
-        private Chunk(ByteBuffer buffer, Callback callback)
+        @Override
+        public void succeeded()
         {
-            this.buffer = Objects.requireNonNull(buffer);
-            this.callback = Objects.requireNonNull(callback);
+            chunk.release();
+            callback.succeeded();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            chunk.release();
+            callback.failed(x);
         }
     }
 }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
@@ -160,13 +160,13 @@ public class FastCGIProxyHandlerTest
         });
 
         var request = client.newRequest("localhost", proxyConnector.getLocalPort())
-            .onResponseContentAsync((response, chunk, demand) ->
+            .onResponseContentAsync((response, chunk, demander) ->
             {
                 try
                 {
                     if (delay > 0)
                         TimeUnit.MILLISECONDS.sleep(delay);
-                    demand.run();
+                    demander.run();
                 }
                 catch (InterruptedException x)
                 {

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
@@ -160,17 +160,21 @@ public class FastCGIProxyHandlerTest
         });
 
         var request = client.newRequest("localhost", proxyConnector.getLocalPort())
-            .onResponseContentAsync((response, content, callback) ->
+            .onResponseContentAsync((response, chunk, demand) ->
             {
                 try
                 {
                     if (delay > 0)
                         TimeUnit.MILLISECONDS.sleep(delay);
-                    callback.succeeded();
+                    demand.run();
                 }
                 catch (InterruptedException x)
                 {
-                    callback.failed(x);
+                    response.abort(x);
+                }
+                finally
+                {
+                    chunk.release();
                 }
             })
             .path(proxyContext.getContextPath() + path);

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/HttpClientTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/HttpClientTest.java
@@ -644,21 +644,22 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         });
 
         AtomicInteger contentCount = new AtomicInteger();
-        AtomicReference<Callback> callbackRef = new AtomicReference<>();
+        AtomicReference<Runnable> demanderRef = new AtomicReference<>();
         AtomicReference<CountDownLatch> contentLatch = new AtomicReference<>(new CountDownLatch(1));
         CountDownLatch completeLatch = new CountDownLatch(1);
         client.newRequest("localhost", connector.getLocalPort())
             .scheme(scheme)
-            .onResponseContentAsync((response, content, callback) ->
+            .onResponseContentAsync((response, chunk, demander) ->
             {
+                chunk.release();
                 contentCount.incrementAndGet();
-                callbackRef.set(callback);
+                demanderRef.set(demander);
                 contentLatch.get().countDown();
             })
             .send(result -> completeLatch.countDown());
 
         assertTrue(contentLatch.get().await(5, TimeUnit.SECONDS));
-        Callback callback = callbackRef.get();
+        Runnable demander = demanderRef.get();
 
         // Wait a while to be sure that the parsing does not proceed.
         TimeUnit.MILLISECONDS.sleep(1000);
@@ -666,12 +667,12 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         assertEquals(1, contentCount.get());
 
         // Succeed the content callback to proceed with parsing.
-        callbackRef.set(null);
+        demanderRef.set(null);
         contentLatch.set(new CountDownLatch(1));
-        callback.succeeded();
+        demander.run();
 
         assertTrue(contentLatch.get().await(5, TimeUnit.SECONDS));
-        callback = callbackRef.get();
+        demander = demanderRef.get();
 
         // Wait a while to be sure that the parsing does not proceed.
         TimeUnit.MILLISECONDS.sleep(1000);
@@ -680,9 +681,9 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         assertEquals(1, completeLatch.getCount());
 
         // Succeed the content callback to proceed with parsing.
-        callbackRef.set(null);
+        demanderRef.set(null);
         contentLatch.set(new CountDownLatch(1));
-        callback.succeeded();
+        demander.run();
 
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
         assertEquals(2, contentCount.get());

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.LongConsumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.IntStream;
 
@@ -70,6 +69,7 @@ import org.eclipse.jetty.http2.internal.parser.ServerParser;
 import org.eclipse.jetty.http2.server.RawHTTP2ServerConnectionFactory;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -235,27 +235,35 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             }
         });
 
-        AtomicReference<LongConsumer> demandRef = new AtomicReference<>();
+        AtomicReference<Runnable> demanderRef = new AtomicReference<>();
         CountDownLatch beforeContentLatch = new CountDownLatch(1);
         AtomicInteger contentCount = new AtomicInteger();
         CountDownLatch latch = new CountDownLatch(1);
         httpClient.newRequest("localhost", connector.getLocalPort())
-            .onResponseContentDemanded(new org.eclipse.jetty.client.api.Response.DemandedContentListener()
+            .onResponseContentSource(new Response.ContentSourceListener()
             {
                 @Override
-                public void onBeforeContent(org.eclipse.jetty.client.api.Response response, LongConsumer demand)
+                public void onContentSource(Response response, Content.Source contentSource)
                 {
-                    // Do not demand.
-                    demandRef.set(demand);
-                    beforeContentLatch.countDown();
-                }
+                    Runnable demander = () -> contentSource.demand(() -> onContentSource(response, contentSource));
+                    if (demanderRef.getAndSet(demander) == null)
+                    {
+                        // 1st time, do not demand.
+                        beforeContentLatch.countDown();
+                        return;
+                    }
 
-                @Override
-                public void onContent(org.eclipse.jetty.client.api.Response response, LongConsumer demand, ByteBuffer content, Callback callback)
-                {
-                    contentCount.incrementAndGet();
-                    callback.succeeded();
-                    demand.accept(1);
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        demander.run();
+                        return;
+                    }
+                    if (!chunk.isTerminal())
+                        contentCount.incrementAndGet();
+                    chunk.release();
+                    if (!chunk.isLast())
+                        demander.run();
                 }
             })
             .timeout(5, TimeUnit.SECONDS)
@@ -273,7 +281,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         assertEquals(0, contentCount.get());
 
         // Demand to receive the content.
-        demandRef.get().accept(1);
+        demanderRef.get().run();
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertEquals(2, contentCount.get());

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -622,7 +622,7 @@ public class HttpClientDemandTest extends AbstractTest
         }
     }
 
-    private static class TestProcessor extends Handler.Processor
+    private static class TestProcessor extends Handler.Abstract
     {
         private final int totalBytes;
 
@@ -632,7 +632,7 @@ public class HttpClientDemandTest extends AbstractTest
         }
 
         @Override
-        public void process(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+        public boolean process(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
         {
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain");
 
@@ -650,6 +650,8 @@ public class HttpClientDemandTest extends AbstractTest
                 }
             };
             iteratingCallback.iterate();
+
+            return true;
         }
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -16,14 +16,15 @@ package org.eclipse.jetty.test.client.transport;
 import java.io.InterruptedIOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.LongConsumer;
 import java.util.zip.GZIPOutputStream;
 
 import org.eclipse.jetty.client.api.Response;
@@ -36,7 +37,10 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.MappedByteBufferPool;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IteratingCallback;
+import org.eclipse.jetty.util.IteratingNestedCallback;
 import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -231,15 +236,17 @@ public class HttpClientDemandTest extends AbstractTest
         });
 
         long delay = 1000;
-        AtomicReference<LongConsumer> demandRef = new AtomicReference<>();
+        AtomicReference<Runnable> demanderRef = new AtomicReference<>();
+        AtomicReference<Content.Chunk> chunkRef = new AtomicReference<>();
         CountDownLatch clientContentLatch = new CountDownLatch(2);
         CountDownLatch resultLatch = new CountDownLatch(1);
         client.newRequest(newURI(transport))
-            .onResponseContentDemanded((response, demand, content, callback) ->
+            .onResponseContentAsync((response, chunk, demander) ->
             {
+                chunkRef.set(chunk);
                 try
                 {
-                    if (demandRef.getAndSet(demand) == null)
+                    if (demanderRef.getAndSet(demander) == null)
                     {
                         // Produce more content just before stalling.
                         serverContentLatch.countDown();
@@ -247,12 +254,10 @@ public class HttpClientDemandTest extends AbstractTest
                         Thread.sleep(delay);
                     }
                     clientContentLatch.countDown();
-                    // Succeed the callback but don't demand.
-                    callback.succeeded();
                 }
-                catch (InterruptedException x)
+                catch (InterruptedException e)
                 {
-                    callback.failed(x);
+                    throw new RuntimeException(e);
                 }
             })
             .timeout(5, TimeUnit.SECONDS)
@@ -267,16 +272,34 @@ public class HttpClientDemandTest extends AbstractTest
         // We did not demand, so we only expect one chunk of content.
         assertFalse(clientContentLatch.await(2 * delay, TimeUnit.MILLISECONDS));
         assertEquals(1, clientContentLatch.getCount());
+        Content.Chunk c1 = chunkRef.getAndSet(null);
+        assertThat(asStringAndRelease(c1), is("A"));
 
         // Now demand, we should be notified of the second chunk.
-        demandRef.get().accept(1);
-
+        demanderRef.get().run();
         assertTrue(clientContentLatch.await(5, TimeUnit.SECONDS));
+        Content.Chunk c2 = chunkRef.getAndSet(null);
+        assertThat(asStringAndRelease(c2), is("B"));
 
         // Demand once more to trigger response success.
-        demandRef.get().accept(1);
-
+        demanderRef.get().run();
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
+
+        // Make sure the chunks were not leaked.
+        assertThrows(IllegalStateException.class, c1::release);
+        assertThrows(IllegalStateException.class, c2::release);
+    }
+
+    private static String asStringAndRelease(Content.Chunk chunk)
+    {
+        try
+        {
+            return BufferUtil.toString(chunk.getByteBuffer());
+        }
+        finally
+        {
+            chunk.release();
+        }
     }
 
     @ParameterizedTest
@@ -304,29 +327,29 @@ public class HttpClientDemandTest extends AbstractTest
 
         AtomicInteger listener1Chunks = new AtomicInteger();
         AtomicInteger listener1ContentSize = new AtomicInteger();
-        AtomicReference<LongConsumer> listener1DemandRef = new AtomicReference<>();
-        Response.DemandedContentListener listener1 = (response, demand, content, callback) ->
+        AtomicReference<Runnable> listener1DemanderRef = new AtomicReference<>();
+        Response.AsyncContentListener listener1 = (response, chunk, demander) ->
         {
             listener1Chunks.incrementAndGet();
-            listener1ContentSize.addAndGet(content.remaining());
-            callback.succeeded();
-            listener1DemandRef.set(demand);
+            listener1ContentSize.addAndGet(chunk.remaining());
+            chunk.release();
+            listener1DemanderRef.set(demander);
         };
         AtomicInteger listener2Chunks = new AtomicInteger();
         AtomicInteger listener2ContentSize = new AtomicInteger();
-        AtomicReference<LongConsumer> listener2DemandRef = new AtomicReference<>();
-        Response.DemandedContentListener listener2 = (response, demand, content, callback) ->
+        AtomicReference<Runnable> listener2DemanderRef = new AtomicReference<>();
+        Response.AsyncContentListener listener2 = (response, chunk, demander) ->
         {
             listener2Chunks.incrementAndGet();
-            listener2ContentSize.addAndGet(content.remaining());
-            callback.succeeded();
-            listener2DemandRef.set(demand);
+            listener2ContentSize.addAndGet(chunk.remaining());
+            chunk.release();
+            listener2DemanderRef.set(demander);
         };
 
         CountDownLatch resultLatch = new CountDownLatch(1);
         client.newRequest(newURI(transport))
-            .onResponseContentDemanded(listener1)
-            .onResponseContentDemanded(listener2)
+            .onResponseContentAsync(listener1)
+            .onResponseContentAsync(listener2)
             .send(result ->
             {
                 Assertions.assertFalse(result.isFailed(), String.valueOf(result.getFailure()));
@@ -341,16 +364,16 @@ public class HttpClientDemandTest extends AbstractTest
         {
             i++;
 
-            await().atMost(5, TimeUnit.SECONDS).until(listener1DemandRef::get, not(nullValue()));
-            await().atMost(5, TimeUnit.SECONDS).until(listener2DemandRef::get, not(nullValue()));
+            await().atMost(5, TimeUnit.SECONDS).until(listener1DemanderRef::get, not(nullValue()));
+            await().atMost(5, TimeUnit.SECONDS).until(listener2DemanderRef::get, not(nullValue()));
 
             // Assert that no listener can progress for as long as both listeners did not demand.
             assertThat(listener1Chunks.get(), is(i));
             assertThat(listener2Chunks.get(), is(i));
-            listener2DemandRef.getAndSet(null).accept(1);
+            listener2DemanderRef.getAndSet(null).run();
             assertThat(listener1Chunks.get(), is(i));
             assertThat(listener2Chunks.get(), is(i));
-            listener1DemandRef.getAndSet(null).accept(1);
+            listener1DemanderRef.getAndSet(null).run();
         }
 
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
@@ -389,11 +412,12 @@ public class HttpClientDemandTest extends AbstractTest
         ByteBuffer received = ByteBuffer.wrap(bytes);
         CountDownLatch resultLatch = new CountDownLatch(1);
         client.newRequest(newURI(transport))
-            .onResponseContentDemanded((response, demand, buffer, callback) ->
+            .onResponseContentAsync((response, chunk, demander) ->
             {
-                received.put(buffer);
-                callback.succeeded();
-                new Thread(() -> demand.accept(1)).start();
+                received.put(chunk.getByteBuffer());
+                chunk.release();
+                if (!chunk.isTerminal())
+                    new Thread(demander).start();
             })
             .send(result ->
             {
@@ -424,28 +448,40 @@ public class HttpClientDemandTest extends AbstractTest
 
         byte[] bytes = new byte[content.length];
         ByteBuffer received = ByteBuffer.wrap(bytes);
-        AtomicReference<LongConsumer> beforeContentDemandRef = new AtomicReference<>();
+        AtomicReference<Runnable> beforeContentDemanderRef = new AtomicReference<>();
         CountDownLatch beforeContentLatch = new CountDownLatch(1);
         CountDownLatch contentLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
         client.newRequest(newURI(transport))
-            .onResponseContentDemanded(new Response.DemandedContentListener()
+            .onResponseContentSource(new Response.ContentSourceListener()
             {
                 @Override
-                public void onBeforeContent(Response response, LongConsumer demand)
+                public void onContentSource(Response response, Content.Source contentSource)
                 {
-                    // Do not demand now.
-                    beforeContentDemandRef.set(demand);
-                    beforeContentLatch.countDown();
-                }
+                    Runnable demander = () -> contentSource.demand(() -> onContentSource(response, contentSource));
+                    if (beforeContentDemanderRef.getAndSet(demander) == null)
+                    {
+                        // 1st time, do not demand now.
+                        beforeContentLatch.countDown();
+                        return;
+                    }
 
-                @Override
-                public void onContent(Response response, LongConsumer demand, ByteBuffer buffer, Callback callback)
-                {
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        demander.run();
+                        return;
+                    }
+                    if (chunk.isTerminal())
+                    {
+                        chunk.release();
+                        return;
+                    }
+
                     contentLatch.countDown();
-                    received.put(buffer);
-                    callback.succeeded();
-                    demand.accept(1);
+                    received.put(chunk.getByteBuffer());
+                    chunk.release();
+                    demander.run();
                 }
             })
             .send(result ->
@@ -456,12 +492,12 @@ public class HttpClientDemandTest extends AbstractTest
             });
 
         assertTrue(beforeContentLatch.await(5, TimeUnit.SECONDS));
-        LongConsumer demand = beforeContentDemandRef.get();
+        Runnable demander = beforeContentDemanderRef.get();
 
         // Content must not be notified until we demand.
         assertFalse(contentLatch.await(1, TimeUnit.SECONDS));
 
-        demand.accept(1);
+        demander.run();
 
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
         assertArrayEquals(content, bytes);
@@ -473,27 +509,39 @@ public class HttpClientDemandTest extends AbstractTest
     {
         start(transport, new EmptyServerHandler());
 
-        AtomicReference<LongConsumer> beforeContentDemandRef = new AtomicReference<>();
+        AtomicReference<Runnable> beforeContentDemanderRef = new AtomicReference<>();
         CountDownLatch beforeContentLatch = new CountDownLatch(1);
         CountDownLatch contentLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
         client.newRequest(newURI(transport))
-            .onResponseContentDemanded(new Response.DemandedContentListener()
+            .onResponseContentSource(new Response.ContentSourceListener()
             {
                 @Override
-                public void onBeforeContent(Response response, LongConsumer demand)
+                public void onContentSource(Response response, Content.Source contentSource)
                 {
-                    // Do not demand now.
-                    beforeContentDemandRef.set(demand);
-                    beforeContentLatch.countDown();
-                }
+                    Runnable demander = () -> contentSource.demand(() -> onContentSource(response, contentSource));
+                    if (beforeContentDemanderRef.getAndSet(demander) == null)
+                    {
+                        // 1st time, do not demand now.
+                        beforeContentLatch.countDown();
+                        return;
+                    }
 
-                @Override
-                public void onContent(Response response, LongConsumer demand, ByteBuffer buffer, Callback callback)
-                {
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        demander.run();
+                        return;
+                    }
+                    if (chunk.isTerminal())
+                    {
+                        chunk.release();
+                        return;
+                    }
+
                     contentLatch.countDown();
-                    callback.succeeded();
-                    demand.accept(1);
+                    chunk.release();
+                    demander.run();
                 }
             })
             .send(result ->
@@ -504,16 +552,104 @@ public class HttpClientDemandTest extends AbstractTest
             });
 
         assertTrue(beforeContentLatch.await(5, TimeUnit.SECONDS));
-        LongConsumer demand = beforeContentDemandRef.get();
+        Runnable demander = beforeContentDemanderRef.get();
 
         // Content must not be notified until we demand.
         assertFalse(contentLatch.await(1, TimeUnit.SECONDS));
 
-        demand.accept(1);
+        demander.run();
 
         // Content must not be notified as there is no content.
         assertFalse(contentLatch.await(1, TimeUnit.SECONDS));
 
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testReadDemandInSpawnedThread(Transport transport) throws Exception
+    {
+        int totalBytes = 1024;
+        start(transport, new TestProcessor(totalBytes));
+
+        List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
+        CountDownLatch resultLatch = new CountDownLatch(1);
+        client.newRequest(newURI(transport))
+            .onResponseContentSource((response, contentSource) -> contentSource.demand(() -> new Thread(new Accumulator(contentSource, chunks)).start()))
+            .send(result ->
+            {
+                Assertions.assertTrue(result.isSucceeded());
+                Assertions.assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+                resultLatch.countDown();
+            });
+
+        assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
+
+        Content.Chunk lastChunk = chunks.get(chunks.size() - 1);
+        assertThat(lastChunk.isLast(), is(true));
+        int accumulatedSize = chunks.stream().mapToInt(chunk ->
+        {
+            int remaining = chunk.remaining();
+            chunk.release();
+            return remaining;
+        }).sum();
+        assertThat(accumulatedSize, is(totalBytes));
+    }
+
+    private static class Accumulator implements Runnable
+    {
+        private final Content.Source contentSource;
+        private final List<Content.Chunk> chunks;
+
+        private Accumulator(Content.Source contentSource, List<Content.Chunk> chunks)
+        {
+            this.contentSource = contentSource;
+            this.chunks = chunks;
+        }
+
+        @Override
+        public void run()
+        {
+            Content.Chunk chunk = contentSource.read();
+            if (chunk == null)
+            {
+                contentSource.demand(this);
+                return;
+            }
+            chunks.add(chunk);
+            if (!chunk.isLast())
+                contentSource.demand(this);
+        }
+    }
+
+    private static class TestProcessor extends Handler.Processor
+    {
+        private final int totalBytes;
+
+        private TestProcessor(int totalBytes)
+        {
+            this.totalBytes = totalBytes;
+        }
+
+        @Override
+        public void process(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+        {
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain");
+
+            IteratingCallback iteratingCallback = new IteratingNestedCallback(callback)
+            {
+                int count = 0;
+                @Override
+                protected Action process()
+                {
+                    boolean last = ++count == totalBytes;
+                    if (count > totalBytes)
+                        return Action.SUCCEEDED;
+                    response.write(last, ByteBuffer.wrap(new byte[1]), this);
+                    return Action.SCHEDULED;
+                }
+            };
+            iteratingCallback.iterate();
+        }
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -306,8 +306,8 @@ public class HttpClientStreamTest extends AbstractTest
             @Override
             public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                latch.countDown();
                 super.onContent(response, chunk, demander);
+                latch.countDown();
             }
         };
         client.newRequest(newURI(transport))
@@ -352,15 +352,15 @@ public class HttpClientStreamTest extends AbstractTest
             @Override
             public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                contentLatch.countDown();
                 super.onContent(response, chunk, demander);
+                contentLatch.countDown();
             }
 
             @Override
             public void onFailure(Response response, Throwable failure)
             {
-                failedLatch.countDown();
                 super.onFailure(response, failure);
+                failedLatch.countDown();
             }
         };
         client.newRequest(newURI(transport))
@@ -402,15 +402,15 @@ public class HttpClientStreamTest extends AbstractTest
             @Override
             public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                contentLatch.countDown();
                 super.onContent(response, chunk, demander);
+                contentLatch.countDown();
             }
 
             @Override
             public void onFailure(Response response, Throwable failure)
             {
-                failedLatch.countDown();
                 super.onFailure(response, failure);
+                failedLatch.countDown();
             }
         };
         client.newRequest(newURI(transport))

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -304,17 +304,10 @@ public class HttpClientStreamTest extends AbstractTest
         InputStreamResponseListener listener = new InputStreamResponseListener()
         {
             @Override
-            public void onContent(Response response, ByteBuffer content, Callback callback)
+            public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                super.onContent(response, content, new Callback()
-                {
-                    @Override
-                    public void failed(Throwable x)
-                    {
-                        latch.countDown();
-                        callback.failed(x);
-                    }
-                });
+                latch.countDown();
+                super.onContent(response, chunk, demander);
             }
         };
         client.newRequest(newURI(transport))
@@ -357,18 +350,17 @@ public class HttpClientStreamTest extends AbstractTest
         InputStreamResponseListener listener = new InputStreamResponseListener()
         {
             @Override
-            public void onContent(Response response, ByteBuffer content, Callback callback)
+            public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                super.onContent(response, content, new Callback()
-                {
-                    @Override
-                    public void failed(Throwable x)
-                    {
-                        failedLatch.countDown();
-                        callback.failed(x);
-                    }
-                });
                 contentLatch.countDown();
+                super.onContent(response, chunk, demander);
+            }
+
+            @Override
+            public void onFailure(Response response, Throwable failure)
+            {
+                failedLatch.countDown();
+                super.onFailure(response, failure);
             }
         };
         client.newRequest(newURI(transport))
@@ -408,18 +400,17 @@ public class HttpClientStreamTest extends AbstractTest
         InputStreamResponseListener listener = new InputStreamResponseListener()
         {
             @Override
-            public void onContent(Response response, ByteBuffer content, Callback callback)
+            public void onContent(Response response, Content.Chunk chunk, Runnable demander)
             {
-                super.onContent(response, content, new Callback()
-                {
-                    @Override
-                    public void failed(Throwable x)
-                    {
-                        failedLatch.countDown();
-                        callback.failed(x);
-                    }
-                });
                 contentLatch.countDown();
+                super.onContent(response, chunk, demander);
+            }
+
+            @Override
+            public void onFailure(Response response, Throwable failure)
+            {
+                failedLatch.countDown();
+                super.onFailure(response, failure);
             }
         };
         client.newRequest(newURI(transport))

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
@@ -216,15 +216,7 @@ public class ProxyServlet extends AbstractProxyServlet
                 content.get(buffer);
                 offset = 0;
             }
-            Callback callback = Callback.from(() ->
-            {
-                chunk.release();
-                demander.run();
-            }, (x) ->
-            {
-                chunk.release();
-                proxyResponse.abort(x);
-            });
+            Callback callback = Callback.from(chunk::release, Callback.from(demander, proxyResponse::abort));
             onResponseContent(request, response, proxyResponse, buffer, offset, length, callback);
         }
 

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
@@ -199,8 +199,9 @@ public class ProxyServlet extends AbstractProxyServlet
         }
 
         @Override
-        public void onContent(Response proxyResponse, ByteBuffer content, Callback callback)
+        public void onContent(Response proxyResponse, Content.Chunk chunk, Runnable demander)
         {
+            ByteBuffer content = chunk.getByteBuffer();
             byte[] buffer;
             int offset;
             int length = content.remaining();
@@ -215,16 +216,16 @@ public class ProxyServlet extends AbstractProxyServlet
                 content.get(buffer);
                 offset = 0;
             }
-
-            onResponseContent(request, response, proxyResponse, buffer, offset, length, new Callback.Nested(callback)
+            Callback callback = Callback.from(() ->
             {
-                @Override
-                public void failed(Throwable x)
-                {
-                    super.failed(x);
-                    proxyResponse.abort(x);
-                }
+                chunk.release();
+                demander.run();
+            }, (x) ->
+            {
+                chunk.release();
+                proxyResponse.abort(x);
             });
+            onResponseContent(request, response, proxyResponse, buffer, offset, length, callback);
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
@@ -217,15 +217,7 @@ public class ProxyServlet extends AbstractProxyServlet
                 offset = 0;
             }
 
-            Callback callback = Callback.from(() ->
-            {
-                chunk.release();
-                demander.run();
-            }, (x) ->
-            {
-                chunk.release();
-                proxyResponse.abort(x);
-            });
+            Callback callback = Callback.from(chunk::release, Callback.from(demander, proxyResponse::abort));
             onResponseContent(request, response, proxyResponse, buffer, offset, length, callback);
         }
 


### PR DESCRIPTION
Proposal: get rid of `DemandedContentListener` and change `AsyncContentListener` API to adopt the `SimpleContentListener` one.

This depends on #8993