### PR TITLE
MultiPart API improvements for the Servlet implementation.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/MultiPartRequestContent.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/MultiPartRequestContent.java
@@ -69,7 +69,7 @@ public class MultiPartRequestContent extends MultiPartFormData.ContentSource imp
         if (headers.contains(HttpHeader.CONTENT_TYPE))
             return headers;
 
-        Content.Source partContent = part.getContent();
+        Content.Source partContent = part.getContentSource();
         if (partContent instanceof Request.Content requestContent)
         {
             String contentType = requestContent.getContentType();

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/util/MultiPartRequestContentTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/util/MultiPartRequestContentTest.java
@@ -135,7 +135,7 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
                 int equal = contentType.lastIndexOf('=');
                 Charset charset = Charset.forName(contentType.substring(equal + 1));
                 assertEquals(encoding, charset);
-                assertEquals(value, Content.Source.asString(part.getContent(), charset));
+                assertEquals(value, Content.Source.asString(part.getContentSource(), charset));
             }
         });
 
@@ -169,7 +169,7 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
                 MultiPart.Part part = parts.iterator().next();
                 assertEquals(name, part.getName());
                 assertEquals("text/plain", part.getHeaders().get(HttpHeader.CONTENT_TYPE));
-                assertArrayEquals(data, Content.Source.asByteBuffer(part.getContent()).array());
+                assertArrayEquals(data, Content.Source.asByteBuffer(part.getContentSource()).array());
             }
         });
 
@@ -221,8 +221,8 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
                 assertEquals(name, part.getName());
                 assertEquals(contentType, part.getHeaders().get(HttpHeader.CONTENT_TYPE));
                 assertEquals(fileName, part.getFileName());
-                assertEquals(data.length, part.getContent().getLength());
-                assertArrayEquals(data, Content.Source.asByteBuffer(part.getContent()).array());
+                assertEquals(data.length, part.getContentSource().getLength());
+                assertArrayEquals(data, Content.Source.asByteBuffer(part.getContentSource()).array());
             }
         });
 
@@ -277,8 +277,8 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
                 assertEquals(name, part.getName());
                 assertEquals(contentType, part.getHeaders().get(HttpHeader.CONTENT_TYPE));
                 assertEquals(tmpPath.getFileName().toString(), part.getFileName());
-                assertEquals(Files.size(tmpPath), part.getContent().getLength());
-                assertEquals(data, Content.Source.asString(part.getContent(), encoding));
+                assertEquals(Files.size(tmpPath), part.getContentSource().getLength());
+                assertEquals(data, Content.Source.asString(part.getContentSource(), encoding));
             }
         });
 
@@ -329,14 +329,14 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
 
                 assertEquals(field, fieldPart.getName());
                 assertEquals(contentType, fieldPart.getHeaders().get(HttpHeader.CONTENT_TYPE));
-                assertEquals(value, Content.Source.asString(fieldPart.getContent(), encoding));
+                assertEquals(value, Content.Source.asString(fieldPart.getContentSource(), encoding));
                 assertEquals(headerValue, fieldPart.getHeaders().get(headerName));
 
                 assertEquals(fileField, filePart.getName());
                 assertEquals("application/octet-stream", filePart.getHeaders().get(HttpHeader.CONTENT_TYPE));
                 assertEquals(tmpPath.getFileName().toString(), filePart.getFileName());
-                assertEquals(Files.size(tmpPath), filePart.getContent().getLength());
-                assertArrayEquals(data, Content.Source.asByteBuffer(filePart.getContent()).array());
+                assertEquals(Files.size(tmpPath), filePart.getContentSource().getLength());
+                assertArrayEquals(data, Content.Source.asByteBuffer(filePart.getContentSource()).array());
             }
         });
 
@@ -373,11 +373,11 @@ public class MultiPartRequestContentTest extends AbstractHttpClientServerTest
                 MultiPart.Part fieldPart = parts.get(0);
                 MultiPart.Part filePart = parts.get(1);
 
-                assertEquals(value, Content.Source.asString(fieldPart.getContent(), encoding));
+                assertEquals(value, Content.Source.asString(fieldPart.getContentSource(), encoding));
                 assertEquals("file", filePart.getName());
                 assertEquals("application/octet-stream", filePart.getHeaders().get(HttpHeader.CONTENT_TYPE));
                 assertEquals("fileName", filePart.getFileName());
-                assertArrayEquals(fileData, Content.Source.asByteBuffer(filePart.getContent()).array());
+                assertArrayEquals(fileData, Content.Source.asByteBuffer(filePart.getContentSource()).array());
             }
         });
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -211,6 +211,11 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
             this.byteRange = byteRange;
         }
 
+        public ByteRange getByteRange()
+        {
+            return byteRange;
+        }
+
         @Override
         protected SeekableByteChannel open() throws IOException
         {
@@ -244,7 +249,7 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
      */
     public static class Part extends MultiPart.Part
     {
-        private final PathContentSource content;
+        private final PathContentSource contentSource;
 
         public Part(String contentType, Path path, ByteRange byteRange, long contentLength)
         {
@@ -255,13 +260,19 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
         public Part(HttpFields headers, Path path, ByteRange byteRange)
         {
             super(null, null, headers);
-            content = new PathContentSource(path, byteRange);
+            contentSource = new PathContentSource(path, byteRange);
         }
 
         @Override
-        public Content.Source getContent()
+        public Content.Source getContentSource()
         {
-            return content;
+            return contentSource;
+        }
+
+        @Override
+        public Content.Source newContentSource()
+        {
+            return new PathContentSource(contentSource.getPath(), contentSource.getByteRange());
         }
     }
 
@@ -318,7 +329,7 @@ public class MultiPartByteRanges extends CompletableFuture<MultiPartByteRanges.P
                 toFail = new ArrayList<>(parts);
                 parts.clear();
             }
-            toFail.forEach(part -> part.getContent().fail(cause));
+            toFail.forEach(part -> part.getContentSource().fail(cause));
         }
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
@@ -542,7 +542,7 @@ public class MultiPartFormData extends CompletableFuture<MultiPartFormData.Parts
                 if (part instanceof MultiPart.PathPart pathPart)
                     pathPart.delete();
                 else
-                    part.getContent().fail(cause);
+                    part.getContentSource().fail(cause);
             }
             close();
             delete();

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartCaptureTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartCaptureTest.java
@@ -51,7 +51,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiPartCaptureTest
 {
@@ -245,7 +244,7 @@ public class MultiPartCaptureTest
             List<MultiPart.Part> charSetParts = allParts.get("_charset_");
             if (charSetParts != null)
             {
-                defaultCharset = Promise.Completable.<String>with(p -> Content.Source.asString(charSetParts.get(0).getContent(), StandardCharsets.US_ASCII, p))
+                defaultCharset = Promise.Completable.<String>with(p -> Content.Source.asString(charSetParts.get(0).newContentSource(), StandardCharsets.US_ASCII, p))
                     .get();
             }
 
@@ -255,8 +254,7 @@ public class MultiPartCaptureTest
                 assertThat("Part[" + expected.name + "]", parts, is(notNullValue()));
                 MultiPart.Part part = parts.get(0);
                 String charset = getCharsetFromContentType(part.getHeaders().get(HttpHeader.CONTENT_TYPE), defaultCharset);
-                assertTrue(part.getContent().rewind());
-                String partContent = Content.Source.asString(part.getContent(), Charset.forName(charset));
+                String partContent = Content.Source.asString(part.newContentSource(), Charset.forName(charset));
                 assertThat("Part[" + expected.name + "].contents", partContent, containsString(expected.value));
             }
 
@@ -276,8 +274,7 @@ public class MultiPartCaptureTest
                 assertThat("Part[" + expected.name + "]", parts, is(notNullValue()));
                 MultiPart.Part part = parts.get(0);
                 MessageDigest digest = MessageDigest.getInstance("SHA1");
-                assertTrue(part.getContent().rewind());
-                try (InputStream partInputStream = Content.Source.asInputStream(part.getContent());
+                try (InputStream partInputStream = Content.Source.asInputStream(part.newContentSource());
                      DigestOutputStream digester = new DigestOutputStream(OutputStream.nullOutputStream(), digest))
                 {
                     IO.copy(partInputStream, digester);

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
@@ -189,25 +189,25 @@ public class MultiPartFormDataTest
 
         MultiPart.Part fileName = parts.getFirst("fileName");
         assertThat(fileName, notNullValue());
-        Content.Source partContent = fileName.getContent();
+        Content.Source partContent = fileName.getContentSource();
         assertThat(partContent.getLength(), is(3L));
         assertThat(Content.Source.asString(partContent), is("abc"));
 
         MultiPart.Part desc = parts.getFirst("desc");
         assertThat(desc, notNullValue());
-        partContent = desc.getContent();
+        partContent = desc.getContentSource();
         assertThat(partContent.getLength(), is(3L));
         assertThat(Content.Source.asString(partContent), is("123"));
 
         MultiPart.Part title = parts.getFirst("title");
         assertThat(title, notNullValue());
-        partContent = title.getContent();
+        partContent = title.getContentSource();
         assertThat(partContent.getLength(), is(3L));
         assertThat(Content.Source.asString(partContent), is("ttt"));
 
         MultiPart.Part datafile = parts.getFirst("datafile5239138112980980385.txt");
         assertThat(datafile, notNullValue());
-        partContent = datafile.getContent();
+        partContent = datafile.getContentSource();
         assertThat(partContent.getLength(), is(3L));
         assertThat(Content.Source.asString(partContent), is("000"));
     }
@@ -275,11 +275,11 @@ public class MultiPartFormDataTest
         assertThat(parts.size(), is(2));
         MultiPart.Part part1 = parts.getFirst("field1");
         assertThat(part1, notNullValue());
-        Content.Source partContent = part1.getContent();
+        Content.Source partContent = part1.getContentSource();
         assertThat(Content.Source.asString(partContent), is("Joe Blow"));
         MultiPart.Part part2 = parts.getFirst("stuff");
         assertThat(part2, notNullValue());
-        partContent = part2.getContent();
+        partContent = part2.getContentSource();
         assertThat(Content.Source.asString(partContent), is("aaaabbbbb"));
     }
 
@@ -312,7 +312,7 @@ public class MultiPartFormDataTest
         assertThat(parts.size(), is(1));
         MultiPart.Part part2 = parts.getFirst("stuff");
         assertThat(part2, notNullValue());
-        Content.Source partContent = part2.getContent();
+        Content.Source partContent = part2.getContentSource();
         assertThat(Content.Source.asString(partContent), is("aaaabbbbb"));
     }
 
@@ -340,7 +340,7 @@ public class MultiPartFormDataTest
         assertThat(part, instanceOf(MultiPart.PathPart.class));
         MultiPart.PathPart pathPart = (MultiPart.PathPart)part;
         assertTrue(Files.exists(pathPart.getPath()));
-        assertEquals("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Content.Source.asString(part.getContent()));
+        assertEquals("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Content.Source.asString(part.getContentSource()));
     }
 
     @Test
@@ -422,13 +422,13 @@ public class MultiPartFormDataTest
 
         MultiPart.Part part1 = parts.get(0);
         assertThat(part1, instanceOf(MultiPart.ChunksPart.class));
-        assertEquals(chunk, Content.Source.asString(part1.getContent()));
+        assertEquals(chunk, Content.Source.asString(part1.getContentSource()));
 
         MultiPart.Part part2 = parts.get(1);
         assertThat(part2, instanceOf(MultiPart.PathPart.class));
         MultiPart.PathPart pathPart2 = (MultiPart.PathPart)part2;
         assertTrue(Files.exists(pathPart2.getPath()));
-        assertEquals(chunk.repeat(4), Content.Source.asString(part2.getContent()));
+        assertEquals(chunk.repeat(4), Content.Source.asString(part2.getContentSource()));
     }
 
     @Test

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
@@ -361,11 +361,11 @@ public class MultiPartTest
 
         MultiPart.Part part1 = listener.parts.get(0);
         assertEquals("value", part1.getHeaders().get("name"));
-        assertEquals("Hello", Content.Source.asString(part1.getContent()));
+        assertEquals("Hello", Content.Source.asString(part1.getContentSource()));
 
         MultiPart.Part part2 = listener.parts.get(1);
         assertEquals("9001", part2.getHeaders().get("powerLevel"));
-        assertEquals("secondary\r\ncontent", Content.Source.asString(part2.getContent()));
+        assertEquals("secondary\r\ncontent", Content.Source.asString(part2.getContentSource()));
 
         assertEquals(0, data.remaining());
     }
@@ -397,11 +397,11 @@ public class MultiPartTest
 
         MultiPart.Part part1 = listener.parts.get(0);
         assertEquals("value", part1.getHeaders().get("name"));
-        assertEquals("Hello", Content.Source.asString(part1.getContent()));
+        assertEquals("Hello", Content.Source.asString(part1.getContentSource()));
 
         MultiPart.Part part2 = listener.parts.get(1);
         assertEquals("9001", part2.getHeaders().get("powerLevel"));
-        assertEquals("secondary\ncontent", Content.Source.asString(part2.getContent()));
+        assertEquals("secondary\ncontent", Content.Source.asString(part2.getContentSource()));
 
         assertEquals(0, data.remaining());
     }
@@ -457,7 +457,7 @@ public class MultiPartTest
         assertEquals(1, listener.parts.size());
         MultiPart.Part part = listener.parts.get(0);
         assertEquals("value", part.getHeaders().get("name"));
-        assertEquals("", Content.Source.asString(part.getContent()));
+        assertEquals("", Content.Source.asString(part.getContentSource()));
     }
 
     @Test
@@ -477,7 +477,7 @@ public class MultiPartTest
         assertEquals(1, listener.parts.size());
         MultiPart.Part part = listener.parts.get(0);
         assertEquals("value", part.getHeaders().get("name"));
-        assertEquals("", Content.Source.asString(part.getContent()));
+        assertEquals("", Content.Source.asString(part.getContentSource()));
     }
 
     @Test
@@ -508,7 +508,7 @@ public class MultiPartTest
         assertEquals(1, listener.parts.size());
         MultiPart.Part part = listener.parts.get(0);
         assertEquals("value", part.getHeaders().get("name"));
-        assertThat(Content.Source.asString(part.getContent()), is("""
+        assertThat(Content.Source.asString(part.getContentSource()), is("""
             Hello\r
             this is not a --BOUNDARY\r
             that's a boundary"""));
@@ -532,7 +532,7 @@ public class MultiPartTest
         assertThat(epilogueBuffer.remaining(), is(0));
         assertEquals(1, listener.parts.size());
         MultiPart.Part part = listener.parts.get(0);
-        assertThat(Content.Source.asByteBuffer(part.getContent()), is(ByteBuffer.wrap(random)));
+        assertThat(Content.Source.asByteBuffer(part.getContentSource()), is(ByteBuffer.wrap(random)));
     }
 
     @Test
@@ -556,7 +556,7 @@ public class MultiPartTest
         assertEquals(1, listener.parts.size());
         MultiPart.Part part = listener.parts.get(0);
         assertEquals("value", part.getHeaders().get("name"));
-        assertEquals("Hello", Content.Source.asString(part.getContent()));
+        assertEquals("Hello", Content.Source.asString(part.getContentSource()));
     }
 
     @Test

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
@@ -73,7 +73,7 @@ public class ChunksContentSource implements Content.Source
             if (last)
                 terminated = Content.Chunk.EOF;
         }
-        return chunk;
+        return Content.Chunk.from(chunk.getByteBuffer().slice(), chunk.isLast(), chunk);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartByteRangesTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartByteRangesTest.java
@@ -119,11 +119,11 @@ public class MultiPartByteRangesTest
 
             assertEquals(3, parts.size());
             MultiPart.Part part1 = parts.get(0);
-            assertEquals("12", Content.Source.asString(part1.getContent()));
+            assertEquals("12", Content.Source.asString(part1.getContentSource()));
             MultiPart.Part part2 = parts.get(1);
-            assertEquals("456", Content.Source.asString(part2.getContent()));
+            assertEquals("456", Content.Source.asString(part2.getContentSource()));
             MultiPart.Part part3 = parts.get(2);
-            assertEquals("CDEF", Content.Source.asString(part3.getContent()));
+            assertEquals("CDEF", Content.Source.asString(part3.getContentSource()));
         }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MultiPartFormDataHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MultiPartFormDataHandlerTest.java
@@ -80,7 +80,7 @@ public class MultiPartFormDataHandlerTest
                     .whenComplete((parts, failure) ->
                     {
                         if (parts != null)
-                            Content.copy(parts.get(0).getContent(), response, callback);
+                            Content.copy(parts.get(0).getContentSource(), response, callback);
                         else
                             Response.writeError(request, response, callback, failure);
                     });
@@ -129,7 +129,7 @@ public class MultiPartFormDataHandlerTest
                 MultiPartFormData formData = (MultiPartFormData)request.getAttribute(MultiPartFormData.class.getName());
                 assertNotNull(formData);
                 MultiPart.Part part = formData.get().get(0);
-                Content.copy(part.getContent(), response, callback);
+                Content.copy(part.getContentSource(), response, callback);
                 return true;
             }
         });
@@ -321,7 +321,7 @@ public class MultiPartFormDataHandlerTest
             HttpFields headers2 = part2.getHeaders();
             assertEquals(2, headers2.size());
             assertEquals("application/octet-stream", headers2.get(HttpHeader.CONTENT_TYPE));
-            assertEquals(32, part2.getContent().getLength());
+            assertEquals(32, part2.getContentSource().getLength());
         }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerByteRangesTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerByteRangesTest.java
@@ -181,10 +181,10 @@ public class ResourceHandlerByteRangesTest
             assertEquals(2, parts.size());
             MultiPart.Part part1 = parts.get(0);
             assertEquals("text/plain", part1.getHeaders().get(HttpHeader.CONTENT_TYPE));
-            assertEquals("234", Content.Source.asString(part1.getContent()));
+            assertEquals("234", Content.Source.asString(part1.getContentSource()));
             MultiPart.Part part2 = parts.get(1);
             assertEquals("text/plain", part2.getHeaders().get(HttpHeader.CONTENT_TYPE));
-            assertEquals("xyz", Content.Source.asString(part2.getContent()));
+            assertEquals("xyz", Content.Source.asString(part2.getContentSource()));
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
@@ -147,22 +147,17 @@ public class ServletMultiPartFormData
     {
         private final MultiPartFormData _formData;
         private final MultiPart.Part _part;
-        private final long _length;
-        private final InputStream _input;
 
         private ServletPart(MultiPartFormData formData, MultiPart.Part part)
         {
             _formData = formData;
             _part = part;
-            Content.Source content = part.getContent();
-            _length = content.getLength();
-            _input = Content.Source.asInputStream(content);
         }
 
         @Override
         public InputStream getInputStream() throws IOException
         {
-            return _input;
+            return Content.Source.asInputStream(_part.newContentSource());
         }
 
         @Override
@@ -186,7 +181,7 @@ public class ServletMultiPartFormData
         @Override
         public long getSize()
         {
-            return _length;
+            return _part.getContentSource().getLength();
         }
 
         @Override


### PR DESCRIPTION
* Renamed Part.getContent() to getContentSource().
* Introduced Part.newContentSource().

Apparently, the Servlet implementation needs Part.getInputStream() to return a new InputStream every time, so we need a way to reproduce the part's content. This is now possible with Part.newContentSource(), which can be implemented easily for the parts that have a reproducible content (all apart one).

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>