### PR TITLE
Fixes #9183 - ConnectHandler may close the connection instead of send…

### DIFF
--- a/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ConnectHandler.java
+++ b/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ConnectHandler.java
@@ -562,7 +562,7 @@ public class ConnectHandler extends HandlerWrapper
         }
     }
 
-    public class UpstreamConnection extends ProxyConnection
+    public class UpstreamConnection extends ProxyConnection implements AsyncListener
     {
         private final ConnectContext connectContext;
 
@@ -577,7 +577,7 @@ public class ConnectHandler extends HandlerWrapper
         {
             super.onOpen();
             // Delay fillInterested() until the 200 OK response has been sent.
-            connectContext.asyncContext.addListener(new OnCompleteListener(this::fillInterested));
+            connectContext.asyncContext.addListener(this);
             onConnectSuccess(connectContext, UpstreamConnection.this);
         }
 
@@ -593,36 +593,26 @@ public class ConnectHandler extends HandlerWrapper
             ConnectHandler.this.write(endPoint, buffer, callback, getContext());
         }
 
-        private class OnCompleteListener implements AsyncListener
+        @Override
+        public void onComplete(AsyncEvent event)
         {
-            private final Runnable onComplete;
+            fillInterested();
+        }
 
-            private OnCompleteListener(Runnable onComplete)
-            {
-                this.onComplete = onComplete;
-            }
+        @Override
+        public void onTimeout(AsyncEvent event)
+        {
+        }
 
-            @Override
-            public void onComplete(AsyncEvent event)
-            {
-                onComplete.run();
-            }
+        @Override
+        public void onError(AsyncEvent event)
+        {
+            close(event.getThrowable());
+        }
 
-            @Override
-            public void onTimeout(AsyncEvent event)
-            {
-            }
-
-            @Override
-            public void onError(AsyncEvent event)
-            {
-                close(event.getThrowable());
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event)
-            {
-            }
+        @Override
+        public void onStartAsync(AsyncEvent event)
+        {
         }
     }
 

--- a/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ConnectHandlerTest.java
+++ b/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ConnectHandlerTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -81,6 +83,59 @@ public class ConnectHandlerTest extends AbstractConnectHandlerTest
             // Expect 200 OK from the CONNECT request
             HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(socket.getInputStream()));
             assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testCONNECTAndClose() throws Exception
+    {
+        disposeProxy();
+        connectHandler = new ConnectHandler()
+        {
+            @Override
+            protected void handleConnect(Request baseRequest, HttpServletRequest request, HttpServletResponse response, String serverAddress)
+            {
+                try
+                {
+                    super.handleConnect(baseRequest, request, response, serverAddress);
+                    // Delay the return of this method to trigger the race
+                    // with the server closing the connection immediately.
+                    Thread.sleep(500);
+                }
+                catch (InterruptedException x)
+                {
+                    throw new RuntimeException(x);
+                }
+            }
+        };
+        proxy.setHandler(connectHandler);
+        proxy.start();
+
+        try (ServerSocket server = new ServerSocket(0))
+        {
+            String hostPort = "localhost:" + server.getLocalPort();
+            String request =
+                "CONNECT " + hostPort + " HTTP/1.1\r\n" +
+                "Host: " + hostPort + "\r\n" +
+                "\r\n";
+            try (Socket socket = newSocket())
+            {
+                OutputStream output = socket.getOutputStream();
+                output.write(request.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+
+                Socket serverSocket = server.accept();
+                // Close immediately to trigger the race with
+                // the return from ConnectHandler.handle().
+                serverSocket.close();
+
+                // Expect 200 OK from the CONNECT request
+                HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(socket.getInputStream()));
+                assertNotNull(response);
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                // Expect the connection to be closed.
+                assertEquals(-1, socket.getInputStream().read());
+            }
         }
     }
 


### PR DESCRIPTION
…ing 200 OK.

Delaying the call to UpstreamConnection.fillInterested() until the 200 OK response has been sent.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>