### PR TITLE
Issue #9233 - Fix some JPMS issues for websocket-core

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Frame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/Frame.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.TypeUtil;
 
 /**
  * A Base Frame as seen in <a href="https://tools.ietf.org/html/rfc6455#section-5.2">RFC 6455. Sec 5.2</a>
@@ -412,7 +411,7 @@ public class Frame
         b.append(((finRsvOp & 0x40) != 0) ? '1' : '0');
         b.append(((finRsvOp & 0x20) != 0) ? '1' : '0');
         b.append(((finRsvOp & 0x10) != 0) ? '1' : '0');
-        b.append(",m=").append(mask == null ? "null" : TypeUtil.toHexString(mask));
+        b.append(",m=").append(mask == null ? "null" : StringUtil.toHexString(mask));
         b.append(']');
         if (payload != null)
             b.append(BufferUtil.toDetailString(payload));

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/ServerUpgradeRequest.java
@@ -14,131 +14,23 @@
 package org.eclipse.jetty.websocket.core.server;
 
 import java.util.List;
-import java.util.Set;
 
-import org.eclipse.jetty.http.BadMessageException;
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
-import org.eclipse.jetty.websocket.core.WebSocketConstants;
-import org.eclipse.jetty.websocket.core.server.internal.WebSocketNegotiation;
 
-/**
- * Upgrade request used for websocket negotiation.
- * Provides getters for things like the requested extensions and subprotocols so that the headers don't have to be parsed manually.
- */
-public class ServerUpgradeRequest extends Request.Wrapper
+public interface ServerUpgradeRequest extends Request
 {
-    private final Request request;
-    private final WebSocketNegotiation negotiation;
-    private final Attributes attributes = new Attributes.Lazy();
-    private boolean upgraded = false;
+    WebSocketComponents getWebSocketComponents();
 
-    public ServerUpgradeRequest(WebSocketNegotiation negotiation, Request baseRequest) throws BadMessageException
-    {
-        super(baseRequest);
-        this.negotiation = negotiation;
-        this.request = baseRequest;
-    }
+    void upgrade(Attributes attributes);
 
-    public WebSocketComponents getWebSocketComponents()
-    {
-        return negotiation.getWebSocketComponents();
-    }
+    List<ExtensionConfig> getExtensions();
 
-    public void upgrade(Attributes attributes)
-    {
-        this.attributes.clearAttributes();
-        for (String name : attributes.getAttributeNameSet())
-        {
-            this.attributes.setAttribute(name, attributes.getAttribute(name));
-        }
-        upgraded = true;
-    }
+    String getProtocolVersion();
 
-    @Override
-    public Object removeAttribute(String name)
-    {
-        if (upgraded)
-            return attributes.removeAttribute(name);
-        return super.removeAttribute(name);
-    }
+    List<String> getSubProtocols();
 
-    @Override
-    public Object setAttribute(String name, Object attribute)
-    {
-        if (upgraded)
-            return attributes.setAttribute(name, attribute);
-        return super.setAttribute(name, attribute);
-    }
-
-    @Override
-    public Object getAttribute(String name)
-    {
-        if (upgraded)
-            return attributes.getAttribute(name);
-        return super.getAttribute(name);
-    }
-
-    @Override
-    public Set<String> getAttributeNameSet()
-    {
-        if (upgraded)
-            return attributes.getAttributeNameSet();
-        return super.getAttributeNameSet();
-    }
-
-    @Override
-    public void clearAttributes()
-    {
-        if (upgraded)
-            attributes.clearAttributes();
-        else
-            super.clearAttributes();
-    }
-
-    /**
-     * @return The extensions offered
-     */
-    public List<ExtensionConfig> getExtensions()
-    {
-        return negotiation.getOfferedExtensions();
-    }
-
-    /**
-     * @return WebSocket protocol version from "Sec-WebSocket-Version" header
-     */
-    public String getProtocolVersion()
-    {
-        String version = request.getHeaders().get(HttpHeader.SEC_WEBSOCKET_VERSION.asString());
-        if (version == null)
-        {
-            return Integer.toString(WebSocketConstants.SPEC_VERSION);
-        }
-        return version;
-    }
-
-    /**
-     * @return Get WebSocket negotiation offered sub protocols
-     */
-    public List<String> getSubProtocols()
-    {
-        return negotiation.getOfferedSubprotocols();
-    }
-
-    /**
-     * @param subprotocol A sub protocol name
-     * @return True if the sub protocol was offered
-     */
-    public boolean hasSubProtocol(String subprotocol)
-    {
-        for (String protocol : getSubProtocols())
-        {
-            if (protocol.equalsIgnoreCase(subprotocol))
-                return true;
-        }
-        return false;
-    }
+    boolean hasSubProtocol(String subprotocol);
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeRequestImpl.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeRequestImpl.java
@@ -1,0 +1,150 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.server.internal;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.Attributes;
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
+import org.eclipse.jetty.websocket.core.WebSocketComponents;
+import org.eclipse.jetty.websocket.core.WebSocketConstants;
+import org.eclipse.jetty.websocket.core.server.ServerUpgradeRequest;
+
+/**
+ * Upgrade request used for websocket negotiation.
+ * Provides getters for things like the requested extensions and subprotocols so that the headers don't have to be parsed manually.
+ */
+public class ServerUpgradeRequestImpl extends Request.Wrapper implements ServerUpgradeRequest
+{
+    private final Request request;
+    private final WebSocketNegotiation negotiation;
+    private final Attributes attributes = new Attributes.Lazy();
+    private boolean upgraded = false;
+
+    public ServerUpgradeRequestImpl(WebSocketNegotiation negotiation, Request baseRequest) throws BadMessageException
+    {
+        super(baseRequest);
+        this.negotiation = negotiation;
+        this.request = baseRequest;
+    }
+
+    @Override
+    public WebSocketComponents getWebSocketComponents()
+    {
+        return negotiation.getWebSocketComponents();
+    }
+
+    @Override
+    public void upgrade(Attributes attributes)
+    {
+        this.attributes.clearAttributes();
+        for (String name : attributes.getAttributeNameSet())
+        {
+            this.attributes.setAttribute(name, attributes.getAttribute(name));
+        }
+        upgraded = true;
+    }
+
+    @Override
+    public Object removeAttribute(String name)
+    {
+        if (upgraded)
+            return attributes.removeAttribute(name);
+        return super.removeAttribute(name);
+    }
+
+    @Override
+    public Object setAttribute(String name, Object attribute)
+    {
+        if (upgraded)
+            return attributes.setAttribute(name, attribute);
+        return super.setAttribute(name, attribute);
+    }
+
+    @Override
+    public Object getAttribute(String name)
+    {
+        if (upgraded)
+            return attributes.getAttribute(name);
+        return super.getAttribute(name);
+    }
+
+    @Override
+    public Set<String> getAttributeNameSet()
+    {
+        if (upgraded)
+            return attributes.getAttributeNameSet();
+        return super.getAttributeNameSet();
+    }
+
+    @Override
+    public void clearAttributes()
+    {
+        if (upgraded)
+            attributes.clearAttributes();
+        else
+            super.clearAttributes();
+    }
+
+    /**
+     * @return The extensions offered
+     */
+    @Override
+    public List<ExtensionConfig> getExtensions()
+    {
+        return negotiation.getOfferedExtensions();
+    }
+
+    /**
+     * @return WebSocket protocol version from "Sec-WebSocket-Version" header
+     */
+    @Override
+    public String getProtocolVersion()
+    {
+        String version = request.getHeaders().get(HttpHeader.SEC_WEBSOCKET_VERSION.asString());
+        if (version == null)
+        {
+            return Integer.toString(WebSocketConstants.SPEC_VERSION);
+        }
+        return version;
+    }
+
+    /**
+     * @return Get WebSocket negotiation offered sub protocols
+     */
+    @Override
+    public List<String> getSubProtocols()
+    {
+        return negotiation.getOfferedSubprotocols();
+    }
+
+    /**
+     * @param subprotocol A sub protocol name
+     * @return True if the sub protocol was offered
+     */
+    @Override
+    public boolean hasSubProtocol(String subprotocol)
+    {
+        for (String protocol : getSubProtocols())
+        {
+            if (protocol.equalsIgnoreCase(subprotocol))
+                return true;
+        }
+        return false;
+    }
+}

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeResponseImpl.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeResponseImpl.java
@@ -1,0 +1,100 @@
+//
+// ========================================================================
+// Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core.server.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.websocket.core.ExtensionConfig;
+import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
+
+/**
+ * Upgrade response used for websocket negotiation.
+ * Allows setting of extensions and subprotocol without using headers directly.
+ */
+public class ServerUpgradeResponseImpl extends Response.Wrapper implements ServerUpgradeResponse
+{
+    private final Response response;
+    private final WebSocketNegotiation negotiation;
+    private final HttpFields.Mutable fields;
+
+    public ServerUpgradeResponseImpl(WebSocketNegotiation negotiation, Response baseResponse)
+    {
+        super(baseResponse.getRequest(), baseResponse);
+        this.negotiation = negotiation;
+        this.response = baseResponse;
+        this.fields = new WebSocketHttpFieldsWrapper(response.getHeaders(), this, negotiation);
+    }
+
+    @Override
+    public HttpFields.Mutable getHeaders()
+    {
+        return fields;
+    }
+
+    @Override
+    public String getAcceptedSubProtocol()
+    {
+        return negotiation.getSubprotocol();
+    }
+
+    @Override
+    public void setAcceptedSubProtocol(String protocol)
+    {
+        negotiation.setSubprotocol(protocol);
+    }
+
+    @Override
+    public List<ExtensionConfig> getExtensions()
+    {
+        return negotiation.getNegotiatedExtensions();
+    }
+
+    @Override
+    public void addExtensions(List<ExtensionConfig> configs)
+    {
+        ArrayList<ExtensionConfig> combinedConfig = new ArrayList<>();
+        combinedConfig.addAll(getExtensions());
+        combinedConfig.addAll(configs);
+        setExtensions(combinedConfig);
+    }
+
+    @Override
+    public void setExtensions(List<ExtensionConfig> configs)
+    {
+        // This validation is also done later in RFC6455Handshaker but it is better to fail earlier
+        for (ExtensionConfig config : configs)
+        {
+            if (config.getName().startsWith("@"))
+                continue;
+
+            long matches = negotiation.getOfferedExtensions().stream().filter(e -> e.getName().equals(config.getName())).count();
+            if (matches < 1)
+                throw new IllegalArgumentException("Extension not a requested extension");
+
+            matches = configs.stream().filter(e -> e.getName().equals(config.getName())).count();
+            if (matches > 1)
+                throw new IllegalArgumentException("Multiple extensions of the same name");
+        }
+
+        negotiation.setNegotiatedExtensions(configs);
+    }
+
+    public String toString()
+    {
+        return String.format("UpgradeResponse=%s", response);
+    }
+}

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
@@ -45,8 +45,8 @@ public abstract class WebSocketNegotiation
 
     public WebSocketNegotiation(Request request, Response response, Callback callback, WebSocketComponents webSocketComponents)
     {
-        this.request = new ServerUpgradeRequest(this, request);
-        this.response = new ServerUpgradeResponse(this, response);
+        this.request = new ServerUpgradeRequestImpl(this, request);
+        this.response = new ServerUpgradeResponseImpl(this, response);
         this.callback = callback;
         this.components = webSocketComponents;
     }


### PR DESCRIPTION
## Issue #9233

make `ServerUpgradeRequest` and `ServerUpgradeResponse` interfaces so we do not expose the `WebSocketNegotitation` needed to construct them, as the `WebSocketNegotitation` has now been moved to the internal package.