### PR TITLE
Fixes #9038 - Jetty 12 - Review EE10 Http[Input|Output].Interceptor APIs

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -165,7 +165,6 @@ public class BufferedResponseHandler extends Handler.Wrapper
             }
         }
 
-        // Install buffered interceptor and handle.
         return (rq, rs, callback) ->
         {
             BufferedResponse bufferedResponse = new BufferedResponse(rq, rs, callback);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.servlet;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
@@ -21,10 +20,8 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.StaticException;
-import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,12 +37,9 @@ class AsyncContentProducer implements ContentProducer
 
     final AutoLock _lock;
     private final ServletChannel _servletChannel;
-    private HttpInput.Interceptor _interceptor;
-    private Content.Chunk _rawChunk;
-    private Content.Chunk _transformedChunk;
-    private boolean _error;
+    private Content.Chunk _chunk;
     private long _firstByteNanoTime = Long.MIN_VALUE;
-    private long _rawBytesArrived;
+    private long _bytesArrived;
 
     /**
      * @param servletChannel The ServletChannel to produce input from.
@@ -66,19 +60,10 @@ class AsyncContentProducer implements ContentProducer
 
         // Make sure that the chunk has been fully consumed before destroying the interceptor and also make sure
         // that asking this instance for chunks between recycle and reopen will only produce error'ed chunks.
-        if (_rawChunk == null)
-            _rawChunk = RECYCLED_ERROR_CHUNK;
-        else if (!_rawChunk.isTerminal())
-            throw new IllegalStateException("ContentProducer with unconsumed raw chunk cannot be recycled");
-
-        if (_transformedChunk == null)
-            _transformedChunk = RECYCLED_ERROR_CHUNK;
-        else if (!_transformedChunk.isTerminal())
-            throw new IllegalStateException("ContentProducer with unconsumed transformed chunk cannot be recycled");
-
-        if (_interceptor instanceof Destroyable)
-            ((Destroyable)_interceptor).destroy();
-        _interceptor = null;
+        if (_chunk == null)
+            _chunk = RECYCLED_ERROR_CHUNK;
+        else if (!_chunk.isTerminal())
+            throw new IllegalStateException("ContentProducer with unconsumed chunk cannot be recycled");
     }
 
     @Override
@@ -87,32 +72,16 @@ class AsyncContentProducer implements ContentProducer
         assertLocked();
         if (LOG.isDebugEnabled())
             LOG.debug("reopening {}", this);
-        _rawChunk = null;
-        _transformedChunk = null;
-        _error = false;
+        _chunk = null;
         _firstByteNanoTime = Long.MIN_VALUE;
-        _rawBytesArrived = 0L;
-    }
-
-    @Override
-    public HttpInput.Interceptor getInterceptor()
-    {
-        assertLocked();
-        return _interceptor;
-    }
-
-    @Override
-    public void setInterceptor(HttpInput.Interceptor interceptor)
-    {
-        assertLocked();
-        this._interceptor = interceptor;
+        _bytesArrived = 0L;
     }
 
     @Override
     public int available()
     {
         assertLocked();
-        Content.Chunk chunk = nextTransformedChunk();
+        Content.Chunk chunk = produceChunk();
         int available = chunk == null ? 0 : chunk.remaining();
         if (LOG.isDebugEnabled())
             LOG.debug("available = {} {}", available, this);
@@ -123,7 +92,7 @@ class AsyncContentProducer implements ContentProducer
     public boolean hasChunk()
     {
         assertLocked();
-        boolean hasChunk = _rawChunk != null;
+        boolean hasChunk = _chunk != null;
         if (LOG.isDebugEnabled())
             LOG.debug("hasChunk = {} {}", hasChunk, this);
         return hasChunk;
@@ -133,9 +102,10 @@ class AsyncContentProducer implements ContentProducer
     public boolean isError()
     {
         assertLocked();
+        boolean error = _chunk instanceof Content.Chunk.Error;
         if (LOG.isDebugEnabled())
-            LOG.debug("isError = {} {}", _error, this);
-        return _error;
+            LOG.debug("isError = {} {}", error, this);
+        return error;
     }
 
     @Override
@@ -151,7 +121,7 @@ class AsyncContentProducer implements ContentProducer
             if (period > 0)
             {
                 long minimumData = minRequestDataRate * TimeUnit.NANOSECONDS.toMillis(period) / TimeUnit.SECONDS.toMillis(1);
-                if (getRawBytesArrived() < minimumData)
+                if (getBytesArrived() < minimumData)
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("checkMinDataRate check failed {}", this);
@@ -171,12 +141,12 @@ class AsyncContentProducer implements ContentProducer
     }
 
     @Override
-    public long getRawBytesArrived()
+    public long getBytesArrived()
     {
         assertLocked();
         if (LOG.isDebugEnabled())
-            LOG.debug("getRawBytesArrived = {} {}", _rawBytesArrived, this);
-        return _rawBytesArrived;
+            LOG.debug("getBytesArrived = {} {}", _bytesArrived, this);
+        return _bytesArrived;
     }
 
     @Override
@@ -198,28 +168,16 @@ class AsyncContentProducer implements ContentProducer
 
     private boolean consumeCurrentChunk()
     {
-        if (_transformedChunk != null && !_transformedChunk.isTerminal())
-        {
-            if (_transformedChunk != _rawChunk)
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("releasing current transformed chunk {}", this);
-                _transformedChunk.skip(_transformedChunk.remaining());
-                _transformedChunk.release();
-            }
-            _transformedChunk = null;
-        }
-
-        if (_rawChunk != null && !_rawChunk.isTerminal())
+        if (_chunk != null && !_chunk.isTerminal())
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("releasing current raw chunk {}", this);
-            _rawChunk.skip(_rawChunk.remaining());
-            _rawChunk.release();
-            _rawChunk = _rawChunk.isLast() ? Content.Chunk.EOF : null;
+                LOG.debug("releasing current chunk {}", this);
+            _chunk.skip(_chunk.remaining());
+            _chunk.release();
+            _chunk = _chunk.isLast() ? Content.Chunk.EOF : null;
         }
 
-        return _rawChunk != null && _rawChunk.isLast();
+        return _chunk != null && _chunk.isLast();
     }
 
     private boolean consumeAvailableChunks()
@@ -251,7 +209,7 @@ class AsyncContentProducer implements ContentProducer
     public Content.Chunk nextChunk()
     {
         assertLocked();
-        Content.Chunk chunk = nextTransformedChunk();
+        Content.Chunk chunk = produceChunk();
         if (LOG.isDebugEnabled())
             LOG.debug("nextChunk = {} {}", chunk, this);
         if (chunk != null)
@@ -265,24 +223,20 @@ class AsyncContentProducer implements ContentProducer
         assertLocked();
         if (LOG.isDebugEnabled())
             LOG.debug("reclaim {} {}", chunk, this);
-        if (_transformedChunk == chunk)
-        {
-            chunk.release();
-            if (_transformedChunk == _rawChunk)
-                _rawChunk = null;
-            _transformedChunk = null;
-        }
+        assert chunk == _chunk;
+        chunk.release();
+        _chunk = null;
     }
 
     @Override
     public boolean isReady()
     {
         assertLocked();
-        Content.Chunk chunk = nextTransformedChunk();
+        Content.Chunk chunk = produceChunk();
         if (chunk != null)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("isReady(), got transformed chunk {} {}", chunk, this);
+                LOG.debug("isReady(), got chunk {} {}", chunk, this);
             return true;
         }
 
@@ -303,197 +257,71 @@ class AsyncContentProducer implements ContentProducer
         return _servletChannel.getState().isInputUnready();
     }
 
-    private Content.Chunk nextTransformedChunk()
+    private Content.Chunk produceChunk()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("nextTransformedChunk {}", this);
+            LOG.debug("produceChunk() {}", this);
 
         while (true)
         {
-            if (_transformedChunk != null)
+            if (_chunk != null)
             {
-                if (_transformedChunk.isTerminal() || _transformedChunk.hasRemaining())
+                if (_chunk.isTerminal() || _chunk.hasRemaining())
                 {
-                    if (_transformedChunk instanceof Content.Chunk.Error && !_error)
-                    {
-                        // In case the _rawChunk was set by consumeAvailable(), check the ServletChannel
-                        // to see if it has a more precise error. Otherwise, the exact same
-                        // terminal chunk will be returned by the ServletChannel; do not do that
-                        // if the _error flag was set, meaning the current error is definitive.
-                        Content.Chunk refreshedRawChunk = produceRawChunk();
-                        if (refreshedRawChunk != null)
-                            _rawChunk = _transformedChunk = refreshedRawChunk;
-                        _error = _rawChunk instanceof Content.Chunk.Error;
-
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("refreshed raw chunk: {} {}", _rawChunk, this);
-                    }
-
                     if (LOG.isDebugEnabled())
-                        LOG.debug("transformed chunk not yet depleted, returning it {}", this);
-                    return _transformedChunk;
+                        LOG.debug("chunk not yet depleted, returning it {}", this);
+                    return _chunk;
                 }
                 else
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("current transformed chunk depleted {}", this);
+                        LOG.debug("current chunk depleted {}", this);
 
-                    _transformedChunk.release();
-                    _transformedChunk = null;
+                    _chunk.release();
+                    _chunk = null;
                 }
             }
-
-            if (_rawChunk == null)
+            else
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("producing new raw chunk {}", this);
-                _rawChunk = produceRawChunk();
-                if (_rawChunk == null)
+                    LOG.debug("reading new chunk {}", this);
+                _chunk = readChunk();
+                if (_chunk == null)
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("channel has no new raw chunk {}", this);
+                        LOG.debug("channel has no new chunk {}", this);
                     return null;
                 }
             }
 
-            if (LOG.isDebugEnabled())
-                LOG.debug("transforming raw chunk {}", this);
-            transformRawChunk();
+            assert _chunk != null;
+            // Release the chunk immediately, if it is empty.
+            if (!_chunk.hasRemaining() && !_chunk.isTerminal())
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("releasing empty chunk {}", this);
+                _chunk.release();
+                _chunk = null;
+            }
         }
     }
 
-    private void transformRawChunk()
-    {
-        assert _rawChunk != null;
-        if (_interceptor != null)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("intercepting raw chunk {}", this);
-            _transformedChunk = intercept();
-
-            // If the interceptor generated a terminal chunk, _rawChunk must become that terminal chunk.
-            if (_transformedChunk != null && _transformedChunk.isTerminal() && _transformedChunk != _rawChunk)
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("interceptor generated a terminal chunk, _rawChunk must become that terminal chunk {}", this);
-                _rawChunk.release();
-                _rawChunk = _transformedChunk;
-                return;
-            }
-
-            // If the interceptor generated a null chunk, release the raw chunk now if it is empty.
-            if (_transformedChunk == null && !_rawChunk.hasRemaining() && !_rawChunk.isTerminal())
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("interceptor generated a null chunk, releasing the empty raw chunk now {}", this);
-                _rawChunk.release();
-                _rawChunk = null;
-                return;
-            }
-
-            // If the interceptor returned the raw chunk, release the raw chunk now if it is empty.
-            if (_transformedChunk == _rawChunk && !_rawChunk.hasRemaining() && !_rawChunk.isTerminal())
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("interceptor returned the raw chunk, releasing the empty raw chunk now {}", this);
-                _rawChunk.release();
-                _rawChunk = _transformedChunk = null;
-            }
-        }
-        else
-        {
-            // Release the raw chunk now if it is empty.
-            if (!_rawChunk.hasRemaining() && !_rawChunk.isTerminal())
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("releasing the empty raw chunk now {}", this);
-                _rawChunk.release();
-                _rawChunk = null;
-            }
-
-            if (LOG.isDebugEnabled())
-                LOG.debug("no interceptor, transformed chunk is raw chunk {}", this);
-            _transformedChunk = _rawChunk;
-        }
-    }
-
-    private Content.Chunk intercept()
-    {
-        try
-        {
-            int remainingBeforeInterception = _rawChunk.remaining();
-            Content.Chunk chunk = _interceptor.readFrom(_rawChunk);
-            if (chunk != null && chunk.isTerminal() && !_rawChunk.isTerminal())
-            {
-                if (chunk instanceof Content.Chunk.Error errorChunk)
-                {
-                    // Set the _error flag to mark the chunk as definitive, i.e.:
-                    // do not try to produce new raw chunk to get a fresher error
-                    // when the terminal chunk was generated by the interceptor.
-                    _error = true;
-                    if (_servletChannel.getResponse().isCommitted())
-                        _servletChannel.abort(errorChunk.getCause());
-                }
-
-                if (LOG.isDebugEnabled())
-                    LOG.debug("interceptor generated terminal chunk {}", this);
-            }
-            else if (chunk != _rawChunk && !_rawChunk.isTerminal() && _rawChunk.hasRemaining() && _rawChunk.remaining() == remainingBeforeInterception)
-            {
-                IOException failure = new IOException("Interceptor " + _interceptor + " did not consume any of the " + _rawChunk.remaining() + " remaining byte(s) of chunk");
-                if (chunk != null)
-                    chunk.release();
-                consumeCurrentChunk();
-                // Set the _error flag to mark the chunk as definitive, i.e.:
-                // do not try to produce new raw chunk to get a fresher error
-                // when the terminal chunk was caused by the interceptor not
-                // consuming the raw chunk.
-                _error = true;
-                Response response = _servletChannel.getResponse();
-                if (response.isCommitted())
-                    _servletChannel.abort(failure);
-                if (LOG.isDebugEnabled())
-                    LOG.debug("interceptor did not consume chunk {}", this);
-                chunk = _transformedChunk;
-            }
-
-            if (LOG.isDebugEnabled())
-                LOG.debug("intercepted raw chunk {}", this);
-            return chunk;
-        }
-        catch (Throwable x)
-        {
-            IOException failure = new IOException("bad chunk", x);
-            consumeCurrentChunk();
-            // Set the _error flag to mark the chunk as definitive, i.e.:
-            // do not try to produce new raw chunk to get a fresher error
-            // when the terminal chunk was caused by the interceptor throwing.
-            _error = true;
-            Response response = _servletChannel.getResponse();
-            if (response.isCommitted())
-                _servletChannel.abort(failure);
-            if (LOG.isDebugEnabled())
-                LOG.debug("interceptor threw exception {}", this, x);
-            return _transformedChunk;
-        }
-    }
-
-    private Content.Chunk produceRawChunk()
+    private Content.Chunk readChunk()
     {
         Content.Chunk chunk = _servletChannel.getServletContextRequest().read();
         if (chunk != null)
         {
-            _rawBytesArrived += chunk.remaining();
+            _bytesArrived += chunk.remaining();
             if (_firstByteNanoTime == Long.MIN_VALUE)
                 _firstByteNanoTime = NanoTime.now();
             if (LOG.isDebugEnabled())
-                LOG.debug("produceRawChunk updated _rawBytesArrived to {} and _firstByteTimeStamp to {} {}", _rawBytesArrived, _firstByteNanoTime, this);
+                LOG.debug("readChunk() updated _bytesArrived to {} and _firstByteTimeStamp to {} {}", _bytesArrived, _firstByteNanoTime, this);
             // TODO: notify channel listeners (see ee9)?
             if (chunk instanceof Trailers trailers)
                 _servletChannel.onTrailers(trailers.getTrailers());
         }
         if (LOG.isDebugEnabled())
-            LOG.debug("produceRawChunk produced {} {}", chunk, this);
+            LOG.debug("readChunk() produced {} {}", chunk, this);
         return chunk;
     }
 
@@ -506,13 +334,10 @@ class AsyncContentProducer implements ContentProducer
     @Override
     public String toString()
     {
-        return String.format("%s@%x[r=%s,t=%s,i=%s,error=%b]",
+        return String.format("%s@%x[c=%s]",
             getClass().getSimpleName(),
             hashCode(),
-            _rawChunk,
-            _transformedChunk,
-            _interceptor,
-            _error
+            _chunk
         );
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/BlockingContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/BlockingContentProducer.java
@@ -79,9 +79,9 @@ class BlockingContentProducer implements ContentProducer
     }
 
     @Override
-    public long getRawBytesArrived()
+    public long getBytesArrived()
     {
-        return _asyncContentProducer.getRawBytesArrived();
+        return _asyncContentProducer.getBytesArrived();
     }
 
     @Override
@@ -138,18 +138,6 @@ class BlockingContentProducer implements ContentProducer
         if (LOG.isDebugEnabled())
             LOG.debug("isReady = {}", ready);
         return ready;
-    }
-
-    @Override
-    public HttpInput.Interceptor getInterceptor()
-    {
-        return _asyncContentProducer.getInterceptor();
-    }
-
-    @Override
-    public void setInterceptor(HttpInput.Interceptor interceptor)
-    {
-        _asyncContentProducer.setInterceptor(interceptor);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ContentProducer.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee10.servlet;
 
 import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.util.component.Destroyable;
 
 /**
  * ContentProducer is the bridge between {@link HttpInput} and {@link Content.Source}.
@@ -22,7 +21,6 @@ import org.eclipse.jetty.util.component.Destroyable;
 public interface ContentProducer
 {
     /**
-     * Clear the interceptor and call {@link Destroyable#destroy()} on it if it implements {@link Destroyable}.
      * A recycled {@link ContentProducer} will only produce special content with a non-null error until
      * {@link #reopen()} is called.
      */
@@ -57,7 +55,7 @@ public interface ContentProducer
      * Doesn't change state.
      * @return the byte count produced by the underlying {@link Content.Source}.
      */
-    long getRawBytesArrived();
+    long getBytesArrived();
 
     /**
      * Get the byte count that can immediately be read from this
@@ -93,8 +91,6 @@ public interface ContentProducer
      * Get the next content chunk that can be read from or that describes the terminal condition
      * that was reached (error, eof).
      * This call may or may not block until some content is available, depending on the implementation.
-     * The returned content is decoded by the interceptor set with {@link #setInterceptor(HttpInput.Interceptor)}
-     * or left as-is if no intercept is set.
      * After this call, state can be either of UNREADY or IDLE.
      *
      * @return the next content chunk that can be read from or null if the implementation does not block
@@ -117,18 +113,6 @@ public interface ContentProducer
      * @return true if some content is immediately available, false otherwise.
      */
     boolean isReady();
-
-    /**
-     * Get the {@link HttpInput.Interceptor}.
-     * @return The {@link HttpInput.Interceptor}, or null if none set.
-     */
-    HttpInput.Interceptor getInterceptor();
-
-    /**
-     * Set the interceptor.
-     * @param interceptor The interceptor to use.
-     */
-    void setInterceptor(HttpInput.Interceptor interceptor);
 
     /**
      * Wake up the thread that is waiting for the next content.

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -14,14 +14,12 @@
 package org.eclipse.jetty.ee10.test.client.transport;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Deque;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -53,9 +51,7 @@ import org.eclipse.jetty.client.util.BufferingResponseListener;
 import org.eclipse.jetty.client.util.InputStreamRequestContent;
 import org.eclipse.jetty.client.util.OutputStreamRequestContent;
 import org.eclipse.jetty.client.util.StringRequestContent;
-import org.eclipse.jetty.ee10.servlet.HttpInput;
 import org.eclipse.jetty.ee10.servlet.HttpOutput;
-import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
@@ -64,7 +60,6 @@ import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.client.transport.internal.HttpConnectionOverHTTP2;
 import org.eclipse.jetty.http2.internal.HTTP2Session;
 import org.eclipse.jetty.io.Connection;
-import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Request;
@@ -80,9 +75,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static java.nio.ByteBuffer.wrap;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.jetty.util.BufferUtil.toArray;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -1201,174 +1194,6 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncIntercepted(Transport transport) throws Exception
-    {
-        start(transport, new HttpServlet()
-        {
-            @Override
-            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
-            {
-                System.err.println("Service " + request);
-
-                HttpInput httpInput = Objects.requireNonNull(ServletContextRequest.getServletContextRequest(request)).getHttpInput();
-                httpInput.addInterceptor(new HttpInput.Interceptor()
-                {
-                    int state = 0;
-                    Content.Chunk saved;
-
-                    @Override
-                    public Content.Chunk readFrom(Content.Chunk chunk)
-                    {
-                        switch (state)
-                        {
-                            case 0:
-                                // null transform
-                                chunk.skip(chunk.remaining());
-                                chunk.release();
-                                state++;
-                                return null;
-
-                            case 1:
-                            {
-                                // copy transform
-                                if (!chunk.hasRemaining())
-                                {
-                                    state++;
-                                    return chunk;
-                                }
-                                ByteBuffer copy = wrap(toArray(chunk.getByteBuffer()));
-                                chunk.skip(copy.remaining());
-                                chunk.release();
-                                return Content.Chunk.from(copy, false);
-                            }
-
-                            case 2:
-                                // byte by byte
-                                if (!chunk.hasRemaining())
-                                {
-                                    state++;
-                                    return chunk;
-                                }
-                                byte[] b = new byte[1];
-                                int l = chunk.get(b, 0, 1);
-                                if (!chunk.hasRemaining())
-                                    chunk.release();
-                                return Content.Chunk.from(wrap(b, 0, l), false);
-
-                            case 3:
-                            {
-                                // double vision
-                                if (!chunk.hasRemaining())
-                                {
-                                    if (saved == null)
-                                    {
-                                        state++;
-                                        return chunk;
-                                    }
-                                    Content.Chunk ref = saved;
-                                    saved = null;
-                                    return ref;
-                                }
-
-                                byte[] data = toArray(chunk.getByteBuffer());
-                                chunk.skip(data.length);
-                                chunk.release();
-                                saved = Content.Chunk.from(wrap(data), false);
-                                return Content.Chunk.from(wrap(data), false);
-                            }
-
-                            default:
-                                return chunk;
-                        }
-                    }
-                });
-
-                AsyncContext asyncContext = request.startAsync();
-                ServletInputStream input = request.getInputStream();
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-                input.setReadListener(new ReadListener()
-                {
-                    @Override
-                    public void onDataAvailable() throws IOException
-                    {
-                        while (input.isReady())
-                        {
-                            int b = input.read();
-                            if (b > 0)
-                            {
-                                // System.err.printf("0x%2x %s %n", b, Character.isISOControl(b)?"?":(""+(char)b));
-                                out.write(b);
-                            }
-                            else if (b < 0)
-                                return;
-                        }
-                    }
-
-                    @Override
-                    public void onAllDataRead() throws IOException
-                    {
-                        response.getOutputStream().write(out.toByteArray());
-                        asyncContext.complete();
-                    }
-
-                    @Override
-                    public void onError(Throwable x)
-                    {
-                    }
-                });
-            }
-        });
-
-        AsyncRequestContent content = new AsyncRequestContent();
-        CountDownLatch clientLatch = new CountDownLatch(1);
-
-        String expected =
-                "S1" +
-                "S2" +
-                "S3S3" +
-                "S4" +
-                "S5" +
-                "S6";
-
-        client.newRequest(newURI(transport))
-            .method(HttpMethod.POST)
-            .body(content)
-            .send(new BufferingResponseListener()
-            {
-                @Override
-                public void onComplete(Result result)
-                {
-                    if (result.isSucceeded())
-                    {
-                        Response response = result.getResponse();
-                        assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.OK_200));
-                        assertThat(getContentAsString(), Matchers.equalTo(expected));
-                        clientLatch.countDown();
-                    }
-                }
-            });
-
-        content.write(BufferUtil.toBuffer("S0"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S1"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S2"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S3"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S4"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S5"), Callback.NOOP);
-        content.flush();
-        content.write(BufferUtil.toBuffer("S6"), Callback.NOOP);
-        content.close();
-
-        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
-    }
-
-    @ParameterizedTest
-    @MethodSource("transportsNoFCGI")
     public void testAsyncEcho(Transport transport) throws Exception
     {
         // TODO: investigate why H3 does not work.
@@ -1441,236 +1266,6 @@ public class AsyncIOServletTest extends AbstractTest
         assertTrue(clientLatch.await(30, TimeUnit.SECONDS));
         assertThat(resultRef.get().isSucceeded(), Matchers.is(true));
         assertThat(resultRef.get().getResponse().getStatus(), Matchers.equalTo(HttpStatus.OK_200));
-    }
-
-/*
-    // TODO: there is no GzipHttpInputInterceptor anymore, use something else.
-    @ParameterizedTest
-    @MethodSource("transportsNoFCGI")
-    public void testAsyncInterceptedTwice(Transport transport) throws Exception
-    {
-        init(transport);
-        start(transport, new HttpServlet()
-        {
-            @Override
-            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
-            {
-                System.err.println("Service " + request);
-
-                HttpInput httpInput = ((Request)request).getHttpInput();
-                httpInput.addInterceptor(new GzipHttpInputInterceptor(new InflaterPool(-1, true), ((Request)request).getHttpChannel().getByteBufferPool(), 1024));
-                httpInput.addInterceptor(chunk ->
-                {
-                    if (chunk.isTerminal())
-                        return chunk;
-                    ByteBuffer byteBuffer = chunk.getByteBuffer();
-                    byte[] bytes = new byte[2];
-                    bytes[1] = byteBuffer.get();
-                    bytes[0] = byteBuffer.get();
-                    return Content.Chunk.from(wrap(bytes), false);
-                });
-
-                AsyncContext asyncContext = request.startAsync();
-                ServletInputStream input = request.getInputStream();
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-                input.setReadListener(new ReadListener()
-                {
-                    @Override
-                    public void onDataAvailable() throws IOException
-                    {
-                        while (input.isReady())
-                        {
-                            int b = input.read();
-                            if (b > 0)
-                            {
-                                // System.err.printf("0x%2x %s %n", b, Character.isISOControl(b)?"?":(""+(char)b));
-                                out.write(b);
-                            }
-                            else if (b < 0)
-                                return;
-                        }
-                    }
-
-                    @Override
-                    public void onAllDataRead() throws IOException
-                    {
-                        response.getOutputStream().write(out.toByteArray());
-                        asyncContext.complete();
-                    }
-
-                    @Override
-                    public void onError(Throwable x)
-                    {
-                    }
-                });
-            }
-        });
-
-        AsyncRequestContent contentProvider = new AsyncRequestContent();
-        CountDownLatch clientLatch = new CountDownLatch(1);
-
-        String expected =
-                "0S" +
-                "1S" +
-                "2S" +
-                "3S" +
-                "4S" +
-                "5S" +
-                "6S";
-
-        client.newRequest(newURI(transport))
-            .method(HttpMethod.POST)
-            .path(scenario.servletPath)
-            .body(contentProvider)
-            .send(new BufferingResponseListener()
-            {
-                @Override
-                public void onComplete(Result result)
-                {
-                    if (result.isSucceeded())
-                    {
-                        Response response = result.getResponse();
-                        assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.OK_200));
-                        assertThat(getContentAsString(), Matchers.equalTo(expected));
-                        clientLatch.countDown();
-                    }
-                }
-            });
-
-        for (int i = 0; i < 7; i++)
-        {
-            contentProvider.write(gzipToBuffer("S" + i), Callback.NOOP);
-            contentProvider.flush();
-        }
-        contentProvider.close();
-
-        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
-    }
-*/
-
-    @ParameterizedTest
-    @MethodSource("transportsNoFCGI")
-    public void testAsyncInterceptedTwiceWithNulls(Transport transport) throws Exception
-    {
-        start(transport, new HttpServlet()
-        {
-            @Override
-            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
-            {
-                System.err.println("Service " + request);
-
-                HttpInput httpInput = ((ServletContextRequest)request).getHttpInput();
-                httpInput.addInterceptor(chunk ->
-                {
-                    if (!chunk.hasRemaining())
-                        return chunk;
-
-                    // skip contents with odd numbers
-                    ByteBuffer duplicate = chunk.getByteBuffer().duplicate();
-                    duplicate.get();
-                    byte integer = duplicate.get();
-                    int idx = Character.getNumericValue(integer);
-                    Content.Chunk chunkCopy = Content.Chunk.from(chunk.getByteBuffer().duplicate(), false);
-                    chunk.skip(chunk.remaining());
-                    chunk.release();
-                    if (idx % 2 == 0)
-                        return chunkCopy;
-                    return null;
-                });
-                httpInput.addInterceptor(chunk ->
-                {
-                    if (!chunk.hasRemaining())
-                        return chunk;
-
-                    // reverse the bytes
-                    ByteBuffer byteBuffer = chunk.getByteBuffer();
-                    byte[] bytes = new byte[2];
-                    bytes[1] = byteBuffer.get();
-                    bytes[0] = byteBuffer.get();
-                    return Content.Chunk.from(wrap(bytes), false);
-                });
-
-                AsyncContext asyncContext = request.startAsync();
-                ServletInputStream input = request.getInputStream();
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-                input.setReadListener(new ReadListener()
-                {
-                    @Override
-                    public void onDataAvailable() throws IOException
-                    {
-                        while (input.isReady())
-                        {
-                            int b = input.read();
-                            if (b > 0)
-                            {
-                                // System.err.printf("0x%2x %s %n", b, Character.isISOControl(b)?"?":(""+(char)b));
-                                out.write(b);
-                            }
-                            else if (b < 0)
-                                return;
-                        }
-                    }
-
-                    @Override
-                    public void onAllDataRead() throws IOException
-                    {
-                        response.getOutputStream().write(out.toByteArray());
-                        asyncContext.complete();
-                    }
-
-                    @Override
-                    public void onError(Throwable x)
-                    {
-                    }
-                });
-            }
-        });
-
-        AsyncRequestContent contentProvider = new AsyncRequestContent();
-        CountDownLatch clientLatch = new CountDownLatch(1);
-
-        String expected =
-                "0S" +
-                "2S" +
-                "4S" +
-                "6S";
-
-        client.newRequest(newURI(transport))
-            .method(HttpMethod.POST)
-            .body(contentProvider)
-            .send(new BufferingResponseListener()
-            {
-                @Override
-                public void onComplete(Result result)
-                {
-                    if (result.isSucceeded())
-                    {
-                        Response response = result.getResponse();
-                        assertThat(response.getStatus(), Matchers.equalTo(HttpStatus.OK_200));
-                        assertThat(getContentAsString(), Matchers.equalTo(expected));
-                        clientLatch.countDown();
-                    }
-                }
-            });
-
-        contentProvider.write(BufferUtil.toBuffer("S0"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S1"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S2"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S3"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S4"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S5"), Callback.NOOP);
-        contentProvider.flush();
-        contentProvider.write(BufferUtil.toBuffer("S6"), Callback.NOOP);
-        contentProvider.close();
-
-        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Removed HttpInput.Interceptor and HttpOutput.Interceptor.
Simplified AsyncContentProducer.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>