### PR TITLE
Wrong value of `RequestDispatcher.FORWARD_CONTEXT_PATH` attribute on root context

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -178,7 +178,7 @@ public class Dispatcher implements RequestDispatcher
                 if (old_attr.getAttribute(FORWARD_REQUEST_URI) == null)
                     baseRequest.setAttributes(new ForwardAttributes(old_attr,
                         old_uri.getPath(),
-                        old_context == null ? null : old_context.getContextHandler().getRequestContextPath(),
+                        baseRequest.getContextPath(),
                         baseRequest.getPathInContext(),
                         source_mapping,
                         old_uri.getQuery()));

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java
@@ -178,7 +178,7 @@ public class Dispatcher implements RequestDispatcher
                 if (old_attr.getAttribute(FORWARD_REQUEST_URI) == null)
                     baseRequest.setAttributes(new ForwardAttributes(old_attr,
                         old_uri.getPath(),
-                        old_context == null ? null : old_context.getContextHandler().getContextPathEncoded(),
+                        old_context == null ? null : old_context.getContextHandler().getRequestContextPath(),
                         baseRequest.getPathInContext(),
                         source_mapping,
                         old_uri.getQuery()));

--- a/jetty-servlet/src/test/resources/jetty-logging.properties
+++ b/jetty-servlet/src/test/resources/jetty-logging.properties
@@ -5,3 +5,4 @@
 #org.eclipse.jetty.io.SocketChannelEndPoint.LEVEL=DEBUG
 #org.eclipse.jetty.server.DebugListener.LEVEL=DEBUG
 #org.eclipse.jetty.server.HttpChannelState.LEVEL=DEBUG
+#org.eclipse.jetty.servlet.DispatcherTest.LEVEL=DEBUG


### PR DESCRIPTION
* Fixes #9119 - uses proper context path that satisfies the root context rules of the servlet spec

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>