### PR TITLE
Jetty 12.0.x silence tests' stacktraces

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.http.HttpFields;
@@ -46,6 +47,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -655,7 +657,7 @@ public class IdleTimeoutTest extends AbstractTest
     @Test
     public void testServerIdleTimeoutIsEnforcedForQueuedRequest() throws Exception
     {
-        long idleTimeout = 2000;
+        long idleTimeout = 750;
         // Use a small thread pool to cause request queueing.
         QueuedThreadPool serverExecutor = new QueuedThreadPool(5);
         serverExecutor.setName("server");
@@ -667,6 +669,8 @@ public class IdleTimeoutTest extends AbstractTest
         connector = new ServerConnector(server, 1, 1, h2);
         connector.setIdleTimeout(10 * idleTimeout);
         server.addConnector(connector);
+        AtomicInteger requests = new AtomicInteger();
+        AtomicInteger handled = new AtomicInteger();
         AtomicReference<CountDownLatch> phaser = new AtomicReference<>();
         server.setHandler(new Handler.Abstract()
         {
@@ -674,10 +678,13 @@ public class IdleTimeoutTest extends AbstractTest
             public boolean process(Request request, Response response, Callback callback)
             {
                 System.err.println("processing request " + request.getHttpURI().getPath());
+                requests.incrementAndGet();
+                handled.incrementAndGet();
                 phaser.get().countDown();
                 // Hold the dispatched requests enough for the idle requests to idle timeout.
                 sleep(2 * idleTimeout);
                 callback.succeeded();
+                handled.decrementAndGet();
                 return true;
             }
         });
@@ -688,6 +695,7 @@ public class IdleTimeoutTest extends AbstractTest
 
         Session client = newClientSession(new Session.Listener() {});
 
+        AtomicInteger responses = new AtomicInteger();
         // Send requests until one is queued on the server but not dispatched.
         int count = 0;
         while (true)
@@ -698,12 +706,19 @@ public class IdleTimeoutTest extends AbstractTest
             MetaData.Request request = newRequest("GET", "/" + count, HttpFields.EMPTY);
             HeadersFrame frame = new HeadersFrame(request, null, false);
             FuturePromise<Stream> promise = new FuturePromise<>();
-            client.newStream(frame, promise, null);
+            client.newStream(frame, promise, new Stream.Listener()
+            {
+                @Override
+                public void onHeaders(Stream stream, HeadersFrame frame)
+                {
+                    responses.incrementAndGet();
+                }
+            });
             Stream stream = promise.get(5, TimeUnit.SECONDS);
             ByteBuffer data = ByteBuffer.allocate(10);
             stream.data(new DataFrame(stream.getId(), data, true), Callback.NOOP);
 
-            if (!phaser.get().await(1, TimeUnit.SECONDS))
+            if (!phaser.get().await(idleTimeout / 2, TimeUnit.MILLISECONDS))
                 break;
         }
 
@@ -728,9 +743,13 @@ public class IdleTimeoutTest extends AbstractTest
         assertTrue(resetLatch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
 
         // Wait for WINDOW_UPDATEs to be processed by the client.
-        sleep(1000);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> ((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
 
-        assertThat(((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
+        // Wait for the server to finish serving requests.
+        await().atMost(5, TimeUnit.SECONDS).until(handled::get, Matchers.is(0));
+        assertThat(requests.get(), Matchers.is(count - 1));
+
+        await().atMost(5, TimeUnit.SECONDS).until(responses::get, Matchers.is(count - 1));
     }
 
     private void sleep(long value)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.server;
 import java.nio.ByteBuffer;
 import java.util.ListIterator;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -254,7 +255,7 @@ public interface Response extends Content.Sink
         // Let's be less verbose with BadMessageExceptions & QuietExceptions
         if (logger.isDebugEnabled())
             logger.debug("writeError: status={}, message={}, response={}", status, message, response, cause);
-        else if (cause instanceof BadMessageException || cause instanceof QuietException)
+        else if (cause instanceof BadMessageException || cause instanceof QuietException || cause instanceof TimeoutException)
             logger.debug("writeError: status={}, message={}, response={} {}", status, message, response, cause.toString());
         else if (cause != null)
             logger.warn("writeError: status={}, message={}, response={}", status, message, response, cause);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/DetectorConnectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/DetectorConnectionTest.java
@@ -55,6 +55,7 @@ public class DetectorConnectionTest
 {
     private final AtomicInteger _bufferLeaks = new AtomicInteger();
     private Server _server;
+    private StacklessLogging _stacklessLogging;
 
     private static String inputStreamToString(InputStream is) throws IOException
     {
@@ -139,6 +140,7 @@ public class DetectorConnectionTest
         _server.addConnector(new ServerConnector(_server, 1, 1, connectionFactories));
         _server.setHandler(new DumpHandler());
         _server.start();
+        _stacklessLogging = new StacklessLogging(DetectorConnectionFactory.class);
     }
 
     @AfterEach
@@ -151,6 +153,8 @@ public class DetectorConnectionTest
             .until(() -> _bufferLeaks.get() == 0);
         if (_server != null)
             _server.stop();
+        if (_stacklessLogging != null)
+            _stacklessLogging.close();
     }
 
     @Test
@@ -536,11 +540,9 @@ public class DetectorConnectionTest
             Connection: close\r
             \r
             """;
-        try (StacklessLogging ignore = new StacklessLogging(DetectorConnectionFactory.class))
-        {
-            String response = getResponse(StringUtil.fromHexString(proxyReq), httpReq.getBytes(StandardCharsets.US_ASCII));
-            assertThat(response, Matchers.nullValue());
-        }
+
+        String response = getResponse(StringUtil.fromHexString(proxyReq), httpReq.getBytes(StandardCharsets.US_ASCII));
+        assertThat(response, Matchers.nullValue());
     }
 
     @Test


### PR DESCRIPTION
Prevent expected stack traces to pollute the output during builds.