### PR TITLE
Fix Jenkins build to not use `-Peclipse-release`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              mavenBuild( "jdk19", "clean install -Dspotbugs.skip=true -Djacoco.skip=true -Peclipse-release", "maven3")
+              mavenBuild( "jdk19", "clean install -Dspotbugs.skip=true -Djacoco.skip=true", "maven3")
               recordIssues id: "jdk19", name: "Static Analysis jdk19", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle()]
             }
           }


### PR DESCRIPTION
Jenkins doesn't have gpg (the executable) or the keyring anyway.