### PR TITLE
Jetty 12.0.x ee10 convert cookie

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -48,7 +48,7 @@ public class CookieCache
             @Override
             protected void addCookie(String cookieName, String cookieValue, String cookieDomain, String cookiePath, int cookieVersion, String cookieComment)
             {
-                _cookieList.add(new HttpCookie(cookieName, cookieValue));
+                _cookieList.add(new HttpCookie(cookieName, cookieValue, cookieDomain, cookiePath, -1, false, false, cookieComment, cookieVersion));
             }
         };
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
@@ -171,6 +171,21 @@ public abstract class CookieCutter
                                                 case "$version" -> cookieVersion = Integer.parseInt(value);
                                             }
                                         }
+                                        else if (CookieCompliance.RFC6265.equals(_complianceMode))
+                                        {
+                                            //$ prefixed names are treated as separate cookies, so add the completed last cookie if we have one
+                                            //and start a new cookie
+                                            if (cookieName != null)
+                                            {
+                                                if (!reject)
+                                                    addCookie(cookieName, cookieValue, cookieDomain, cookiePath, cookieVersion, cookieComment);
+                                                cookieDomain = null;
+                                                cookiePath = null;
+                                                cookieComment = null;
+                                            }
+                                            cookieName = name;
+                                            cookieValue = value;
+                                        }
                                     }
                                     else
                                     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -367,12 +367,8 @@ public class HttpCookie
             else
                 DateGenerator.formatCookieDate(buf, System.currentTimeMillis() + 1000L * _maxAge);
 
-            // for v1 cookies, also send max-age
-            if (version >= 1)
-            {
-                buf.append(";Max-Age=");
-                buf.append(_maxAge);
-            }
+            buf.append(";Max-Age=");
+            buf.append(_maxAge);
         }
 
         // add the other fields

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterLenientTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterLenientTest.java
@@ -86,7 +86,7 @@ public class CookieCutterLenientTest
             Arguments.of("abc=\"#hash\"", Collections.singletonMap("abc", "#hash")),
             // RFC2109 - other valid name types that conform to 'attr'/'token' syntax
             Arguments.of("!f!o!o!=wat", Collections.singletonMap("!f!o!o!", "wat")),
-            Arguments.of("__MyHost=Foo", Collections.singletonMap( "__MyHost", "Foo")),
+            Arguments.of("__MyHost=Foo", Collections.singletonMap("__MyHost", "Foo")),
             Arguments.of("some-thing-else=to-parse", Collections.singletonMap("some-thing-else", "to-parse")),
             // RFC2109 - names with attr/token syntax starting with '$' (and not a cookie reserved word)
             // See https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00#section-5.2

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
@@ -146,9 +146,11 @@ public class CookieCutterTest
         assertCookie("Cookies[1]", cookies[1], "session_id", "1111", 1, null);
 
         cookies = parseCookieHeaders(CookieCompliance.RFC6265, rawCookie);
-        assertThat("Cookies.length", cookies.length, is(2));
-        assertCookie("Cookies[0]", cookies[0], "session_id", "1234\", $Version=\"1", 0, null);
-        assertCookie("Cookies[1]", cookies[1], "session_id", "1111", 0, null);
+        assertThat("Cookies.length", cookies.length, is(4));
+        assertCookie("Cookies[0]", cookies[0], "$Version", "1", 0, null);
+        assertCookie("Cookies[0]", cookies[1], "session_id", "1234\", $Version=\"1", 0, null);
+        assertCookie("Cookies[1]", cookies[2], "session_id", "1111", 0, null);
+        assertCookie("Cookies[2]", cookies[3], "$Domain", ".cracker.edu", 0, null);
     }
 
     /**

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
@@ -206,7 +206,7 @@ public class CookieCutterTest
 
         Cookie[] cookies = parseCookieHeaders(CookieCompliance.RFC6265, rawCookie);
 
-        assertThat("Cookies.length", cookies.length, is(0));
+        assertThat("Cookies.length", cookies.length, is(1));
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -58,6 +58,7 @@ import jakarta.servlet.http.PushBuilder;
 import org.eclipse.jetty.ee10.servlet.security.Authentication;
 import org.eclipse.jetty.ee10.servlet.security.UserIdentity;
 import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -491,13 +492,12 @@ public class ServletContextRequest extends ContextRequest
         public Cookie convertCookie(HttpCookie cookie)
         {
             Cookie result = new Cookie(cookie.getName(), cookie.getValue());
-            // TODO: inbound (client-to-server) cookies don't have all these parameters.
-//            result.setPath(cookie.getPath());
-//            result.setDomain(cookie.getDomain());
-//            result.setSecure(cookie.isSecure());
-//            result.setHttpOnly(cookie.isHttpOnly());
-//            result.setMaxAge((int)cookie.getMaxAge());
-            // TODO: sameSite?
+            //RFC2965 defines the cookie header as supporting path and domain but RFC6265 permits only name=value
+            if (CookieCompliance.RFC2965.equals(getRequest().getConnectionMetaData().getHttpConfiguration().getRequestCookieCompliance()))
+            {
+                result.setPath(cookie.getPath());
+                result.setDomain(cookie.getDomain());
+            }
             return result;
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -483,8 +483,11 @@ public class ServletContextRequest extends ContextRequest
         @Override
         public Cookie[] getCookies()
         {
+            List<HttpCookie> httpCookies = Request.getCookies(getRequest());
+            if (httpCookies.isEmpty())
+                return null;
             // TODO: optimize this.
-            return Request.getCookies(getRequest()).stream()
+            return httpCookies.stream()
                 .map(this::convertCookie)
                 .toArray(Cookie[]::new);
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -486,7 +486,6 @@ public class ServletContextRequest extends ContextRequest
             List<HttpCookie> httpCookies = Request.getCookies(getRequest());
             if (httpCookies.isEmpty())
                 return null;
-            // TODO: optimize this.
             return httpCookies.stream()
                 .map(this::convertCookie)
                 .toArray(Cookie[]::new);


### PR DESCRIPTION
Fix a number of ee10 cookie parsing issues, and also ensure  `ServletContextRequest.getCookies()` implements spec of returning `null` for no cookies rather than empty list.

Fixes these tck tests:
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java.getDomainTest
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java.getPathTest
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java.setMaxAgeZeroTest
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest/URLClient.java.getCookiesNoCookiesTest
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java.getDomainTest
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java.getPathTest
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java.setMaxAgeZeroTest
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/httpservletrequest/URLClient.java.getCookiesNoCookiesTest