### PR TITLE
Improve DatastoreEmulatorContainer usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
-    <testcontainers.version>1.17.5</testcontainers.version>
+    <testcontainers.version>1.17.6</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
     <wildfly.elytron.version>2.0.0.Final</wildfly.elytron.version>

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.DatastoreEmulatorContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -36,29 +35,11 @@ public class GCloudSessionDistributionTests extends AbstractSessionDistributionT
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.tests.distribution.session.gcloudLogs");
 
     public DatastoreEmulatorContainer emulator =
-            new CustomDatastoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"))
-                    .withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG));
-
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk");
-
-    private static final String CMD = "gcloud beta emulators datastore start --project test-project --host-port 0.0.0.0:8081 --consistency=1.0";
-    private static final int HTTP_PORT = 8081;
+            new DatastoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"))
+                    .withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
+                    .withFlags("--consistency=1.0");
 
     String host;
-
-    public static class CustomDatastoreEmulatorContainer extends DatastoreEmulatorContainer
-    {
-        public CustomDatastoreEmulatorContainer(DockerImageName dockerImageName)
-        {
-            super(dockerImageName);
-
-            dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-
-            withExposedPorts(HTTP_PORT);
-            setWaitStrategy(Wait.forHttp("/").forStatusCode(200));
-            withCommand("/bin/sh", "-c", CMD);
-        }
-    }
 
     @Override
     public void startExternalSessionStorage() throws Exception

--- a/tests/test-sessions/test-gcloud-sessions/src/test/java/org/eclipse/jetty/gcloud/session/GCloudSessionTestSupport.java
+++ b/tests/test-sessions/test-gcloud-sessions/src/test/java/org/eclipse/jetty/gcloud/session/GCloudSessionTestSupport.java
@@ -65,28 +65,10 @@ public class GCloudSessionTestSupport
     private static final Logger LOGGER = LoggerFactory.getLogger(GCloudSessionTestSupport.class);
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.gcloud.session.gcloudLogs");
 
-    public DatastoreEmulatorContainer emulator = new CustomDatastoreEmulatorContainer(
+    public DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
         DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators")
-    ).withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG));
-
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk");
-
-    private static final String CMD = "gcloud beta emulators datastore start --project test-project --host-port 0.0.0.0:8081 --consistency=1.0";
-    private static final int HTTP_PORT = 8081;
-
-    public static class CustomDatastoreEmulatorContainer extends DatastoreEmulatorContainer
-    {
-        public CustomDatastoreEmulatorContainer(DockerImageName dockerImageName)
-        {
-            super(dockerImageName);
-
-            dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-
-            withExposedPorts(HTTP_PORT);
-            setWaitStrategy(Wait.forHttp("/").forStatusCode(200));
-            withCommand("/bin/sh", "-c", CMD);
-        }
-    }
+    ).withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
+            .withFlags("--consistency=1.0");
 
     public static class TestGCloudSessionDataStoreFactory extends GCloudSessionDataStoreFactory
     {

--- a/tests/test-sessions/test-gcloud-sessions/src/test/java/org/eclipse/jetty/gcloud/session/GCloudSessionTestSupport.java
+++ b/tests/test-sessions/test-gcloud-sessions/src/test/java/org/eclipse/jetty/gcloud/session/GCloudSessionTestSupport.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.DatastoreEmulatorContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Update to testcontainers 1.17.6 and take advantage of
`DatastoreEmulatorContainer#withFlags()`
