### PR TITLE
ee10: DefaultServlet: Replace checks for isStreaming() by !isWriting()

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -801,10 +801,10 @@ public class DefaultServlet extends HttpServlet
             return servletContextResponse.isWritingOrStreaming();
         }
 
-        public boolean isStreaming()
+        public boolean isWriting()
         {
             ServletContextResponse servletContextResponse = Response.as(_coreResponse, ServletContextResponse.class);
-            return servletContextResponse.isStreaming();
+            return servletContextResponse.isWriting();
         }
 
         @Override
@@ -814,7 +814,7 @@ public class DefaultServlet extends HttpServlet
             {
                 if (BufferUtil.hasContent(byteBuffer))
                 {
-                    if (isStreaming())
+                    if (!isWriting())
                     {
                         BufferUtil.writeTo(byteBuffer, _response.getOutputStream());
                         if (last)


### PR DESCRIPTION
Checking for isStreaming() will return false even when no data has been written yet. This erroneously triggers double-encoding of binary data in a Writer.

If the Writer is not set to ISO-8859-1 or similar, the output will be corrupted, causing errors like "java.io.IOException: written 25746 > 12014 content-length", and interrupted transmissions.

Replace the isStreaming() check by !isWriting().

https://github.com/eclipse/jetty.project/issues/9134

Signed-off-by: Christian Kohlschütter <christian@kohlschutter.com>