### PR TITLE
Remove duplicate osgi dependency declarations in top level pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,14 +87,12 @@
 
     <osgi-version>3.18.200</osgi-version>
     <!-- really used -->
-    <osgi-annotation-version>8.1.0</osgi-annotation-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.1</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
     <osgi-util-version>3.7.100</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>
-    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
     <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
     <osgi-util-position-version>1.0.1</osgi-util-position-version>
     <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
@@ -1495,11 +1493,6 @@
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>osgi.annotation</artifactId>
-        <version>${osgi-annotation-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
         <artifactId>org.osgi.service.component</artifactId>
         <version>${osgi-service-component-version}</version>
       </dependency>
@@ -1512,12 +1505,6 @@
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.util.tracker</artifactId>
         <version>${osgi-util-tracker-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.util.promise</artifactId>
-        <version>${osgi-util-promise-version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>


### PR DESCRIPTION
Duplicate declarations of dependencies causes the following build warning:

```
> [INFO] Scanning for projects...
> [WARNING] 
> [WARNING] Some problems were encountered while building the effective model for org.eclipse.jetty.ee10:jetty-ee10-test-http2-webapp:war:12.0.0-SNAPSHOT
> [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.osgi:osgi.annotation:jar -> version ${osgi-annotation-version} vs ${org.osgi.annotation.version} @ org.eclipse.jetty:jetty-project:12.0.0-SNAPSHOT, /home/janb/src/jetty-eclipse/jetty-12.0.x/pom.xml, line 1681, column 19
> [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.osgi:org.osgi.util.promise:jar -> version ${osgi-util-promise-version} vs ${org.osgi.util.promise.version} @ org.eclipse.jetty:jetty-project:12.0.0-SNAPSHOT, /home/janb/src/jetty-eclipse/jetty-12.0.x/pom.xml, line 1691, column 19
> [WARNING] 
> [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
> [WARNING] 
> [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
> 
```