### PR TITLE
Jetty 12 - Issue #8999 - Remove FileID.isArchive() from ResourceFactory

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1862,9 +1862,6 @@ public final class URIUtil
         Objects.requireNonNull(uri, "URI");
         String scheme = Objects.requireNonNull(uri.getScheme(), "URI scheme");
 
-        if (!FileID.isArchive(uri))
-            return uri;
-
         boolean hasInternalReference = uri.getRawSchemeSpecificPart().indexOf("!/") > 0;
 
         if (scheme.equalsIgnoreCase("jar"))
@@ -1882,6 +1879,8 @@ public final class URIUtil
         else if (scheme.equalsIgnoreCase("file"))
         {
             String rawUri = uri.toASCIIString();
+            if (rawUri.endsWith("/")) // skip directories
+                return uri;
             if (hasInternalReference)
                 return URI.create("jar:" + rawUri);
             else

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -13,19 +13,18 @@
 
 package org.eclipse.jetty.util.resource;
 
+import org.eclipse.jetty.util.Loader;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.Dumpable;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-
-import org.eclipse.jetty.util.FileID;
-import org.eclipse.jetty.util.Loader;
-import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
-import org.eclipse.jetty.util.component.Container;
-import org.eclipse.jetty.util.component.Dumpable;
 
 /**
  * ResourceFactory.
@@ -237,8 +236,6 @@ public interface ResourceFactory
 
     default Resource newJarFileResource(URI uri)
     {
-        if (!FileID.isArchive(uri))
-            throw new IllegalArgumentException("Path is not a Java Archive: " + uri);
         if (!uri.getScheme().equalsIgnoreCase("file"))
             throw new IllegalArgumentException("Not an allowed path: " + uri);
         return newResource(URIUtil.toJarFileUri(uri));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -13,18 +13,18 @@
 
 package org.eclipse.jetty.util.resource;
 
-import org.eclipse.jetty.util.Loader;
-import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
-import org.eclipse.jetty.util.component.Container;
-import org.eclipse.jetty.util.component.Dumpable;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+
+import org.eclipse.jetty.util.Loader;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.Dumpable;
 
 /**
  * ResourceFactory.


### PR DESCRIPTION
Fixes #8999

Remove `FileID.isArchive()` check from ResourceFactory.
Now the exception will occur from the JVM if the archive is unsupported.