### PR TITLE
Jetty 12 simplify Retainable.canRetain usage

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
@@ -112,8 +112,7 @@ public class InputStreamResponseListener extends Listener.Adapter
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Queueing chunk {}", chunk);
-                if (chunk.canRetain())
-                    chunk.retain();
+                chunk.retain();
                 chunkCallbacks.add(new ChunkCallback(chunk, demander, response::abort));
                 l.signalAll();
                 return;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/HttpReceiver.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/HttpReceiver.java
@@ -574,7 +574,7 @@ public abstract class HttpReceiver
                     return _chunk;
 
                 // Retain the input chunk because its ByteBuffer will be referenced by the Inflater.
-                if (retain && _chunk.canRetain())
+                if (retain)
                     _chunk.retain();
                 if (LOG.isDebugEnabled())
                     LOG.debug("decoding: {}", _chunk);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/ResponseNotifier.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/ResponseNotifier.java
@@ -412,8 +412,7 @@ public class ResponseNotifier
                     if (chunk.hasRemaining())
                         chunk = Content.Chunk.asChunk(chunk.getByteBuffer().slice(), chunk.isLast(), chunk);
                     // Retain the slice because it is stored for later reads.
-                    if (chunk.canRetain())
-                        chunk.retain();
+                    chunk.retain();
                     this.chunk = chunk;
                 }
                 else if (!currentChunk.isLast())

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -99,8 +99,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         if (this.chunk != null)
             throw new IllegalStateException();
         // Retain the chunk because it is stored for later reads.
-        if (chunk.canRetain())
-            chunk.retain();
+        chunk.retain();
         this.chunk = chunk;
         responseContentAvailable();
     }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -192,8 +192,7 @@ public class HttpStreamOverFCGI implements HttpStream
     public void onContent(Content.Chunk chunk)
     {
         // Retain the chunk because it is stored for later reads.
-        if (chunk.canRetain())
-            chunk.retain();
+        chunk.retain();
         _chunk = chunk;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -284,8 +284,7 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
         public void onPartContent(Content.Chunk chunk)
         {
             // Retain the chunk because it is stored for later use.
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             partChunks.add(chunk);
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
@@ -444,8 +444,7 @@ public class MultiPartFormData extends CompletableFuture<MultiPartFormData.Parts
                 }
             }
             // Retain the chunk because it is stored for later use.
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             partChunks.add(chunk);
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/Trailers.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/Trailers.java
@@ -43,22 +43,4 @@ public class Trailers implements Content.Chunk
     {
         return trailers;
     }
-
-    @Override
-    public boolean canRetain()
-    {
-        return false;
-    }
-
-    @Override
-    public void retain()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean release()
-    {
-        return true;
-    }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
@@ -690,8 +690,7 @@ public class MultiPartTest
         public void onPartContent(Content.Chunk chunk)
         {
             // Retain the chunk because it is stored for later use.
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             partContent.add(chunk);
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -432,24 +432,6 @@ public interface Stream
             {
                 super(new DataFrame(streamId, BufferUtil.EMPTY_BUFFER, true));
             }
-
-            @Override
-            public boolean canRetain()
-            {
-                return false;
-            }
-
-            @Override
-            public void retain()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean release()
-            {
-                return true;
-            }
         }
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -411,24 +411,6 @@ public interface Stream
             {
                 super(new DataFrame(BufferUtil.EMPTY_BUFFER, true));
             }
-
-            @Override
-            public boolean canRetain()
-            {
-                return false;
-            }
-
-            @Override
-            public void retain()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean release()
-            {
-                return true;
-            }
         }
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/internal/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/internal/HTTP3Stream.java
@@ -335,8 +335,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
     public void onData(Data data)
     {
         // Retain the data because it is stored for later reads.
-        if (data.canRetain())
-            data.retain();
+        data.retain();
         if (!dataRef.compareAndSet(null, data))
             throw new IllegalStateException();
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -436,11 +436,50 @@ public class Content
         /**
          * <p>An empty, non-last, chunk.</p>
          */
-        Chunk EMPTY = ByteBufferChunk.EMPTY;
+        Chunk EMPTY = new Chunk()
+        {
+            @Override
+            public ByteBuffer getByteBuffer()
+            {
+                return BufferUtil.EMPTY_BUFFER;
+            }
+
+            @Override
+            public boolean isLast()
+            {
+                return false;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "EMPTY";
+            }
+        };
+
         /**
          * <p>An empty, last, chunk.</p>
          */
-        Content.Chunk EOF = ByteBufferChunk.EOF;
+        Content.Chunk EOF = new Chunk()
+        {
+            @Override
+            public ByteBuffer getByteBuffer()
+            {
+                return BufferUtil.EMPTY_BUFFER;
+            }
+
+            @Override
+            public boolean isLast()
+            {
+                return true;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "EOF";
+            }
+        };
 
         /**
          * <p>Creates a Chunk with the given ByteBuffer.</p>
@@ -653,24 +692,6 @@ public class Content
 
             @Override
             public boolean isLast()
-            {
-                return true;
-            }
-
-            @Override
-            public boolean canRetain()
-            {
-                return false;
-            }
-
-            @Override
-            public void retain()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean release()
             {
                 return true;
             }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Retainable.java
@@ -27,30 +27,36 @@ import java.util.concurrent.atomic.AtomicInteger;
 public interface Retainable
 {
     /**
-     * <p>Returns whether this resource can be retained, that is whether {@link #retain()}
-     * can be called safely.</p>
-     * <p>Implementations may decide that special resources are not retainable (for example,
-     * {@code static} constants) so calling {@link #retain()} is not safe because it may throw.</p>
-     * <p>Calling {@link #release()} on those special resources is typically allowed, and
-     * it is a no-operation.</p>
+     * <p>Returns whether this resource is referenced counted by calls to {@link #retain()}
+     * and {@link #release()}.</p>
+     * <p>Implementations may decide that special resources are not not referenced counted (for example,
+     * {@code static} constants) so calling {@link #retain()} is a no-operation, and
+     * calling {@link #release()} on those special resources is a no-operation that always returns true.</p>
      *
-     * @return whether it is safe to call {@link #retain()}
+     * @return true if calls to {@link #retain()} are reference counted.
      */
-    boolean canRetain();
+    default boolean canRetain()
+    {
+        return false;
+    }
 
     /**
-     * <p>Retains this resource, incrementing the reference count.</p>
+     * <p>Retains this resource, potentially incrementing a reference count if there are resources that will be released.</p>
      */
-    void retain();
+    default void retain()
+    {
+    }
 
     /**
-     * <p>Releases this resource, decrementing the reference count.</p>
-     * <p>This method returns {@code true} when the reference count goes to zero,
-     * {@code false} otherwise.</p>
+     * <p>Releases this resource, potentially decrementing a reference count (if any).</p>
      *
-     * @return whether the invocation of this method decremented the reference count to zero
+     * @return {@code true} when the reference count goes to zero or if there was no reference count,
+     *         {@code false} otherwise.
      */
-    boolean release();
+    default boolean release()
+    {
+        return true;
+    }
 
     /**
      * A wrapper of {@link Retainable} instances.

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSinkSubscriber.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSinkSubscriber.java
@@ -48,8 +48,7 @@ public class ContentSinkSubscriber implements Flow.Subscriber<Content.Chunk>
     public void onNext(Content.Chunk chunk)
     {
         // Retain the chunk because the write may not complete immediately.
-        if (chunk.canRetain())
-            chunk.retain();
+        chunk.retain();
         sink.write(chunk.isLast(), chunk.getByteBuffer(), Callback.from(() -> succeeded(chunk), x -> failed(chunk, x)));
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/ByteBufferChunk.java
@@ -24,23 +24,6 @@ import org.eclipse.jetty.util.BufferUtil;
 
 public abstract class ByteBufferChunk implements Content.Chunk
 {
-    public static final ByteBufferChunk EMPTY = new ByteBufferChunk(BufferUtil.EMPTY_BUFFER, false)
-    {
-        @Override
-        public String toString()
-        {
-            return "%s[EMPTY]".formatted(ByteBufferChunk.class.getSimpleName());
-        }
-    };
-    public static final ByteBufferChunk EOF = new ByteBufferChunk(BufferUtil.EMPTY_BUFFER, true)
-    {
-        @Override
-        public String toString()
-        {
-            return "%s[EOF]".formatted(ByteBufferChunk.class.getSimpleName());
-        }
-    };
-
     private final ByteBuffer byteBuffer;
     private final boolean last;
 
@@ -60,24 +43,6 @@ public abstract class ByteBufferChunk implements Content.Chunk
     public boolean isLast()
     {
         return last;
-    }
-
-    @Override
-    public boolean canRetain()
-    {
-        return false;
-    }
-
-    @Override
-    public void retain()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean release()
-    {
-        return true;
     }
 
     @Override

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentSourceTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentSourceTest.java
@@ -525,8 +525,7 @@ public class ContentSourceTest
         private void add(Content.Chunk chunk)
         {
             // Retain the chunk because it is stored for later use.
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             _chunks.add(chunk);
         }
 

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -688,8 +688,7 @@ public abstract class ProxyHandler extends Handler.Abstract
             if (LOG.isDebugEnabled())
                 LOG.debug("{} S2P received content {}", requestId(clientToProxyRequest), BufferUtil.toDetailString(serverToProxyContent));
 
-            if (serverToProxyChunk.canRetain())
-                serverToProxyChunk.retain();
+            serverToProxyChunk.retain();
             Callback callback = new Callback()
             {
                 @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipRequest.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipRequest.java
@@ -165,7 +165,7 @@ public class GzipRequest extends Request.Wrapper
                 return Content.Chunk.EOF;
 
             // Retain the input chunk because its ByteBuffer will be referenced by the Inflater.
-            if (retain && _chunk.canRetain())
+            if (retain)
                 _chunk.retain();
             ByteBuffer decodedBuffer = _decoder.decode(_chunk);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
@@ -46,24 +46,6 @@ public class MockHttpStream implements HttpStream
         {
             return false;
         }
-
-        @Override
-        public boolean canRetain()
-        {
-            return false;
-        }
-
-        @Override
-        public void retain()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean release()
-        {
-            return true;
-        }
     };
     private final long _nanoTime = NanoTime.now();
     private final AtomicReference<Content.Chunk> _content = new AtomicReference<>();
@@ -106,8 +88,7 @@ public class MockHttpStream implements HttpStream
 
     private Runnable addContent(Content.Chunk chunk)
     {
-        if (chunk.canRetain())
-            chunk.retain();
+        chunk.retain();
         chunk = _content.getAndSet(chunk);
         if (chunk == DEMAND)
             return _channel.onContentAvailable();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -154,8 +154,7 @@ public class HttpClientDemandTest extends AbstractTest
                 public void onContent(Response response, Content.Chunk chunk, Runnable demander)
                 {
                     // Store the chunk and don't demand.
-                    if (chunk.canRetain())
-                        chunk.retain();
+                    chunk.retain();
                     contentQueue.offer(chunk);
                     demanderQueue.offer(demander);
                 }
@@ -244,8 +243,7 @@ public class HttpClientDemandTest extends AbstractTest
         client.newRequest(newURI(transport))
             .onResponseContentAsync((response, chunk, demander) ->
             {
-                if (chunk.canRetain())
-                    chunk.retain();
+                chunk.retain();
                 chunkRef.set(chunk);
                 try
                 {

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
@@ -439,8 +439,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         public void onContent(Response serverResponse, Content.Chunk chunk, Runnable demander)
         {
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             Callback callback = Callback.from(chunk::release, Callback.from(demander, serverResponse::abort));
             try
             {

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
@@ -216,8 +216,7 @@ public class ProxyServlet extends AbstractProxyServlet
                 content.get(buffer);
                 offset = 0;
             }
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             Callback callback = Callback.from(chunk::release, Callback.from(demander, proxyResponse::abort));
             onResponseContent(request, response, proxyResponse, buffer, offset, length, callback);
         }

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
@@ -439,8 +439,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         public void onContent(Response serverResponse, Content.Chunk chunk, Runnable demander)
         {
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             Callback callback = Callback.from(chunk::release, Callback.from(demander, serverResponse::abort));
             try
             {

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
@@ -216,8 +216,7 @@ public class ProxyServlet extends AbstractProxyServlet
                 content.get(buffer);
                 offset = 0;
             }
-            if (chunk.canRetain())
-                chunk.retain();
+            chunk.retain();
             Callback callback = Callback.from(chunk::release, Callback.from(demander, proxyResponse::abort));
             onResponseContent(request, response, proxyResponse, buffer, offset, length, callback);
         }


### PR DESCRIPTION
I believe that `canRetain` is no longer needed. The only place it is used for real logic is in `AsyncContent`, which can use it's own chunk class to pass on how to succeed the callback. 