### PR TITLE
Jetty 12 - Fix wasted effort on empty `IncludeExcludeSet`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
@@ -159,6 +159,8 @@ public class IncludeExcludeSet<T, P> implements Predicate<P>
     {
         if (!_includes.isEmpty() && !_includePredicate.test(t))
             return false;
+        if (_excludes.isEmpty())
+            return true;
         return !_excludePredicate.test(t);
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IncludeExcludeSetTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IncludeExcludeSetTest.java
@@ -23,6 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class IncludeExcludeSetTest
 {
     @Test
+    public void testEmptySet()
+    {
+        IncludeExcludeSet<String, String> empty = new IncludeExcludeSet<>();
+
+        assertTrue(empty.test("abc"));
+    }
+
+    @Test
     public void testWithInetAddressSet() throws Exception
     {
         IncludeExcludeSet<String, InetAddress> set = new IncludeExcludeSet<>(InetAddressSet.class);


### PR DESCRIPTION
Improve (slightly) the performance of `IncludeExcludeSet` when it comes to an empty exclude set.