### PR TITLE
Converted PathMappings to be an AbstractMap

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MappedResource.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/MappedResource.java
@@ -13,11 +13,13 @@
 
 package org.eclipse.jetty.http.pathmap;
 
+import java.util.Map;
+
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
 @ManagedObject("Mapped Resource")
-public class MappedResource<E> implements Comparable<MappedResource<E>>
+public class MappedResource<E> implements Comparable<MappedResource<E>>, Map.Entry<PathSpec, E>
 {
     private final PathSpec pathSpec;
     private final E resource;
@@ -88,6 +90,24 @@ public class MappedResource<E> implements Comparable<MappedResource<E>>
             return false;
         }
         return true;
+    }
+
+    @Override
+    public PathSpec getKey()
+    {
+        return getPathSpec();
+    }
+
+    @Override
+    public E getValue()
+    {
+        return getResource();
+    }
+
+    @Override
+    public E setValue(E value)
+    {
+        throw new UnsupportedOperationException();
     }
 
     @ManagedAttribute(value = "path spec", readonly = true)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 @ManagedObject("Path Mappings")
 public class PathMappings<E> extends AbstractMap<PathSpec, E> implements Iterable<MappedResource<E>>, Dumpable
 {
-    // TODO this class should be an AbstractMap
     private static final Logger LOG = LoggerFactory.getLogger(PathMappings.class);
 
     private final Set<MappedResource<E>> _mappings = new TreeSet<>(Map.Entry.comparingByKey());

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathSpecSet.java
@@ -56,13 +56,13 @@ public class PathSpecSet extends AbstractSet<String> implements Predicate<String
     @Override
     public boolean add(String s)
     {
-        return specs.put(PathSpec.from(s), Boolean.TRUE);
+        return specs.put(PathSpec.from(s), Boolean.TRUE) == null;
     }
 
     @Override
     public boolean remove(Object o)
     {
-        return specs.remove(asPathSpec(o));
+        return specs.remove(asPathSpec(o)) != null;
     }
 
     @Override

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.http.pathmap;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -270,15 +272,15 @@ public class PathMappingsTest
     public void testPutRejectsDuplicates()
     {
         PathMappings<String> p = new PathMappings<>();
-        assertThat(p.put(new UriTemplatePathSpec("/a/{var1}/c"), "resourceA"), is(true));
-        assertThat(p.put(new UriTemplatePathSpec("/a/{var2}/c"), "resourceAA"), is(false));
-        assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceB"), is(true));
-        assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceBB"), is(false));
-        assertThat(p.put(new ServletPathSpec("/a/b/c"), "resourceBB"), is(true));
-        assertThat(p.put(new RegexPathSpec("/a/b/c"), "resourceBB"), is(true));
+        assertThat(p.put(new UriTemplatePathSpec("/a/{var2}/c"), "resourceA"), nullValue());
+        assertThat(p.put(new UriTemplatePathSpec("/a/{var1}/c"), "resourceAA"), is("resourceA"));
+        assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceB"), nullValue());
+        assertThat(p.put(new UriTemplatePathSpec("/a/b/c"), "resourceBB"), is("resourceB"));
+        assertThat(p.put(new ServletPathSpec("/a/b/c"), "resourceBB"), nullValue());
+        assertThat(p.put(new RegexPathSpec("/a/b/c"), "resourceBB"), nullValue());
 
-        assertThat(p.put(new ServletPathSpec("/*"), "resourceC"), is(true));
-        assertThat(p.put(new RegexPathSpec("/(.*)"), "resourceCC"), is(true));
+        assertThat(p.put(new ServletPathSpec("/*"), "resourceC"), nullValue());
+        assertThat(p.put(new RegexPathSpec("/(.*)"), "resourceCC"), nullValue());
     }
 
     @Test
@@ -373,27 +375,27 @@ public class PathMappingsTest
         PathMappings<String> p = new PathMappings<>();
 
         p.put(new UriTemplatePathSpec("/a/{var1}/c"), "resourceA");
-        assertThat(p.remove(new UriTemplatePathSpec("/a/{var1}/c")), is(true));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/{var1}/c")), is("resourceA"));
 
         p.put(new UriTemplatePathSpec("/a/{var1}/c"), "resourceA");
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new UriTemplatePathSpec("/a/{b}/c")), is(true));
-        assertThat(p.remove(new UriTemplatePathSpec("/a/{b}/c")), is(false));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new UriTemplatePathSpec("/a/{b}/c")), is("resourceA"));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/{b}/c")), nullValue());
 
         p.put(new UriTemplatePathSpec("/{var1}/b/c"), "resourceA");
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new UriTemplatePathSpec("/{a}/b/c")), is(true));
-        assertThat(p.remove(new UriTemplatePathSpec("/{a}/b/c")), is(false));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new UriTemplatePathSpec("/{a}/b/c")), is("resourceA"));
+        assertThat(p.remove(new UriTemplatePathSpec("/{a}/b/c")), nullValue());
 
         p.put(new UriTemplatePathSpec("/a/b/{var1}"), "resourceA");
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/{c}")), is(true));
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/{c}")), is(false));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/{c}")), is("resourceA"));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/{c}")), nullValue());
 
         p.put(new UriTemplatePathSpec("/{var1}/{var2}/{var3}"), "resourceA");
-        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new UriTemplatePathSpec("/{a}/{b}/{c}")), is(true));
-        assertThat(p.remove(new UriTemplatePathSpec("/{a}/{b}/{c}")), is(false));
+        assertThat(p.remove(new UriTemplatePathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new UriTemplatePathSpec("/{a}/{b}/{c}")), is("resourceA"));
+        assertThat(p.remove(new UriTemplatePathSpec("/{a}/{b}/{c}")), nullValue());
     }
 
     @Test
@@ -402,24 +404,24 @@ public class PathMappingsTest
         PathMappings<String> p = new PathMappings<>();
 
         p.put(new RegexPathSpec("/a/(.*)/c"), "resourceA");
-        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new RegexPathSpec("/a/(.*)/c")), is(true));
-        assertThat(p.remove(new RegexPathSpec("/a/(.*)/c")), is(false));
+        assertThat(p.remove(new RegexPathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new RegexPathSpec("/a/(.*)/c")), is("resourceA"));
+        assertThat(p.remove(new RegexPathSpec("/a/(.*)/c")), nullValue());
 
         p.put(new RegexPathSpec("/(.*)/b/c"), "resourceA");
-        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new RegexPathSpec("/(.*)/b/c")), is(true));
-        assertThat(p.remove(new RegexPathSpec("/(.*)/b/c")), is(false));
+        assertThat(p.remove(new RegexPathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new RegexPathSpec("/(.*)/b/c")), is("resourceA"));
+        assertThat(p.remove(new RegexPathSpec("/(.*)/b/c")), nullValue());
 
         p.put(new RegexPathSpec("/a/b/(.*)"), "resourceA");
-        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new RegexPathSpec("/a/b/(.*)")), is(true));
-        assertThat(p.remove(new RegexPathSpec("/a/b/(.*)")), is(false));
+        assertThat(p.remove(new RegexPathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new RegexPathSpec("/a/b/(.*)")), is("resourceA"));
+        assertThat(p.remove(new RegexPathSpec("/a/b/(.*)")), nullValue());
 
         p.put(new RegexPathSpec("/a/b/c"), "resourceA");
-        assertThat(p.remove(new RegexPathSpec("/a/b/d")), is(false));
-        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is(true));
-        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is(false));
+        assertThat(p.remove(new RegexPathSpec("/a/b/d")), nullValue());
+        assertThat(p.remove(new RegexPathSpec("/a/b/c")), is("resourceA"));
+        assertThat(p.remove(new RegexPathSpec("/a/b/c")), nullValue());
     }
 
     @Test
@@ -428,34 +430,34 @@ public class PathMappingsTest
         PathMappings<String> p = new PathMappings<>();
 
         p.put(new ServletPathSpec("/a/*"), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("/a/b")), is(false));
-        assertThat(p.remove(new ServletPathSpec("/a/*")), is(true));
-        assertThat(p.remove(new ServletPathSpec("/a/*")), is(false));
+        assertThat(p.remove(new ServletPathSpec("/a/b")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("/a/*")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("/a/*")), nullValue());
 
         p.put(new ServletPathSpec("/a/b/*"), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(false));
-        assertThat(p.remove(new ServletPathSpec("/a/b/*")), is(true));
-        assertThat(p.remove(new ServletPathSpec("/a/b/*")), is(false));
+        assertThat(p.remove(new ServletPathSpec("/a/b/c")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("/a/b/*")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("/a/b/*")), nullValue());
 
         p.put(new ServletPathSpec("*.do"), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("*.gz")), is(false));
-        assertThat(p.remove(new ServletPathSpec("*.do")), is(true));
-        assertThat(p.remove(new ServletPathSpec("*.do")), is(false));
+        assertThat(p.remove(new ServletPathSpec("*.gz")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("*.do")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("*.do")), nullValue());
 
         p.put(new ServletPathSpec("/"), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("/a")), is(false));
-        assertThat(p.remove(new ServletPathSpec("/")), is(true));
-        assertThat(p.remove(new ServletPathSpec("/")), is(false));
+        assertThat(p.remove(new ServletPathSpec("/a")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("/")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("/")), nullValue());
 
         p.put(new ServletPathSpec(""), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("/")), is(false));
-        assertThat(p.remove(new ServletPathSpec("")), is(true));
-        assertThat(p.remove(new ServletPathSpec("")), is(false));
+        assertThat(p.remove(new ServletPathSpec("/")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("")), nullValue());
 
         p.put(new ServletPathSpec("/a/b/c"), "resourceA");
-        assertThat(p.remove(new ServletPathSpec("/a/b/d")), is(false));
-        assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(true));
-        assertThat(p.remove(new ServletPathSpec("/a/b/c")), is(false));
+        assertThat(p.remove(new ServletPathSpec("/a/b/d")), nullValue());
+        assertThat(p.remove(new ServletPathSpec("/a/b/c")), is("resourceA"));
+        assertThat(p.remove(new ServletPathSpec("/a/b/c")), nullValue());
     }
 
     @Test
@@ -510,6 +512,37 @@ public class PathMappingsTest
         assertThat(p.getMatched("/foo.do").getResource(), equalTo("resourceS"));
         assertThat(p.getMatched("/a/foo.do").getResource(), equalTo("resourceP"));
         assertThat(p.getMatched("/b/foo.do").getResource(), equalTo("resourceS"));
-
     }
+
+    @Test
+    public void testAsMap()
+    {
+        PathMappings<String> p = new PathMappings<>();
+        p.put(new ServletPathSpec(""), "resourceR");
+        p.put(new ServletPathSpec("/"), "resourceD");
+        p.put(new ServletPathSpec("/exact"), "REPLACED");
+        p.put(new ServletPathSpec("/exact"), "resourceE");
+        p.put(new ServletPathSpec("/a/*"), "resourceP");
+        p.put(new ServletPathSpec("*.do"), "resourceS");
+
+        @SuppressWarnings("redundant")
+        Map<PathSpec, String> map = p;
+
+        assertThat(map.keySet(), containsInAnyOrder(
+            new ServletPathSpec(""),
+            new ServletPathSpec("/"),
+            new ServletPathSpec("/exact"),
+            new ServletPathSpec("/a/*"),
+            new ServletPathSpec("*.do")
+            ));
+
+        assertThat(map.values(), containsInAnyOrder(
+            "resourceR",
+            "resourceD",
+            "resourceE",
+            "resourceP",
+            "resourceS"
+            ));
+    }
+
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -73,22 +73,17 @@ public class PathMappingsHandler extends Handler.AbstractContainer
             throw new IllegalStateException("Cannot add mapping: " + this);
 
         // check that self isn't present
-        if (handler == this || handler instanceof Handler.Container container && container.getDescendants().contains(this))
+        if (handler == this)
             throw new IllegalStateException("Unable to addHandler of self: " + handler);
 
-        // check existing mappings
-        for (MappedResource<Handler> entry : mappings)
-        {
-            Handler entryHandler = entry.getResource();
+        // check for loops
+        if (handler instanceof Handler.Container container && container.getDescendants().contains(this))
+            throw new IllegalStateException("loop detected: " + handler);
 
-            if (entryHandler == this ||
-                entryHandler == handler ||
-                (entryHandler instanceof Handler.Container container && container.getDescendants().contains(this)))
-                throw new IllegalStateException("addMapping loop detected: " + handler);
-        }
-
+        // add new mapping and remove any old
+        Handler old = mappings.get(pathSpec);
         mappings.put(pathSpec, handler);
-        addBean(handler);
+        updateBean(old, handler);
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketMappings.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketMappings.java
@@ -205,7 +205,7 @@ public class WebSocketMappings implements Dumpable, LifeCycle.Listener
 
     public boolean removeMapping(PathSpec pathSpec)
     {
-        return mappings.remove(pathSpec);
+        return mappings.remove(pathSpec) != null;
     }
 
     /**


### PR DESCRIPTION
This was primarily done to avoid surprise of the previous behavior of puts for a duplicate key being ignored. 
The use of the AbstractMap class now provides javadoc and known/expected behavior for key methods. 
The only significant behavior change is in the return type of some key methods, with the old/previous value replacing a boolean. 
Some stream usage has also been replaced by the more efficient iterator.
Some methods provided by AbstractMap may not be efficient.