### PR TITLE
Ensure all eeX versions of the plugin use prefix "jetty"

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
@@ -62,6 +62,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <goalPrefix>jetty</goalPrefix>
+        </configuration>
         <executions>
           <execution>
             <id>exec-plugin-doc</id>

--- a/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
@@ -61,6 +61,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <goalPrefix>jetty</goalPrefix>
+        </configuration>
         <executions>
           <execution>
             <id>exec-plugin-doc</id>

--- a/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
@@ -61,6 +61,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <goalPrefix>jetty</goalPrefix>
+        </configuration>
         <executions>
           <execution>
             <id>exec-plugin-doc</id>


### PR DESCRIPTION
Closes #9155.

Ensure all jetty maven plugins use the prefix `jetty`, rather than the default generated `jetty-eeX` prefix.