### PR TITLE
Jetty 12 - Fix `jakarta.servlet.jsp.jstl-api:jar:3.0.0-RC1` warning

### DIFF
--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -32,7 +32,7 @@
     <jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
     <jakarta.servlet.jsp.api.version>3.1.0</jakarta.servlet.jsp.api.version>
     <jakarta.servlet.jsp.jstl.api.version>3.0.0</jakarta.servlet.jsp.jstl.api.version>
-    <jakarta.servlet.jsp.jstl.impl.version>3.0.0</jakarta.servlet.jsp.jstl.impl.version> <!-- TODO: remove? -->
+    <jakarta.servlet.jsp.jstl.impl.version>3.0.1</jakarta.servlet.jsp.jstl.impl.version>
     <jakarta.ws.rs.api.version>3.1.0</jakarta.ws.rs.api.version>
     <jakarta.xml.bind.api.version>4.0.0</jakarta.xml.bind.api.version>
     <jakarta.xml.bind.impl.version>4.0.0</jakarta.xml.bind.impl.version>


### PR DESCRIPTION
Fix for warning on jetty-home build...

```
[WARNING] The POM for jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:jar:3.0.0-RC1 is missing, no dependency information available
```