### PR TITLE
jetty 12.0.x cleanup duplicate osgi pom metadata

### DIFF
--- a/jetty-core/jetty-osgi/pom.xml
+++ b/jetty-core/jetty-osgi/pom.xml
@@ -13,19 +13,6 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.osgi</bundle-symbolic-name>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.osgi.*</spotbugs.onlyAnalyze>
-    <osgi-version>3.18.100</osgi-version>
-    <osgi-services-version>3.11.0</osgi-services-version>
-    <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
-    <osgi-service-component-version>1.5.0</osgi-service-component-version>
-    <osgi-service-event-version>1.4.1</osgi-service-event-version>
-    <osgi-util-version>3.7.100</osgi-util-version>
-    <osgi-util-function-version>1.2.0</osgi-util-function-version>
-    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
-    <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
-    <osgi-util-position-version>1.0.1</osgi-util-position-version>
-    <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
-    <osgi-util-xml-version>1.0.2</osgi-util-xml-version>
-    <equinox-http-servlet-version>1.0.0-v20070606</equinox-http-servlet-version>
     <jacoco.skip>true</jacoco.skip>
   </properties>
 
@@ -53,58 +40,6 @@
       </plugin>
     </plugins>
   </build>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi.services</artifactId>
-        <version>${osgi-services-version}</version>
-        <exclusions>
-          <exclusion>
-            <!-- we use the servlet jar from orbit -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- cannot override core java classes with Java 9+ -->
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.foundation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi</artifactId>
-        <version>${osgi-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.cm</artifactId>
-        <version>${osgi-service-cm-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.component</artifactId>
-        <version>${osgi-service-component-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.event</artifactId>
-        <version>${osgi-service-event-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.util.tracker</artifactId>
-        <version>${osgi-util-tracker-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.equinox.http</groupId>
-        <artifactId>servlet</artifactId>
-        <version>${equinox-http-servlet-version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -139,7 +74,6 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.tracker</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
@@ -20,7 +20,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee10.osgi</groupId>
       <artifactId>jetty-ee10-osgi-boot</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -54,11 +53,11 @@
               <id>set-jsp-api-version</id>
               <phase>validate</phase>
               <goals>
-                  <goal>parse-version</goal>
+                <goal>parse-version</goal>
               </goals>
               <configuration>
-                  <versionString>${jsp.impl.version}</versionString>
-                  <propertyPrefix>jspImpl</propertyPrefix>
+                <versionString>${jsp.impl.version}</versionString>
+                <propertyPrefix>jspImpl</propertyPrefix>
               </configuration>
           </execution>
         </executions>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-warurl/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-warurl/pom.xml
@@ -1,9 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-osgi-boot-warurl</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
@@ -16,22 +16,18 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-annotations</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-webapp</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-osgi</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -67,22 +67,6 @@
         </excludes>
       </resource>
     </resources>
-    <plugins>
-      <!-- is it really used?? this plugiin has been abandonned and no version since 2012... -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <manifest>prevent/overwriting/by/pointing/to/nonexisting/MANIFEST.MF</manifest>
-          <pde>true</pde>
-          <downloadSources>true</downloadSources>
-          <sourceExcludes>
-            <sourceExclude>**/.svn/**</sourceExclude>
-          </sourceExcludes>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -7,7 +7,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-  <artifactId>jetty-ee10-osgi-project</artifactId>
+  <artifactId>jetty-ee10-osgi</artifactId>
   <name>EE10 :: Jetty :: OSGi</name>
   <packaging>pom</packaging>
 
@@ -67,9 +67,11 @@
       </resource>
     </resources>
     <plugins>
+      <!-- is it really used?? this plugiin has been abandonned and no version since 2012... -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.9</version>
         <configuration>
           <manifest>prevent/overwriting/by/pointing/to/nonexisting/MANIFEST.MF</manifest>
           <pde>true</pde>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -12,19 +12,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <osgi-version>3.18.100</osgi-version>
-    <osgi-services-version>3.11.0</osgi-services-version>
-    <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
-    <osgi-service-component-version>1.5.0</osgi-service-component-version>
-    <osgi-service-event-version>1.4.1</osgi-service-event-version>
-    <osgi-util-version>3.7.100</osgi-util-version>
-    <osgi-util-function-version>1.2.0</osgi-util-function-version>
-    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
-    <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
-    <osgi-util-position-version>1.0.1</osgi-util-position-version>
-    <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
-    <osgi-util-xml-version>1.0.2</osgi-util-xml-version>
-    <equinox-http-servlet-version>1.0.0-v20070606</equinox-http-servlet-version>
     <jacoco.skip>true</jacoco.skip>
   </properties>
 
@@ -37,6 +24,21 @@
     <module>test-jetty-ee10-osgi-server</module>
     <module>test-jetty-ee10-osgi</module>
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.osgi</groupId>
+        <artifactId>jetty-ee10-osgi-boot</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.osgi</groupId>
+        <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <resources>
@@ -82,57 +84,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi.services</artifactId>
-        <version>${osgi-services-version}</version>
-        <exclusions>
-          <exclusion>
-            <!-- we use the servlet jar from orbit -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- cannot override core java classes with Java 9+ -->
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.foundation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi</artifactId>
-        <version>${osgi-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.cm</artifactId>
-        <version>${osgi-service-cm-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.component</artifactId>
-        <version>${osgi-service-component-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.event</artifactId>
-        <version>${osgi-service-event-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.util.tracker</artifactId>
-        <version>${osgi-util-tracker-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.equinox.http</groupId>
-        <artifactId>servlet</artifactId>
-        <version>${equinox-http-servlet-version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
 </project>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <osgi-version>3.18.100</osgi-version>
-    <osgi-annotation-version>8.1.0</osgi-annotation-version>
     <osgi-services-version>3.11.0</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>
@@ -132,11 +131,6 @@
         <groupId>org.eclipse.equinox.http</groupId>
         <artifactId>servlet</artifactId>
         <version>${equinox-http-servlet-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>osgi.annotation</artifactId>
-        <version>${osgi-annotation-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
@@ -1,9 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-fragment</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -16,26 +16,26 @@
   </properties>
   <build>
     <plugins>
-       <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-resources</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${basedir}/target/classes</outputDirectory>
-                  <resources>
-                    <resource>
-                        <directory>src/main/resources</directory>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes</outputDirectory>
+              <resources>
+                <resource>
+                    <directory>src/main/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -1,9 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
-    <artifactId>jetty-ee10-osgi-project</artifactId>
+    <artifactId>jetty-ee10-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -12,12 +12,6 @@
     <bundle-symbolic-name>${project.groupId}.boot.test.osgi</bundle-symbolic-name>
     <jetty-orbit-url>https://download.eclipse.org/jetty/orbit/</jetty-orbit-url>
     <assembly-directory>target/distribution</assembly-directory>
-    <pax.exam.version>4.13.1</pax.exam.version>
-    <pax.url.version>2.6.2</pax.url.version>
-    <swissbox.version>1.8.3</swissbox.version>
-    <tinybundles.version>3.0.0</tinybundles.version>
-    <spifly.version>1.3.6</spifly.version>
-    <injection.bundle.version>1.2</injection.bundle.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
   <dependencies>
@@ -25,20 +19,17 @@
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-inject</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Use the forked container so we can pass it system properties eg for alpn -->
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-container-forked</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -54,12 +45,10 @@
     <dependency>
       <groupId>org.ops4j.pax.tinybundles</groupId>
       <artifactId>tinybundles</artifactId>
-      <version>${tinybundles.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.swissbox</groupId>
       <artifactId>pax-swissbox-framework</artifactId>
-      <version>${swissbox.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -71,31 +60,26 @@
     <dependency>
       <groupId>org.ops4j.pax.swissbox</groupId>
       <artifactId>pax-swissbox-tracker</artifactId>
-      <version>${swissbox.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-junit4</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-aether</artifactId>
-      <version>${pax.url.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-wrap</artifactId>
-      <version>${pax.url.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -127,37 +111,31 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi.util</artifactId>
-      <version>${osgi-util-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-atinject_1.0_spec</artifactId>
-      <version>1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.promise</artifactId>
-      <version>${osgi-util-promise-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.measurement</artifactId>
-      <version>${osgi-util-measurement-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.position</artifactId>
-      <version>${osgi-util-position-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.xml</artifactId>
-      <version>${osgi-util-xml-version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Jetty OSGi Deps -->
@@ -181,7 +159,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee10.osgi</groupId>
       <artifactId>jetty-ee10-osgi-boot</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -197,7 +174,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee10.osgi</groupId>
       <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -242,7 +218,6 @@
     <dependency>
       <groupId>org.apache.aries.spifly</groupId>
       <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-      <version>${spifly.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -385,7 +360,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-server</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -461,72 +435,60 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-analysis</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-client-transport</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-conscrypt-server</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-conscrypt-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.conscrypt</groupId>
       <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${conscrypt.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-java-server</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-java-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -607,7 +569,7 @@
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
-            </execution>
+          </execution>
         </executions>
         <configuration>
           <includeArtifactIds>test-jetty-ee10-osgi-webapp-resources</includeArtifactIds>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
@@ -20,7 +20,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee9.osgi</groupId>
       <artifactId>jetty-ee9-osgi-boot</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -57,8 +57,8 @@
                   <goal>parse-version</goal>
               </goals>
               <configuration>
-                  <versionString>${jsp.impl.version}</versionString>
-                  <propertyPrefix>jspImpl</propertyPrefix>
+                <versionString>${jsp.impl.version}</versionString>
+                <propertyPrefix>jspImpl</propertyPrefix>
               </configuration>
           </execution>
         </executions>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
@@ -16,22 +16,18 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-annotations</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-webapp</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-osgi</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -66,21 +66,5 @@
         </excludes>
       </resource>
     </resources>
-    <plugins>
-      <!-- is it really used?? this plugiin has been abandonned and no version since 2012... -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <manifest>prevent/overwriting/by/pointing/to/nonexisting/MANIFEST.MF</manifest>
-          <pde>true</pde>
-          <downloadSources>true</downloadSources>
-          <sourceExcludes>
-            <sourceExclude>**/.svn/**</sourceExclude>
-          </sourceExcludes>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -7,7 +7,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-  <artifactId>jetty-ee9-osgi-project</artifactId>
+  <artifactId>jetty-ee9-osgi</artifactId>
   <name>EE9 :: Jetty :: OSGi</name>
   <packaging>pom</packaging>
 
@@ -66,9 +66,11 @@
       </resource>
     </resources>
     <plugins>
+      <!-- is it really used?? this plugiin has been abandonned and no version since 2012... -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.9</version>
         <configuration>
           <manifest>prevent/overwriting/by/pointing/to/nonexisting/MANIFEST.MF</manifest>
           <pde>true</pde>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -12,20 +12,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <osgi-annotation-version>8.1.0</osgi-annotation-version>
-    <osgi-version>3.18.200</osgi-version>
-    <osgi-services-version>3.11.100</osgi-services-version>
-    <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
-    <osgi-service-component-version>1.5.0</osgi-service-component-version>
-    <osgi-service-event-version>1.4.1</osgi-service-event-version>
-    <osgi-util-version>3.7.100</osgi-util-version>
-    <osgi-util-function-version>1.2.0</osgi-util-function-version>
-    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
-    <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
-    <osgi-util-position-version>1.0.1</osgi-util-position-version>
-    <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
-    <osgi-util-xml-version>1.0.2</osgi-util-xml-version>
-    <equinox-http-servlet-version>1.0.0-v20070606</equinox-http-servlet-version>
     <jacoco.skip>true</jacoco.skip>
   </properties>
 
@@ -37,6 +23,21 @@
     <module>test-jetty-ee9-osgi-server</module>
     <module>test-jetty-ee9-osgi</module>
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee9.osgi</groupId>
+        <artifactId>jetty-ee9-osgi-boot</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee9.osgi</groupId>
+        <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <resources>
@@ -82,62 +83,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi.services</artifactId>
-        <version>${osgi-services-version}</version>
-        <exclusions>
-          <exclusion>
-            <!-- we use the servlet jar from orbit -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- cannot override core java classes with Java 9+ -->
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.foundation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi</artifactId>
-        <version>${osgi-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.cm</artifactId>
-        <version>${osgi-service-cm-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.component</artifactId>
-        <version>${osgi-service-component-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.event</artifactId>
-        <version>${osgi-service-event-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.util.tracker</artifactId>
-        <version>${osgi-util-tracker-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.equinox.http</groupId>
-        <artifactId>servlet</artifactId>
-        <version>${equinox-http-servlet-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>osgi.annotation</artifactId>
-        <version>${osgi-annotation-version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
 </project>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
@@ -1,9 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-fragment</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -30,7 +30,7 @@
               <outputDirectory>${basedir}/target/classes</outputDirectory>
               <resources>
                 <resource>
-                    <directory>src/main/resources</directory>
+                  <directory>src/main/resources</directory>
                 </resource>
               </resources>
             </configuration>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -1,9 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
-    <artifactId>jetty-ee9-osgi-project</artifactId>
+    <artifactId>jetty-ee9-osgi</artifactId>
     <version>12.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -12,12 +12,6 @@
     <bundle-symbolic-name>${project.groupId}.boot.test.osgi</bundle-symbolic-name>
     <jetty-orbit-url>https://download.eclipse.org/jetty/orbit/</jetty-orbit-url>
     <assembly-directory>target/distribution</assembly-directory>
-    <pax.exam.version>4.13.1</pax.exam.version>
-    <pax.url.version>2.6.2</pax.url.version>
-    <swissbox.version>1.8.3</swissbox.version>
-    <tinybundles.version>3.0.0</tinybundles.version>
-    <spifly.version>1.3.6</spifly.version>
-    <injection.bundle.version>1.2</injection.bundle.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
   <dependencies>
@@ -25,20 +19,17 @@
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-inject</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Use the forked container so we can pass it system properties eg for alpn -->
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-container-forked</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -54,12 +45,10 @@
     <dependency>
       <groupId>org.ops4j.pax.tinybundles</groupId>
       <artifactId>tinybundles</artifactId>
-      <version>${tinybundles.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.swissbox</groupId>
       <artifactId>pax-swissbox-framework</artifactId>
-      <version>${swissbox.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -71,31 +60,26 @@
     <dependency>
       <groupId>org.ops4j.pax.swissbox</groupId>
       <artifactId>pax-swissbox-tracker</artifactId>
-      <version>${swissbox.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-junit4</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-aether</artifactId>
-      <version>${pax.url.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-wrap</artifactId>
-      <version>${pax.url.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -127,37 +111,31 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi.util</artifactId>
-      <version>${osgi-util-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-atinject_1.0_spec</artifactId>
-      <version>1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.promise</artifactId>
-      <version>${osgi-util-promise-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.measurement</artifactId>
-      <version>${osgi-util-measurement-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.position</artifactId>
-      <version>${osgi-util-position-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.xml</artifactId>
-      <version>${osgi-util-xml-version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Jetty OSGi Deps -->
@@ -181,7 +159,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee9.osgi</groupId>
       <artifactId>jetty-ee9-osgi-boot</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -197,7 +174,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee9.osgi</groupId>
       <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -242,7 +218,6 @@
     <dependency>
       <groupId>org.apache.aries.spifly</groupId>
       <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-      <version>${spifly.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -460,72 +435,60 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-analysis</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
       <scope>test</scope>
-      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-client-transport</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-conscrypt-server</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-conscrypt-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.conscrypt</groupId>
       <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${conscrypt.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-java-server</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-java-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,32 @@
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>
     <org.osgi.util.promise.version>1.2.0</org.osgi.util.promise.version>
+
+    <osgi-version>3.18.200</osgi-version>
+    <!-- really used -->
+    <osgi-annotation-version>8.1.0</osgi-annotation-version>
+    <osgi-services-version>3.11.100</osgi-services-version>
+    <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
+    <osgi-service-component-version>1.5.0</osgi-service-component-version>
+    <osgi-service-event-version>1.4.1</osgi-service-event-version>
+    <osgi-util-version>3.7.100</osgi-util-version>
+    <osgi-util-function-version>1.2.0</osgi-util-function-version>
+    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
+    <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
+    <osgi-util-position-version>1.0.1</osgi-util-position-version>
+    <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
+    <osgi-util-xml-version>1.0.2</osgi-util-xml-version>
+    <equinox-http-servlet-version>1.0.0-v20070606</equinox-http-servlet-version>
+    <pax.exam.version>4.13.1</pax.exam.version>
+    <pax.url.version>2.6.2</pax.url.version>
+    <swissbox.version>1.8.3</swissbox.version>
+    <tinybundles.version>3.0.0</tinybundles.version>
+    <injection.bundle.version>1.2</injection.bundle.version>
+
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>3.5.0</plexus-utils.version>
     <slf4j.version>2.0.5</slf4j.version>
+    <spifly.version>1.3.6</spifly.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
@@ -272,12 +295,12 @@
                   <message>[ERROR] OLD JDK [${java.version}] in use. Jetty ${project.version} requires JDK 17 or newer</message>
                 </requireJavaVersion>
                 <versionTxtRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.VersionTxtRule" />
-		<versionOsgiRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireOsgiCompatibleVersionRule" />
-		<!-- do not support alphax as a version number -->
-	        <!--
-                <versionRedhatRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireRedhatCompatibleVersionRule" />
-		<versionDebianRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireDebianCompatibleVersionRule" />
-		-->
+		            <versionOsgiRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireOsgiCompatibleVersionRule" />
+                <!-- do not support alphax as a version number -->
+                      <!--
+                            <versionRedhatRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireRedhatCompatibleVersionRule" />
+                <versionDebianRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireDebianCompatibleVersionRule" />
+                -->
                 <requireUpperBoundDeps/>
               </rules>
             </configuration>
@@ -1059,6 +1082,11 @@
         <version>${ant.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.aries.spifly</groupId>
+        <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+        <version>${spifly.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
@@ -1067,6 +1095,11 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>org.apache.felix.framework</artifactId>
         <version>${felix.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-atinject_1.0_spec</artifactId>
+        <version>${injection.bundle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.kerby</groupId>
@@ -1537,6 +1570,88 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.osgi.services</artifactId>
+        <version>${osgi-services-version}</version>
+        <exclusions>
+          <exclusion>
+            <!-- we use the servlet jar from orbit -->
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <!-- cannot override core java classes with Java 9+ -->
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.foundation</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.osgi</artifactId>
+        <version>${osgi-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.osgi.util</artifactId>
+        <version>${osgi-util-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.cm</artifactId>
+        <version>${osgi-service-cm-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>osgi.annotation</artifactId>
+        <version>${osgi-annotation-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.component</artifactId>
+        <version>${osgi-service-component-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.event</artifactId>
+        <version>${osgi-service-event-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.tracker</artifactId>
+        <version>${osgi-util-tracker-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.promise</artifactId>
+        <version>${osgi-util-promise-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.measurement</artifactId>
+        <version>${osgi-util-measurement-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.position</artifactId>
+        <version>${osgi-util-position-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.xml</artifactId>
+        <version>${osgi-util-xml-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.equinox.http</groupId>
+        <artifactId>servlet</artifactId>
+        <version>${equinox-http-servlet-version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
         <version>${hamcrest.version}</version>
@@ -1602,6 +1717,59 @@
         <artifactId>jetty-quiche-native</artifactId>
         <version>${jetty-quiche-native.version}</version>
       </dependency>
+
+      <!-- Pax Exam Dependencies -->
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam</artifactId>
+        <version>${pax.exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-inject</artifactId>
+        <version>${pax.exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-container-forked</artifactId>
+        <version>${pax.exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.tinybundles</groupId>
+        <artifactId>tinybundles</artifactId>
+        <version>${tinybundles.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-framework</artifactId>
+        <version>${swissbox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-tracker</artifactId>
+        <version>${swissbox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-junit4</artifactId>
+        <version>${pax.exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-link-mvn</artifactId>
+        <version>${pax.exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-aether</artifactId>
+        <version>${pax.url.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-wrap</artifactId>
+        <version>${pax.url.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.osgi</groupId>
         <!-- older artifact location, some of our transitive deps still use this coordinate -->


### PR DESCRIPTION
- fix naming convention, artifactId == directtory, add comment on maven-eclipse-plugin
- cleanup dependencies from jetty-ee9 osgi
- cleanup dependencies from jetty-ee10 osgi
