### PR TITLE
Issue #7650 - Fix race condition when stopping QueuedThreadPool

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -280,9 +280,13 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
         }
 
         // Close any un-executed jobs
-        while (!_jobs.isEmpty())
+        while (true)
         {
             Runnable job = _jobs.poll();
+            if (job == null)
+            {
+                break;
+            }
             if (job instanceof Closeable)
             {
                 try


### PR DESCRIPTION
Fixes #7650 that causes the warning message `Stopped without executing or closing null`