### PR TITLE
jetty 12: ee10: DefaultServlet should initialize ResourceFactory unconditionally

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -108,12 +108,13 @@ public class DefaultServlet extends HttpServlet
         _resourceService.setWelcomeFactory(_resourceService);
 
         _baseResource = servletContextHandler.getBaseResource();
+        _resourceFactory = ResourceFactory.closeable();
+
         String rb = getInitParameter("baseResource", "resourceBase");
         if (rb != null)
         {
             try
             {
-                _resourceFactory = ResourceFactory.closeable();
                 _baseResource = _resourceFactory.newResource(rb);
             }
             catch (Exception e)


### PR DESCRIPTION
Currently, unlike ee9 and ee8, ee10's DefaultServlet initializes _resourceFactory  only when either "baseResource" or "resourceBase" are set as init parameters.

In embedded jetty, the resource base can also be set using ContextHandler#setBaseResource(Resource), which means that DefaultServlet would not initialize correctly and therefore prevent operations like overriding the jetty-dir.css stylesheet by throwing an otherwise unexplicable NullPointerException.

Change ee10 DefaultServlet to always initialize ResourceFactory, like the ee9 and ee8 variants do.

Signed-off-by: Christian Kohlschütter <christian@kohlschutter.com>