### PR TITLE
Jetty 12.0.x 9145 fix openid stats modules

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/config/modules/websocket.mod
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/config/modules/websocket.mod
@@ -5,5 +5,9 @@ Enable both jetty and jakarta websocket jetty modules for deployed web applicati
 websocket
 
 [depend]
-websocket-jetty
-websocket-jakarta
+ee8-websocket-jetty
+ee8-websocket-javax
+ee9-websocket-jetty
+ee9-websocket-jakarta
+ee10-websocket-jetty
+ee10-websocket-jakarta

--- a/jetty-ee8/jetty-ee8-nested/src/main/config/etc/ee8-jetty-stats.xml
+++ b/jetty-ee8/jetty-ee8-nested/src/main/config/etc/ee8-jetty-stats.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<!-- =============================================================== -->
+<!-- Mixin the Statistics Handler                                    -->
+<!-- =============================================================== -->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="insertHandler">
+    <Arg>
+      <New id="StatsHandler" class="org.eclipse.jetty.ee8.nested.StatisticsHandler">
+        <Set name="gracefulShutdownWaitsForRequests"><Property name="jetty.statistics.gracefulShutdownWaitsForRequests" default="true"/></Set>
+      </New>
+    </Arg>
+  </Call>
+  <Call name="addBeanToAllConnectors">
+    <Arg>
+      <New class="org.eclipse.jetty.io.ConnectionStatistics"/>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-ee8/jetty-ee8-nested/src/main/config/modules/ee8-stats.mod
+++ b/jetty-ee8/jetty-ee8-nested/src/main/config/modules/ee8-stats.mod
@@ -3,14 +3,21 @@
 [description]
 Enables detailed statistics collection for the server.
 
-[tags]
-server
+[environment]
+ee8
 
 [depend]
 server
+ee8-servlet
+
+[lib]
+lib/jetty-util-ajax-${jetty.version}.jar
 
 [xml]
-etc/jetty-stats.xml
+etc/ee8-jetty-stats.xml
+
+[ini]
+jetty.webapp.addServerClasses+=,-org.eclipse.jetty.ee8.servlet.StatisticsServlet
 
 [ini-template]
 

--- a/jetty-ee8/jetty-ee8-openid/src/main/config/modules/ee8-openid.mod
+++ b/jetty-ee8/jetty-ee8-openid/src/main/config/modules/ee8-openid.mod
@@ -4,7 +4,7 @@
 Adds OpenId Connect authentication to the server.
 
 [depend]
-security
+ee8-security
 client
 
 [lib]

--- a/jetty-ee9/jetty-ee9-nested/src/main/config/etc/ee9-jetty-stats.xml
+++ b/jetty-ee9/jetty-ee9-nested/src/main/config/etc/ee9-jetty-stats.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<!-- =============================================================== -->
+<!-- Mixin the Statistics Handler                                    -->
+<!-- =============================================================== -->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="insertHandler">
+    <Arg>
+      <New id="StatsHandler" class="org.eclipse.jetty.ee9.nested.StatisticsHandler">
+        <Set name="gracefulShutdownWaitsForRequests"><Property name="jetty.statistics.gracefulShutdownWaitsForRequests" default="true"/></Set>
+      </New>
+    </Arg>
+  </Call>
+  <Call name="addBeanToAllConnectors">
+    <Arg>
+      <New class="org.eclipse.jetty.io.ConnectionStatistics"/>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-ee9/jetty-ee9-nested/src/main/config/modules/ee9-stats.mod
+++ b/jetty-ee9/jetty-ee9-nested/src/main/config/modules/ee9-stats.mod
@@ -3,14 +3,21 @@
 [description]
 Enables detailed statistics collection for the server.
 
-[tags]
-server
+[environment]
+ee9
 
 [depend]
 server
+ee9-servlet
+
+[lib]
+lib/jetty-util-ajax-${jetty.version}.jar
 
 [xml]
-etc/jetty-stats.xml
+etc/ee9-jetty-stats.xml
+
+[ini]
+jetty.webapp.addServerClasses+=,-org.eclipse.jetty.ee9.servlet.StatisticsServlet
 
 [ini-template]
 


### PR DESCRIPTION
Fixes #9145.

`openid` and `websocket` modules should be fixed, but the `stats` one still is a WIP.