### PR TITLE
jetty 10.0.x fix jdk19 build upgrading and re enable m-invoker-p which now supports jdk19

### DIFF
--- a/jetty-jspc-maven-plugin/src/it/simple-jsp/postbuild.groovy
+++ b/jetty-jspc-maven-plugin/src/it/simple-jsp/postbuild.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 System.out.println( "running postbuild.groovy" )
 
 File webfrag = new File(basedir, 'target/webfrag.xml')

--- a/jetty-maven-plugin/src/it/jetty-effective-web-xml-it/postbuild.groovy
+++ b/jetty-maven-plugin/src/it/jetty-effective-web-xml-it/postbuild.groovy
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import groovy.xml.XmlParser
 
 def rootNode = new XmlParser().parse(new File( basedir, 'webapp-war/target/effective-web.xml'))
 // find context-param node with param-name == org.eclipse.jetty.resources

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,11 @@
               <scope>runtime</scope>
               <version>${groovy.version}</version>
             </dependency>
+            <dependency>
+              <groupId>org.apache.ant</groupId>
+              <artifactId>ant</artifactId>
+              <version>${ant.version}</version>
+            </dependency>
           </dependencies>
           <configuration>
             <mergeUserSettings>${invoker.mergeUserSettings}</mergeUserSettings>
@@ -677,13 +682,6 @@
               <localRepo>${localRepoPath}</localRepo>
             </filterProperties>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.ant</groupId>
-              <artifactId>ant</artifactId>
-              <version>${ant.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2487,25 +2487,6 @@
         <spotbugs.skip>true</spotbugs.skip>
       </properties>
     </profile>
-    <profile>
-      <id>jdk19</id>
-      <activation>
-        <jdk>19</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-invoker-plugin</artifactId>
-              <configuration>
-                <skipInvocation>true</skipInvocation>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
   </profiles>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,7 @@
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
     <maven.install.plugin.version>3.1.0</maven.install.plugin.version>
-    <!-- cleanup groovy dependencies of m-invoker-p when upgrading to 3.4.0 -->
-    <maven.invoker.plugin.version>3.3.0</maven.invoker.plugin.version>
+    <maven.invoker.plugin.version>3.4.0</maven.invoker.plugin.version>
     <groovy.version>4.0.6</groovy.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
@@ -623,42 +622,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>${maven.invoker.plugin.version}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-script-interpreter</artifactId>
-              <version>1.3</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>org.codehaus.groovy</groupId>
-                  <artifactId>groovy</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.groovy</groupId>
-              <artifactId>groovy</artifactId>
-              <scope>runtime</scope>
-              <version>${groovy.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.groovy</groupId>
-              <artifactId>groovy-json</artifactId>
-              <scope>runtime</scope>
-              <version>${groovy.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.groovy</groupId>
-              <artifactId>groovy-xml</artifactId>
-              <scope>runtime</scope>
-              <version>${groovy.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.ant</groupId>
-              <artifactId>ant</artifactId>
-              <version>${ant.version}</version>
-            </dependency>
-          </dependencies>
           <configuration>
             <mergeUserSettings>${invoker.mergeUserSettings}</mergeUserSettings>
             <writeJunitReport>true</writeJunitReport>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
     <maven.install.plugin.version>3.1.0</maven.install.plugin.version>
-    <maven.invoker.plugin.version>3.3.0</maven.invoker.plugin.version>
+    <maven.invoker.plugin.version>3.4.0-SNAPSHOT</maven.invoker.plugin.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
     <maven.plugin-tools.version>3.7.0</maven.plugin-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,9 @@
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
     <maven.install.plugin.version>3.1.0</maven.install.plugin.version>
-    <maven.invoker.plugin.version>3.4.0-SNAPSHOT</maven.invoker.plugin.version>
+    <!-- cleanup groovy dependencies of m-invoker-p when upgrading to 3.4.0 -->
+    <maven.invoker.plugin.version>3.3.0</maven.invoker.plugin.version>
+    <groovy.version>4.0.6</groovy.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
     <maven.plugin-tools.version>3.7.0</maven.plugin-tools.version>
@@ -621,6 +623,37 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>${maven.invoker.plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-script-interpreter</artifactId>
+              <version>1.3</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>org.codehaus.groovy</groupId>
+                  <artifactId>groovy</artifactId>
+                </exclusion>
+              </exclusions>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy</artifactId>
+              <scope>runtime</scope>
+              <version>${groovy.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy-json</artifactId>
+              <scope>runtime</scope>
+              <version>${groovy.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.groovy</groupId>
+              <artifactId>groovy-xml</artifactId>
+              <scope>runtime</scope>
+              <version>${groovy.version}</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <mergeUserSettings>${invoker.mergeUserSettings}</mergeUserSettings>
             <writeJunitReport>true</writeJunitReport>


### PR DESCRIPTION
- use m-invoker-p 3.4.0-SNAPSHOT
- add import for XmlSlurper
- import groovy.xml.XmlParser
- use some workaround to get this working with jdk 19 without a release
- it is working now with jdk 19
- fix pom
