### PR TITLE
Jetty 12 - Dependency updates (with focus on isolated ee deps)

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -333,11 +333,6 @@
       <scope>provided</scope>
     </dependency>
     <!--<dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-unixsocket-client</artifactId>
-      <scope>provided</scope>
-    </dependency>-->
-    <!--<dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-jakarta-server</artifactId>
       <scope>provided</scope>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -358,21 +358,6 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
         <version>12.0.0-SNAPSHOT</version>
       </dependency>

--- a/jetty-ee10/jetty-ee10-jaas/pom.xml
+++ b/jetty-ee10/jetty-ee10-jaas/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.jaas</bundle-symbolic-name>
     <apacheds.version>2.0.0.AM26</apacheds.version>
-    <apache.directory.api.version>2.1.0</apache.directory.api.version>
+    <apache.directory.api.version>2.1.2</apache.directory.api.version>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.ee10.jaas.*</spotbugs.onlyAnalyze>
   </properties>
 

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -410,4 +410,37 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <!--
+        $ mvn -Pdependency-updates-reports validate
+        # once done, check the jetty-ee10/target/site/dependency-updates-aggregate-report.html
+        -->
+      <id>dependency-updates-reports</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <version>2.14.2</version>
+            <executions>
+              <execution>
+                <id>ee10-report</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>dependency-updates-aggregate-report</goal>
+                </goals>
+                <configuration>
+                  <formats>
+                    <format>html</format>
+                  </formats>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -35,7 +35,7 @@
     <jakarta.servlet.jsp.jstl.impl.version>3.0.1</jakarta.servlet.jsp.jstl.impl.version>
     <jakarta.ws.rs.api.version>3.1.0</jakarta.ws.rs.api.version>
     <jakarta.xml.bind.api.version>4.0.0</jakarta.xml.bind.api.version>
-    <jakarta.xml.bind.impl.version>4.0.0</jakarta.xml.bind.impl.version>
+    <jakarta.xml.bind.impl.version>4.0.1</jakarta.xml.bind.impl.version>
     <jakarta.xml.ws.api.version>4.0.0</jakarta.xml.ws.api.version>
     <jakarta.xml.jaxws.impl.version>4.0.0</jakarta.xml.jaxws.impl.version>
     <jakarta.websocket.api.version>2.1.0</jakarta.websocket.api.version>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -423,7 +423,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.14.2</version>
             <executions>
               <execution>
                 <id>ee10-report</id>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -19,7 +19,7 @@
     <javax.security.auth.message.version>1.0.0.v201108011116</javax.security.auth.message.version>
     <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version>
 
-    <jakarta.activation.api.version>2.1.0</jakarta.activation.api.version>
+    <jakarta.activation.api.version>2.1.1</jakarta.activation.api.version>
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
     <jakarta.authentication.api.version>3.0.0</jakarta.authentication.api.version>
     <jakarta.el.api.version>5.0.0</jakarta.el.api.version>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -27,7 +27,7 @@
     <jakarta.enterprise.lang.model.version>4.0.1</jakarta.enterprise.lang.model.version>
     <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>
     <jakarta.interceptor.api.version>2.1.0</jakarta.interceptor.api.version>
-    <jakarta.mail.api.version>2.1.0</jakarta.mail.api.version>
+    <jakarta.mail.api.version>2.1.1</jakarta.mail.api.version>
     <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
     <jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
     <jakarta.servlet.jsp.api.version>3.1.0</jakarta.servlet.jsp.api.version>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -22,7 +22,7 @@
     <jakarta.activation.api.version>2.1.1</jakarta.activation.api.version>
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
     <jakarta.authentication.api.version>3.0.0</jakarta.authentication.api.version>
-    <jakarta.el.api.version>5.0.0</jakarta.el.api.version>
+    <jakarta.el.api.version>5.0.1</jakarta.el.api.version>
     <jakarta.enterprise.cdi.api.version>4.0.1</jakarta.enterprise.cdi.api.version>
     <jakarta.enterprise.lang.model.version>4.0.1</jakarta.enterprise.lang.model.version>
     <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -37,7 +37,7 @@
     <jakarta.xml.bind.api.version>4.0.0</jakarta.xml.bind.api.version>
     <jakarta.xml.bind.impl.version>4.0.0</jakarta.xml.bind.impl.version>
     <jakarta.xml.ws.api.version>4.0.0</jakarta.xml.ws.api.version>
-    <jakarta.xml.jaxws.impl.version>4.0.0-M4</jakarta.xml.jaxws.impl.version>
+    <jakarta.xml.jaxws.impl.version>4.0.0</jakarta.xml.jaxws.impl.version>
     <jakarta.websocket.api.version>2.1.0</jakarta.websocket.api.version>
     <jsp.impl.version>10.1.1</jsp.impl.version>
     <sonar.skip>true</sonar.skip>

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -432,4 +432,36 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <!--
+        $ mvn -Pdependency-updates-reports validate
+        # once done, check the jetty-ee9/target/site/dependency-updates-aggregate-report.html
+        -->
+      <id>dependency-updates-reports</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>ee9-report</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>dependency-updates-aggregate-report</goal>
+                </goals>
+                <configuration>
+                  <formats>
+                    <format>html</format>
+                  </formats>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <guava.version>31.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <hawtio.version>2.15.2</hawtio.version>
     <hazelcast.version>4.2.5</hazelcast.version>
     <infinispan.protostream.version>4.6.0.Final</infinispan.protostream.version>
     <infinispan.version>11.0.16.Final</infinispan.version>
@@ -978,12 +977,6 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.hawt</groupId>
-        <artifactId>hawtio-default</artifactId>
-        <version>${hawtio.version}</version>
-        <type>war</type>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>3.5.0</plexus-utils.version>
-    <slf4j.version>2.0.5</slf4j.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <spifly.version>1.3.6</spifly.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jetty.test.version>6.0</jetty.test.version>
     <jetty.xhtml.schemas-version>1.1</jetty.xhtml.schemas-version>
     <jmh.version>1.36</jmh.version>
-    <jna.version>5.12.1</jna.version>
+    <jna.version>5.13.0</jna.version>
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.4.8</json-smart.version>
     <junit.version>5.9.1</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1581,6 +1581,11 @@
         <version>${infinispan.protostream.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.infinispan.protostream</groupId>
+        <artifactId>protostream-processor</artifactId>
+        <version>${infinispan.protostream.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <google.errorprone.version>2.18.0</google.errorprone.version>
-    <grpc.version>1.49.2</grpc.version>
+    <grpc.version>1.52.1</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <logback.version>1.4.5</logback.version>
     <mariadb.version>3.0.8</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
-    <maven.deps.version>3.8.4</maven.deps.version>
+    <maven.deps.version>3.8.7</maven.deps.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
     <maven.resolver.version>1.9.2</maven.resolver.version>
     <maven.version>3.8.7</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,29 +54,6 @@
     <infinispan.protostream.version>4.6.0.Final</infinispan.protostream.version>
     <infinispan.version>11.0.16.Final</infinispan.version>
     <jackson.version>2.14.1</jackson.version>
-    <jakarta.activation.api.version>2.0.1</jakarta.activation.api.version>
-    <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
-    <jakarta.authentication.api.version>2.0.0</jakarta.authentication.api.version>
-    <jakarta.el.api.version>4.0.0</jakarta.el.api.version>
-    <jakarta.enterprise.cdi.api.version>3.0.0</jakarta.enterprise.cdi.api.version>
-    <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>
-    <jakarta.interceptor.api.version>2.0.0</jakarta.interceptor.api.version>
-    <jakarta.mail.api.version>2.0.1</jakarta.mail.api.version>
-    <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
-    <jakarta.servlet.jsp.api.version>3.0.0</jakarta.servlet.jsp.api.version>
-    <jakarta.servlet.jsp.jstl.api.version>2.0.0</jakarta.servlet.jsp.jstl.api.version>
-    <jakarta.servlet.jsp.jstl.impl.version>2.0.0</jakarta.servlet.jsp.jstl.impl.version> <!-- TODO: remove? -->
-    <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
-    <jakarta.websocket.api.version>2.0.0</jakarta.websocket.api.version>
-    <jakarta.ws.rs.api.version>3.1.0</jakarta.ws.rs.api.version>
-    <jakarta.xml.bind.api.version>3.0.1</jakarta.xml.bind.api.version>
-    <jakarta.xml.bind.impl.version>3.0.2</jakarta.xml.bind.impl.version>
-    <jakarta.xml.jaxws.impl.version>3.0.2</jakarta.xml.jaxws.impl.version>
-    <jakarta.xml.ws.api.version>3.0.1</jakarta.xml.ws.api.version>
-    <javax.activation.impl.version>1.1.0.v201105071233</javax.activation.impl.version> <!-- TODO: remove? -->
-    <javax.cdi.api.version>2.0</javax.cdi.api.version> <!-- TODO: remove? -->
-    <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version> <!-- TODO: remove? -->
-    <javax.security.auth.message.version>1.0.0.v201108011116</javax.security.auth.message.version> <!-- TODO: remove? -->
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.5.0.Final</jboss.logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <jna.version>5.13.0</jna.version>
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.4.8</json-smart.version>
-    <junit.version>5.9.1</junit.version>
+    <junit.version>5.9.2</junit.version>
     <kerb-simplekdc.version>2.0.2</kerb-simplekdc.version>
     <log4j2.version>2.19.0</log4j2.version>
     <logback.version>1.4.5</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -989,29 +989,6 @@
         <version>${json-simple.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.jamonapi</groupId>
-        <artifactId>jamon</artifactId>
-        <version>${jamon.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.jamonapi</groupId>
-        <artifactId>jamon_war</artifactId>
-        <version>${jamon.version}</version>
-        <type>war</type>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.jolokia</groupId>
         <artifactId>jolokia-war</artifactId>
         <version>${jolokia.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1275,21 +1275,6 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-client</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-common</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-unixsocket-server</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <google.errorprone.version>2.15.0</google.errorprone.version>
     <grpc.version>1.49.2</grpc.version>
-    <gson.version>2.9.1</gson.version>
+    <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <guava.version>31.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <hazelcast.version>4.2.5</hazelcast.version>
+    <hazelcast.version>4.2.6</hazelcast.version>
     <infinispan.protostream.version>4.6.0.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <groovy.version>4.0.6</groovy.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
-    <maven.plugin-tools.version>3.7.0</maven.plugin-tools.version>
+    <maven.plugin-tools.version>3.7.1</maven.plugin-tools.version>
     <maven-plugin.plugin.version>3.7.0</maven-plugin.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.remote-resources-plugin.version>3.0.0</maven.remote-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <disruptor.version>3.4.2</disruptor.version>
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-    <google.errorprone.version>2.15.0</google.errorprone.version>
+    <google.errorprone.version>2.18.0</google.errorprone.version>
     <grpc.version>1.49.2</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <!-- dependency versions -->
     <alpn.agent.version>2.0.10</alpn.agent.version>
-    <ant.version>1.10.12</ant.version>
+    <ant.version>1.10.13</ant.version>
     <apache.avro.version>1.11.1</apache.avro.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -958,12 +958,6 @@
         <version>${json-simple.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.jolokia</groupId>
-        <artifactId>jolokia-war</artifactId>
-        <version>${jolokia.version}</version>
-        <type>war</type>
-      </dependency>
-      <dependency>
         <groupId>com.openpojo</groupId>
         <artifactId>openpojo</artifactId>
         <version>${openpojo.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <osgi-annotation-version>8.1.0</osgi-annotation-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
-    <osgi-service-component-version>1.5.0</osgi-service-component-version>
+    <osgi-service-component-version>1.5.1</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
     <osgi-util-version>3.7.100</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <hazelcast.version>4.2.5</hazelcast.version>
     <infinispan.protostream.version>4.6.0.Final</infinispan.protostream.version>
     <infinispan.version>11.0.16.Final</infinispan.version>
-    <jackson.version>2.14.1</jackson.version>
+    <jackson.version>2.14.2</jackson.version>
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.5.0.Final</jboss.logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <spotbugs.maven.plugin.version>4.7.2.0</spotbugs.maven.plugin.version>
-    <versions.maven.plugin.version>2.12.0</versions.maven.plugin.version>
+    <versions.maven.plugin.version>2.14.2</versions.maven.plugin.version>
 
     <!-- testing -->
     <invoker.mergeUserSettings>false</invoker.mergeUserSettings>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <hazelcast.version>4.2.5</hazelcast.version>
     <infinispan.protostream.version>4.6.0.Final</infinispan.protostream.version>
-    <infinispan.version>11.0.16.Final</infinispan.version>
+    <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <asciidoctorj-diagram.version>2.2.3</asciidoctorj-diagram.version>
-    <asciidoctorj.version>2.5.6</asciidoctorj.version>
+    <asciidoctorj.version>2.5.7</asciidoctorj.version>
     <asm.version>9.4</asm.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bndlib.version>6.3.1</bndlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <kerb-simplekdc.version>2.0.2</kerb-simplekdc.version>
     <log4j2.version>2.19.0</log4j2.version>
     <logback.version>1.4.5</logback.version>
-    <mariadb.version>3.0.8</mariadb.version>
+    <mariadb.version>3.0.10</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.deps.version>3.8.7</maven.deps.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
     <jetty.xhtml.schemas-version>1.1</jetty.xhtml.schemas-version>
     <jmh.version>1.36</jmh.version>
     <jna.version>5.12.1</jna.version>
-    <jnr-constants.version>0.10.4</jnr-constants.version>
-    <jnr-enxio.version>0.32.13</jnr-enxio.version>
-    <jnr-ffi.version>2.2.12</jnr-ffi.version>
-    <jnr-posix.version>3.1.15</jnr-posix.version>
-    <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.4.8</json-smart.version>
     <junit.version>5.9.1</junit.version>
@@ -932,31 +927,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-constants</artifactId>
-        <version>${jnr-constants.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-enxio</artifactId>
-        <version>${jnr-enxio.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-ffi</artifactId>
-        <version>${jnr-ffi.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-posix</artifactId>
-        <version>${jnr-posix.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-unixsocket</artifactId>
-        <version>${jnr-unixsocket.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Cleanup top level pom.xml and jetty-ee#/pom.xml to isolate ee deps properly.

Also upgrade ee10 deps that need updating.