### PR TITLE
Fixes #9006 - WebSocket MessageInputStream.read() returns signed byte

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartInputStreamParser.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartInputStreamParser.java
@@ -941,7 +941,7 @@ public class MultiPartInputStreamParser
                 _pos = 0;
             }
 
-            return _buffer[_pos++];
+            return _buffer[_pos++] & 0xFF;
         }
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/MessageInputStream.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/MessageInputStream.java
@@ -87,7 +87,7 @@ public class MessageInputStream extends InputStream implements MessageSink
             if (len < 0) // EOF
                 return -1;
             if (len > 0) // did read something
-                return buf[0];
+                return buf[0] & 0xFF;
             // reading nothing (len == 0) tries again
         }
     }

--- a/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageInputStreamTest.java
+++ b/jetty-websocket/websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageInputStreamTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 
@@ -278,5 +279,24 @@ public class MessageInputStreamTest
                 assertThat("Message", message, is("Hello World"));
             }
         });
+    }
+
+    @Test
+    public void testReadSingleByteIsNotSigned() throws Exception
+    {
+        try (MessageInputStream stream = new MessageInputStream())
+        {
+            // Byte must be greater than 127.
+            int theByte = 200;
+            // Append a single message (simple, short)
+            Frame frame = new Frame(OpCode.BINARY);
+            frame.setPayload(new byte[]{(byte)theByte});
+            frame.setFin(true);
+            stream.accept(frame, Callback.NOOP);
+
+            // Single byte read must not return a signed byte.
+            int read = stream.read();
+            assertEquals(theByte, read);
+        }
     }
 }


### PR DESCRIPTION
Now properly coverting to `int`.
Added test.

Also fixed MultiPartInputStreamParser.Base64InputStream for the same issue.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>