### PR TITLE
Jetty 12.0.x 9301 fix ee10 jstl jpms

### DIFF
--- a/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
@@ -79,10 +79,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.el</groupId>
-      <artifactId>jakarta.el-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
@@ -39,24 +39,13 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet.jsp</groupId>
-      <artifactId>jakarta.servlet.jsp-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.el</groupId>
-      <artifactId>jakarta.el-api</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-apache-jsp</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-apache-jsp</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
@@ -6,5 +6,8 @@ Enables the glassfish version of JSTL for all webapps.
 [environment]
 ee10
 
+[depends]
+ee10-apache-jsp
+
 [lib]
 lib/ee10-glassfish-jstl/*.jar

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -240,8 +240,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-el,apache-jsp,ecj</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp,jakart.el,org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
+              <includeArtifactIds>jakart.servlet.jsp-api,jakarta.el-api,apache-el,apache-jsp,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee10-apache-jsp</outputDirectory>
@@ -255,8 +255,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-el,apache-jsp,ecj</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp,jakarta.el,org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
+              <includeArtifactIds>jakarta.servlet.jsp-api,jakarta.el-api,apache-el,apache-jsp,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee10-apache-jsp</outputDirectory>
             </configuration>

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -269,8 +269,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web,jakarta.el,jakarta.servlet.jsp,jakarta.el</includeGroupIds>
-              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl,jakarta.el-api,jakarta.servlet.jsp-api,jakarta.el-api</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web</includeGroupIds>
+              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee10-glassfish-jstl</outputDirectory>
@@ -284,8 +284,8 @@
             </goals>
             <configuration>
               <prependGroupId>true</prependGroupId>
-              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web,jakarta.el,jakarta.servlet.jsp,jakarta.el</includeGroupIds>
-              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl,jakarta.el-api,jakarta.servlet.jsp-api,jakarta.el-api</includeArtifactIds>
+              <includeGroupIds>jakarta.servlet.jsp.jstl,org.glassfish.web</includeGroupIds>
+              <includeArtifactIds>jakarta.servlet.jsp.jstl-api,jakarta.servlet.jsp.jstl</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee10-glassfish-jstl</outputDirectory>
             </configuration>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -167,6 +167,8 @@ public class TestOSGiUtil
         res.add(CoreOptions.streamBundle(loggingPropertiesBundle.build()).noStart());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-slf4j-impl").versionAsInProject().start());
         // END - slf4j 2.x
+        
+        res.add(mavenBundle().groupId("jakarta.el").artifactId("jakarta.el-api").versionAsInProject().start());
 
         res.add(mavenBundle().groupId("jakarta.servlet").artifactId("jakarta.servlet-api").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.platform").artifactId("org.eclipse.osgi.util").versionAsInProject());
@@ -195,11 +197,10 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("org.apache.aries.spifly").artifactId("org.apache.aries.spifly.dynamic.bundle").versionAsInProject().start());
         res.add(mavenBundle().groupId("jakarta.inject").artifactId("jakarta.inject-api").versionAsInProject().start());
         res.add(mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject().start());
-        res.add(mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.cdi-api").versionAsInProject().start());
-        res.add(mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.lang-model").versionAsInProject().start());
         res.add(mavenBundle().groupId("jakarta.interceptor").artifactId("jakarta.interceptor-api").versionAsInProject().start());
+        res.add(mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.lang-model").versionAsInProject().start());
+        res.add(mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.cdi-api").versionAsInProject().start());
         res.add(mavenBundle().groupId("jakarta.transaction").artifactId("jakarta.transaction-api").versionAsInProject().start());
-        res.add(mavenBundle().groupId("jakarta.el").artifactId("jakarta.el-api").versionAsInProject().start());
 
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-io").versionAsInProject().start());
@@ -237,26 +238,8 @@ public class TestOSGiUtil
     public static void coreJspDependencies(List<Option> res)
     {
         //jetty jsp bundles
-
-        /* The coreJettyDependencies() method needs to configure jakarta.el-api to satisfy the jakarta.transaction-api bundle.
-         * However, as we are now configuring the full jsp bundle set, we need to remove the jakarta.el-api
-         * bundle because the org.mortbay.jasper.apache-el bundle will be providing both the api and the impl.
-         */
-        MavenArtifactProvisionOption option = mavenBundle().groupId("jakarta.el").artifactId("jakarta.el-api").versionAsInProject();
-        
-        ListIterator<Option> iter = res.listIterator();
-        while (iter.hasNext())
-        {
-            Option o = iter.next();
-            if (o instanceof MavenArtifactProvisionOption)
-            {
-                if (((MavenArtifactProvisionOption)o).getURL().contains("jakarta.el-api"))
-                {
-                    iter.remove();
-                }
-            }
-        }
-
+        res.add(systemProperty("jakarta.el.ExpressionFactory").value("org.apache.el.ExpressionFactoryImpl"));
+        res.add(mavenBundle().groupId("jakarta.servlet.jsp").artifactId("jakarta.servlet.jsp-api").versionAsInProject());
         res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-el").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-jsp").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty.ee10").artifactId("jetty-ee10-apache-jsp").versionAsInProject().start());

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -34,7 +34,7 @@
     <jakarta.xml.jaxws.impl.version>4.0.0</jakarta.xml.jaxws.impl.version>
     <jakarta.websocket.api.version>2.1.0</jakarta.websocket.api.version>
 
-    <jsp.impl.version>10.1-SNAPSHOT</jsp.impl.version>
+    <jsp.impl.version>10.1.5</jsp.impl.version>
     <mail.impl.version>2.0.1</mail.impl.version>
 
     <sonar.skip>true</sonar.skip>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -34,7 +34,7 @@
     <jakarta.xml.jaxws.impl.version>4.0.0</jakarta.xml.jaxws.impl.version>
     <jakarta.websocket.api.version>2.1.0</jakarta.websocket.api.version>
 
-    <jsp.impl.version>10.1.1</jsp.impl.version>
+    <jsp.impl.version>10.1-SNAPSHOT</jsp.impl.version>
     <mail.impl.version>2.0.1</mail.impl.version>
 
     <sonar.skip>true</sonar.skip>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -194,7 +194,6 @@ public class DistributionTests extends AbstractJettyHomeTest
         }
     }
 
-    @Disabled //TODO glassfish-jstl not working in jpms
     @ParameterizedTest
     @ValueSource(strings = {"ee10"})
     public void testSimpleWebAppWithJSPOnModulePath(String env) throws Exception
@@ -237,7 +236,6 @@ public class DistributionTests extends AbstractJettyHomeTest
 
                 response = client.GET("http://localhost:" + port + "/test/jstl.jsp");
                 assertEquals(HttpStatus.OK_200, response.getStatus());
-                System.err.println(response.getContentAsString());
                 assertThat(response.getContentAsString(), containsString("JSTL Example"));
                 assertThat(response.getContentAsString(), not(containsString("<c:")));
             }


### PR DESCRIPTION
Closes #9301 

Fixing jstl dependencies for jpms meant using jakarta api jars everywhere, including in osgi, and making a new release of the org.mortbay.jasper jars minus the apis.