### PR TITLE
Jetty 12 - Add tests in util/resource for alternate FileSystem implementations

### DIFF
--- a/jetty-core/jetty-util/pom.xml
+++ b/jetty-core/jetty-util/pom.xml
@@ -71,6 +71,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.jimfs</groupId>
+      <artifactId>jimfs</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -49,12 +49,6 @@ import org.slf4j.LoggerFactory;
 public final class URIUtil
 {
     private static final Logger LOG = LoggerFactory.getLogger(URIUtil.class);
-    private static final Index<String> KNOWN_SCHEMES = new Index.Builder<String>()
-        .caseSensitive(false)
-        .with("file:")
-        .with("jrt:")
-        .with("jar:")
-        .build();
 
     // From https://www.rfc-editor.org/rfc/rfc3986
     private static final String UNRESERVED = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~";

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.util.resource;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.util.List;
@@ -48,10 +49,17 @@ class ResourceFactoryInternals
         CURRENT_WORKING_DIR = Path.of(System.getProperty("user.dir"));
 
         // The default resource factories
-        RESOURCE_FACTORIES.put("jar", new MountedPathResourceFactory());
+        MountedPathResourceFactory mountedPathResourceFactory = new MountedPathResourceFactory();
+        RESOURCE_FACTORIES.put("jar", mountedPathResourceFactory);
         PathResourceFactory pathResourceFactory = new PathResourceFactory();
         RESOURCE_FACTORIES.put("file", pathResourceFactory);
         RESOURCE_FACTORIES.put("jrt", pathResourceFactory);
+
+        URL url = ResourceFactoryInternals.class.getResource("/org/eclipse/jetty/version/build.properties");
+        if ((url != null) && !RESOURCE_FACTORIES.contains(url.getProtocol()))
+        {
+            RESOURCE_FACTORIES.put(url.getProtocol(), mountedPathResourceFactory);
+        }
     }
 
     static ResourceFactory ROOT = new CompositeResourceFactory()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -55,6 +55,12 @@ class ResourceFactoryInternals
         RESOURCE_FACTORIES.put("file", pathResourceFactory);
         RESOURCE_FACTORIES.put("jrt", pathResourceFactory);
 
+        /* Best effort attempt to detect that an alternate FileSystem type that is in use.
+         * We don't attempt to look up a Class, as not all runtimes and environments have the classes anymore
+         * (eg: they were compiled into native code)
+         * The build.properties is present in the jetty-util jar, so it's reasonably safe to look for that
+         * as a resource
+         */
         URL url = ResourceFactoryInternals.class.getResource("/org/eclipse/jetty/version/build.properties");
         if ((url != null) && !RESOURCE_FACTORIES.contains(url.getProtocol()))
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
@@ -1,0 +1,112 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.eclipse.jetty.util.IO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test to ensure that Alternate FileSystem providers work as expected.
+ *
+ * <p>
+ * Uses the <a href="https://github.com/google/jimfs">google/jimfs</a> In-Memory FileSystem provider
+ * to have a FileSystem based on scheme `jimfs` (with an authority)
+ * </p>
+ */
+public class AlternateFileSystemResourceTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AlternateFileSystemResourceTest.class);
+    private FileSystem jimfs;
+    private URI fsBaseURI;
+
+    @BeforeEach
+    public void initInMemoryFileSystem(TestInfo testInfo)
+    {
+        Optional<Method> testMethod = testInfo.getTestMethod();
+        String testMethodName = testMethod.map(Method::getName).orElseGet(AlternateFileSystemResourceTest.class::getSimpleName);
+        jimfs = Jimfs.newFileSystem(testMethodName, Configuration.unix());
+        fsBaseURI = jimfs.getPath("/").toUri();
+
+        ResourceFactory.registerResourceFactory(fsBaseURI.getScheme(), new MountedPathResourceFactory());
+    }
+
+    @AfterEach
+    public void closeInMemoryFileSystem()
+    {
+        IO.close(jimfs);
+    }
+
+    @Test
+    public void testNewResource() throws IOException
+    {
+        // Create some content to reference
+        Files.writeString(jimfs.getPath("/foo.txt"), "Hello Foo", StandardCharsets.UTF_8);
+
+        // Reference it via Resource object
+        Resource resource = ResourceFactory.root().newResource(fsBaseURI.resolve("/foo.txt"));
+        assertTrue(Resources.isReadable(resource));
+
+        LOG.info("resource = {}", resource);
+
+        try (InputStream in = resource.newInputStream())
+        {
+            String contents = IO.toString(in, StandardCharsets.UTF_8);
+            assertThat(contents, is("Hello Foo"));
+        }
+    }
+
+    @Test
+    public void testNavigateResource() throws IOException
+    {
+        // Create some content to reference
+        Files.createDirectories(jimfs.getPath("/zed"));
+        Files.writeString(jimfs.getPath("/zed/bar.txt"), "Hello Bar", StandardCharsets.UTF_8);
+
+        // Reference it via Resource object
+        Resource resourceRoot = ResourceFactory.root().newResource(fsBaseURI.resolve("/"));
+        assertTrue(Resources.isDirectory(resourceRoot));
+
+        Resource resourceZedDir = resourceRoot.resolve("zed");
+        assertTrue(Resources.isDirectory(resourceZedDir));
+
+        Resource resourceBarText = resourceZedDir.resolve("bar.txt");
+        LOG.info("resource = {}", resourceBarText);
+
+        try (InputStream in = resourceBarText.newInputStream())
+        {
+            String contents = IO.toString(in, StandardCharsets.UTF_8);
+            assertThat(contents, is("Hello Bar"));
+        }
+    }
+}

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
@@ -54,8 +54,19 @@ public class AlternateFileSystemResourceTest
     public void initInMemoryFileSystem(TestInfo testInfo)
     {
         Optional<Method> testMethod = testInfo.getTestMethod();
-        String testMethodName = testMethod.map(Method::getName).orElseGet(AlternateFileSystemResourceTest.class::getSimpleName);
-        jimfs = Jimfs.newFileSystem(testMethodName, Configuration.unix());
+        if (testMethod.isPresent())
+        {
+            String testMethodName = testMethod.get().getName();
+            // Create a jimfs that has the testMethodName as its authority
+            // eg:  jimfs://<test-method-name>/
+            jimfs = Jimfs.newFileSystem(testMethodName, Configuration.unix());
+        }
+        else
+        {
+            // Let jimfs establish a unique name on its own
+            // eg:  jimfs://a3cc0bda-1238-4847-864f-22fae7614146/
+            jimfs = Jimfs.newFileSystem(Configuration.unix());
+        }
         fsBaseURI = jimfs.getPath("/").toUri();
 
         ResourceFactory.registerResourceFactory(fsBaseURI.getScheme(), new MountedPathResourceFactory());


### PR DESCRIPTION
This adds some jetty-util Resource tests for alternate FileSystem providers, to ensure that we are not doing anything awkward in our implementation that would prevent it.

This uses the https://github.com/google/jimfs implementation of an In-Memory FileSystem implementation to accomplish these tests.
(This filesystem uses scheme `jimfs` and has a URI authority representing the named FileSystem)

This was initiated as a response to a question about our support for alternate FileSystem implementations in PR #9136