### PR TITLE
Async not supported without wrappers

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -345,6 +345,7 @@ public class ServletContextRequest extends ContextRequest
         private String _method;
         private ServletMultiPartFormData.Parts _parts;
         private ServletPathMapping _servletPathMapping;
+        private boolean _asyncSupported = true;
 
         public static Session getSession(HttpSession httpSession)
         {
@@ -1362,6 +1363,8 @@ public class ServletContextRequest extends ContextRequest
         @Override
         public AsyncContext startAsync() throws IllegalStateException
         {
+            if (!isAsyncSupported())
+                throw new IllegalStateException("Async Not Supported");
             ServletRequestState state = getState();
             if (_async == null)
                 _async = new AsyncContextState(state);
@@ -1374,6 +1377,8 @@ public class ServletContextRequest extends ContextRequest
         @Override
         public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException
         {
+            if (!isAsyncSupported())
+                throw new IllegalStateException("Async Not Supported");
             ServletRequestState state = getState();
             if (_async == null)
                 _async = new AsyncContextState(state);
@@ -1398,7 +1403,12 @@ public class ServletContextRequest extends ContextRequest
         @Override
         public boolean isAsyncSupported()
         {
-            return true;
+            return _asyncSupported;
+        }
+
+        public void setAsyncSupported(boolean asyncSupported)
+        {
+            _asyncSupported = asyncSupported;
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.atomic.AtomicLong;
 
-import jakarta.servlet.AsyncContext;
 import jakarta.servlet.GenericServlet;
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.Servlet;
@@ -39,12 +38,9 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletRequestWrapper;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.ServletSecurityElement;
 import jakarta.servlet.UnavailableException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee10.servlet.security.IdentityService;
 import org.eclipse.jetty.ee10.servlet.security.RunAsToken;
@@ -1376,49 +1372,24 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
         }
 
         @Override
-        public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException
+        public void service(ServletRequest request, ServletResponse response) throws ServletException, IOException
         {
-            if (req.isAsyncSupported())
+            if (request.isAsyncSupported())
             {
-                if (req instanceof HttpServletRequest httpServletRequest)
+                ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
+                servletContextRequest.getServletApiRequest().setAsyncSupported(false);
+                try
                 {
-                    getWrapped().service(new HttpServletRequestWrapper(httpServletRequest)
-                    {
-                        @Override
-                        public boolean isAsyncSupported()
-                        {
-                            return false;
-                        }
-
-                        @Override
-                        public AsyncContext startAsync() throws IllegalStateException
-                        {
-                            throw new IllegalStateException("Async Not Supported");
-                        }
-                    }, res);
+                    getWrapped().service(request, response);
                 }
-                else
+                finally
                 {
-                    //TODO is this necessary to support?
-                    getWrapped().service(new ServletRequestWrapper(req)
-                    {
-                        @Override
-                        public boolean isAsyncSupported()
-                        {
-                            return false;
-                        }
-
-                        @Override
-                        public AsyncContext startAsync() throws IllegalStateException
-                        {
-                            throw new IllegalStateException("Async Not Supported");
-                        }
-                    }, res);
+                    servletContextRequest.getServletApiRequest().setAsyncSupported(true);
                 }
             }
             else
             {
-                getWrapped().service(req, res);
+                getWrapped().service(request, response);
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
@@ -182,7 +182,6 @@ public class AsyncServletTest
         assertThat(response, Matchers.startsWith("HTTP/1.1 200 OK"));
         assertThat(_history, contains(
             "REQUEST /ctx/noasync/info",
-            "wrapped REQ",
             "initial"
         ));
 
@@ -199,7 +198,6 @@ public class AsyncServletTest
             assertThat(response, Matchers.startsWith("HTTP/1.1 500 "));
             assertThat(_history, contains(
                 "REQUEST /ctx/noasync/info?start=200",
-                "wrapped REQ",
                 "initial",
                 "ERROR /ctx/error/custom?start=200",
                 "wrapped REQ",


### PR DESCRIPTION
Avoid using wrappers in the filter doChain.

See https://github.com/jakartaee/servlet/issues/492