### PR TITLE
PathMappings optimizations

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MappedResource.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MappedResource.java
@@ -21,11 +21,34 @@ public class MappedResource<E> implements Comparable<MappedResource<E>>
 {
     private final PathSpec pathSpec;
     private final E resource;
+    private final MatchedResource<E> preMatched;
 
     public MappedResource(PathSpec pathSpec, E resource)
     {
         this.pathSpec = pathSpec;
         this.resource = resource;
+
+        MatchedResource<E> matched;
+        switch (pathSpec.getGroup())
+        {
+            case ROOT:
+                matched = new MatchedResource<>(resource, pathSpec, pathSpec.matched("/"));
+                break;
+            case EXACT:
+                matched = new MatchedResource<>(resource, pathSpec, pathSpec.matched(pathSpec.getDeclaration()));
+                break;
+            default:
+                matched = null;
+        }
+        this.preMatched = matched;
+    }
+
+    /**
+     * @return A pre match {@link MatchedResource} for ROOT and EXACT matches, else null;
+     */
+    public MatchedResource<E> getPreMatched()
+    {
+        return preMatched;
     }
 
     /**

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -17,8 +17,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -43,12 +45,13 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     private static final Logger LOG = LoggerFactory.getLogger(PathMappings.class);
     private final Set<MappedResource<E>> _mappings = new TreeSet<>(Comparator.comparing(MappedResource::getPathSpec));
 
-    private boolean _nonServletPathSpecs;
+    /**
+     * When _orderIsSignificant is true, the order of the MappedResources is significant and a match needs to be iteratively
+     * tried against each mapping (ordered by group then add order) to find the first that matches.
+     */
+    private boolean _orderIsSignificant;
     private boolean _optimizedExact = true;
-    private final Index.Mutable<MappedResource<E>> _exactMap = new Index.Builder<MappedResource<E>>()
-        .caseSensitive(true)
-        .mutable()
-        .build();
+    private final Map<String, MappedResource<E>> _exactMap = new HashMap<>();
     private boolean _optimizedPrefix = true;
     private final Index.Mutable<MappedResource<E>> _prefixMap = new Index.Builder<MappedResource<E>>()
         .caseSensitive(true)
@@ -94,7 +97,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         _optimizedExact = true;
         _optimizedPrefix = true;
         _optimizedSuffix = true;
-        _nonServletPathSpecs = false;
+        _orderIsSignificant = false;
         _servletRoot = null;
         _servletDefault = null;
     }
@@ -132,11 +135,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
      */
     public List<MappedResource<E>> getMatches(String path)
     {
-        boolean isRootPath = "/".equals(path);
-
         if (_mappings.isEmpty())
             return Collections.emptyList();
 
+        boolean isRootPath = "/".equals(path);
+
+        // Iterator over all the mapping, adding only those that match.
         List<MappedResource<E>> matches = null;
         for (MappedResource<E> mr : _mappings)
         {
@@ -171,33 +175,44 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         return matches == null ? Collections.emptyList() : matches;
     }
 
+    /**
+     * <p>Find the best single match for a path.</p>
+     * <p>The match may be found by optimized direct lookups when possible, otherwise all mappings
+     * are iterated over and the first match returned</p>
+     * @param path The path to match
+     * @return A {@link MatchedResource} instance or null if no mappings matched.
+     * @see #getMatchedIteratively(String)
+     */
     public MatchedResource<E> getMatched(String path)
     {
         if (_mappings.isEmpty())
             return null;
 
-        if (_nonServletPathSpecs)
-            return getMatchedMixed(path);
+        // If order is significant, then we need to match by iterating over all mappings.
+        if (_orderIsSignificant)
+            return getMatchedIteratively(path);
 
+        // Otherwise, we can try optimized matches against each group
+
+        // Try a root match
         if (_servletRoot != null && "/".equals(path))
-            return new MatchedResource<>(_servletRoot.getResource(), _servletRoot.getPathSpec(), _servletRoot.getPathSpec().matched(path));
+            return _servletRoot.getPreMatched();
 
-        MappedResource<E> candidate = _exactMap.getBest(path);
-        if (candidate != null)
+        // try an exact match
+        MappedResource<E> exact = _exactMap.get(path);
+        if (exact != null)
+            return exact.getPreMatched();
+
+        // Try a prefix match
+        MappedResource<E> prefix = _prefixMap.getBest(path);
+        if (prefix != null)
         {
-            MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+            MatchedPath matchedPath = prefix.getPathSpec().matched(path);
             if (matchedPath != null)
-                return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+                return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
         }
 
-        candidate = _prefixMap.getBest(path);
-        if (candidate != null)
-        {
-            MatchedPath matchedPath = candidate.getPathSpec().matched(path);
-            if (matchedPath != null)
-                return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
-        }
-
+        // Try a suffix match
         if (!_suffixMap.isEmpty())
         {
             int i = Math.max(0, path.lastIndexOf("/"));
@@ -208,13 +223,13 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
             //  Loop 3: "foo"
             while ((i = path.indexOf('.', i + 1)) > 0)
             {
-                candidate = _suffixMap.get(path, i + 1, path.length() - i - 1);
-                if (candidate == null)
+                prefix = _suffixMap.get(path, i + 1, path.length() - i - 1);
+                if (prefix == null)
                     continue;
 
-                MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+                MatchedPath matchedPath = prefix.getPathSpec().matched(path);
                 if (matchedPath != null)
-                    return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+                    return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
             }
         }
 
@@ -224,7 +239,13 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         return null;
     }
 
-    private MatchedResource<E> getMatchedMixed(String path)
+    /**
+     * <p>Iterate over all mappings, returning the first that matches.</p>
+     * @param path The path to match.
+     * @return A {@link MatchedResource} instance or null if no mappings matched.
+     * @see #getMatched(String)
+     */
+    private MatchedResource<E> getMatchedIteratively(String path)
     {
         MatchedPath matchedPath;
         PathSpecGroup lastGroup = null;
@@ -252,13 +273,9 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         if (_optimizedExact)
                         {
-                            MappedResource<E> candidate = _exactMap.getBest(path);
-                            if (candidate != null)
-                            {
-                                matchedPath = candidate.getPathSpec().matched(path);
-                                if (matchedPath != null)
-                                    return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
-                            }
+                            MappedResource<E> exact = _exactMap.get(path);
+                            if (exact != null)
+                                return exact.getPreMatched();
                             // If we reached here, there's NO optimized EXACT Match possible, skip simple match below
                             skipRestOfGroup = true;
                         }
@@ -387,7 +404,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example exact in Regex that can cause problems `^/a\Q/b\E/` (which is only ever matching `/a/b/`)
                         // Note: UriTemplate can handle exact easily enough
                         _optimizedExact = false;
-                        _nonServletPathSpecs = true;
+                        _orderIsSignificant = true;
                     }
                     break;
                 case PREFIX_GLOB:
@@ -404,7 +421,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example Prefix in Regex that can cause problems `^/a/b+` or `^/a/bb*` ('b' one or more times)
                         // Note: Example Prefix in UriTemplate that might cause problems `/a/{b}/{c}`
                         _optimizedPrefix = false;
-                        _nonServletPathSpecs = true;
+                        _orderIsSignificant = true;
                     }
                     break;
                 case SUFFIX_GLOB:
@@ -421,7 +438,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example suffix in Regex that can cause problems `^.*/path/name.ext` or `^/a/.*(ending)`
                         // Note: Example suffix in UriTemplate that can cause problems `/{a}/name.ext`
                         _optimizedSuffix = false;
-                        _nonServletPathSpecs = true;
+                        _orderIsSignificant = true;
                     }
                     break;
                 case ROOT:
@@ -432,7 +449,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     }
                     else
                     {
-                        _nonServletPathSpecs = true;
+                        _orderIsSignificant = true;
                     }
                     break;
                 case DEFAULT:
@@ -443,7 +460,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     }
                     else
                     {
-                        _nonServletPathSpecs = true;
+                        _orderIsSignificant = true;
                     }
                     break;
                 default:
@@ -482,7 +499,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _exactMap.remove(exact);
                         // Recalculate _optimizeExact
                         _optimizedExact = canBeOptimized(PathSpecGroup.EXACT);
-                        _nonServletPathSpecs = nonServletPathSpec();
+                        _orderIsSignificant = nonServletPathSpec();
                     }
                     break;
                 case PREFIX_GLOB:
@@ -492,7 +509,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _prefixMap.remove(prefix);
                         // Recalculate _optimizePrefix
                         _optimizedPrefix = canBeOptimized(PathSpecGroup.PREFIX_GLOB);
-                        _nonServletPathSpecs = nonServletPathSpec();
+                        _orderIsSignificant = nonServletPathSpec();
                     }
                     break;
                 case SUFFIX_GLOB:
@@ -502,7 +519,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _suffixMap.remove(suffix);
                         // Recalculate _optimizeSuffix
                         _optimizedSuffix = canBeOptimized(PathSpecGroup.SUFFIX_GLOB);
-                        _nonServletPathSpecs = nonServletPathSpec();
+                        _orderIsSignificant = nonServletPathSpec();
                     }
                     break;
                 case ROOT:
@@ -510,14 +527,14 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         .filter(mapping -> mapping.getPathSpec().getGroup() == PathSpecGroup.ROOT)
                         .filter(mapping -> mapping.getPathSpec() instanceof ServletPathSpec)
                         .findFirst().orElse(null);
-                    _nonServletPathSpecs = nonServletPathSpec();
+                    _orderIsSignificant = nonServletPathSpec();
                     break;
                 case DEFAULT:
                     _servletDefault = _mappings.stream()
                         .filter(mapping -> mapping.getPathSpec().getGroup() == PathSpecGroup.DEFAULT)
                         .filter(mapping -> mapping.getPathSpec() instanceof ServletPathSpec)
                         .findFirst().orElse(null);
-                    _nonServletPathSpecs = nonServletPathSpec();
+                    _orderIsSignificant = nonServletPathSpec();
                     break;
             }
         }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -200,7 +200,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
 
         if (!_suffixMap.isEmpty())
         {
-            int i = 0;
+            int i = Math.max(0, path.lastIndexOf("/"));
             // Loop through each suffix mark
             // Input is "/a.b.c.foo"
             //  Loop 1: "b.c.foo"

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http.pathmap;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -42,6 +43,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     private static final Logger LOG = LoggerFactory.getLogger(PathMappings.class);
     private final Set<MappedResource<E>> _mappings = new TreeSet<>(Comparator.comparing(MappedResource::getPathSpec));
 
+    private boolean _nonServletPathSpecs;
     private boolean _optimizedExact = true;
     private final Index.Mutable<MappedResource<E>> _exactMap = new Index.Builder<MappedResource<E>>()
         .caseSensitive(true)
@@ -57,6 +59,8 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         .caseSensitive(true)
         .mutable()
         .build();
+
+    private MappedResource<E> _servletRoot;
 
     @Override
     public String dump()
@@ -86,6 +90,11 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         _mappings.clear();
         _prefixMap.clear();
         _suffixMap.clear();
+        _optimizedExact = true;
+        _optimizedPrefix = true;
+        _optimizedSuffix = true;
+        _nonServletPathSpecs = false;
+        _servletRoot = null;
     }
 
     public void removeIf(Predicate<MappedResource<E>> predicate)
@@ -123,29 +132,94 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     {
         boolean isRootPath = "/".equals(path);
 
-        List<MappedResource<E>> ret = new ArrayList<>();
+        if (_mappings.isEmpty())
+            return Collections.emptyList();
+
+        List<MappedResource<E>> matches = null;
         for (MappedResource<E> mr : _mappings)
         {
             switch (mr.getPathSpec().getGroup())
             {
                 case ROOT:
                     if (isRootPath)
-                        ret.add(mr);
+                    {
+                        if (matches == null)
+                            matches = new ArrayList<>();
+                        matches.add(mr);
+                    }
                     break;
                 case DEFAULT:
                     if (isRootPath || mr.getPathSpec().matched(path) != null)
-                        ret.add(mr);
+                    {
+                        if (matches == null)
+                            matches = new ArrayList<>();
+                        matches.add(mr);
+                    }
                     break;
                 default:
                     if (mr.getPathSpec().matched(path) != null)
-                        ret.add(mr);
+                    {
+                        if (matches == null)
+                            matches = new ArrayList<>();
+                        matches.add(mr);
+                    }
                     break;
             }
         }
-        return ret;
+        return matches == null ? Collections.emptyList() : matches;
     }
 
     public MatchedResource<E> getMatched(String path)
+    {
+        if (_mappings.isEmpty())
+            return null;
+
+        if (_nonServletPathSpecs)
+            return getMatchedMixed(path);
+
+        if (_servletRoot != null && "/".equals(path))
+            return new MatchedResource<>(_servletRoot.getResource(), _servletRoot.getPathSpec(), _servletRoot.getPathSpec().matched(path));
+
+        MappedResource<E> candidate = _exactMap.getBest(path);
+        if (candidate != null)
+        {
+            MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+            if (matchedPath != null)
+                return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+        }
+
+        candidate = _prefixMap.getBest(path);
+        if (candidate != null)
+        {
+            MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+            if (matchedPath != null)
+                return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+        }
+
+        if (!_suffixMap.isEmpty())
+        {
+            int i = 0;
+            // Loop through each suffix mark
+            // Input is "/a.b.c.foo"
+            //  Loop 1: "b.c.foo"
+            //  Loop 2: "c.foo"
+            //  Loop 3: "foo"
+            while ((i = path.indexOf('.', i + 1)) > 0)
+            {
+                candidate = _suffixMap.get(path, i + 1, path.length() - i - 1);
+                if (candidate == null)
+                    continue;
+
+                MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+                if (matchedPath != null)
+                    return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+            }
+        }
+
+        return null;
+    }
+
+    private MatchedResource<E> getMatchedMixed(String path)
     {
         MatchedPath matchedPath;
         PathSpecGroup lastGroup = null;
@@ -173,18 +247,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         if (_optimizedExact)
                         {
-                            int i = path.length();
-                            while (i >= 0)
+                            MappedResource<E> candidate = _exactMap.getBest(path);
+                            if (candidate != null)
                             {
-                                MappedResource<E> candidate = _exactMap.getBest(path, 0, i--);
-                                if (candidate == null)
-                                    continue;
-
                                 matchedPath = candidate.getPathSpec().matched(path);
                                 if (matchedPath != null)
-                                {
                                     return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
-                                }
                             }
                             // If we reached here, there's NO optimized EXACT Match possible, skip simple match below
                             skipRestOfGroup = true;
@@ -196,17 +264,14 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                     {
                         if (_optimizedPrefix)
                         {
-                            int i = path.length();
-                            while (i >= 0)
+                            MappedResource<E> candidate = _prefixMap.getBest(path);
+                            if (candidate != null)
                             {
-                                MappedResource<E> candidate = _prefixMap.getBest(path, 0, i--);
-                                if (candidate == null)
-                                    continue;
-
                                 matchedPath = candidate.getPathSpec().matched(path);
                                 if (matchedPath != null)
                                     return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
                             }
+
                             // If we reached here, there's NO optimized PREFIX Match possible, skip simple match below
                             skipRestOfGroup = true;
                         }
@@ -317,6 +382,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example exact in Regex that can cause problems `^/a\Q/b\E/` (which is only ever matching `/a/b/`)
                         // Note: UriTemplate can handle exact easily enough
                         _optimizedExact = false;
+                        _nonServletPathSpecs = true;
                     }
                     break;
                 case PREFIX_GLOB:
@@ -333,6 +399,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example Prefix in Regex that can cause problems `^/a/b+` or `^/a/bb*` ('b' one or more times)
                         // Note: Example Prefix in UriTemplate that might cause problems `/a/{b}/{c}`
                         _optimizedPrefix = false;
+                        _nonServletPathSpecs = true;
                     }
                     break;
                 case SUFFIX_GLOB:
@@ -349,8 +416,22 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         // Note: Example suffix in Regex that can cause problems `^.*/path/name.ext` or `^/a/.*(ending)`
                         // Note: Example suffix in UriTemplate that can cause problems `/{a}/name.ext`
                         _optimizedSuffix = false;
+                        _nonServletPathSpecs = true;
                     }
                     break;
+
+                case ROOT:
+                    if (pathSpec instanceof ServletPathSpec)
+                    {
+                        if (_servletRoot == null)
+                            _servletRoot = entry;
+                    }
+                    else
+                    {
+                        _nonServletPathSpecs = true;
+                    }
+                    break;
+
                 default:
             }
         }
@@ -387,6 +468,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _exactMap.remove(exact);
                         // Recalculate _optimizeExact
                         _optimizedExact = canBeOptimized(PathSpecGroup.EXACT);
+                        _nonServletPathSpecs = nonServletPathSpec();
                     }
                     break;
                 case PREFIX_GLOB:
@@ -396,6 +478,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _prefixMap.remove(prefix);
                         // Recalculate _optimizePrefix
                         _optimizedPrefix = canBeOptimized(PathSpecGroup.PREFIX_GLOB);
+                        _nonServletPathSpecs = nonServletPathSpec();
                     }
                     break;
                 case SUFFIX_GLOB:
@@ -405,7 +488,16 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                         _suffixMap.remove(suffix);
                         // Recalculate _optimizeSuffix
                         _optimizedSuffix = canBeOptimized(PathSpecGroup.SUFFIX_GLOB);
+                        _nonServletPathSpecs = nonServletPathSpec();
                     }
+                    break;
+
+                case ROOT:
+                    _servletRoot = _mappings.stream()
+                        .filter(mapping -> mapping.getPathSpec().getGroup() == PathSpecGroup.ROOT)
+                        .filter(mapping -> mapping.getPathSpec() instanceof ServletPathSpec)
+                        .findFirst().orElse(null);
+                    _nonServletPathSpecs = nonServletPathSpec();
                     break;
             }
         }
@@ -417,6 +509,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
     {
         return _mappings.stream()
             .filter((mapping) -> mapping.getPathSpec().getGroup() == suffixGlob)
+            .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
+    }
+
+    private boolean nonServletPathSpec()
+    {
+        return _mappings.stream()
             .allMatch((mapping) -> mapping.getPathSpec() instanceof ServletPathSpec);
     }
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -471,4 +471,42 @@ public class PathMappingsTest
         assertThat(PathSpec.from("^.*"), instanceOf(RegexPathSpec.class));
         assertThat(PathSpec.from("^/"), instanceOf(RegexPathSpec.class));
     }
+
+    @Test
+    public void testOptimalExactIterative()
+    {
+        PathMappings<String> p = new PathMappings<>();
+        p.put(new ServletPathSpec(""), "resourceR");
+        p.put(new ServletPathSpec("/"), "resourceD");
+        p.put(new ServletPathSpec("/a/*"), "resourceP");
+        p.put(new ServletPathSpec("*.do"), "resourceS");
+
+        // Add an non-servlet Exact to avoid non iterative
+        RegexPathSpec regexPathSpec = new RegexPathSpec("^/some/exact$");
+        p.put(regexPathSpec, "someExact");
+
+        assertThat(p.getMatched("/").getResource(), equalTo("resourceR"));
+        assertThat(p.getMatched("/something").getResource(), equalTo("resourceD"));
+        assertThat(p.getMatched("/a").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/a/").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/a/info").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/foo.do").getResource(), equalTo("resourceS"));
+        assertThat(p.getMatched("/a/foo.do").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/b/foo.do").getResource(), equalTo("resourceS"));
+
+        // Make regex a prefix match to test iterative exact match code
+        p.remove(regexPathSpec);
+        regexPathSpec = new RegexPathSpec("/prefix/.*");
+        p.put(regexPathSpec, "somePrefix");
+
+        assertThat(p.getMatched("/").getResource(), equalTo("resourceR"));
+        assertThat(p.getMatched("/something").getResource(), equalTo("resourceD"));
+        assertThat(p.getMatched("/a").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/a/").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/a/info").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/foo.do").getResource(), equalTo("resourceS"));
+        assertThat(p.getMatched("/a/foo.do").getResource(), equalTo("resourceP"));
+        assertThat(p.getMatched("/b/foo.do").getResource(), equalTo("resourceS"));
+
+    }
 }

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -478,6 +478,7 @@ public class PathMappingsTest
         PathMappings<String> p = new PathMappings<>();
         p.put(new ServletPathSpec(""), "resourceR");
         p.put(new ServletPathSpec("/"), "resourceD");
+        p.put(new ServletPathSpec("/exact"), "resourceE");
         p.put(new ServletPathSpec("/a/*"), "resourceP");
         p.put(new ServletPathSpec("*.do"), "resourceS");
 
@@ -487,6 +488,7 @@ public class PathMappingsTest
 
         assertThat(p.getMatched("/").getResource(), equalTo("resourceR"));
         assertThat(p.getMatched("/something").getResource(), equalTo("resourceD"));
+        assertThat(p.getMatched("/exact").getResource(), equalTo("resourceE"));
         assertThat(p.getMatched("/a").getResource(), equalTo("resourceP"));
         assertThat(p.getMatched("/a/").getResource(), equalTo("resourceP"));
         assertThat(p.getMatched("/a/info").getResource(), equalTo("resourceP"));
@@ -501,6 +503,7 @@ public class PathMappingsTest
 
         assertThat(p.getMatched("/").getResource(), equalTo("resourceR"));
         assertThat(p.getMatched("/something").getResource(), equalTo("resourceD"));
+        assertThat(p.getMatched("/exact").getResource(), equalTo("resourceE"));
         assertThat(p.getMatched("/a").getResource(), equalTo("resourceP"));
         assertThat(p.getMatched("/a/").getResource(), equalTo("resourceP"));
         assertThat(p.getMatched("/a/info").getResource(), equalTo("resourceP"));

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -189,6 +189,9 @@ public class PathMappingsTest
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
         p.put(new ServletPathSpec("/\u20ACuro/*"), "11");
         // @checkstyle-enable-check : AvoidEscapedUnicodeCharactersCheck
+        p.put(new ServletPathSpec("/prefix"), "12");
+        p.put(new ServletPathSpec("/prefix/"), "13");
+        p.put(new ServletPathSpec("/prefix/*"), "14");
 
         p.put(new ServletPathSpec("/*"), "0");
 
@@ -209,6 +212,10 @@ public class PathMappingsTest
         assertEquals("0", p.getMatched("/suffix/path.tar.gz").getResource(), "Match longest suffix");
         assertEquals("0", p.getMatched("/suffix/path.gz").getResource(), "Match longest suffix");
         assertEquals("5", p.getMatched("/animal/path.gz").getResource(), "prefix rather than suffix");
+
+        assertEquals("12", p.getMatched("/prefix").getResource());
+        assertEquals("13", p.getMatched("/prefix/").getResource());
+        assertEquals("14", p.getMatched("/prefix/info").getResource());
 
         assertEquals("0", p.getMatched("/Other/path").getResource(), "default");
 

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
@@ -157,10 +157,9 @@ public class IncludeExcludeSet<T, P> implements Predicate<P>
     @Override
     public boolean test(P t)
     {
-        // return true IFF the passed object is not in the excluded set AND
-        //  either the included set is empty OR the object is in the included set
-        return (_excludes.isEmpty() || !_excludePredicate.test(t)) &&
-            (_includes.isEmpty() || _includePredicate.test(t));
+        if (!_includes.isEmpty() && !_includePredicate.test(t))
+            return false;
+        return !_excludePredicate.test(t);
     }
 
     /**

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java
@@ -157,9 +157,10 @@ public class IncludeExcludeSet<T, P> implements Predicate<P>
     @Override
     public boolean test(P t)
     {
-        if (!_includes.isEmpty() && !_includePredicate.test(t))
-            return false;
-        return !_excludePredicate.test(t);
+        // return true IFF the passed object is not in the excluded set AND
+        //  either the included set is empty OR the object is in the included set
+        return (_excludes.isEmpty() || !_excludePredicate.test(t)) &&
+            (_includes.isEmpty() || _includePredicate.test(t));
     }
 
     /**


### PR DESCRIPTION
Avoid iterations if only ServletPathSpec instances
Avoid tests for empty mappings.
Better reset implementation
