### PR TITLE
jetty 10.0.x disable concurrent build abort previous

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     skipDefaultCheckout()
     durabilityHint('PERFORMANCE_OPTIMIZED')
     buildDiscarder logRotator( numToKeepStr: '60' )
+    disableConcurrentBuilds abortPrevious: true
   }
   stages {
     stage("Parallel Stage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@
 
 pipeline {
   agent any
-  // save some io during the build
   options {
     skipDefaultCheckout()
+    // save some io during the build
     durabilityHint('PERFORMANCE_OPTIMIZED')
     buildDiscarder logRotator( numToKeepStr: '60' )
     disableConcurrentBuilds abortPrevious: true


### PR DESCRIPTION
- disable concurrent builds by aborting previous one
BUT we will not know which change break the build! 
