### PR TITLE
Thought bubble to better deal with wrapping EOF and EMPTY chunks

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ResponseNotifier.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ResponseNotifier.java
@@ -369,6 +369,12 @@ public class ResponseNotifier
                 }
 
                 @Override
+                public boolean isRetainable()
+                {
+                    return false;
+                }
+
+                @Override
                 public void retain()
                 {
                     throw new UnsupportedOperationException();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -721,6 +721,12 @@ public class Content
             }
 
             @Override
+            public boolean isRetainable()
+            {
+                return false;
+            }
+
+            @Override
             public void retain()
             {
                 throw new UnsupportedOperationException();
@@ -753,6 +759,29 @@ public class Content
              * @return True if the chunk will be process and the callback will be called (or may have already been called), false otherwise.
              */
             boolean process(Chunk chunk, Callback callback);
+        }
+
+        class Wrapper extends Retainable.Wrapper implements Chunk
+        {
+            private final Chunk _chunk;
+
+            public Wrapper(Chunk chunk)
+            {
+                super(chunk);
+                _chunk = Objects.requireNonNull(chunk);
+            }
+
+            @Override
+            public ByteBuffer getByteBuffer()
+            {
+                return _chunk.getByteBuffer();
+            }
+
+            @Override
+            public boolean isLast()
+            {
+                return _chunk.isLast();
+            }
         }
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
@@ -27,6 +27,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 public interface Retainable
 {
     /**
+     * <p>Test if the implementation actually supports {@link Retainable} calls</p>
+     *
+     * @return
+     */
+    default boolean isRetainable()
+    {
+        return true;
+    }
+
+    /**
      * <p>Retains this resource, incrementing the reference count.</p>
      */
     void retain();
@@ -43,10 +53,12 @@ public interface Retainable
     class Wrapper implements Retainable
     {
         private final Retainable wrapped;
+        private final Retainable retainable;
 
         public Wrapper(Retainable wrapped)
         {
             this.wrapped = Objects.requireNonNull(wrapped);
+            this.retainable = wrapped.isRetainable() ? wrapped : new ReferenceCounter();
         }
 
         public Retainable getWrapped()
@@ -57,13 +69,13 @@ public interface Retainable
         @Override
         public void retain()
         {
-            getWrapped().retain();
+            retainable.retain();
         }
 
         @Override
         public boolean release()
         {
-            return getWrapped().release();
+            return retainable.release();
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
@@ -50,6 +50,11 @@ public interface Retainable
      */
     boolean release();
 
+    static Retainable asRetainable(Retainable retainable)
+    {
+        return retainable.isRetainable() ? retainable : new Wrapper(retainable);
+    }
+
     class Wrapper implements Retainable
     {
         private final Retainable wrapped;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
@@ -63,6 +63,12 @@ public abstract class ByteBufferChunk implements Content.Chunk
     }
 
     @Override
+    public boolean isRetainable()
+    {
+        return false;
+    }
+
+    @Override
     public void retain()
     {
         throw new UnsupportedOperationException();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
@@ -101,6 +101,12 @@ public abstract class ByteBufferChunk implements Content.Chunk
         }
 
         @Override
+        public boolean isRetainable()
+        {
+            return true;
+        }
+
+        @Override
         public void retain()
         {
             references.retain();
@@ -169,6 +175,12 @@ public abstract class ByteBufferChunk implements Content.Chunk
         {
             super(byteBuffer, last);
             this.retainable = retainable;
+        }
+
+        @Override
+        public boolean isRetainable()
+        {
+            return retainable.isRetainable();
         }
 
         @Override


### PR DESCRIPTION
I still think we can do better with retaining terminal chunks.

Since we have few implementations of `Retainable` that throw `UnsupportedOperationException`, I think it would be good to have an `boolean isRetainable()` method so we can know.  Then `Retainable.Wrapper` and
a new `Chunk.Wrapper` can take action to use their own reference counter if they are passed a non retainable `Retainable`.

I think with something like this, we could always call release on passed chunks.   If you want to call retain, then you just need to check that it is retainable... which you have to do now anyway!

This is far from complete or perfect.... I just think there might be something there to clean up just a bit.

thoughts?
