### PR TITLE
Excluding javadoc jar from jetty-home

### DIFF
--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -134,7 +134,7 @@
                 org.eclipse.jetty.demo,org.eclipse.jetty.orbit,org.eclipse.jetty.http2,org.eclipse.jetty.http3,org.eclipse.jetty.quic,org.eclipse.jetty.websocket,org.eclipse.jetty.fcgi,org.eclipse.jetty.toolchain,org.apache.taglibs
               </excludeGroupIds>
               <excludeArtifactIds>
-                apache-jsp,apache-jstl,jetty-start,jetty-slf4j-impl
+                apache-jsp,apache-jstl,jetty-start,jetty-slf4j-impl,javadoc
               </excludeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib</outputDirectory>


### PR DESCRIPTION
Fixes #9003 