### PR TITLE
Issue #9293 - Jetty 12 - Relax JPMS dependencies (fcgi)

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/module-info.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/module-info.java
@@ -19,7 +19,6 @@ module org.eclipse.jetty.fcgi.client
 
     exports org.eclipse.jetty.fcgi;
     exports org.eclipse.jetty.fcgi.client.transport;
-
-    exports org.eclipse.jetty.fcgi.generator to org.eclipse.jetty.fcgi.server;
-    exports org.eclipse.jetty.fcgi.parser to org.eclipse.jetty.fcgi.server;
+    exports org.eclipse.jetty.fcgi.generator;
+    exports org.eclipse.jetty.fcgi.parser;
 }


### PR DESCRIPTION
Relaxed jetty-fcgi JPMS dependencies.
Packages generator and parser were not internal,
was just matters of exporting them.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>