### PR TITLE
Jetty 12 - Fixing simple `@named` virtualhost configuration

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -289,9 +289,9 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
      * matching virtual host name.
      *
      * @param vhosts List of virtual hosts that this context responds to. A null/empty list means any hostname is acceptable. Host names may be String
-     * representation of IP addresses. Host names may start with '*.' to wildcard one level of names. Hosts and wildcard hosts may be followed with
-     * '@connectorname', in which case they will match only if the the {@link Connector#getName()}for the request also matches. If an entry is just
-     * '@connectorname' it will match any host if that connector was used.
+     * representation of IP addresses. Host names may start with {@code "*."} to wildcard one level of names. Hosts and wildcard hosts may be followed with
+     * {@code "@connectorname"} (eg: {@code "*.example.org@connectorname"}), in which case they will match only if the {@link Connector#getName()}
+     * for the request also matches. If an entry is just {@code "@connectorname"} it will match any host if that connector was used.
      */
     public void setVirtualHosts(List<String> vhosts)
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -313,7 +313,11 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
                     vhost = vhost.substring(0, at);
                 }
 
-                if (vhost.startsWith("*."))
+                if (StringUtil.isBlank(vhost))
+                {
+                    vhost = null;
+                }
+                else if (vhost.startsWith("*."))
                 {
                     vhost = vhost.substring(1);
                     wild = true;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerCollectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerCollectionTest.java
@@ -60,6 +60,9 @@ public class ContextHandlerCollectionTest
             Arguments.of(1, "www.example.com", "/ctx/info", "A", HttpStatus.OK_200),
             Arguments.of(1, "alias.example.com", "/ctx/info", "A", HttpStatus.OK_200),
 
+            Arguments.of(0, "simple.example.com", "/ctxsimple/info", "H", HttpStatus.OK_200),
+            Arguments.of(1, "simple.example.com", "/ctxsimple/info", "G", HttpStatus.OK_200),
+
             Arguments.of(1, "www.other.com", "/ctx", "-", HttpStatus.MOVED_PERMANENTLY_301),
             Arguments.of(1, "www.other.com", "/ctx/", "B", HttpStatus.OK_200),
             Arguments.of(1, "www.other.com", "/ctx/info", "B", HttpStatus.OK_200),
@@ -105,10 +108,19 @@ public class ContextHandlerCollectionTest
         ContextHandler contextF = new ContextHandler("/ctxlong");
         contextF.setHandler(new IsHandledHandler("F"));
 
+        ContextHandler contextG = new ContextHandler("/ctxsimple");
+        contextG.setHandler(new IsHandledHandler("G"));
+        contextG.setVirtualHosts(List.of("@connector1")); // simple named connector
+
+        ContextHandler contextH = new ContextHandler("/ctxsimple");
+        contextH.setHandler(new IsHandledHandler("H"));
+
         ContextHandlerCollection c = new ContextHandlerCollection();
         c.addHandler(contextA);
         c.addHandler(contextB);
         c.addHandler(contextC);
+        c.addHandler(contextG);
+        c.addHandler(contextH);
 
         Handler.Collection handlers = new Handler.Collection();
         handlers.addHandler(contextE);


### PR DESCRIPTION
Seems that a simple `ContextHandler.setVirtualHosts(List.of("@named"))` was broken, and had no active test cases.

This adds a testcase and restores that functionality.