### PR TITLE
util: Fix PathWatcherTest on macOS (takes over 6 minutes to run)

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/PathWatcherTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/PathWatcherTest.java
@@ -55,14 +55,12 @@ public class PathWatcherTest
 
     static
     {
-        if (org.junit.jupiter.api.condition.OS.LINUX.isCurrentOs())
-            QUIET_TIME = 300;
-        else if (org.junit.jupiter.api.condition.OS.MAC.isCurrentOs())
-            QUIET_TIME = 5000;
-        else
-            QUIET_TIME = 1000;
-        WAIT_TIME = 2 * QUIET_TIME;
-        LONG_TIME = 5 * QUIET_TIME;
+      boolean isLinux = org.junit.jupiter.api.condition.OS.LINUX.isCurrentOs();
+      boolean isMac = org.junit.jupiter.api.condition.OS.MAC.isCurrentOs();
+
+      QUIET_TIME = isLinux || isMac ? 300 : 1000;
+      WAIT_TIME = 2 * QUIET_TIME;
+      LONG_TIME = isMac ? 25_000 : 5 * QUIET_TIME;
     }
 
     public static class PathWatchEventCapture implements PathWatcher.Listener


### PR DESCRIPTION
PathWatcherTest observes system-level path notification behavior, which appears to be different across platforms (Linux, Mac, other). The tests involve Thread sleeping and await-ing certain conditions for extended time spans.

Currently, there is a 16x higher sleep limit on macOS compared to Linux, resulting in a heavily slowed-down test execution on that platform.

Fix the sleep intervals such that QUIET_TIME is identical on both Linux and macOS. Adjust LONG_TIME, which is solely used as a maximum await timeout, such that it has desired maximum timeout on macOS. The tests now take less than 30 seconds on macOS.

https://github.com/eclipse/jetty.project/issues/9131

Signed-off-by: Christian Kohlschütter <christian@kohlschutter.com>