### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ All [stable versions](https://www.eclipse.org/jetty/download.php) of jetty are a
 
 ## Reporting a Vulnerability
 
-Do not open a public issue to report a security vulnerability.  Please send a message to security@eclipse.org and we will create a private issue in which the issue can be triaged and handled.
+Do not open a public issue to report a security vulnerability.  Please send a message to security@webtide.com and we will create a private issue in which the issue can be triaged and handled.
 
 ## Handling a Vulnerability
 


### PR DESCRIPTION
remove security@eclipse.org, if something goes there that is fine, and we will get it corrected, but our place of authority for security issues should be security@webtide.com