### PR TITLE
Rename Handler Nested & Collection

### DIFF
--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/HandlerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/HandlerDocs.java
@@ -189,7 +189,7 @@ public class HandlerDocs
         }
     }
 
-    public static class RootHandler extends Handler.Collection
+    public static class RootHandler extends Handler.Sequence
     {
         @Override
         public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -511,11 +511,11 @@ public class HTTPServerDocs
         GzipHandler gzipHandler = new GzipHandler();
         server.setHandler(gzipHandler);
 
-        Handler.Collection collection = new Handler.Collection();
-        gzipHandler.setHandler(collection);
+        Handler.Sequence sequence = new Handler.Sequence();
+        gzipHandler.setHandler(sequence);
 
-        collection.addHandler(new App1Handler());
-        collection.addHandler(new App2Handler());
+        sequence.addHandler(new App1Handler());
+        sequence.addHandler(new App2Handler());
         // end::handlerTree[]
     }
 
@@ -583,7 +583,7 @@ public class HTTPServerDocs
         }
 
         // tag::handlerFilter[]
-        class FilterHandler extends Handler.Wrapper
+        class FilterHandler extends Handler.BaseWrapper
         {
             @Override
             public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
@@ -208,7 +208,7 @@ public class FastCGIProxyHandlerTest
         fcgiHandler.setOriginalQueryAttribute(queryAttribute);
 
         proxyContext.stop();
-        proxyContext.insertHandler(new Handler.Wrapper()
+        proxyContext.insertHandler(new Handler.BaseWrapper()
         {
             @Override
             public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -37,7 +37,7 @@ import org.eclipse.jetty.util.Callback;
  * {@link PatternRule} subclasses), via regular expression matching (using
  * {@link RegexRule} subclasses), or by a custom implementation of {@code Rule}.</p>
  */
-public class RewriteHandler extends Handler.Wrapper
+public class RewriteHandler extends Handler.BaseWrapper
 {
     private final RuleContainer _rules;
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
@@ -134,13 +134,6 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
      */
     interface Container extends Handler
     {
-        void addHandler(Handler handler);
-
-        default void addHandler(Supplier<Handler> supplier)
-        {
-            addHandler(supplier.get());
-        }
-
         /**
          * @return an immutable collection of {@code Handler}s directly contained by this {@code Handler}.
          */
@@ -223,20 +216,56 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
             }
             return null;
         }
+
+        /**
+         * <p>Make a {@link Container} the parent of a {@link Handler}</p>
+         * @param parent The {@link Container} that will be the parent
+         * @param handler The {@link Handler} that will be the child
+         */
+        static void setAsParent(Container parent, Handler handler)
+        {
+            if (parent instanceof Collection collection)
+                collection.addHandler(handler);
+            else if (parent instanceof Wrapper wrapper)
+                wrapper.setHandler(handler);
+            else if (parent != null)
+                throw new IllegalArgumentException("Unknown parent type: " + parent);
+        }
     }
 
     /**
-     * <p>A {@link Handler.Container} that wraps a single other {@code Handler}.</p>
-     * @see Handler.Wrapper for an implementation of nested.
+     * <p>A {@link Handler.Container} that can contain multiple other {@link Handler}s.</p>
+     * @see Sequence for an implementation of {@link Collection}.
      */
-    interface Nested extends Container
+    interface Collection extends Container
+    {
+        void addHandler(Handler handler);
+
+        default void addHandler(Supplier<Handler> supplier)
+        {
+            addHandler(supplier.get());
+        }
+
+        void setHandlers(List<Handler> handlers);
+
+        default void setHandlers(Handler... handlers)
+        {
+            setHandlers(handlers.length == 0 ? null : List.of(handlers));
+        }
+    }
+
+    /**
+     * <p>A {@link Handler.Container} that can contain a single other {@code Handler}.</p>
+     * @see BaseWrapper for an implementation of {@link Wrapper}.
+     */
+    interface Wrapper extends Container
     {
         Handler getHandler();
 
         /**
          * Set the nested handler.
          * Implementations should check for loops, set the server and update any {@link ContainerLifeCycle} beans, all
-         * of which can be done by using the utility method {@link #updateHandler(Nested, Handler)}
+         * of which can be done by using the utility method {@link #updateHandler(Wrapper, Handler)}
          * @param handler The handler to set.
          */
         void setHandler(Handler handler);
@@ -253,27 +282,16 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
         @Override
         default List<Handler> getHandlers()
         {
-            Handler h = getHandler();
-            if (h == null)
-                return Collections.emptyList();
-            return Collections.singletonList(h);
+            Handler next = getHandler();
+            return (next == null) ? Collections.emptyList() : Collections.singletonList(next);
         }
 
-        @Override
-        default void addHandler(Handler handler)
+        default void insertHandler(Wrapper handler)
         {
-            Handler existing = getHandler();
-            setHandler(handler);
-            if (existing != null && handler instanceof Container container)
-                container.addHandler(existing);
-        }
-
-        default void insertHandler(Handler.Nested handler)
-        {
-            Handler.Nested tail = handler;
-            while (tail.getHandler() instanceof Handler.Wrapper)
+            Wrapper tail = handler;
+            while (tail.getHandler() instanceof BaseWrapper)
             {
-                tail = (Handler.Wrapper)tail.getHandler();
+                tail = (BaseWrapper)tail.getHandler();
             }
             if (tail.getHandler() != null)
                 throw new IllegalArgumentException("bad tail of inserted wrapper chain");
@@ -283,20 +301,31 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
         }
 
         /**
+         * @return The tail {@link Wrapper} of a chain of {@link Wrapper}s
+         */
+        default Wrapper getTail()
+        {
+            Wrapper tail = this;
+            while (tail.getHandler() instanceof Wrapper wrapped)
+                tail = wrapped;
+            return tail;
+        }
+
+        /**
          * Utility method to: <ul>
          *     <li>Check the server state and invocation type</li>
          *     <li>Check for handler loops</li>
          *     <li>Set the server on the handler</li>
          *     <li>Update the beans on if the Nests is a {@link ContainerLifeCycle} </li>
          * </ul>
-         * @param nested The Nested implementation to update
+         * @param wrapper The Nested implementation to update
          * @param handler The handle to set
          * @return The set handler.
          */
-        static Handler updateHandler(Nested nested, Handler handler)
+        static Handler updateHandler(Wrapper wrapper, Handler handler)
         {
             // check state
-            Server server = nested.getServer();
+            Server server = wrapper.getServer();
 
             // If the collection is changed whilst started, then the risk is that if we switch from NON_BLOCKING to BLOCKING
             // whilst the execution strategy may have already dispatched the very last available thread, thinking it would
@@ -310,15 +339,15 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
             }
 
             // Check for loops.
-            if (handler == nested || (handler instanceof Handler.Container container &&
-                container.getDescendants().contains(nested)))
+            if (handler == wrapper || (handler instanceof Handler.Container container &&
+                container.getDescendants().contains(wrapper)))
                 throw new IllegalStateException("setHandler loop");
 
             if (handler != null && server != null)
                 handler.setServer(server);
 
-            if (nested instanceof org.eclipse.jetty.util.component.ContainerLifeCycle container)
-                container.updateBean(nested.getHandler(), handler);
+            if (wrapper instanceof org.eclipse.jetty.util.component.ContainerLifeCycle container)
+                container.updateBean(wrapper.getHandler(), handler);
 
             return handler;
         }
@@ -532,50 +561,45 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
     }
 
     /**
-     * An implementation of {@link Nested}, which is a {@link Handler.Container} that wraps a single other {@link Handler}.
+     * An implementation of {@link Wrapper}, which is a {@link Handler.Container} that wraps a single other {@link Handler}.
      */
-    class Wrapper extends AbstractContainer implements Nested
+    class BaseWrapper extends AbstractContainer implements Wrapper
     {
         private Handler _handler;
 
-        public Wrapper()
+        public BaseWrapper()
         {
             this(null);
         }
 
-        public Wrapper(boolean dynamic)
+        public BaseWrapper(boolean dynamic)
         {
             this(dynamic, null);
         }
 
-        public Wrapper(Handler handler)
+        public BaseWrapper(Handler handler)
         {
             this(false, handler);
         }
 
-        public Wrapper(boolean dynamic, Handler handler)
+        public BaseWrapper(boolean dynamic, Handler handler)
         {
             super(dynamic);
-            _handler = handler == null ? null : Nested.updateHandler(this, handler);
+            _handler = handler == null ? null : Wrapper.updateHandler(this, handler);
         }
 
+        @Override
         public Handler getHandler()
         {
             return _handler;
         }
 
+        @Override
         public void setHandler(Handler handler)
         {
             if (!isDynamic() && isStarted())
                 throw new IllegalStateException(getState());
-            _handler = Nested.updateHandler(this, handler);
-        }
-
-        @Override
-        public List<Handler> getHandlers()
-        {
-            Handler next = getHandler();
-            return (next == null) ? Collections.emptyList() : Collections.singletonList(next);
+            _handler = Wrapper.updateHandler(this, handler);
         }
 
         @Override
@@ -596,25 +620,24 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
     }
 
     /**
-     * <p>A {@link Handler.Container} that contains a list of other {@code Handler}s.</p>
-     * 
-     * TODO this should be called List instead
+     * <p>A {@link Handler.Container} that contains a list of other {@code Handler}s that are
+     * tried in sequence by {@link #process(Request, Response, Callback)}.</p>
      */
-    class Collection extends AbstractContainer
+    class Sequence extends AbstractContainer implements Collection
     {
         private volatile List<Handler> _handlers = new ArrayList<>();
 
-        public Collection(Handler... handlers)
+        public Sequence(Handler... handlers)
         {
             this(handlers.length == 0, List.of(handlers));
         }
 
-        public Collection(boolean dynamic)
+        public Sequence(boolean dynamic)
         {
             this(dynamic, Collections.emptyList());
         }
 
-        public Collection(List<Handler> handlers)
+        public Sequence(List<Handler> handlers)
         {
             this(handlers == null || handlers.size() == 0, handlers);
         }
@@ -626,7 +649,7 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
          *
          * @param handlers The handlers to add.
          */
-        public Collection(boolean dynamic, List<Handler> handlers)
+        public Sequence(boolean dynamic, List<Handler> handlers)
         {
             super(dynamic);
             setHandlers(handlers);
@@ -649,11 +672,7 @@ public interface Handler extends LifeCycle, Destroyable, Invocable, Request.Proc
             return _handlers;
         }
 
-        public void setHandlers(Handler... handlers)
-        {
-            setHandlers(handlers.length == 0 ? null : List.of(handlers));
-        }
-
+        @Override
         public void setHandlers(List<Handler> handlers)
         {
             if (!isDynamic() && isStarted())

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -68,7 +68,7 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Server extends Handler.Wrapper implements Attributes
+public class Server extends Handler.BaseWrapper implements Attributes
 {
     private static final Logger LOG = LoggerFactory.getLogger(Server.class);
     private static final String __serverInfo = "jetty/" + Server.getVersion();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AbstractLatencyRecordingHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/AbstractLatencyRecordingHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * (obtained from {@link HttpStream#getNanoTime()}) until the stream completion event has been handled by
  * {@link HttpStream#succeeded()} or {@link HttpStream#failed(Throwable)}.</p>
  */
-public abstract class AbstractLatencyRecordingHandler extends Handler.Wrapper
+public abstract class AbstractLatencyRecordingHandler extends Handler.BaseWrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractLatencyRecordingHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * generated can also be unbounded.
  * </p>
  */
-public class BufferedResponseHandler extends Handler.Wrapper
+public class BufferedResponseHandler extends Handler.BaseWrapper
 {
     public static final String BUFFER_SIZE_ATTRIBUTE_NAME = BufferedResponseHandler.class.getName() + ".buffer-size";
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>Implementation of a {@link Handler} that supports HTTP CONNECT.</p>
  */
-public class ConnectHandler extends Handler.Wrapper
+public class ConnectHandler extends Handler.BaseWrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -63,7 +63,7 @@ import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ContextHandler extends Handler.Wrapper implements Attributes, Graceful, AliasCheck
+public class ContextHandler extends Handler.BaseWrapper implements Attributes, Graceful, AliasCheck
 {
     // TODO where should the alias checking go?
     // TODO add protected paths to ServletContextHandler?
@@ -166,8 +166,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
         _context = newContext();
         if (contextPath != null)
             setContextPath(contextPath);
-        if (parent != null)
-            parent.addHandler(this);
+        Container.setAsParent(parent, this);
 
         if (File.separatorChar == '/')
             addAliasCheck(new SymlinkAllowedResourceAliasChecker(this));

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * handles the request.
  */
 @ManagedObject("Context Handler Collection")
-public class ContextHandlerCollection extends Handler.Collection
+public class ContextHandlerCollection extends Handler.Sequence
 {
     private static final Logger LOG = LoggerFactory.getLogger(ContextHandlerCollection.class);
     private final SerializedExecutor _serializedExecutor = new SerializedExecutor();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
@@ -35,7 +35,7 @@ import org.eclipse.jetty.util.RolloverFileOutputStream;
  * and the current thread name is updated with information that will link
  * to the details in that output.
  */
-public class DebugHandler extends Handler.Wrapper implements Connection.Listener
+public class DebugHandler extends Handler.BaseWrapper implements Connection.Listener
 {
     private final DateCache _date = new DateCache("HH:mm:ss", Locale.US);
     private OutputStream _out;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
@@ -36,7 +36,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.StringUtil;
 
-public class DelayedHandler extends Handler.Wrapper
+public class DelayedHandler extends Handler.BaseWrapper
 {
     @Override
     public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Handler to track active requests and allow them to gracefully complete.
  */
-public class GracefulHandler extends Handler.Wrapper implements Graceful
+public class GracefulHandler extends Handler.BaseWrapper implements Graceful
 {
     private static final Logger LOG = LoggerFactory.getLogger(GracefulHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.jetty.server.handler;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -26,7 +23,7 @@ import org.eclipse.jetty.util.thread.Invocable;
 /**
  * A <code>HandlerContainer</code> that allows a hot swap of a wrapped handler.
  */
-public class HotSwapHandler extends Handler.AbstractContainer implements Handler.Nested
+public class HotSwapHandler extends Handler.AbstractContainer implements Handler.Wrapper
 {
     // TODO unit tests
 
@@ -49,22 +46,12 @@ public class HotSwapHandler extends Handler.AbstractContainer implements Handler
     }
 
     /**
-     * @return Returns the handlers.
-     */
-    @Override
-    public List<Handler> getHandlers()
-    {
-        Handler next = _handler;
-        return (next == null) ? Collections.emptyList() : Collections.singletonList(next);
-    }
-
-    /**
      * @param handler Set the {@link Handler} which should be wrapped.
      */
     public void setHandler(Handler handler)
     {
         // check state
-        Server server1 = ((Nested)this).getServer();
+        Server server1 = ((Wrapper)this).getServer();
         if (server1 != null && server1.isStarted() && handler != null &&
             server1.getInvocationType() != Invocable.combine(server1.getInvocationType(), handler.getInvocationType()))
             throw new IllegalArgumentException("Cannot change invocation type of started server");

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
@@ -31,7 +31,7 @@ import org.eclipse.jetty.util.Callback;
  *   &lt;/Set&gt;
  * </pre>
  */
-public class IdleTimeoutHandler extends Handler.Wrapper
+public class IdleTimeoutHandler extends Handler.BaseWrapper
 {
     private long _idleTimeoutMs = 1000;
     private boolean _applyToAsync = false;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -41,7 +41,7 @@ import static org.eclipse.jetty.server.handler.InetAccessSet.PatternTuple;
  * the forwarded for headers, as this cannot be as easily forged.
  * </p>
  */
-public class InetAccessHandler extends Handler.Wrapper
+public class InetAccessHandler extends Handler.BaseWrapper
 {
     // TODO replace this handler with a general conditional handler wrapper.
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MovedContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MovedContextHandler.java
@@ -42,9 +42,9 @@ public class MovedContextHandler extends ContextHandler
         setAllowNullPathInContext(true);
     }
 
-    public MovedContextHandler(Handler.Collection parent, String contextPath, String redirectURI)
+    public MovedContextHandler(Handler.Container parent, String contextPath, String redirectURI)
     {
-        parent.addHandler(this);
+        Handler.Container.setAsParent(parent, this);
         setContextPath(contextPath);
         setRedirectURI(redirectURI);
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.server.handler;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
@@ -47,18 +46,6 @@ public class PathMappingsHandler extends Handler.AbstractContainer
     public PathMappingsHandler(boolean dynamic)
     {
         super(dynamic);
-    }
-
-    @Override
-    public void addHandler(Handler handler)
-    {
-        throw new UnsupportedOperationException("Arbitrary addHandler() not supported, use addMapping() instead");
-    }
-
-    @Override
-    public void addHandler(Supplier<Handler> supplier)
-    {
-        throw new UnsupportedOperationException("Arbitrary addHandler() not supported, use addMapping() instead");
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ProxiedRequestHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.HostPort;
 
-public class ProxiedRequestHandler extends Handler.Wrapper
+public class ProxiedRequestHandler extends Handler.BaseWrapper
 {
     @Override
     public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -53,7 +53,7 @@ import org.eclipse.jetty.util.resource.Resources;
  *  - request ranges
  *  - a way to configure caching or not
  */
-public class ResourceHandler extends Handler.Wrapper
+public class ResourceHandler extends Handler.BaseWrapper
 {
     private final ResourceService _resourceService;
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -35,7 +35,7 @@ import org.eclipse.jetty.util.URIUtil;
  * {@link HttpConfiguration#getSecurePort()}
  * </p>
  */
-public class SecuredRedirectHandler extends Handler.Wrapper
+public class SecuredRedirectHandler extends Handler.BaseWrapper
 {
     /**
      * The redirect code to send in response.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
  * }
  * }</pre>
  */
-public class ShutdownHandler extends Handler.Wrapper
+public class ShutdownHandler extends Handler.BaseWrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ShutdownHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -37,7 +37,7 @@ import org.eclipse.jetty.util.component.DumpableCollection;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.eclipse.jetty.util.statistic.SampleStatistic;
 
-public class StatisticsHandler extends Handler.Wrapper
+public class StatisticsHandler extends Handler.BaseWrapper
 {
     private final Set<String> _connectionStats = ConcurrentHashMap.newKeySet();
     private final CounterStatistic _requestStats = new CounterStatistic();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
  * a thread is available.
  * <p>This is a simpler alternative to DosFilter</p>
  */
-public class ThreadLimitHandler extends Handler.Wrapper
+public class ThreadLimitHandler extends Handler.BaseWrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ThreadLimitHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -65,7 +65,7 @@ import org.eclipse.jetty.util.URIUtil;
  * under the names specified by {@link #setOriginalPathAttribute(String)}
  * and {@link #setOriginalQueryAttribute(String)}.</p>
  */
-public class TryPathsHandler extends Handler.Wrapper
+public class TryPathsHandler extends Handler.BaseWrapper
 {
     private String originalPathAttribute;
     private String originalQueryAttribute;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -37,7 +37,7 @@ import org.eclipse.jetty.util.compression.InflaterPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GzipHandler extends Handler.Wrapper implements GzipFactory
+public class GzipHandler extends Handler.BaseWrapper implements GzipFactory
 {
     public static final String GZIP_HANDLER_ETAGS = "o.e.j.s.h.gzip.GzipHandler.etag";
     public static final String GZIP = "gzip";

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConfigurationAuthorityOverrideTest.java
@@ -637,7 +637,7 @@ public class HttpConfigurationAuthorityOverrideTest
         connector.setPort(0);
         server.addConnector(connector);
 
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         handlers.addHandler(new RedirectHandler());
         handlers.addHandler(new DumpHandler());
         handlers.addHandler(new ErrorMsgHandler());

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -1825,7 +1825,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
     public void testProcessingAfterCompletion() throws Exception
     {
         AtomicReference<String> result = new AtomicReference<>();
-        Handler.Wrapper wrapper = new Handler.Wrapper()
+        Handler.Wrapper wrapper = new Handler.BaseWrapper()
         {
             @Override
             public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -60,7 +60,7 @@ public class PartialRFC2616Test
         context.setContextPath("/");
         context.setHandler(new DumpHandler());
 
-        server.setHandler(new Handler.Collection(vcontext, context));
+        server.setHandler(new Handler.Sequence(vcontext, context));
 
         server.start();
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerCollectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerCollectionTest.java
@@ -122,7 +122,7 @@ public class ContextHandlerCollectionTest
         c.addHandler(contextG);
         c.addHandler(contextH);
 
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         handlers.addHandler(contextE);
         handlers.addHandler(contextF);
         handlers.addHandler(contextD);
@@ -320,7 +320,7 @@ public class ContextHandlerCollectionTest
 
         ContextHandler contextB = new ContextHandler("/b");
         IsHandledHandler handlerB = new IsHandledHandler("B");
-        Handler.Wrapper wrapperB = new Handler.Wrapper();
+        Handler.Wrapper wrapperB = new Handler.BaseWrapper();
         wrapperB.setHandler(handlerB);
         contextB.setHandler(wrapperB);
 
@@ -334,16 +334,16 @@ public class ContextHandlerCollectionTest
         collection.addHandler(contextB);
         collection.addHandler(contextC);
 
-        Handler.Wrapper wrapper = new Handler.Wrapper();
+        Handler.Wrapper wrapper = new Handler.BaseWrapper();
         wrapper.setHandler(collection);
         server.setHandler(wrapper);
 
-        assertEquals(wrapper, Handler.AbstractContainer.findContainerOf(server, Handler.Wrapper.class, handlerA));
+        assertEquals(wrapper, Handler.AbstractContainer.findContainerOf(server, Handler.BaseWrapper.class, handlerA));
         assertEquals(contextA, Handler.AbstractContainer.findContainerOf(server, ContextHandler.class, handlerA));
         assertEquals(contextB, Handler.AbstractContainer.findContainerOf(server, ContextHandler.class, handlerB));
-        assertEquals(wrapper, Handler.AbstractContainer.findContainerOf(server, Handler.Wrapper.class, handlerB));
-        assertEquals(contextB, Handler.AbstractContainer.findContainerOf(collection, Handler.Wrapper.class, handlerB));
-        assertEquals(wrapperB, Handler.AbstractContainer.findContainerOf(contextB, Handler.Wrapper.class, handlerB));
+        assertEquals(wrapper, Handler.AbstractContainer.findContainerOf(server, Handler.BaseWrapper.class, handlerB));
+        assertEquals(contextB, Handler.AbstractContainer.findContainerOf(collection, Handler.BaseWrapper.class, handlerB));
+        assertEquals(wrapperB, Handler.AbstractContainer.findContainerOf(contextB, Handler.BaseWrapper.class, handlerB));
     }
 
     @Test
@@ -359,7 +359,7 @@ public class ContextHandlerCollectionTest
         ContextHandler left = new ContextHandler("/left");
         left.setHandler(new IsHandledHandler("left"));
 
-        Handler.Collection centre = new Handler.Collection();
+        Handler.Sequence centre = new Handler.Sequence();
         ContextHandler centreLeft = new ContextHandler("/leftcentre");
         centreLeft.setHandler(new IsHandledHandler("left of centre"));
         ContextHandler centreRight = new ContextHandler("/rightcentre");
@@ -407,7 +407,7 @@ public class ContextHandlerCollectionTest
         assertThat(response, containsString("Wrapped: right"));
     }
 
-    private static final class WrappedHandler extends Handler.Wrapper
+    private static final class WrappedHandler extends Handler.BaseWrapper
     {
         private final String tag;
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -658,7 +658,7 @@ public class ContextHandlerTest
     public void testSetHandlerLoopDeepWrapper()
     {
         ContextHandler contextHandlerA = new ContextHandler();
-        Handler.Wrapper handlerWrapper = new Handler.Wrapper();
+        Handler.Wrapper handlerWrapper = new Handler.BaseWrapper();
         contextHandlerA.setHandler(handlerWrapper);
         assertThrows(IllegalStateException.class, () -> handlerWrapper.setHandler(contextHandlerA));
     }
@@ -667,7 +667,7 @@ public class ContextHandlerTest
     public void testAddHandlerLoopDeep()
     {
         ContextHandler contextHandlerA = new ContextHandler();
-        Handler.Collection handlerCollection = new Handler.Collection();
+        Handler.Sequence handlerCollection = new Handler.Sequence();
         contextHandlerA.setHandler(handlerCollection);
         assertThrows(IllegalStateException.class, () -> handlerCollection.addHandler(contextHandlerA));
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DefaultHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DefaultHandlerTest.java
@@ -48,7 +48,7 @@ public class DefaultHandlerTest
         server.addConnector(connector);
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        server.setHandler(new Handler.Collection(contexts, new DefaultHandler(true, true)));
+        server.setHandler(new Handler.Sequence(contexts, new DefaultHandler(true, true)));
 
         contexts.addHandler(new ContextHandler("/foo"));
         contexts.addHandler(new ContextHandler("/bar"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/HandlerTest.java
@@ -38,9 +38,9 @@ public class HandlerTest
     public void testWrapperSetServer()
     {
         Server s = new Server();
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
         a.setHandler(b);
         b.setHandler(c);
 
@@ -53,9 +53,9 @@ public class HandlerTest
     public void testWrapperServerSet()
     {
         Server s = new Server();
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
         a.setServer(s);
         b.setHandler(c);
         a.setHandler(b);
@@ -67,7 +67,7 @@ public class HandlerTest
     @Test
     public void testWrapperThisLoop()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
 
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> a.setHandler(a));
         assertThat(e.getMessage(), containsString("loop"));
@@ -76,8 +76,8 @@ public class HandlerTest
     @Test
     public void testWrapperSimpleLoop()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
 
         a.setHandler(b);
 
@@ -88,9 +88,9 @@ public class HandlerTest
     @Test
     public void testWrapperDeepLoop()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
 
         a.setHandler(b);
         b.setHandler(c);
@@ -102,9 +102,9 @@ public class HandlerTest
     @Test
     public void testWrapperChainLoop()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
 
         a.setHandler(b);
         c.setHandler(a);
@@ -117,13 +117,13 @@ public class HandlerTest
     public void testHandlerCollectionSetServer()
     {
         Server s = new Server();
-        Handler.Collection a = new Handler.Collection();
-        Handler.Collection b = new Handler.Collection();
-        Handler.Collection b1 = new Handler.Collection();
-        Handler.Collection b2 = new Handler.Collection();
-        Handler.Collection c = new Handler.Collection();
-        Handler.Collection c1 = new Handler.Collection();
-        Handler.Collection c2 = new Handler.Collection();
+        Handler.Sequence a = new Handler.Sequence();
+        Handler.Sequence b = new Handler.Sequence();
+        Handler.Sequence b1 = new Handler.Sequence();
+        Handler.Sequence b2 = new Handler.Sequence();
+        Handler.Sequence c = new Handler.Sequence();
+        Handler.Sequence c1 = new Handler.Sequence();
+        Handler.Sequence c2 = new Handler.Sequence();
 
         a.addHandler(b);
         a.addHandler(c);
@@ -143,13 +143,13 @@ public class HandlerTest
     public void testHandlerCollectionServerSet()
     {
         Server s = new Server();
-        Handler.Collection a = new Handler.Collection();
-        Handler.Collection b = new Handler.Collection();
-        Handler.Collection b1 = new Handler.Collection();
-        Handler.Collection b2 = new Handler.Collection();
-        Handler.Collection c = new Handler.Collection();
-        Handler.Collection c1 = new Handler.Collection();
-        Handler.Collection c2 = new Handler.Collection();
+        Handler.Sequence a = new Handler.Sequence();
+        Handler.Sequence b = new Handler.Sequence();
+        Handler.Sequence b1 = new Handler.Sequence();
+        Handler.Sequence b2 = new Handler.Sequence();
+        Handler.Sequence c = new Handler.Sequence();
+        Handler.Sequence c1 = new Handler.Sequence();
+        Handler.Sequence c2 = new Handler.Sequence();
 
         a.setServer(s);
         a.addHandler(b);
@@ -168,7 +168,7 @@ public class HandlerTest
     @Test
     public void testHandlerCollectionThisLoop()
     {
-        Handler.Collection a = new Handler.Collection();
+        Handler.Sequence a = new Handler.Sequence();
 
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> a.addHandler(a));
         assertThat(e.getMessage(), containsString("loop"));
@@ -177,13 +177,13 @@ public class HandlerTest
     @Test
     public void testHandlerCollectionDeepLoop()
     {
-        Handler.Collection a = new Handler.Collection();
-        Handler.Collection b = new Handler.Collection();
-        Handler.Collection b1 = new Handler.Collection();
-        Handler.Collection b2 = new Handler.Collection();
-        Handler.Collection c = new Handler.Collection();
-        Handler.Collection c1 = new Handler.Collection();
-        Handler.Collection c2 = new Handler.Collection();
+        Handler.Sequence a = new Handler.Sequence();
+        Handler.Sequence b = new Handler.Sequence();
+        Handler.Sequence b1 = new Handler.Sequence();
+        Handler.Sequence b2 = new Handler.Sequence();
+        Handler.Sequence c = new Handler.Sequence();
+        Handler.Sequence c1 = new Handler.Sequence();
+        Handler.Sequence c2 = new Handler.Sequence();
 
         a.addHandler(b);
         a.addHandler(c);
@@ -197,13 +197,13 @@ public class HandlerTest
     @Test
     public void testHandlerCollectionChainLoop()
     {
-        Handler.Collection a = new Handler.Collection();
-        Handler.Collection b = new Handler.Collection();
-        Handler.Collection b1 = new Handler.Collection();
-        Handler.Collection b2 = new Handler.Collection();
-        Handler.Collection c = new Handler.Collection();
-        Handler.Collection c1 = new Handler.Collection();
-        Handler.Collection c2 = new Handler.Collection();
+        Handler.Sequence a = new Handler.Sequence();
+        Handler.Sequence b = new Handler.Sequence();
+        Handler.Sequence b1 = new Handler.Sequence();
+        Handler.Sequence b2 = new Handler.Sequence();
+        Handler.Sequence c = new Handler.Sequence();
+        Handler.Sequence c1 = new Handler.Sequence();
+        Handler.Sequence c2 = new Handler.Sequence();
 
         a.addHandler(c);
         b.setHandlers(b1, b2);
@@ -217,8 +217,8 @@ public class HandlerTest
     @Test
     public void testInsertWrapperTail()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
 
         a.insertHandler(b);
         assertThat(a.getHandler(), equalTo(b));
@@ -228,9 +228,9 @@ public class HandlerTest
     @Test
     public void testInsertWrapper()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
 
         a.insertHandler(c);
         a.insertHandler(b);
@@ -242,10 +242,10 @@ public class HandlerTest
     @Test
     public void testInsertWrapperChain()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
-        Handler.Wrapper d = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
+        Handler.Wrapper d = new Handler.BaseWrapper();
 
         a.insertHandler(d);
         b.insertHandler(c);
@@ -259,10 +259,10 @@ public class HandlerTest
     @Test
     public void testInsertWrapperBadChain()
     {
-        Handler.Wrapper a = new Handler.Wrapper();
-        Handler.Wrapper b = new Handler.Wrapper();
-        Handler.Wrapper c = new Handler.Wrapper();
-        Handler.Wrapper d = new Handler.Wrapper();
+        Handler.Wrapper a = new Handler.BaseWrapper();
+        Handler.Wrapper b = new Handler.BaseWrapper();
+        Handler.Wrapper c = new Handler.BaseWrapper();
+        Handler.Wrapper d = new Handler.BaseWrapper();
 
         a.insertHandler(d);
         b.insertHandler(c);
@@ -282,8 +282,8 @@ public class HandlerTest
     @Test
     public void testSetServerPropagation()
     {
-        Handler.Wrapper wrapper = new Handler.Wrapper();
-        Handler.Collection collection = new Handler.Collection();
+        Handler.Wrapper wrapper = new Handler.BaseWrapper();
+        Handler.Sequence collection = new Handler.Sequence();
         Handler handler = new Handler.Abstract()
         {
             @Override
@@ -305,8 +305,8 @@ public class HandlerTest
     @Test
     public void testSetHandlerServerPropagation()
     {
-        Handler.Wrapper wrapper = new Handler.Wrapper();
-        Handler.Collection collection = new Handler.Collection();
+        Handler.Wrapper wrapper = new Handler.BaseWrapper();
+        Handler.Sequence collection = new Handler.Sequence();
         Handler handler = new Handler.Abstract()
         {
             @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
@@ -54,7 +54,7 @@ public class PathMappingsHandlerTest
         connector = new LocalConnector(server);
         server.addConnector(connector);
 
-        server.addHandler(handler);
+        server.setHandler(handler);
         server.start();
     }
 
@@ -216,22 +216,22 @@ public class PathMappingsHandlerTest
         ContextHandler contextHandler = new ContextHandler();
         contextHandler.setContextPath("/");
 
-        Handler.Collection handlerCollection = new Handler.Collection();
-        handlerCollection.addHandler(new SimpleHandler("phpIndex"));
-        Handler.Wrapper handlerWrapper = new Handler.Wrapper(new SimpleHandler("other"));
-        handlerCollection.addHandler(handlerWrapper);
+        Handler.Sequence sequence = new Handler.Sequence();
+        sequence.addHandler(new SimpleHandler("phpIndex"));
+        Handler.Wrapper handlerWrapper = new Handler.BaseWrapper(new SimpleHandler("other"));
+        sequence.addHandler(handlerWrapper);
 
         PathMappingsHandler pathMappingsHandler = new PathMappingsHandler();
         pathMappingsHandler.addMapping(new ServletPathSpec("/"), new SimpleHandler("default"));
         pathMappingsHandler.addMapping(new ServletPathSpec("/index.html"), new SimpleHandler("specific"));
-        pathMappingsHandler.addMapping(new ServletPathSpec("*.php"), handlerCollection);
+        pathMappingsHandler.addMapping(new ServletPathSpec("*.php"), sequence);
 
         List<String> actualHandlers = pathMappingsHandler.getDescendants().stream().map(Objects::toString).toList();
 
         String[] expectedHandlers = {
             "SimpleHandler[msg=\"default\"]",
             "SimpleHandler[msg=\"specific\"]",
-            handlerCollection.toString(),
+            sequence.toString(),
             handlerWrapper.toString(),
             "SimpleHandler[msg=\"phpIndex\"]",
             "SimpleHandler[msg=\"other\"]"

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SecuredRedirectHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SecuredRedirectHandlerTest.java
@@ -295,7 +295,7 @@ public class SecuredRedirectHandlerTest
     @Test
     public void testUnsecuredRequestToNullChildHandler() throws Exception
     {
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         SecuredRedirectHandler securedRedirectHandler = new SecuredRedirectHandler(HttpStatus.MOVED_PERMANENTLY_301);
         handlers.addHandler(securedRedirectHandler); // first handler (no children)
         handlers.addHandler(new HelloHandler("Hello-from-test"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ShutdownHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ShutdownHandlerTest.java
@@ -155,7 +155,7 @@ public class ShutdownHandlerTest
         }
     }
 
-    static class FakeRemoteAddressHandlerWrapper extends Handler.Wrapper
+    static class FakeRemoteAddressHandlerWrapper extends Handler.BaseWrapper
     {
         private final InetSocketAddress fakeRemoteAddress;
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -743,7 +743,7 @@ public class StatisticsHandlerTest
     // This handler is external to the statistics handler and it is used to ensure that statistics handler's
     // handle() is fully executed before asserting its values in the tests, to avoid race conditions with the
     // tests' code where the test executes but the statistics handler has not finished yet.
-    private static class LatchHandler extends Handler.Wrapper
+    private static class LatchHandler extends Handler.BaseWrapper
     {
         private volatile CountDownLatch _latch = new CountDownLatch(1);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -1999,7 +1999,7 @@ public class GzipHandlerTest
         public int uncompressedSize;
     }
 
-    public static class CheckHandler extends Handler.Wrapper
+    public static class CheckHandler extends Handler.BaseWrapper
     {
         @Override
         public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SniSslConnectionFactoryTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SniSslConnectionFactoryTest.java
@@ -97,7 +97,7 @@ public class SniSslConnectionFactoryTest
         SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
         httpConfiguration.addCustomizer(secureRequestCustomizer);
 
-        Handler.Wrapper xCertHandler = new Handler.Wrapper()
+        Handler.Wrapper xCertHandler = new Handler.BaseWrapper()
         {
             @Override
             public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-core/jetty-session/src/test/java/org/eclipse/jetty/session/SimpleSessionHandler.java
+++ b/jetty-core/jetty-session/src/test/java/org/eclipse/jetty/session/SimpleSessionHandler.java
@@ -27,7 +27,7 @@ import org.eclipse.jetty.util.Callback;
 /**
  * SimpleSessionHandler example
  */
-public class SimpleSessionHandler extends AbstractSessionManager implements Handler.Nested
+public class SimpleSessionHandler extends AbstractSessionManager implements Handler.Wrapper
 {
     private Server _server;
     private Handler _handler;
@@ -47,7 +47,7 @@ public class SimpleSessionHandler extends AbstractSessionManager implements Hand
     @Override
     public void setHandler(Handler handler)
     {
-        _handler = Nested.updateHandler(this, handler);
+        _handler = Handler.Wrapper.updateHandler(this, handler);
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketUpgradeHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketUpgradeHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.Configuration;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
 
-public class WebSocketUpgradeHandler extends Handler.Wrapper
+public class WebSocketUpgradeHandler extends Handler.BaseWrapper
 {
     private final WebSocketMappings mappings;
     private final Configuration.ConfigurationCustomizer customizer = new Configuration.ConfigurationCustomizer();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/proxy/WebSocketProxyTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/proxy/WebSocketProxyTest.java
@@ -100,7 +100,7 @@ public class WebSocketProxyTest
         ServerConnector connector = new ServerConnector(_server);
         _server.addConnector(connector);
 
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         testHandler = new TestHandler();
         handlers.addHandler(testHandler);
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ExampleServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ExampleServer.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.demos;
 
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -25,6 +24,7 @@ public class ExampleServer
     public static Server createServer(int port)
     {
         Server server = new Server();
+        server.setDefaultHandler(new DefaultHandler());
 
         ServerConnector connector = new ServerConnector(server);
         connector.setPort(port);
@@ -35,7 +35,7 @@ public class ExampleServer
         context.addServlet(HelloServlet.class, "/hello");
         context.addServlet(AsyncEchoServlet.class, "/echo/*");
 
-        server.setHandler(new Handler.Collection(context, new DefaultHandler()));
+        server.setHandler(context);
 
         return server;
     }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServer.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -36,6 +35,7 @@ public class FileServer
         // then a randomly available port will be assigned that you can either look in the logs for the port,
         // or programmatically obtain it for use in test cases.
         Server server = new Server(port);
+        server.setDefaultHandler(new DefaultHandler());
 
         // Create the ResourceHandler. It is the object that will actually handle the request for a given file. It is
         // a Jetty Handler object so it is suitable for chaining with other handlers as you will see in other examples.
@@ -48,7 +48,7 @@ public class FileServer
         resourceHandler.setBaseResource(baseResource);
 
         // Add the ResourceHandler to the server.
-        server.setHandler(new Handler.Collection(resourceHandler, new DefaultHandler()));
+        server.setHandler(resourceHandler);
 
         return server;
     }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/JarServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/JarServer.java
@@ -23,9 +23,7 @@ import java.util.Objects;
 import org.eclipse.jetty.ee10.servlet.DefaultServlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -53,7 +51,7 @@ public class JarServer
         ServletHolder defaultHolder = new ServletHolder("default", new DefaultServlet());
         context.addServlet(defaultHolder, "/");
 
-        server.setHandler(new Handler.Collection(context, new DefaultHandler()));
+        server.setHandler(context);
         return server;
     }
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/LikeJettyXml.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/LikeJettyXml.java
@@ -36,7 +36,6 @@ import org.eclipse.jetty.rewrite.handler.InvalidURIRule;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.server.AsyncRequestLogWriter;
 import org.eclipse.jetty.server.CustomRequestLog;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LowResourceMonitor;
@@ -76,6 +75,7 @@ public class LikeJettyXml
 
         // Server
         Server server = new Server(threadPool);
+        server.setDefaultHandler(new DefaultHandler());
 
         // Scheduler
         server.addBean(new ScheduledExecutorScheduler(null, false, -1));
@@ -93,11 +93,7 @@ public class LikeJettyXml
 
         // Handler Structure
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        DefaultHandler defaultHandler = new DefaultHandler();
-
-        Handler.Collection handlers = new Handler.Collection();
-        handlers.setHandlers(contexts, defaultHandler);
-        server.setHandler(handlers);
+        server.setHandler(contexts);
 
         // === jetty-jmx.xml ===
         MBeanContainer mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ManyHandlers.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ManyHandlers.java
@@ -13,8 +13,28 @@
 
 package org.eclipse.jetty.ee10.demos;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.CustomRequestLog;
+import org.eclipse.jetty.server.FormFields;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Fields;
+import org.eclipse.jetty.util.ajax.JSON;
 
 /**
  * Frequently many handlers are combined together to handle different aspects of
@@ -28,123 +48,111 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
  * </ul>
  * Multiple handlers may be combined with:
  * <ul>
- * <li>{@link Handler.Wrapper} which will nest one handler inside another. In
+ * <li>{@link Handler.BaseWrapper} which will nest one handler inside another. In
  * this example, the HelloHandler is nested inside a HandlerWrapper that sets
  * the greeting as a request attribute.
- * <li>{@link Handler.Collection} which will call a collection of handlers until the
+ * <li>{@link Handler.Sequence} which will call a collection of handlers until the
  * request is marked as handled. In this example, a list is used to combine the
  * param handler (which only handles the request if there are parameters) and
  * the wrapper handler. Frequently handler lists are terminated with the
  * {@link DefaultHandler}, which will generate a suitable 404 response if the
  * request has not been handled.
- * <li>{@link Handler.Collection} which will call each handler regardless if the
+ * <li>{@link Handler.Sequence} which will call each handler regardless if the
  * request has been handled or not. Typically this is used to always pass a
  * request to the logging handler.
  * </ul>
  */
 public class ManyHandlers
 {
-    //TODO fix me
     /**
      * Produce output that lists all of the request parameters
      */
-    /*   public static class ParamHandler extends AbstractHandler
+    public static class ParamHandler extends Handler.Abstract
     {
         @Override
-        public void handle(String target,
-                           Request baseRequest,
-                           HttpServletRequest request,
-                           HttpServletResponse response) throws IOException,
-            ServletException
+        public boolean process(Request request, Response response, Callback callback) throws Exception
         {
-            Map<String, String[]> params = request.getParameterMap();
-            if (!params.isEmpty())
-            {
-                response.setContentType("text/plain");
-                response.getWriter().println(new JSON().toJSON(params));
-                baseRequest.setHandled(true);
-            }
+            Fields queryFields = Request.extractQueryParameters(request);
+            Fields formFields = FormFields.from(request).get();
+
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_JSON.asString());
+            response.write(true,
+                ByteBuffer.wrap(new JSON().toJSON(List.of(queryFields, formFields)).getBytes(StandardCharsets.UTF_8)),
+                callback);
+
+            return true;
         }
     }
     
-    *//**
-       * Add a request attribute, but produce no output.
-       *//*
-          public static class WelcomeWrapHandler extends HandlerWrapper
-          {
-           @Override
-           public void handle(String target,
-                              Request baseRequest,
-                              HttpServletRequest request,
-                              HttpServletResponse response) throws IOException,
-               ServletException
-           {
-               response.setHeader("X-Welcome", "Greetings from WelcomeWrapHandler");
-               super.handle(target, baseRequest, request, response);
-           }
-          }
+    /**
+     * Add a request attribute, but produce no output.
+     */
+    public static class WelcomeWrapHandler extends Handler.BaseWrapper
+    {
+        @Override
+        public boolean process(Request request, Response response, Callback callback) throws Exception
+        {
+            response.getHeaders().add("X-Welcome", "Greetings from WelcomeWrapHandler");
+            return super.process(request, response, callback);
+        }
+    }
           
-          public static Server createServer(int port) throws IOException
-          {
-           Server server = new Server(port);
+    public static Server createServer(int port) throws IOException
+    {
+        Server server = new Server(port);
+        server.setDefaultHandler(new DefaultHandler());
+
+        // create the handlers
+        Handler param = new ParamHandler();
+        Handler.Wrapper wrapper = new WelcomeWrapHandler();
+        Handler hello = new HelloHandler();
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.setMinGzipSize(10);
+        gzipHandler.addIncludedMimeTypes("text/plain");
+        gzipHandler.addIncludedMimeTypes("text/html");
+
+        // configure request logging
+        Path requestLogFile = Files.createTempFile("demo", "log");
+        CustomRequestLog ncsaLog = new CustomRequestLog(requestLogFile.toString());
+        server.setRequestLog(ncsaLog);
+
+        // wrap contexts around specific handlers
+        wrapper.setHandler(hello);
+        ContextHandler helloContext = new ContextHandler("/hello");
+        helloContext.setHandler(wrapper);
+
+        ContextHandler paramContext = new ContextHandler("/params");
+        paramContext.setHandler(param);
           
-           // create the handlers
-           Handler param = new ParamHandler();
-           Handler.Wrapper wrapper = new WelcomeWrapHandler();
-           Handler hello = new HelloHandler();
-           GzipHandler gzipHandler = new GzipHandler();
-           gzipHandler.setMinGzipSize(10);
-           gzipHandler.addIncludedMimeTypes("text/plain");
-           gzipHandler.addIncludedMimeTypes("text/html");
+        ContextHandlerCollection contexts = new ContextHandlerCollection(helloContext, paramContext);
           
-           // configure request logging
-           Path requestLogFile = Files.createTempFile("demo", "log");
-           CustomRequestLog ncsaLog = new CustomRequestLog(requestLogFile.toString());
-           server.setRequestLog(ncsaLog);
-          
-           // create the handlers list
-           Handler.Collection handlers = new Handler.Collection();
-          
-           // wrap contexts around specific handlers
-           wrapper.setHandler(hello);
-           ContextHandler helloContext = new ContextHandler("/hello");
-           helloContext.setHandler(wrapper);
-          
-           ContextHandler paramContext = new ContextHandler("/params");
-           paramContext.setHandler(param);
-          
-           ContextHandlerCollection contexts = new ContextHandlerCollection(helloContext, paramContext);
-          
-           // Wrap Contexts with GZIP
-           gzipHandler.setHandler(contexts);
-          
-           // Set the top level Handler List
-           handlers.addHandler(gzipHandler);
-           handlers.addHandler(new DefaultHandler());
-           server.setHandler(handlers);
-          
-            At this point you have the following handler hierarchy.
-            *
-            * Server.handler:
-            * HandlerList
-            *    \- GzipHandler
-            *    |   \- ContextHandlerCollection
-            *    |       \- ContextHandler ("/hello")
-            *    |       |   \- WelcomeWrapHandler
-            *    |       |       \- HelloHandler
-            *    |       \- ContextHandler ("/params")
-            *    |           \- ParamHandler
-            *    \- DefaultHandler
-            
-          
-           return server;
-          }
-          
-          public static void main(String[] args) throws Exception
-          {
-           int port = ExampleUtil.getPort(args, "jetty.http.port", 8080);
-           Server server = createServer(port);
-           server.start();
-           server.join();
-          }*/
+        // Wrap Contexts with GZIP
+        gzipHandler.setHandler(contexts);
+
+        // Set the top level Handler List
+        server.setHandler(gzipHandler);
+
+        /*
+         * At this point you have the following handler hierarchy:
+         * Server.handler:
+         *    \- GzipHandler
+         *    |   \- ContextHandlerCollection
+         *    |       \- ContextHandler ("/hello")
+         *    |       |   \- WelcomeWrapHandler
+         *    |       |       \- HelloHandler
+         *    |       \- ContextHandler ("/params")
+         *    |           \- ParamHandler
+         *    \- DefaultHandler
+         */
+
+        return server;
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+        int port = ExampleUtil.getPort(args, "jetty.http.port", 8080);
+        Server server = createServer(port);
+        server.start();
+        server.join();
+    }
 }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/test/java/org/eclipse/jetty/ee10/TestServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/test/java/org/eclipse/jetty/ee10/TestServer.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
@@ -33,7 +32,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.FileSessionDataStore;
@@ -84,7 +82,6 @@ public class TestServer
 
         // Handlers
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        Handler.Collection handlers = new Handler.Collection(contexts, new DefaultHandler());
 
         // Add restart handler to test the ability to save sessions and restart
         /* TODO: figure out how to do this

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/ServerSupport.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/ServerSupport.java
@@ -23,12 +23,10 @@ import org.eclipse.jetty.ee10.servlet.security.LoginService;
 import org.eclipse.jetty.ee10.webapp.Configurations;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
@@ -67,11 +65,7 @@ public class ServerSupport
         if (contexts == null)
         {
             contexts = new ContextHandlerCollection();
-            Handler.Collection handlers = server.getDescendant(Handler.Collection.class);
-            if (handlers == null)
-                server.setHandler(new Handler.Collection(contexts, new DefaultHandler()));
-            else
-                handlers.addHandler(contexts);
+            server.setHandler(contexts);
         } 
         
         if (contextHandlers != null)

--- a/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
+++ b/jetty-ee10/jetty-ee10-runner/src/main/java/org/eclipse/jetty/ee10/runner/Runner.java
@@ -319,6 +319,9 @@ public class Runner
                             _server = new Server();
                         }
 
+                        if (_server.getDefaultHandler() == null)
+                            _server.setDefaultHandler(new DefaultHandler());
+
                         //apply jetty config files if there are any
                         if (_configFiles != null)
                         {
@@ -331,10 +334,10 @@ public class Runner
                         }
 
                         //check that everything got configured, and if not, make the handlers
-                        Handler.Collection handlers = _server.getDescendant(Handler.Collection.class);
+                        Handler.Sequence handlers = _server.getDescendant(Handler.Sequence.class);
                         if (handlers == null)
                         {
-                            handlers = new Handler.Collection();
+                            handlers = new Handler.Sequence();
                             _server.setHandler(handlers);
                         }
 
@@ -502,7 +505,7 @@ public class Runner
         }
     }
 
-    protected void prependHandler(Handler handler, Handler.Collection handlers)
+    protected void prependHandler(Handler handler, Handler.Sequence handlers)
     {
         if (handler == null || handlers == null)
             return;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -271,10 +271,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
 
         if (contextPath != null)
             setContextPath(contextPath);
-        if (parent instanceof Handler.Wrapper)
-            ((Handler.Wrapper)parent).setHandler(this);
-        else if (parent instanceof Collection)
-            parent.addHandler(this);
+        Container.setAsParent(parent, this);
 
         _options = options;
         _sessionHandler = sessionHandler;
@@ -897,14 +894,6 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         return (ServletScopedContext)super.getContext();
     }
 
-    protected void setParent(Container parent)
-    {
-        if (parent instanceof Handler.Wrapper)
-            ((Handler.Wrapper)parent).setHandler(this);
-        else if (parent instanceof Collection)
-            ((Collection)parent).addHandler(this);
-    }
-
     /**
      * Add a context event listeners.
      *
@@ -996,7 +985,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         }
     }
 
-    private void doSetHandler(Handler.Nested wrapper, Handler handler)
+    private void doSetHandler(Handler.Wrapper wrapper, Handler handler)
     {
         if (wrapper == this)
             super.setHandler(handler);
@@ -1006,7 +995,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
 
     private void relinkHandlers()
     {
-        Handler.Nested handler = this;
+        Handler.Wrapper handler = this;
 
         // link session handler
         if (getSessionHandler() != null)
@@ -1014,9 +1003,9 @@ public class ServletContextHandler extends ContextHandler implements Graceful
             while (!(handler.getHandler() instanceof SessionHandler) &&
                 !(handler.getHandler() instanceof SecurityHandler) &&
                 !(handler.getHandler() instanceof ServletHandler) &&
-                handler.getHandler() instanceof Handler.Nested)
+                handler.getHandler() instanceof Handler.Wrapper wrapped)
             {
-                handler = (Handler.Nested)handler.getHandler();
+                handler = wrapped;
             }
 
             if (handler.getHandler() != _sessionHandler)
@@ -1029,9 +1018,9 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         {
             while (!(handler.getHandler() instanceof SecurityHandler) &&
                 !(handler.getHandler() instanceof ServletHandler) &&
-                handler.getHandler() instanceof Handler.Nested)
+                handler.getHandler() instanceof Handler.Wrapper wrapped)
             {
-                handler = (Handler.Nested)handler.getHandler();
+                handler = wrapped;
             }
 
             if (handler.getHandler() != _securityHandler)
@@ -1043,9 +1032,9 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         if (getServletHandler() != null)
         {
             while (!(handler.getHandler() instanceof ServletHandler) &&
-                handler.getHandler() instanceof Handler.Nested)
+                handler.getHandler() instanceof Handler.Wrapper wrapped)
             {
-                handler = (Handler.Nested)handler.getHandler();
+                handler = wrapped;
             }
 
             if (handler.getHandler() != _servletHandler)
@@ -1623,7 +1612,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
         l.contextDestroyed(e);
     }
 
-    private void replaceHandler(Handler.Nested handler, Handler.Nested replacement)
+    private void replaceHandler(Handler.Wrapper handler, Handler.Wrapper replacement)
     {
         if (isStarted())
             throw new IllegalStateException("STARTED");
@@ -1643,7 +1632,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
                     break;
                 }
 
-                wrapper = (wrapper.getHandler() instanceof Handler.Wrapper) ? (Handler.Wrapper)wrapper.getHandler() : null;
+                wrapper = (wrapper.getHandler() instanceof Handler.Wrapper wrapped) ? wrapped : null;
             }
         }
 
@@ -1686,7 +1675,7 @@ public class ServletContextHandler extends ContextHandler implements Graceful
      * but after any other HandlerWrappers.
      */
     @Override
-    public void insertHandler(Handler.Nested handler)
+    public void insertHandler(Handler.Wrapper handler)
     {
         if (handler instanceof SessionHandler)
             setSessionHandler((SessionHandler)handler);
@@ -1696,17 +1685,13 @@ public class ServletContextHandler extends ContextHandler implements Graceful
             setServletHandler((ServletHandler)handler);
         else
         {
-            Handler.Nested tail = handler;
-            while (tail.getHandler() instanceof Handler.Wrapper)
-            {
-                tail = (Handler.Wrapper)tail.getHandler();
-            }
+            Handler.Wrapper tail = handler.getTail();
             if (tail.getHandler() != null)
                 throw new IllegalArgumentException("bad tail of inserted wrapper chain");
 
             // Skip any injected handlers
-            Handler.Nested h = this;
-            while (h.getHandler() instanceof Handler.Nested wrapper)
+            Handler.Wrapper h = this;
+            while (h.getHandler() instanceof Handler.Wrapper wrapper)
             {
                 if (wrapper instanceof SessionHandler ||
                     wrapper instanceof SecurityHandler ||

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -82,7 +82,7 @@ import org.slf4j.LoggerFactory;
  * method must be called manually after start().
  */
 @ManagedObject("Servlet Handler")
-public class ServletHandler extends Handler.Wrapper
+public class ServletHandler extends Handler.BaseWrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ServletHandler.class);
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -51,7 +51,7 @@ import org.eclipse.jetty.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SessionHandler extends AbstractSessionManager implements Handler.Nested
+public class SessionHandler extends AbstractSessionManager implements Handler.Wrapper
 {    
     static final Logger LOG = LoggerFactory.getLogger(SessionHandler.class);
     
@@ -93,7 +93,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Ne
     @Override
     public void setHandler(Handler handler)
     {
-        _handler = Nested.updateHandler(this, handler);
+        _handler = Wrapper.updateHandler(this, handler);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/SecurityHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/SecurityHandler.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * that start with "org.eclipse.jetty.security." that do not have
  * values in the SecurityHandler init parameters, are copied.
  */
-public abstract class SecurityHandler extends Handler.Wrapper implements Authenticator.AuthConfiguration
+public abstract class SecurityHandler extends Handler.BaseWrapper implements Authenticator.AuthConfiguration
 {
     private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class);
     private static final List<Authenticator.Factory> __knownAuthenticatorFactories = new ArrayList<>();

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextDispatchWithQueryStrings.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextDispatchWithQueryStrings.java
@@ -21,10 +21,8 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,7 +52,7 @@ public class AsyncContextDispatchWithQueryStrings
         _contextHandler.addServlet(new ServletHolder(new TestServlet()), "/firstDispatchWithNewQueryString");
         _contextHandler.addServlet(new ServletHolder(new TestServlet()), "/secondDispatchNewValueForExistingQueryString");
 
-        _server.setHandler(new Handler.Collection(_contextHandler, new DefaultHandler()));
+        _server.setHandler(_contextHandler);
         _server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
@@ -29,12 +29,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,7 +90,7 @@ public class AsyncContextTest
         errorHandler.addErrorPage(500, "/error/500");
         errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
 
-        _server.setHandler(new Handler.Collection(_contextHandler, new DefaultHandler()));
+        _server.setHandler(_contextHandler);
         _server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -29,7 +29,6 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -104,7 +103,7 @@ public class ErrorPageTest
         _context.addServlet(ErrorContentTypeCharsetWriterInitializedServlet.class, "/error-mime-charset-writer/*");
         _context.addServlet(ExceptionServlet.class, "/exception-servlet");
 
-        Handler.Wrapper noopHandler = new Handler.Wrapper()
+        Handler.Wrapper noopHandler = new Handler.BaseWrapper()
         {
             @Override
             public boolean process(Request request, Response response, Callback callback) throws Exception

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
@@ -1728,7 +1728,7 @@ public class ServletContextHandlerTest
     {
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
 
-        Handler.Wrapper extra = new Handler.Wrapper();
+        Handler.Wrapper extra = new Handler.BaseWrapper();
 
         context.getSessionHandler().insertHandler(extra);
 
@@ -1790,10 +1790,10 @@ public class ServletContextHandlerTest
         SecurityHandler securityHandler = context.getSecurityHandler();
 
         //check the handler linking order
-        Handler.Nested h = (Handler.Nested)context.getHandler();
+        Handler.Wrapper h = (Handler.Wrapper)context.getHandler();
         assertSame(h, sessionHandler);
 
-        h = (Handler.Nested)h.getHandler();
+        h = (Handler.Wrapper)h.getHandler();
         assertSame(h, securityHandler);
 
         //replace the security handler
@@ -1830,10 +1830,10 @@ public class ServletContextHandlerTest
         context.setSecurityHandler(myHandler);
         assertSame(myHandler, context.getSecurityHandler());
 
-        h = (Handler.Nested)context.getHandler();
+        h = (Handler.Wrapper)context.getHandler();
         assertSame(h, sessionHandler);
 
-        h = (Handler.Nested)h.getHandler();
+        h = (Handler.Wrapper)h.getHandler();
         assertSame(h, myHandler);
     }
 
@@ -1915,7 +1915,7 @@ public class ServletContextHandlerTest
     @Test
     public void testFallThrough() throws Exception
     {
-        Handler.Collection list = new Handler.Collection();
+        Handler.Sequence list = new Handler.Sequence();
         _server.setHandler(list);
 
         ServletContextHandler root = new ServletContextHandler(list, "/", ServletContextHandler.SESSIONS);

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestLogTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestLogTest.java
@@ -33,7 +33,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
@@ -293,15 +292,12 @@ public class ServletRequestLogTest
         server.setConnectors(new Connector[]{connector});
 
         // First the behavior as defined in etc/jetty.xml
-        // id="Handlers"
-        Handler.Collection handlers = new Handler.Collection();
         // id="Contexts"
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         // id="DefaultHandler"
         DefaultHandler defaultHandler = new DefaultHandler();
 
-        handlers.setHandlers(contexts, defaultHandler);
-        server.setHandler(handlers);
+        server.setHandler(contexts);
 
         // Next the behavior as defined by etc/jetty-requestlog.xml
         // the id="RequestLog"
@@ -377,8 +373,7 @@ public class ServletRequestLogTest
         server.addBean(errorHandler);
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        DefaultHandler defaultHandler = new DefaultHandler();
-        server.setHandler(new Handler.Collection(contexts, defaultHandler));
+        server.setHandler(contexts);
 
         // Next the behavior as defined by etc/jetty-requestlog.xml
         // the id="RequestLog"
@@ -451,7 +446,7 @@ public class ServletRequestLogTest
         server.setConnectors(new Connector[]{connector});
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        server.setHandler(new Handler.Collection(contexts, new DefaultHandler()));
+        server.setHandler(contexts);
 
         // Next the behavior as defined by etc/jetty-requestlog.xml
         // the id="RequestLog"
@@ -531,9 +526,7 @@ public class ServletRequestLogTest
         // First the behavior as defined in etc/jetty.xml (as is)
         // id="Contexts"
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        // id="DefaultHandler"
-        DefaultHandler defaultHandler = new DefaultHandler();
-        server.setHandler(new Handler.Collection(contexts, defaultHandler));
+        server.setHandler(contexts);
 
         // Next the proposed behavioral change to etc/jetty-requestlog.xml
         // the id="RequestLog"

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletUpgradeTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletUpgradeTest.java
@@ -27,10 +27,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.WebConnection;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -62,9 +60,7 @@ public class ServletUpgradeTest
         contextHandler.setContextPath("/");
         contextHandler.addServlet(new ServletHolder(new TestServlet()), "/TestServlet");
 
-        Handler.Collection handlers = new Handler.Collection();
-        handlers.setHandlers(contextHandler, new DefaultHandler());
-        server.setHandler(handlers);
+        server.setHandler(contextHandler);
 
         server.start();
         port = connector.getLocalPort();

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletWrapperTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletWrapperTest.java
@@ -28,11 +28,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +64,7 @@ public class ServletWrapperTest
         FilterHolder filterHolder = context.addFilter(WrapFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         filterHolder.setAsyncSupported(true);
 
-        server.setHandler(new Handler.Collection(context, new DefaultHandler()));
+        server.setHandler(context);
         server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -50,6 +50,7 @@ import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee10.servlet.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
@@ -222,8 +223,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         super(null, contextPath, sessionHandler, securityHandler, servletHandler, errorHandler, options);
         setErrorProcessor(errorHandler != null ? errorHandler : new ErrorPageErrorHandler());
         setProtectedTargets(__dftProtectedTargets);
-        if (parent != null)
-            setParent(parent);
+        Handler.Container.setAsParent(parent, this);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
@@ -54,12 +54,10 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.MultiPart;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.DelayedHandler;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -227,7 +225,7 @@ public class HugeResourceTest
         server.setHandler(delayedHandler);
         httpConfig.setDelayDispatchUntilContent(false);
 
-        delayedHandler.setHandler(new Handler.Collection(context, new DefaultHandler()));
+        delayedHandler.setHandler(context);
         server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -247,7 +247,7 @@ public class WebAppContextTest
     public void testContextWhiteList() throws Exception
     {
         Server server = newServer();
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         WebAppContext contextA = new WebAppContext(".", "/A");
 
         contextA.addServlet(ServletA.class, "/s");
@@ -319,14 +319,12 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
-        server.setHandler(handlers);
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
         contexts.addHandler(context);
 
         LocalConnector connector = new LocalConnector(server);
@@ -362,14 +360,12 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
-        server.setHandler(handlers);
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
         contexts.addHandler(context);
 
         LocalConnector connector = new LocalConnector(server);
@@ -395,14 +391,12 @@ public class WebAppContextTest
         server.addConnector(connector);
         connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
 
-        Handler.Collection handlers = new Handler.Collection();
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
-        server.setHandler(handlers);
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
         contexts.addHandler(context);
 
         server.start();
@@ -416,14 +410,12 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
-        server.setHandler(handlers);
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
         contexts.addHandler(context);
 
         LocalConnector connector = new LocalConnector(server);
@@ -441,7 +433,6 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext(null, null, null, null, null, new ErrorPageErrorHandler(),
             ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
@@ -449,8 +440,7 @@ public class WebAppContextTest
 
         Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
-        server.setHandler(handlers);
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
         contexts.addHandler(context);
 
         LocalConnector connector = new LocalConnector(server);
@@ -672,7 +662,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         DefaultHandler handler = new DefaultHandler();
-        server.setHandler(new Handler.Collection(context, handler));
+        server.setHandler(new Handler.Sequence(context, handler));
 
         assertThat(handler.getServer(), sameInstance(server));
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletCacheTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletCacheTest.java
@@ -42,7 +42,7 @@ public class WebAppDefaultServletCacheTest
 
         URI uri = getClass().getResource("/org/acme").toURI();
         resourcePath = Paths.get(uri);
-        server.addHandler(new WebAppContext(uri.toString(), "/"));
+        server.setHandler(new WebAppContext(uri.toString(), "/"));
 
         server.start();
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
@@ -68,13 +68,13 @@ public class DeploymentExceptionTest
     }
 
     private Server server;
-    private Handler.Collection contexts;
+    private Handler.Sequence contexts;
 
     @BeforeEach
     public void startServer() throws Exception
     {
         server = new Server(0);
-        contexts = new Handler.Collection();
+        contexts = new Handler.Sequence();
         server.setHandler(contexts);
         server.start();
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ExampleServer.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ExampleServer.java
@@ -15,11 +15,8 @@ package org.eclipse.jetty.ee9.demos;
 
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 
 public class ExampleServer
 {
@@ -36,7 +33,7 @@ public class ExampleServer
         context.addServlet(HelloServlet.class, "/hello");
         context.addServlet(AsyncEchoServlet.class, "/echo/*");
 
-        server.setHandler(new Handler.Collection(context.getCoreContextHandler(), new DefaultHandler()));
+        server.setHandler(context);
 
         return server;
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServer.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServer.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee9.demos;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -35,6 +34,7 @@ public class FileServer
         // then a randomly available port will be assigned that you can either look in the logs for the port,
         // or programmatically obtain it for use in test cases.
         Server server = new Server(port);
+        server.setDefaultHandler(new DefaultHandler());
 
         // Create the ResourceHandler. It is the object that will actually handle the request for a given file. It is
         // a Jetty Handler object so it is suitable for chaining with other handlers as you will see in other examples.
@@ -47,7 +47,7 @@ public class FileServer
         resourceHandler.setBaseResource(baseResource);
 
         // Add the ResourceHandler to the server.
-        server.setHandler(new Handler.Collection(resourceHandler, new DefaultHandler()));
+        server.setHandler(resourceHandler);
 
         return server;
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/JarServer.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/JarServer.java
@@ -23,9 +23,7 @@ import java.util.Objects;
 import org.eclipse.jetty.ee9.servlet.DefaultServlet;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -55,7 +53,7 @@ public class JarServer
         ServletHolder defaultHolder = new ServletHolder("default", new DefaultServlet());
         context.addServlet(defaultHolder, "/");
 
-        server.setHandler(new Handler.Collection(context.getCoreContextHandler(), new DefaultHandler()));
+        server.setHandler(context);
         return server;
     }
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ManyHandlers.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ManyHandlers.java
@@ -44,10 +44,10 @@ import org.eclipse.jetty.util.ajax.JSON;
  * </ul>
  * Multiple handlers may be combined with:
  * <ul>
- * <li>{@link Handler.Wrapper} which will nest one handler inside another. In
+ * <li>{@link Handler.BaseWrapper} which will nest one handler inside another. In
  * this example, the HelloHandler is nested inside a HandlerWrapper that sets
  * the greeting as a request attribute.
- * <li>{@link Handler.Collection} which will call a collection of handlers until the
+ * <li>{@link Handler.Sequence} which will call a collection of handlers until the
  * request is marked as handled. In this example, a list is used to combine the
  * param handler (which only handles the request if there are parameters) and
  * the wrapper handler. Frequently handler lists are terminated with the
@@ -78,7 +78,7 @@ public class ManyHandlers
     /**
      * Add a request attribute, but produce no output.
      */
-    public static class WelcomeWrapHandler extends Handler.Wrapper
+    public static class WelcomeWrapHandler extends Handler.BaseWrapper
     {
         @Override
         public boolean process(Request request, Response response, Callback callback) throws Exception
@@ -94,6 +94,7 @@ public class ManyHandlers
     public static Server createServer(int port) throws IOException
     {
         Server server = new Server(port);
+        server.setDefaultHandler(new DefaultHandler());
 
         // create the handlers
         Handler param = new ParamHandler();
@@ -109,9 +110,6 @@ public class ManyHandlers
         CustomRequestLog ncsaLog = new CustomRequestLog(requestLogFile.toString());
         server.setRequestLog(ncsaLog);
 
-        // create the handlers list
-        Handler.Collection handlers = new Handler.Collection();
-
         // wrap contexts around specific handlers
         wrapper.setHandler(hello);
         ContextHandler helloContext = new ContextHandler("/hello");
@@ -126,15 +124,12 @@ public class ManyHandlers
         gzipHandler.setHandler(contexts);
 
         // Set the top level Handler List
-        handlers.addHandler(gzipHandler);
-        handlers.addHandler(new DefaultHandler());
-        server.setHandler(handlers);
+        server.setHandler(gzipHandler);
         server.setDumpAfterStart(true);
 
         /* At this point you have the following handler hierarchy.
          *
-         * Server.handler:
-         * HandlerList
+         * Server:
          *    \- GzipHandler
          *    |   \- ContextHandlerCollection
          *    |       \- ContextHandler ("/hello")

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/ServerSupport.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/ServerSupport.java
@@ -23,12 +23,10 @@ import org.eclipse.jetty.ee9.security.LoginService;
 import org.eclipse.jetty.ee9.webapp.Configurations;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
@@ -68,11 +66,7 @@ public class ServerSupport
         if (contexts == null)
         {
             contexts = new ContextHandlerCollection();
-            Handler.Collection handlers = server.getDescendant(Handler.Collection.class);
-            if (handlers == null)
-                server.setHandler(new Handler.Collection(contexts, new DefaultHandler()));
-            else
-                handlers.addHandler(contexts);
+            server.setHandler(contexts);
         } 
         
         if (contextHandlers != null)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -248,8 +248,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         _initParams = new HashMap<>();
         if (contextPath != null)
             setContextPath(contextPath);
-        if (parent != null)
-            parent.addHandler(_coreContextHandler);
+        Handler.Container.setAsParent(parent, _coreContextHandler);
     }
 
     @Override
@@ -2503,11 +2502,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         }
         
         @Override
-        public void insertHandler(Nested handler)
+        public void insertHandler(Handler.Wrapper handler)
         {
-            Nested tail = handler;
-            while (tail.getHandler() instanceof Handler.Wrapper)
-                tail = (Handler.Wrapper)tail.getHandler();
+            Handler.Wrapper tail = handler.getTail();
             if (tail.getHandler() != null)
                 throw new IllegalArgumentException("bad tail of inserted wrapper chain");
         

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/AsyncCompletionTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/AsyncCompletionTest.java
@@ -114,7 +114,7 @@ public class AsyncCompletionTest extends HttpServerTestFixture
     @Override
     protected void startServer(Handler handler) throws Exception
     {
-        org.eclipse.jetty.server.Handler.Nested terminateHandler = new org.eclipse.jetty.server.Handler.Wrapper()
+        org.eclipse.jetty.server.Handler.Wrapper terminateHandler = new org.eclipse.jetty.server.Handler.BaseWrapper()
         {
             @Override
             public boolean process(org.eclipse.jetty.server.Request request, Response response, Callback callback) throws Exception

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Context;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -61,11 +60,9 @@ public class ContextHandlerTest
         _connector = new LocalConnector(_server);
         _server.addConnector(_connector);
 
-        Handler.Collection handlers = new Handler.Collection();
-        _server.setHandler(handlers);
 
         _contextHandler = new ContextHandler();
-        handlers.setHandlers(_contextHandler.getCoreContextHandler());
+        _server.setHandler(_contextHandler);
     }
 
     @AfterEach

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -996,7 +996,7 @@ public class RequestTest
         });
         final InetSocketAddress remoteAddr = new InetSocketAddress(local, 32768);
 
-        org.eclipse.jetty.server.Handler.Wrapper handler = new org.eclipse.jetty.server.Handler.Wrapper()
+        org.eclipse.jetty.server.Handler.Wrapper handler = new org.eclipse.jetty.server.Handler.BaseWrapper()
         {
             @Override
             public boolean process(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/AliasedConstraintTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/AliasedConstraintTest.java
@@ -24,10 +24,8 @@ import org.eclipse.jetty.ee9.nested.ResourceHandler;
 import org.eclipse.jetty.ee9.nested.SessionHandler;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
@@ -75,10 +73,7 @@ public class AliasedConstraintTest
         context.setContextPath("/ctx");
         context.setResourceBase(MavenTestingUtils.getTargetFile("test-classes/docroot").getAbsolutePath());
 
-        Handler.Collection handlers = new Handler.Collection();
-        handlers.addHandler(context);
-        handlers.addHandler(new DefaultHandler());
-        server.setHandler(handlers);
+        server.setHandler(context);
 
         context.setHandler(session);
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextDispatchWithQueryStrings.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextDispatchWithQueryStrings.java
@@ -21,10 +21,8 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,9 +52,7 @@ public class AsyncContextDispatchWithQueryStrings
         _contextHandler.addServlet(new ServletHolder(new TestServlet()), "/firstDispatchWithNewQueryString");
         _contextHandler.addServlet(new ServletHolder(new TestServlet()), "/secondDispatchNewValueForExistingQueryString");
 
-        Handler.Collection handlers = new Handler.Collection();
-        handlers.setHandlers(_contextHandler.getCoreContextHandler(), new DefaultHandler());
-        _server.setHandler(handlers);
+        _server.setHandler(_contextHandler);
         _server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
@@ -32,11 +32,9 @@ import org.eclipse.jetty.ee9.nested.QuietServletException;
 import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,9 +93,7 @@ public class AsyncContextTest
         errorHandler.addErrorPage(500, "/error/500");
         errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
 
-        Handler.Collection handlers = new Handler.Collection();
-        _server.setHandler(handlers);
-        handlers.setHandlers(_contextHandler.getCoreContextHandler(), new DefaultHandler());
+        _server.setHandler(_contextHandler);
         _server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
@@ -81,7 +80,7 @@ public class GzipHandlerIsHandledTest
     @Test
     public void testRequest() throws Exception
     {
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
 
         ResourceHandler resourceHandler = new ResourceHandler();
         resourceHandler.setBaseResource(ResourceFactory.root().newResource(workDir.getPath()));
@@ -92,7 +91,7 @@ public class GzipHandlerIsHandledTest
         gzipHandler.setMinGzipSize(32);
         gzipHandler.setHandler(new EventHandler(events, "GzipHandler-wrapped-handler"));
 
-        handlers.setHandlers(resourceHandler, gzipHandler, new DefaultHandler());
+        handlers.setHandlers(resourceHandler, gzipHandler);
 
         startServer(handlers);
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
@@ -29,7 +29,6 @@ import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.WebConnection;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -62,9 +61,7 @@ public class ServletUpgradeTest
         contextHandler.setContextPath("/");
         contextHandler.addServlet(new ServletHolder(new TestServlet()), "/TestServlet");
 
-        org.eclipse.jetty.server.Handler.Collection handlers = new org.eclipse.jetty.server.Handler.Collection();
-        handlers.setHandlers(contextHandler.getCoreContextHandler(), new DefaultHandler());
-        server.setHandler(handlers);
+        server.setHandler(contextHandler);
 
         server.start();
         port = connector.getLocalPort();

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletWrapperTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletWrapperTest.java
@@ -28,11 +28,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,9 +64,7 @@ public class ServletWrapperTest
         FilterHolder filterHolder = context.addFilter(WrapFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         filterHolder.setAsyncSupported(true);
 
-        Handler.Collection handlers = new Handler.Collection();
-        handlers.setHandlers(context.getCoreContextHandler(), new DefaultHandler());
-        server.setHandler(handlers);
+        server.setHandler(context);
         server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/StaticFromJarServerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/StaticFromJarServerTest.java
@@ -24,9 +24,7 @@ import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.ClientConnector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -92,7 +90,7 @@ public class StaticFromJarServerTest
         ServletHolder defaultHolder = new ServletHolder("default", new DefaultServlet());
         context.addServlet(defaultHolder, "/");
 
-        server.setHandler(new Handler.Collection(context.getCoreContextHandler(), new DefaultHandler()));
+        server.setHandler(context);
         server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -234,8 +234,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         _apiContext = new Context();
         setErrorHandler(errorHandler != null ? errorHandler : new ErrorPageErrorHandler());
         setProtectedTargets(__dftProtectedTargets);
-        if (parent != null)
-            parent.addHandler(this);
+        Handler.Container.setAsParent(parent, this.get());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/HugeResourceTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/HugeResourceTest.java
@@ -47,7 +47,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.MultiPart;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -208,7 +207,7 @@ public class HugeResourceTest
         DefaultHandler defaultHandler = new DefaultHandler();
         defaultHandler.setServer(server);
 
-        server.setHandler(new Handler.Collection(context.getCoreContextHandler(), defaultHandler));
+        server.setHandler(context);
         server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -71,7 +70,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -250,7 +248,7 @@ public class WebAppContextTest
     public void testContextWhiteList() throws Exception
     {
         Server server = newServer();
-        Handler.Collection handlers = new Handler.Collection();
+        Handler.Sequence handlers = new Handler.Sequence();
         WebAppContext contextA = new WebAppContext(".", "/A");
 
         contextA.addServlet(ServletA.class, "/s");
@@ -315,11 +313,8 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
-        server.setHandler(handlers);
-
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getTargetPath("test-classes/webapp");
@@ -379,11 +374,8 @@ public class WebAppContextTest
         server.addConnector(connector);
         connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
 
-        Handler.Collection handlers = new Handler.Collection();
-        server.setHandler(handlers);
-
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenTestingUtils.getTargetPath("test-classes/webapp");
@@ -402,11 +394,8 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
-        server.setHandler(handlers);
-
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenPaths.findTestResourceDir("webapp");
@@ -437,11 +426,8 @@ public class WebAppContextTest
     {
         Server server = newServer();
 
-        Handler.Collection handlers = new Handler.Collection();
-        server.setHandler(handlers);
-
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        handlers.addHandler(contexts);
+        server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext(null, null, null, null, null, new ErrorPageErrorHandler(),
             ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
@@ -622,17 +608,5 @@ public class WebAppContextTest
         Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
         assertThat("URL[0]", urls[0].toURI(), is(extLibs.toUri()));
-    }
-
-    @Test
-    void testSetServerPropagation()
-    {
-        Server server = new Server();
-        WebAppContext context = new WebAppContext();
-        context.setContextPath("/");
-        DefaultHandler handler = new DefaultHandler();
-        server.setHandler(new Handler.Collection(context.get(), handler));
-
-        assertThat(handler.getServer(), sameInstance(server));
     }
 }

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceBasesTest.java
@@ -130,10 +130,10 @@ public class AliasCheckerMultipleResourceBasesTest
     @Test
     public void test() throws Exception
     {
-        Handler.Collection collection = new Handler.Collection();
-        collection.addHandler(newResourceHandler(_altDir1Symlink));
-        collection.addHandler(newResourceHandler(_altDir2Symlink));
-        _context.setHandler(collection);
+        Handler.Sequence handlers = new Handler.Sequence();
+        handlers.addHandler(newResourceHandler(_altDir1Symlink));
+        handlers.addHandler(newResourceHandler(_altDir2Symlink));
+        _context.setHandler(handlers);
         _server.start();
 
         // With no alias checkers we cannot access file 1.

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -125,7 +125,7 @@ public class AliasCheckerSymlinkTest
         _context.setContextPath("/");
         _context.setBaseResourceAsPath(webRootPath);
         _context.setProtectedTargets(new String[]{"/WEB-INF", "/META-INF"});
-        _context.addHandler(new ResourceHandler());
+        _context.setHandler(new ResourceHandler());
 
         _server.setHandler(_context);
         _context.clearAliasChecks();


### PR DESCRIPTION
Fixes #8765  #8759 . Part of #9072

There is now a Handler interface hierarchy:
 + Container is a Handler that has 1 or more contained Handlers.
 + Wrapper is a Container with only 1 handler and a setHandler method.
 + Collection is a Container with n handlers and a addHandler method

class are now:
 + Abstract implements Handler
 + AbstractContainer extends Abstract implements Container
 + BaseWrapper extends AbstractContainer implements Wrapper
 + Sequence extends AbstractContainer implements Collection

 Lots of other associated cleanups