### PR TITLE
Make the `Content.Chunk.isTerminal()` contract stricter

### DIFF
--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
@@ -216,7 +216,7 @@ public class MultiPartFormDataTest
     public void testNoBody() throws Exception
     {
         MultiPartFormData formData = new MultiPartFormData("boundary");
-        formData.parse(Content.Chunk.from(ByteBuffer.allocate(0), true));
+        formData.parse(Content.Chunk.EOF);
 
         formData.handle((parts, failure) ->
         {

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
@@ -58,7 +58,7 @@ public class MultiPartTest
 
         assertEquals(0, listener.events.size());
 
-        parser.parse(Content.Chunk.from(BufferUtil.EMPTY_BUFFER, true));
+        parser.parse(Content.Chunk.EOF);
 
         assertEquals(1, listener.events.size());
         assertEquals("complete", listener.events.poll());

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/internal/HTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/internal/HTTP3StreamConnection.java
@@ -425,8 +425,16 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
             if (frame.isLast())
                 shutdownInput();
 
-            networkBuffer.retain();
-            StreamData data = new StreamData(frame, networkBuffer);
+            Stream.Data data;
+            if (!frame.getByteBuffer().hasRemaining() && frame.isLast())
+            {
+                data = Stream.Data.EOF;
+            }
+            else
+            {
+                networkBuffer.retain();
+                data = new StreamData(frame, networkBuffer);
+            }
 
             Runnable existing = action.getAndSet(() ->
             {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
@@ -73,7 +73,7 @@ public class ChunksContentSource implements Content.Source
             if (last)
                 terminated = Content.Chunk.EOF;
         }
-        return Content.Chunk.from(chunk.getByteBuffer().slice(), chunk.isLast(), chunk);
+        return chunk;
     }
 
     @Override

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentTest.java
@@ -1,0 +1,80 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ContentTest
+{
+    @Test
+    public void testFromEmptyByteBufferWithoutReleaser()
+    {
+        assertThrows(IllegalArgumentException.class, () -> Content.Chunk.from(ByteBuffer.wrap(new byte[0]), true));
+        assertThrows(IllegalArgumentException.class, () -> Content.Chunk.from(ByteBuffer.wrap(new byte[0]), false));
+    }
+
+    @Test
+    public void testFromEmptyByteBufferWithRunnableReleaser()
+    {
+        AtomicInteger counter1 = new AtomicInteger();
+        assertThat(Content.Chunk.from(ByteBuffer.wrap(new byte[0]), true, counter1::incrementAndGet), sameInstance(Content.Chunk.EOF));
+        assertThat(counter1.get(), is(1));
+
+        AtomicInteger counter2 = new AtomicInteger();
+        assertThat(Content.Chunk.from(ByteBuffer.wrap(new byte[0]), false, counter2::incrementAndGet), sameInstance(Content.Chunk.EMPTY));
+        assertThat(counter2.get(), is(1));
+    }
+
+    @Test
+    public void testFromEmptyByteBufferWithConsumerReleaser()
+    {
+        List<ByteBuffer> buffers = new ArrayList<>();
+
+        ByteBuffer buffer1 = ByteBuffer.wrap(new byte[0]);
+        assertThat(Content.Chunk.from(buffer1, true, buffers::add), sameInstance(Content.Chunk.EOF));
+        assertThat(buffers.size(), is(1));
+        assertThat(buffers.remove(0), sameInstance(buffer1));
+
+        ByteBuffer buffer2 = ByteBuffer.wrap(new byte[0]);
+        assertThat(Content.Chunk.from(buffer2, false, buffers::add), sameInstance(Content.Chunk.EMPTY));
+        assertThat(buffers.size(), is(1));
+        assertThat(buffers.remove(0), sameInstance(buffer2));
+    }
+
+    @Test
+    public void testFromEmptyByteBufferWithRetainableReleaser()
+    {
+        Retainable.ReferenceCounter referenceCounter1 = new Retainable.ReferenceCounter(2);
+        assertThat(referenceCounter1.isRetained(), is(true));
+        assertThat(Content.Chunk.from(ByteBuffer.wrap(new byte[0]), true, referenceCounter1), sameInstance(Content.Chunk.EOF));
+        assertThat(referenceCounter1.isRetained(), is(false));
+        assertThat(referenceCounter1.release(), is(true));
+
+        Retainable.ReferenceCounter referenceCounter2 = new Retainable.ReferenceCounter(2);
+        assertThat(referenceCounter2.isRetained(), is(true));
+        assertThat(Content.Chunk.from(ByteBuffer.wrap(new byte[0]), false, referenceCounter2), sameInstance(Content.Chunk.EMPTY));
+        assertThat(referenceCounter2.isRetained(), is(false));
+        assertThat(referenceCounter2.release(), is(true));
+    }
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
@@ -33,7 +33,32 @@ import org.eclipse.jetty.util.NanoTime;
 public class MockHttpStream implements HttpStream
 {
     private static final Throwable SUCCEEDED = new Throwable();
-    private static final Content.Chunk DEMAND = Content.Chunk.from(BufferUtil.EMPTY_BUFFER, false);
+    private static final Content.Chunk DEMAND = new Content.Chunk()
+    {
+        @Override
+        public ByteBuffer getByteBuffer()
+        {
+            return BufferUtil.EMPTY_BUFFER;
+        }
+
+        @Override
+        public boolean isLast()
+        {
+            return false;
+        }
+
+        @Override
+        public void retain()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean release()
+        {
+            return true;
+        }
+    };
     private final long _nanoTime = NanoTime.now();
     private final AtomicReference<Content.Chunk> _content = new AtomicReference<>();
     private final AtomicReference<Throwable> _complete = new AtomicReference<>();
@@ -65,7 +90,7 @@ public class MockHttpStream implements HttpStream
 
     public Runnable addContent(ByteBuffer buffer, boolean last)
     {
-        return addContent((last && BufferUtil.isEmpty(buffer)) ? Content.Chunk.EOF : Content.Chunk.from(buffer, last));
+        return addContent(Content.Chunk.from(buffer, last));
     }
 
     public Runnable addContent(String content, boolean last)


### PR DESCRIPTION
Make the `Content.Chunk.isTerminal()` contract stricter by explicitly disallowing the creation of new last chunks with an empty `ByteBuffer`.

Also replace non-last empty chunks with EMPTY where it makes  sense.

Closes #8993