### PR TITLE
Issue #9301 Fix dependencies for ee10-glassfish-jstl module

### DIFF
--- a/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
@@ -39,24 +39,13 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet.jsp</groupId>
-      <artifactId>jakarta.servlet.jsp-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.el</groupId>
-      <artifactId>jakarta.el-api</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-apache-jsp</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-apache-jsp</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
@@ -6,5 +6,8 @@ Enables the glassfish version of JSTL for all webapps.
 [environment]
 ee10
 
+[depends]
+ee10-apache-jsp
+
 [lib]
 lib/ee10-glassfish-jstl/*.jar

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -269,8 +269,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web,jakarta.el,jakarta.servlet.jsp,jakarta.el</includeGroupIds>
-              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl,jakarta.el-api,jakarta.servlet.jsp-api,jakarta.el-api</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web</includeGroupIds>
+              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee10-glassfish-jstl</outputDirectory>
@@ -284,8 +284,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web,jakarta.el,jakarta.servlet.jsp,jakarta.el</includeGroupIds>
-              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl,jakarta.el-api,jakarta.servlet.jsp-api,jakarta.el-api</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web</includeGroupIds>
+              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee10-glassfish-jstl</outputDirectory>
             </configuration>


### PR DESCRIPTION
First part of fixes for #9301.

This PR:

- restores the dependency on `ee10-apache-jsp` to the `ee10-glassfish-jsp` module
- prevents the copying of the `jakarta.servlet.jsp-api` jars to the `jetty-home/lib/ee10-glassfish-jstl` directory