### PR TITLE
Jetty 10 - Fix OpenJDK 19 related build issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,17 @@ pipeline {
   stages {
     stage("Parallel Stage") {
       parallel {
+        stage("Build / Test - JDK19") {
+          agent { node { label 'linux' } }
+          steps {
+            timeout( time: 180, unit: 'MINUTES' ) {
+              checkout scm
+              mavenBuild( "jdk19", "clean install -Dspotbugs.skip=true -Djacoco.skip=true -Peclipse-release", "maven3")
+              recordIssues id: "jdk19", name: "Static Analysis jdk19", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle()]
+            }
+          }
+        }
+
         stage("Build / Test - JDK17") {
           agent { node { label 'linux' } }
           steps {

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
@@ -25,14 +25,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <source>17</source>
-          <release>17</release>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>17</source>
@@ -42,6 +34,14 @@
             <arg>--add-modules</arg>
             <arg>jdk.incubator.foreign</arg>
           </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
@@ -25,6 +25,14 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>17</source>


### PR DESCRIPTION
`Jenkinsfile` now builds with OpenJDK 19
`quic-quiche-foreign-incubator` javadoc source/release aligned with compiler settings.