### PR TITLE
Fixing OSGi bundle + tycho-p2 build failures

### DIFF
--- a/documentation/jetty-asciidoctor-extensions/pom.xml
+++ b/documentation/jetty-asciidoctor-extensions/pom.xml
@@ -11,6 +11,10 @@
   <name>Jetty :: Documentation :: AsciiDoctor Extensions</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.asciidoctor.extensions</bundle-symbolic-name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.asciidoctor</groupId>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -11,6 +11,10 @@
   <name>Jetty :: Documentation</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <bundle-symbolic-name>${project.groupId}</bundle-symbolic-name>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -24,7 +24,7 @@
           <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.p2.core</artifactId>
-            <version>2.6.200</version>
+            <version>2.9.200</version>
           </dependency>
         </dependencies>
         <executions>

--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -20,6 +20,13 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-repository-plugin</artifactId>
         <version>${tycho-version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.equinox.p2.core</artifactId>
+            <version>2.6.200</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <configuration>

--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -12,7 +12,7 @@
   <description>Generates a (maven based) P2 Updatesite</description>
   <packaging>pom</packaging>
   <properties>
-    <tycho-version>3.0.0</tycho-version>
+    <tycho-version>2.7.5</tycho-version>
   </properties>
   <build>
     <plugins>
@@ -20,13 +20,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-repository-plugin</artifactId>
         <version>${tycho-version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.platform</groupId>
-            <artifactId>org.eclipse.equinox.p2.core</artifactId>
-            <version>2.9.200</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <configuration>


### PR DESCRIPTION
Fix for warning (and occasional failure) of the build during jetty-p2 due to missing manifest headers.

```
[INFO] --- tycho-p2-repository-plugin:3.0.0:assemble-maven-repository (maven-p2-site) @ jetty-p2 ---

[WARNING] [18f8d83c-6508-4865-8b34-555866251936][plugin>org.eclipse.tycho:tycho-p2-repository-plugin:3.0.0] An error has occurred while adding 
the bundle /home/jenkins/agent/workspace/jetty.project_PR-9014/documentation/jetty-asciidoctor-extensions/target/jetty-asciidoctor-extensions-10.0.13-SNAPSHOT.jar.

org.osgi.framework.BundleException: Invalid manifest header Bundle-SymbolicName: ""

...

[WARNING] [18f8d83c-6508-4865-8b34-555866251936][plugin>org.eclipse.tycho:tycho-p2-repository-plugin:3.0.0] An error has occurred while adding 
the bundle /home/jenkins/agent/workspace/jetty.project_PR-9014/documentation/jetty-documentation/target/jetty-documentation-10.0.13-SNAPSHOT.jar.

org.osgi.framework.BundleException: Invalid manifest header Bundle-SymbolicName: ""
```

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>