### PR TITLE
Fixes #9005 - Flaky test ConnectionPoolTest.testConcurrentRequestsAllBlockedOnServer

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -379,7 +379,7 @@ public class ConnectionPoolTest
     @MethodSource("pools")
     public void testConcurrentRequestsAllBlockedOnServerWithLargeConnectionPool(ConnectionPoolFactory factory) throws Exception
     {
-        int count = 50;
+        int count = 10;
         testConcurrentRequestsAllBlockedOnServer(factory, count, 2 * count);
     }
 
@@ -387,7 +387,7 @@ public class ConnectionPoolTest
     @MethodSource("pools")
     public void testConcurrentRequestsAllBlockedOnServerWithExactConnectionPool(ConnectionPoolFactory factory) throws Exception
     {
-        int count = 50;
+        int count = 10;
         testConcurrentRequestsAllBlockedOnServer(factory, count, count);
     }
 
@@ -441,10 +441,12 @@ public class ConnectionPoolTest
                 {
                     if (result.isSucceeded())
                         latch.countDown();
+                    else
+                        result.getFailure().printStackTrace();
                 }));
         }
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS), "server requests " + barrier.getNumberWaiting() + "<" + count + " - client: " + client.dump());
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "server requests " + barrier.getNumberWaiting() + "<" + count + " - client: " + client.dump());
         List<Destination> destinations = client.getDestinations();
         assertEquals(1, destinations.size());
         // The max duration connection pool aggressively closes expired connections upon release, which interferes with this assertion.


### PR DESCRIPTION
Reduced test load and increased timeout to avoid flakyness in Jenkins.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>