### PR TITLE
use agent none so we do not steal an agent doing nothing except waiting for parallel builds to finish"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 pipeline {
-  agent any
+  agent none
   // save some io during the build
   options {
     skipDefaultCheckout()


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
