### PR TITLE
Remove `@Disabled` from `jetty-jmx`

### DIFF
--- a/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java
+++ b/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java
@@ -59,7 +59,7 @@ public class ConnectorServer extends AbstractLifeCycle
 {
     public static final String RMI_REGISTRY_CLIENT_SOCKET_FACTORY_ATTRIBUTE = "com.sun.jndi.rmi.factory.socket";
     private static final Logger LOG = LoggerFactory.getLogger(ConnectorServer.class);
-    public static final int DEFAULT_PORT = 1099;
+    private static final int DEFAULT_REGISTRY_PORT = 1099;
 
     private JMXServiceURL _jmxURL;
     private final Map<String, Object> _environment;
@@ -188,13 +188,9 @@ public class ConnectorServer extends AbstractLifeCycle
             HostPort hostPort;
 
             if (StringUtil.isBlank(rawHost)) // no host
-            {
-                hostPort = new HostPort(InetAddress.getLocalHost().getHostName(), DEFAULT_PORT);
-            }
+                hostPort = new HostPort(InetAddress.getLocalHost().getHostAddress(), DEFAULT_REGISTRY_PORT);
             else if (rawHost.startsWith(":")) // port without host
-            {
-                hostPort = new HostPort(InetAddress.getLocalHost().getHostName() + rawHost);
-            }
+                hostPort = new HostPort(InetAddress.getLocalHost().getHostAddress() + rawHost);
             else
                 hostPort = new HostPort(rawHost);
 
@@ -236,7 +232,7 @@ public class ConnectorServer extends AbstractLifeCycle
     private String startRegistry(HostPort hostPort) throws Exception
     {
         String host = hostPort.getHost();
-        int port = hostPort.getPort(DEFAULT_PORT);
+        int port = hostPort.getPort(DEFAULT_REGISTRY_PORT);
 
         try
         {

--- a/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
+++ b/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
@@ -25,14 +25,15 @@ import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Running the tests of this class in the same JVM results often in
@@ -46,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Running each test method in a forked JVM makes these tests all pass,
  * therefore the issue is likely caused by use of stale stubs cached by the JDK.
  */
-@Disabled
 public class ConnectorServerTest
 {
     private String objectName = "org.eclipse.jetty:name=rmiconnectorserver";
@@ -55,8 +55,7 @@ public class ConnectorServerTest
     @AfterEach
     public void tearDown() throws Exception
     {
-        if (connectorServer != null)
-            connectorServer.stop();
+        LifeCycle.stop(connectorServer);
     }
 
     @Test
@@ -66,7 +65,7 @@ public class ConnectorServerTest
         connectorServer.start();
 
         JMXServiceURL address = connectorServer.getAddress();
-        assertTrue(address.toString().matches("service:jmx:rmi://[^:]+:\\d+/jndi/rmi://[^:]+:\\d+/jmxrmi"));
+        assertThat(address.toString(), matchesRegex("service:jmx:rmi://[^:]+(:\\d+)?/jndi/rmi://[^:]+:\\d+/jmxrmi"));
     }
 
     @Test

--- a/jetty-core/jetty-jmx/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-jmx/src/test/resources/jetty-logging.properties
@@ -1,2 +1,2 @@
-# Jetty Logging using jetty-slf4j-impl
 #org.eclipse.jetty.jmx.LEVEL=DEBUG
+#org.eclipse.jetty.util.HostPort.LEVEL=DEBUG


### PR DESCRIPTION
Removing `@Disabled` annotation from `jetty-core/jetty-jmx` tests