### PR TITLE
Issue #9233 - cleanup of websocket-core-common util package

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jetty.websocket.core.exception.InvalidSignatureException;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class InvokerUtils
             if ((this.name != null) || (other.name != null))
             {
                 // They have to match
-                if (this.name.equals(other.name))
+                if (Objects.equals(this.name, other.name))
                 {
                     if (convertible)
                     {
@@ -79,7 +80,7 @@ public class InvokerUtils
                 return false;
             }
 
-            // Not named, then its a simple type / assignable match
+            // Not named, then it's a simple type / assignable match
             return (other.type.isAssignableFrom(this.type));
         }
 
@@ -111,11 +112,6 @@ public class InvokerUtils
         public boolean isRequired()
         {
             return required;
-        }
-
-        public boolean isConvertible()
-        {
-            return convertible;
         }
     }
 
@@ -218,7 +214,7 @@ public class InvokerUtils
         Class<?>[] parameterTypes = method.getParameterTypes();
 
         // Construct Actual Calling Args.
-        // This is the array of args, arriving as all of the named variables (usually static in nature),
+        // This is the array of args, arriving as all the named variables (usually static in nature),
         // then the raw calling arguments (very dynamic in nature)
         Arg[] callingArgs = new Arg[rawCallingArgs.length + (namedVariables == null ? 0 : namedVariables.length)];
         {
@@ -275,9 +271,8 @@ public class InvokerUtils
         List<Class<?>> cTypes = new ArrayList<>();
         {
             cTypes.add(targetClass); // targetClass always at index 0
-            for (int i = 0; i < callingArgs.length; i++)
+            for (Arg arg : callingArgs)
             {
-                Arg arg = callingArgs[i];
                 if (arg.name != null)
                 {
                     hasNamedCallingArgs = true;
@@ -364,7 +359,7 @@ public class InvokerUtils
             {
                 for (int uci = 0; uci < usedCallingArgs.length; uci++)
                 {
-                    if (usedCallingArgs[uci] == false)
+                    if (!usedCallingArgs[uci])
                     {
                         if (callingArgs[uci].required)
                         {
@@ -407,9 +402,8 @@ public class InvokerUtils
                 // Use converted Types for callingArgs
                 cTypes = new ArrayList<>();
                 cTypes.add(targetClass); // targetClass always at index 0
-                for (int i = 0; i < callingArgs.length; i++)
+                for (Arg arg : callingArgs)
                 {
-                    Arg arg = callingArgs[i];
                     cTypes.add(arg.getConvertedType());
                 }
                 callingType = MethodType.methodType(method.getReturnType(), cTypes);
@@ -474,20 +468,6 @@ public class InvokerUtils
             if (comma)
                 str.append(", ");
             str.append(arg.getType().getName());
-            comma = true;
-        }
-        str.append(")");
-    }
-
-    private static void appendTypeList(StringBuilder str, Class<?>[] types)
-    {
-        str.append("(");
-        boolean comma = false;
-        for (Class<?> type : types)
-        {
-            if (comma)
-                str.append(", ");
-            str.append(type.getName());
             comma = true;
         }
         str.append(")");

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/InvokerUtils.java
@@ -249,13 +249,11 @@ public class InvokerUtils
         }
 
         // Parameter to Calling Argument mapping.
-        // The size of this array must be the the same as the parameterArgs array (or bigger)
+        // The size of this array must be the same as the parameterArgs array (or bigger)
         if (callingArgs.length < parameterTypes.length)
         {
             if (!throwOnFailure)
-            {
                 return null;
-            }
 
             StringBuilder err = new StringBuilder();
             err.append("Target method ");
@@ -274,13 +272,9 @@ public class InvokerUtils
             for (Arg arg : callingArgs)
             {
                 if (arg.name != null)
-                {
                     hasNamedCallingArgs = true;
-                }
                 if (arg.convertible)
-                {
                     hasConvertibleTypes = true;
-                }
                 cTypes.add(arg.getType());
             }
         }
@@ -299,9 +293,7 @@ public class InvokerUtils
             // If callingType and rawType are the same (and there's no named args),
             // then there's no need to reorder / permute / drop args
             if (!hasNamedCallingArgs && !hasNamedParamArgs && rawType.equals(callingType))
-            {
                 return methodHandle;
-            }
 
             // If we reached this point, then we know that the callingType and rawType don't
             // match, so we have to drop and/or permute(reorder) the arguments
@@ -336,9 +328,7 @@ public class InvokerUtils
                 if (ref < 0)
                 {
                     if (!throwOnFailure)
-                    {
                         return null;
-                    }
 
                     StringBuilder err = new StringBuilder();
                     err.append("Invalid mapping of type [");
@@ -364,9 +354,7 @@ public class InvokerUtils
                         if (callingArgs[uci].required)
                         {
                             if (!throwOnFailure)
-                            {
                                 return null;
-                            }
 
                             StringBuilder err = new StringBuilder();
                             err.append("Missing required argument [");

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/ReflectUtils.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/ReflectUtils.java
@@ -27,11 +27,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.websocket.core.exception.DuplicateAnnotationException;
-import org.eclipse.jetty.websocket.core.exception.InvalidWebSocketException;
 
 public class ReflectUtils
 {
-
+    private static final Pattern JAVAX_CLASSNAME_PATTERN = Pattern.compile("^javax*\\..*");
     private static final Pattern JAKARTA_CLASSNAME_PATTERN = Pattern.compile("^jakarta*\\..*");
 
     private static class GenericRef
@@ -61,7 +60,6 @@ public class ReflectUtils
 
         public void setGenericFromType(Type type, int index)
         {
-            // debug("setGenericFromType(%s,%d)",toShortName(type),index);
             this.genericType = type;
             this.genericIndex = index;
             if (type instanceof Class)
@@ -73,25 +71,18 @@ public class ReflectUtils
         @Override
         public String toString()
         {
-            StringBuilder builder = new StringBuilder();
-            builder.append("GenericRef [baseClass=");
-            builder.append(baseClass);
-            builder.append(", ifaceClass=");
-            builder.append(ifaceClass);
-            builder.append(", genericType=");
-            builder.append(genericType);
-            builder.append(", genericClass=");
-            builder.append(genericClass);
-            builder.append("]");
-            return builder.toString();
+            return "GenericRef [baseClass=" + baseClass +
+                ", ifaceClass=" + ifaceClass +
+                ", genericType=" + genericType +
+                ", genericClass=" + genericClass +
+                "]";
         }
     }
 
     private static StringBuilder appendTypeName(StringBuilder sb, Type type, boolean ellipses)
     {
-        if (type instanceof Class<?>)
+        if (type instanceof Class<?> ctype)
         {
-            Class<?> ctype = (Class<?>)type;
             if (ctype.isArray())
             {
                 try
@@ -130,63 +121,6 @@ public class ReflectUtils
         }
 
         return sb;
-    }
-
-    public static void assertIsAnnotated(Method method, Class<? extends Annotation> annoClass)
-    {
-        if (method.getAnnotation(annoClass) == null)
-        {
-            StringBuilder err = new StringBuilder();
-            err.append("Method does not declare required @");
-            err.append(annoClass.getName());
-            err.append(" annotation: ");
-            err.append(method);
-
-            throw new InvalidWebSocketException(err.toString());
-        }
-    }
-
-    public static void assertIsPublicNonStatic(Method method)
-    {
-        int mods = method.getModifiers();
-        if (!Modifier.isPublic(mods))
-        {
-            StringBuilder err = new StringBuilder();
-            err.append("Invalid declaration of ");
-            err.append(method);
-            err.append(System.lineSeparator());
-
-            err.append("Method modifier must be public");
-
-            throw new InvalidWebSocketException(err.toString());
-        }
-
-        if (Modifier.isStatic(mods))
-        {
-            StringBuilder err = new StringBuilder();
-            err.append("Invalid declaration of ");
-            err.append(method);
-            err.append(System.lineSeparator());
-
-            err.append("Method modifier must not be static");
-
-            throw new InvalidWebSocketException(err.toString());
-        }
-    }
-
-    public static void assertIsReturn(Method method, Class<?> type)
-    {
-        if (!type.equals(method.getReturnType()))
-        {
-            StringBuilder err = new StringBuilder();
-            err.append("Invalid declaration of ");
-            err.append(method);
-            err.append(System.lineSeparator());
-
-            err.append("Return type must be ").append(type);
-
-            throw new InvalidWebSocketException(err.toString());
-        }
     }
 
     public static Method findMethod(Class<?> pojo, String methodName, Class<?>... params)
@@ -245,28 +179,20 @@ public class ReflectUtils
     {
         GenericRef ref = new GenericRef(baseClass, ifaceClass);
         if (resolveGenericRef(ref, baseClass))
-        {
-            // debug("Generic Found: %s",ref.genericClass);
             return ref.genericClass;
-        }
 
-        // debug("Generic not found: %s",ref);
         return null;
     }
 
     private static int findTypeParameterIndex(Class<?> clazz, TypeVariable<?> needVar)
     {
-        // debug("findTypeParameterIndex(%s, [%s])",toShortName(clazz),toShortName(needVar));
         TypeVariable<?>[] params = clazz.getTypeParameters();
         for (int i = 0; i < params.length; i++)
         {
             if (params[i].getName().equals(needVar.getName()))
-            {
-                // debug("Type Parameter found at index: [%d]",i);
                 return i;
-            }
         }
-        // debug("Type Parameter NOT found");
+
         return -1;
     }
 
@@ -293,26 +219,6 @@ public class ReflectUtils
         }
     }
 
-    public static boolean isSameParameters(Class<?>[] actual, Class<?>[] params)
-    {
-        if (actual.length != params.length)
-        {
-            // skip
-            return false;
-        }
-
-        int len = params.length;
-        for (int i = 0; i < len; i++)
-        {
-            if (!actual[i].equals(params[i]))
-            {
-                return false; // not valid
-            }
-        }
-
-        return true;
-    }
-
     private static boolean resolveGenericRef(GenericRef ref, Class<?> clazz, Type type)
     {
         if (type instanceof Class)
@@ -320,7 +226,6 @@ public class ReflectUtils
             if (type == ref.ifaceClass)
             {
                 // is this a straight ref or a TypeVariable?
-                // debug("Found ref (as class): %s",toShortName(type));
                 ref.setGenericFromType(type, 0);
                 return true;
             }
@@ -337,7 +242,6 @@ public class ReflectUtils
             Type rawType = ptype.getRawType();
             if (rawType == ref.ifaceClass)
             {
-                // debug("Found ref on [%s] as ParameterizedType [%s]",toShortName(clazz),toShortName(ptype));
                 // Always get the raw type parameter, let unwrap() solve for what it is
                 ref.setGenericFromType(ptype.getActualTypeArguments()[0], 0);
                 return true;
@@ -358,12 +262,10 @@ public class ReflectUtils
             return false;
         }
 
-        if (type instanceof Class)
+        if (type instanceof Class<?> clazz)
         {
-            Class<?> clazz = (Class<?>)type;
-            // prevent spinning off into Serialization and other parts of the
-            // standard tree that we could care less about
-            if (JAKARTA_CLASSNAME_PATTERN.matcher(clazz.getName()).matches())
+            // Prevent spinning off into Serialization and other parts of the standard tree that we couldn't care less about.
+            if (JAKARTA_CLASSNAME_PATTERN.matcher(clazz.getName()).matches() || JAVAX_CLASSNAME_PATTERN.matcher(clazz.getName()).matches())
             {
                 return false;
             }
@@ -371,23 +273,17 @@ public class ReflectUtils
             Type[] ifaces = clazz.getGenericInterfaces();
             for (Type iface : ifaces)
             {
-                // debug("resolve %s interface[]: %s",toShortName(clazz),toShortName(iface));
                 if (resolveGenericRef(ref, clazz, iface))
                 {
                     if (ref.needsUnwrap())
                     {
-                        // debug("## Unwrap class %s::%s",toShortName(clazz),toShortName(iface));
                         TypeVariable<?> needVar = (TypeVariable<?>)ref.genericType;
-                        // debug("needs unwrap of type var [%s] - index [%d]",toShortName(needVar),ref.genericIndex);
 
                         // attempt to find typeParameter on class itself
                         int typeParamIdx = findTypeParameterIndex(clazz, needVar);
-                        // debug("type param index for %s[%s] is [%d]",toShortName(clazz),toShortName(needVar),typeParamIdx);
-
                         if (typeParamIdx >= 0)
                         {
                             // found a type parameter, use it
-                            // debug("unwrap from class [%s] - typeParameters[%d]",toShortName(clazz),typeParamIdx);
                             TypeVariable<?>[] params = clazz.getTypeParameters();
                             if (params.length >= typeParamIdx)
                             {
@@ -409,19 +305,15 @@ public class ReflectUtils
             return resolveGenericRef(ref, type);
         }
 
-        if (type instanceof ParameterizedType)
+        if (type instanceof ParameterizedType ptype)
         {
-            ParameterizedType ptype = (ParameterizedType)type;
             Class<?> rawClass = (Class<?>)ptype.getRawType();
             if (resolveGenericRef(ref, rawClass))
             {
                 if (ref.needsUnwrap())
                 {
-                    // debug("## Unwrap ParameterizedType %s::%s",toShortName(type),toShortName(rawClass));
                     TypeVariable<?> needVar = (TypeVariable<?>)ref.genericType;
-                    // debug("needs unwrap of type var [%s] - index [%d]",toShortName(needVar),ref.genericIndex);
                     int typeParamIdx = findTypeParameterIndex(rawClass, needVar);
-                    // debug("type paramIdx of %s::%s is index [%d]",toShortName(rawClass),toShortName(needVar),typeParamIdx);
 
                     Type arg = ptype.getActualTypeArguments()[typeParamIdx];
                     ref.setGenericFromType(arg, typeParamIdx);
@@ -433,60 +325,11 @@ public class ReflectUtils
         return false;
     }
 
-    public static String toShortName(Type type)
-    {
-        if (type == null)
-        {
-            return "<null>";
-        }
-
-        if (type instanceof Class)
-        {
-            String name = ((Class<?>)type).getName();
-            return trimClassName(name);
-        }
-
-        if (type instanceof ParameterizedType)
-        {
-            ParameterizedType ptype = (ParameterizedType)type;
-            StringBuilder str = new StringBuilder();
-            str.append(trimClassName(((Class<?>)ptype.getRawType()).getName()));
-            str.append("<");
-            Type[] args = ptype.getActualTypeArguments();
-            for (int i = 0; i < args.length; i++)
-            {
-                if (i > 0)
-                {
-                    str.append(",");
-                }
-                str.append(args[i]);
-            }
-            str.append(">");
-            return str.toString();
-        }
-
-        return type.toString();
-    }
-
     public static String toString(Class<?> pojo, Method method)
     {
         StringBuilder str = new StringBuilder();
-
         append(str, pojo, method);
-
         return str.toString();
-    }
-
-    public static String trimClassName(String name)
-    {
-        int idx = name.lastIndexOf('.');
-        name = name.substring(idx + 1);
-        idx = name.lastIndexOf('$');
-        if (idx >= 0)
-        {
-            name = name.substring(idx + 1);
-        }
-        return name;
     }
 
     public static void append(StringBuilder str, Class<?> pojo, Method method)
@@ -494,9 +337,7 @@ public class ReflectUtils
         // method modifiers
         int mod = method.getModifiers() & Modifier.methodModifiers();
         if (mod != 0)
-        {
             str.append(Modifier.toString(mod)).append(' ');
-        }
 
         // return type
         Type retType = method.getGenericReturnType();
@@ -525,8 +366,6 @@ public class ReflectUtils
             }
         }
         str.append(')');
-
-        // TODO: show exceptions?
     }
 
     public static void append(StringBuilder str, Method method)

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/ReflectUtils.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/ReflectUtils.java
@@ -63,9 +63,7 @@ public class ReflectUtils
             this.genericType = type;
             this.genericIndex = index;
             if (type instanceof Class)
-            {
                 this.genericClass = (Class<?>)type;
-            }
         }
 
         @Override
@@ -97,13 +95,9 @@ public class ReflectUtils
                     for (int i = 0; i < dimensions; i++)
                     {
                         if (ellipses)
-                        {
                             sb.append("...");
-                        }
                         else
-                        {
                             sb.append("[]");
-                        }
                     }
                     return sb;
                 }
@@ -139,15 +133,9 @@ public class ReflectUtils
     {
         Method[] methods = findAnnotatedMethods(pojo, anno);
         if (methods == null)
-        {
             return null;
-        }
-
         if (methods.length > 1)
-        {
             throw DuplicateAnnotationException.build(pojo, anno, methods);
-        }
-
         return methods[0];
     }
 
@@ -219,61 +207,21 @@ public class ReflectUtils
         }
     }
 
-    private static boolean resolveGenericRef(GenericRef ref, Class<?> clazz, Type type)
-    {
-        if (type instanceof Class)
-        {
-            if (type == ref.ifaceClass)
-            {
-                // is this a straight ref or a TypeVariable?
-                ref.setGenericFromType(type, 0);
-                return true;
-            }
-            else
-            {
-                // Keep digging
-                return resolveGenericRef(ref, type);
-            }
-        }
-
-        if (type instanceof ParameterizedType)
-        {
-            ParameterizedType ptype = (ParameterizedType)type;
-            Type rawType = ptype.getRawType();
-            if (rawType == ref.ifaceClass)
-            {
-                // Always get the raw type parameter, let unwrap() solve for what it is
-                ref.setGenericFromType(ptype.getActualTypeArguments()[0], 0);
-                return true;
-            }
-            else
-            {
-                // Keep digging
-                return resolveGenericRef(ref, rawType);
-            }
-        }
-        return false;
-    }
-
     private static boolean resolveGenericRef(GenericRef ref, Type type)
     {
         if ((type == null) || (type == Object.class))
-        {
             return false;
-        }
 
         if (type instanceof Class<?> clazz)
         {
             // Prevent spinning off into Serialization and other parts of the standard tree that we couldn't care less about.
             if (JAKARTA_CLASSNAME_PATTERN.matcher(clazz.getName()).matches() || JAVAX_CLASSNAME_PATTERN.matcher(clazz.getName()).matches())
-            {
                 return false;
-            }
 
             Type[] ifaces = clazz.getGenericInterfaces();
             for (Type iface : ifaces)
             {
-                if (resolveGenericRef(ref, clazz, iface))
+                if (resolveGenericRef(ref, iface))
                 {
                     if (ref.needsUnwrap())
                     {
@@ -286,9 +234,7 @@ public class ReflectUtils
                             // found a type parameter, use it
                             TypeVariable<?>[] params = clazz.getTypeParameters();
                             if (params.length >= typeParamIdx)
-                            {
                                 ref.setGenericFromType(params[typeParamIdx], typeParamIdx);
-                            }
                         }
                         else if (iface instanceof ParameterizedType)
                         {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/TextUtils.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/util/TextUtils.java
@@ -83,7 +83,7 @@ public final class TextUtils
 
         StringBuilder ret = new StringBuilder();
         int startLen = (int)Math.round((double)max / (double)3);
-        ret.append(raw.substring(0, startLen));
+        ret.append(raw, 0, startLen);
         ret.append("...");
         ret.append(raw.substring(length - (max - startLen - 3)));
 


### PR DESCRIPTION
## Issue #9233

removing unused code and performing other cleanups

This is not intended to change any of the logic here, just performing code cleanups.

`ReflectUtils` is doing checks on `jakarta` and `javax` classes which is questionable to have in core, but this PR is not intended to address that.