### PR TITLE
Cleanup of TypeUtil and ContextHandler stop/start

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -61,6 +63,7 @@ public class TypeUtil
     public static final Class<?>[] NO_ARGS = new Class[]{};
     public static final int CR = '\r';
     public static final int LF = '\n';
+    private static final  Pattern TRAILING_DIGITS = Pattern.compile("^\\D*(\\d+)$");
 
     private static final HashMap<String, Class<?>> name2Class = new HashMap<>();
 
@@ -253,7 +256,12 @@ public class TypeUtil
             {
                 String[] ss = p.split("\\.");
                 for (String s : ss)
+                {
                     b.append(s.charAt(0));
+                    Matcher matcher = TRAILING_DIGITS.matcher(s);
+                    if (matcher.matches())
+                        b.append(matcher.group(1));
+                }
             }
             b.append('.');
         }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/TypeUtilTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.test10.TestClass;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -236,4 +238,20 @@ public class TypeUtilTest
         String expectedJavaBase = "/java.base";
         assertThat(TypeUtil.getLocationOfClass(java.lang.ThreadDeath.class).toASCIIString(), containsString(expectedJavaBase));
     }
+
+    public static Stream<Arguments> shortNames()
+    {
+        return Stream.of(
+            Arguments.of(TypeUtilTest.class, "oeju.TypeUtilTest"),
+            Arguments.of(TestClass.class, "oejut10.TestClass")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shortNames")
+    public void testToShortName(Class<?> clazz, String shortName)
+    {
+        assertThat(TypeUtil.toShortName(clazz), is(shortName));
+    }
+
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/test10/TestClass.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/test10/TestClass.java
@@ -1,0 +1,18 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.test10;
+
+public class TestClass
+{
+}

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -198,7 +198,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     private String[] _welcomeFiles;
     private ErrorHandler _errorHandler;
     private Logger _logger;
-    private boolean _allowNullPathInfo;
     private int _maxFormKeys = Integer.getInteger(MAX_FORM_KEYS_KEY, DEFAULT_MAX_FORM_KEYS);
     private int _maxFormContentSize = Integer.getInteger(MAX_FORM_CONTENT_SIZE_KEY, DEFAULT_MAX_FORM_CONTENT_SIZE);
     private boolean _compactPath = false;
@@ -238,6 +237,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
                              String contextPath)
     {
         _coreContextHandler = new CoreContextHandler();
+        addBean(_coreContextHandler, false);
         _apiContext = context == null ? new APIContext() : context;
         _initParams = new HashMap<>();
         if (contextPath != null)
@@ -274,7 +274,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
     @ManagedAttribute("Checks if the /context is not redirected to /context/")
     public boolean getAllowNullPathInfo()
     {
-        return _allowNullPathInfo;
+        return _coreContextHandler.getAllowNullPathInContext();
     }
 
     // TODO this is a thought bubble
@@ -294,7 +294,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     public void setAllowNullPathInfo(boolean allowNullPathInfo)
     {
-        _allowNullPathInfo = allowNullPathInfo;
+        _coreContextHandler.setAllowNullPathInContext(allowNullPathInfo);
     }
 
     @Override
@@ -612,8 +612,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         // we need to run ourselves in the core context
         if (org.eclipse.jetty.server.handler.ContextHandler.getCurrentContext() != _coreContextHandler.getContext())
         {
-            _coreContextHandler.getContext().call(this::doStart, null);
-            return;
+            _coreContextHandler.unmanage(this);
+            _coreContextHandler.start();
+            _coreContextHandler.manage(this);
         }
 
         if (_logger == null)
@@ -629,6 +630,53 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         // allow the call to super.doStart() to be deferred by extended implementations.
         startContext();
         contextInitialized();
+    }
+
+    @Override
+    protected void doStop() throws Exception
+    {
+        // If we are being stopped directly (rather than via a start of the CoreContextHandler), then
+        // we need to stop ourselves in the core context
+        if (org.eclipse.jetty.server.handler.ContextHandler.getCurrentContext() != _coreContextHandler.getContext())
+        {
+            _coreContextHandler.unmanage(this);
+            _coreContextHandler.stop();
+            _coreContextHandler.manage(this);
+        }
+
+        try
+        {
+            stopContext();
+            contextDestroyed();
+
+            // retain only durable listeners
+            setEventListeners(_durableListeners);
+            _durableListeners.clear();
+
+            if (_errorHandler != null)
+                _errorHandler.stop();
+
+            for (EventListener l : _programmaticListeners)
+            {
+                removeEventListener(l);
+                if (l instanceof ContextScopeListener)
+                {
+                    try
+                    {
+                        ((ContextScopeListener)l).exitScope(_apiContext, null);
+                    }
+                    catch (Throwable e)
+                    {
+                        LOG.warn("Unable to exit scope", e);
+                    }
+                }
+            }
+            _programmaticListeners.clear();
+        }
+        finally
+        {
+            _contextStatus = ContextStatus.NOTSET;
+        }
     }
 
     private String getLogNameSuffix()
@@ -768,44 +816,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         if (LOG.isDebugEnabled())
             LOG.debug("contextDestroyed: {}->{}", e, l);
         l.contextDestroyed(e);
-    }
-
-    @Override
-    protected void doStop() throws Exception
-    {
-        try
-        {
-            stopContext();
-            contextDestroyed();
-
-            // retain only durable listeners
-            setEventListeners(_durableListeners);
-            _durableListeners.clear();
-
-            if (_errorHandler != null)
-                _errorHandler.stop();
-
-            for (EventListener l : _programmaticListeners)
-            {
-                removeEventListener(l);
-                if (l instanceof ContextScopeListener)
-                {
-                    try
-                    {
-                        ((ContextScopeListener)l).exitScope(_apiContext, null);
-                    }
-                    catch (Throwable e)
-                    {
-                        LOG.warn("Unable to exit scope", e);
-                    }
-                }
-            }
-            _programmaticListeners.clear();
-        }
-        finally
-        {
-            _contextStatus = ContextStatus.NOTSET;
-        }
     }
 
     @Override
@@ -1279,20 +1289,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
 
         StringBuilder b = new StringBuilder();
 
-        Package pkg = getClass().getPackage();
-        if (pkg != null)
-        {
-            String p = pkg.getName();
-            if (p.length() > 0)
-            {
-                String[] ss = p.split("\\.");
-                for (String s : ss)
-                {
-                    b.append(s.charAt(0)).append('.');
-                }
-            }
-        }
-        b.append(getClass().getSimpleName()).append('@').append(Integer.toString(hashCode(), 16));
+        b.append(TypeUtil.toShortName(getClass())).append('@').append(Integer.toString(hashCode(), 16));
         b.append('{');
         if (getDisplayName() != null)
             b.append(getDisplayName()).append(',');

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -617,6 +617,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             _coreContextHandler.manage(this);
         }
 
+        _coreContextHandler.getContext().call(this::doStartInContext, null);
+    }
+
+    protected void doStartInContext() throws Exception
+    {
         if (_logger == null)
             _logger = LoggerFactory.getLogger(ContextHandler.class.getName() + getLogNameSuffix());
 
@@ -643,7 +648,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
             _coreContextHandler.stop();
             _coreContextHandler.manage(this);
         }
+        _coreContextHandler.getContext().call(this::doStopInContext, null);
+    }
 
+    protected void doStopInContext() throws Exception
+    {
         try
         {
             stopContext();

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
@@ -26,6 +26,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.logging.StacklessLogging;
@@ -76,17 +77,7 @@ public class ContextHandlerTest
     @Test
     public void testSimple() throws Exception
     {
-        _contextHandler.setHandler(new AbstractHandler()
-        {
-            @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
-            {
-                baseRequest.setHandled(true);
-                response.setStatus(200);
-                response.setContentType("text/plain");
-                response.getOutputStream().print("Hello\n");
-            }
-        });
+        _contextHandler.setHandler(new HelloHandler());
         _server.start();
 
         String rawResponse = _connector.getResponse("""
@@ -97,6 +88,72 @@ public class ContextHandlerTest
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
 
         assertThat(response.getStatus(), is(200));
+        assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
+        assertThat(response.getContent(), containsString("Hello"));
+    }
+
+    @Test
+    public void testStopStart() throws Exception
+    {
+        _contextHandler.setHandler(new HelloHandler());
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("""
+            GET / HTTP/1.0
+            
+            """));
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
+        assertThat(response.getContent(), containsString("Hello"));
+
+        _contextHandler.stop();
+        _contextHandler.setContextPath("/ctx");
+        _contextHandler.start();
+
+        response = HttpTester.parseResponse(_connector.getResponse("""
+            GET /ctx/ HTTP/1.0
+            
+            """));
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
+        assertThat(response.getContent(), containsString("Hello"));
+    }
+
+    @Test
+    public void testNullPath() throws Exception
+    {
+        _contextHandler.setHandler(new HelloHandler());
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("""
+            GET http://localhost:8080 HTTP/1.0
+            
+            """));
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
+        assertThat(response.getContent(), containsString("Hello"));
+
+        _contextHandler.stop();
+        _contextHandler.setContextPath("/ctx");
+        _contextHandler.start();
+
+        response = HttpTester.parseResponse(_connector.getResponse("""
+            GET /ctx HTTP/1.0
+            
+            """));
+        assertThat(response.getStatus(), is(HttpStatus.MOVED_PERMANENTLY_301));
+        assertThat(response.getField(HttpHeader.LOCATION).getValue(), is("/ctx/"));
+
+        _contextHandler.setAllowNullPathInfo(true);
+
+        response = HttpTester.parseResponse(_connector.getResponse("""
+            GET /ctx HTTP/1.0
+            
+            """));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
         assertThat(response.getContent(), containsString("Hello"));
     }
@@ -719,6 +776,18 @@ public class ContextHandlerTest
         public String getErrorPage(HttpServletRequest request)
         {
             return "/errorPage";
+        }
+    }
+
+    private static class HelloHandler extends AbstractHandler
+    {
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+        {
+            baseRequest.setHandled(true);
+            response.setStatus(200);
+            response.setContentType("text/plain");
+            response.getOutputStream().print("Hello\n");
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -490,7 +490,7 @@ public class WebAppContextTest
         // On Unix / Linux this should have no issue.
         // On Windows with fully qualified paths such as "E:\mybase\webapps\dump.war" the
         // resolution of the Resource can trigger various URI issues with the "E:" portion of the provided String.
-        context.setResourceBase(warPath.toString());
+        context.setBaseResourceAsString(warPath.toString());
 
         server.setHandler(context);
         server.start();

--- a/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee9/test-ee9-sessions/test-ee9-jdbc-sessions/src/test/java/org/eclipse/jetty/session/ReloadedSessionMissingClassTest.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -113,7 +112,6 @@ public class ReloadedSessionMissingClassTest
                 assertNotNull(sessionId);
 
                 //Stop the webapp
-                webApp.get().stop();
                 webApp.stop();
 
                 webApp.setClassLoader(loaderWithoutFoo);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
@@ -192,7 +192,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
                 assertFalse(run2.getLogs().stream().anyMatch(s -> s.contains("LinkageError")));
 
                 startHttpClient();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1191,7 +1191,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int httpPort = distribution.freePort();
             try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort)))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.newRequest("localhost", httpPort)


### PR DESCRIPTION
Hopefully non controversial changes from monster PR:
 + TypeUtil class shortname used more often and includes trailing digits
 + Fixed direct stopping/starting of a nested ContextHandler
 + Fixed null path handling in nested context
 + more tests for all of the above