### PR TITLE
Jetty 12 EE10 DefaultServlet: Replace checks for isStreaming() by !isWriting()

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -802,10 +802,10 @@ public class DefaultServlet extends HttpServlet
             return servletContextResponse.isWritingOrStreaming();
         }
 
-        public boolean isStreaming()
+        public boolean isWriting()
         {
             ServletContextResponse servletContextResponse = Response.as(_coreResponse, ServletContextResponse.class);
-            return servletContextResponse.isStreaming();
+            return servletContextResponse.isWriting();
         }
 
         @Override
@@ -815,13 +815,7 @@ public class DefaultServlet extends HttpServlet
             {
                 if (BufferUtil.hasContent(byteBuffer))
                 {
-                    if (isStreaming())
-                    {
-                        BufferUtil.writeTo(byteBuffer, _response.getOutputStream());
-                        if (last)
-                            _response.getOutputStream().close();
-                    }
-                    else
+                    if (isWriting())
                     {
                         String characterEncoding = _response.getCharacterEncoding();
                         try (ByteBufferInputStream bbis = new ByteBufferInputStream(byteBuffer);
@@ -832,6 +826,12 @@ public class DefaultServlet extends HttpServlet
 
                         if (last)
                             _response.getWriter().close();
+                    }
+                    else
+                    {
+                        BufferUtil.writeTo(byteBuffer, _response.getOutputStream());
+                        if (last)
+                            _response.getOutputStream().close();
                     }
                 }
 


### PR DESCRIPTION
Checking for isStreaming() will return false even when no data has been written yet. This erroneously triggers double-encoding of binary data in a Writer.

If the Writer is not set to ISO-8859-1 or similar, the output will be corrupted, causing errors like "java.io.IOException: written 25746 > 12014 content-length", and interrupted transmissions.

Fixes https://github.com/eclipse/jetty.project/issues/9134.