### PR TITLE
Avoid Processor creation when possible.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -666,17 +666,7 @@ public class HttpChannelState implements HttpChannel, Components
             try (AutoLock ignored = _lock.lock())
             {
                 _processState = ProcessState.PROCESSED;
-
-                if (_failure != null)
-                {
-                    if (failure != null)
-                    {
-                        if (ExceptionUtil.areNotAssociated(failure, _failure))
-                            _failure.addSuppressed(failure);
-                    }
-                    failure = _failure;
-                }
-
+                failure = ExceptionUtil.combine(_failure, failure);
                 completeStream = _completed && (failure != null || _writeState == WriteState.LAST_WRITE_COMPLETED);
                 stream = _stream;
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
@@ -152,20 +152,23 @@ public class ExceptionUtil
      */
     public static boolean areNotAssociated(Throwable t1, Throwable t2)
     {
+        if (t1 == null || t2 == null)
+            return false;
         while (t1 != null)
         {
-            while (t2 != null)
+            Throwable two = t2;
+            while (two != null)
             {
-                if (t1 == t2)
+                if (t1 == two)
                     return false;
-                if (t1.getCause() == t2)
+                if (t1.getCause() == two)
                     return false;
-                if (Arrays.asList(t1.getSuppressed()).contains(t2))
+                if (Arrays.asList(t1.getSuppressed()).contains(two))
                     return false;
-                if (Arrays.asList(t2.getSuppressed()).contains(t1))
+                if (Arrays.asList(two.getSuppressed()).contains(t1))
                     return false;
 
-                t2 = t2.getCause();
+                two = two.getCause();
             }
             t1 = t1.getCause();
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -54,8 +54,10 @@ import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.ArrayUtil;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -434,14 +436,15 @@ public class ServletHandler extends Handler.Wrapper
     @Override
     public Request.Processor handle(Request request) throws Exception
     {
-        // TODO avoid lambda creation
-        return (req, resp, cb) ->
-        {
-            // We will always have a ServletScopedRequest and MappedServlet otherwise we will not reach ServletHandler.
-            ServletContextRequest servletRequest = Request.as(request, ServletContextRequest.class);
-            servletRequest.getServletChannel().setCallback(cb);
-            servletRequest.getServletChannel().handle();
-        };
+        return this::process;
+    }
+
+    private void process(Request request, Response response, Callback callback)
+    {
+        // We will always have a ServletScopedRequest and MappedServlet otherwise we will not reach ServletHandler.
+        ServletContextRequest servletRequest = Request.as(request, ServletContextRequest.class);
+        servletRequest.getServletChannel().setCallback(callback);
+        servletRequest.getServletChannel().handle();
     }
 
     /**


### PR DESCRIPTION
Various cleanups from handler-as-processor branch to reduce processor wrapping. Sessions are now touched before handling.