### PR TITLE
Fixes #9009 - Flaky test StreamCloseTest.testRequestDataClosedRespons…

### DIFF
--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/StreamCloseTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/StreamCloseTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http2.client;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +39,8 @@ import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.Promise;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -179,7 +182,7 @@ public class StreamCloseTest extends AbstractTest
         assertTrue(serverDataLatch.await(5, TimeUnit.SECONDS));
         assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
         assertTrue(stream.isClosed());
-        assertEquals(0, stream.getSession().getStreams().size());
+        await().atMost(Duration.ofSeconds(5)).until(() -> stream.getSession().getStreams().size(), equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
…eDataClosedClosesStream.

Regression introduced by #8678.
Now using awaitility to wait for the stream count to go to zero.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>