### PR TITLE
URI Host Mismatch with optional Compliance modes

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -169,7 +169,11 @@ public final class HttpCompliance implements ComplianceViolation.Mode
      * The HttpCompliance mode that supports <a href="https://tools.ietf.org/html/rfc2616">RFC 7230</a>
      * with only the violations that differ from {@link #RFC7230}.
      */
-    public static final HttpCompliance RFC2616 = new HttpCompliance("RFC2616", of(Violation.HTTP_0_9, Violation.MULTILINE_FIELD_VALUE));
+    public static final HttpCompliance RFC2616 = new HttpCompliance("RFC2616", of(
+        Violation.HTTP_0_9,
+        Violation.MULTILINE_FIELD_VALUE,
+        Violation.MISMATCHED_AUTHORITY
+    ));
 
     /**
      * A legacy HttpCompliance mode that allows all violations except case-insensitive methods.

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -117,7 +117,14 @@ public final class HttpCompliance implements ComplianceViolation.Mode
          * should reject a request if the Host headers contains an invalid / unsafe authority.
          * A deployment may include this violation to allow unsafe host headesr on a received request.
          */
-        UNSAFE_HOST_HEADER("https://www.rfc-editor.org/rfc/rfc7230#section-2.7.1", "Invalid Authority");
+        UNSAFE_HOST_HEADER("https://www.rfc-editor.org/rfc/rfc7230#section-2.7.1", "Invalid Authority"),
+
+        /**
+         * Since <a href="https://www.rfc-editor.org/rfc/rfc7230#section-5.4">RFC 7230: Section 5.4</a>, the HTTP protocol
+         * must reject a request if the target URI has an authority that is different than a provided Host header.
+         * A deployment may include this violation to allow different values on the target URI and the Host header on a received request.
+         */
+        MISMATCHED_AUTHORITY("https://www.rfc-editor.org/rfc/rfc7230#section-5.4", "Mismatched Authority");
 
         private final String url;
         private final String description;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -36,6 +36,7 @@ import static org.eclipse.jetty.http.HttpCompliance.Violation;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.CASE_SENSITIVE_FIELD_NAME;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.DUPLICATE_HOST_HEADERS;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.HTTP_0_9;
+import static org.eclipse.jetty.http.HttpCompliance.Violation.MISMATCHED_AUTHORITY;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.MULTIPLE_CONTENT_LENGTHS;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.NO_COLON_AFTER_FIELD_NAME;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.TRANSFER_ENCODING_WITH_CONTENT_LENGTH;
@@ -1037,22 +1038,32 @@ public class HttpParser
                                 LOG.warn("Encountered multiple `Host` headers.  Previous `Host` header already seen as `{}`, new `Host` header has appeared as `{}`", _parsedHost, _valueString);
                             checkViolation(DUPLICATE_HOST_HEADERS);
                         }
+                        if (!MISMATCHED_AUTHORITY.isAllowedBy(_complianceMode))
+                        {
+                            HttpURI httpURI = HttpURI.build().uri(_method == null ? null : _method.toString(), _uri.toString());
+                            if (httpURI.isAbsolute())
+                            {
+                                if (!httpURI.getAuthority().equalsIgnoreCase(_valueString))
+                                {
+                                    if (LOG.isWarnEnabled())
+                                        LOG.warn("Mismatched Authority: request-line authority is [{}], Host header is [{}]", httpURI.getHost(), _valueString);
+                                    throw new BadMessageException(MISMATCHED_AUTHORITY.getDescription());
+                                }
+                            }
+                        }
                         _parsedHost = _valueString;
                         if (!(_field instanceof HostPortHttpField) && _valueString != null && !_valueString.isEmpty())
                         {
                             HostPort hostPort;
                             if (UNSAFE_HOST_HEADER.isAllowedBy(_complianceMode))
-                            {
-                                _field = new HostPortHttpField(_header,
-                                    CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode) ? _headerString : _header.asString(),
-                                    HostPort.unsafe(_valueString));
-                            }
+                                hostPort = HostPort.unsafe(_valueString);
                             else
-                            {
-                                _field = new HostPortHttpField(_header,
-                                    CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode) ? _headerString : _header.asString(),
-                                    _valueString);
-                            }
+                                hostPort = new HostPort(_valueString);
+
+                            _field = new HostPortHttpField(_header,
+                                CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode) ? _headerString : _header.asString(),
+                                hostPort);
+
                             addToFieldCache = _fieldCache.isEnabled();
                         }
                         break;

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1958,41 +1957,6 @@ public class HttpParserTest
 
         HttpParser.RequestHandler handler = new Handler();
         HttpParser parser = new HttpParser(handler);
-        parser.parseNext(buffer);
-        assertNull(_bad);
-        assertEquals("http://host/", _uriOrStatus);
-        assertEquals(0, _port);
-    }
-
-    @Test
-    public void testUriHost11MismatchDeny()
-    {
-        ByteBuffer buffer = BufferUtil.toBuffer(
-            "GET http://host/ HTTP/1.1\r\n" +
-                "Host: foo\r\n" + // different authority
-                "Connection: close\r\n" +
-                "\r\n");
-
-        HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
-        parser.parseNext(buffer);
-        assertEquals("Mismatched Authority", _bad);
-        assertEquals("http://host/", _uriOrStatus);
-        assertEquals(0, _port);
-    }
-
-    @Test
-    public void testUriHost11MismatchAllow()
-    {
-        ByteBuffer buffer = BufferUtil.toBuffer(
-            "GET http://host/ HTTP/1.1\r\n" +
-                "Host: foo\r\n" + // different authority
-                "Connection: close\r\n" +
-                "\r\n");
-
-        HttpParser.RequestHandler handler = new Handler();
-        HttpCompliance httpCompliance = HttpCompliance.from("RFC7230,MISMATCHED_AUTHORITY");
-        HttpParser parser = new HttpParser(handler, httpCompliance);
         parser.parseNext(buffer);
         assertNull(_bad);
         assertEquals("http://host/", _uriOrStatus);

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -1965,6 +1965,41 @@ public class HttpParserTest
     }
 
     @Test
+    public void testUriHost11MismatchDeny()
+    {
+        ByteBuffer buffer = BufferUtil.toBuffer(
+            "GET http://host/ HTTP/1.1\r\n" +
+                "Host: foo\r\n" + // different authority
+                "Connection: close\r\n" +
+                "\r\n");
+
+        HttpParser.RequestHandler handler = new Handler();
+        HttpParser parser = new HttpParser(handler);
+        parser.parseNext(buffer);
+        assertEquals("Mismatched Authority", _bad);
+        assertEquals("http://host/", _uriOrStatus);
+        assertEquals(0, _port);
+    }
+
+    @Test
+    public void testUriHost11MismatchAllow()
+    {
+        ByteBuffer buffer = BufferUtil.toBuffer(
+            "GET http://host/ HTTP/1.1\r\n" +
+                "Host: foo\r\n" + // different authority
+                "Connection: close\r\n" +
+                "\r\n");
+
+        HttpParser.RequestHandler handler = new Handler();
+        HttpCompliance httpCompliance = HttpCompliance.from("RFC7230,MISMATCHED_AUTHORITY");
+        HttpParser parser = new HttpParser(handler, httpCompliance);
+        parser.parseNext(buffer);
+        assertNull(_bad);
+        assertEquals("http://host/", _uriOrStatus);
+        assertEquals(0, _port);
+    }
+
+    @Test
     public void testNoHost()
     {
         ByteBuffer buffer = BufferUtil.toBuffer(

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -66,6 +66,7 @@ import javax.servlet.http.WebConnection;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HostPortHttpField;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpCookie.SetCookieHttpField;
 import org.eclipse.jetty.http.HttpField;
@@ -1748,13 +1749,15 @@ public class Request implements HttpServletRequest
             _uri = uri;
             if (host instanceof HostPortHttpField && !((HostPortHttpField)host).getHostPort().toString().equals(uri.getAuthority()))
             {
-                HttpConfiguration httpConfiguration = getHttpChannel().getHttpConfiguration();
+                HttpChannel httpChannel = getHttpChannel();
+                HttpConfiguration httpConfiguration = httpChannel.getHttpConfiguration();
                 if (httpConfiguration != null)
                 {
-                    if (httpConfiguration.getHttpCompliance().allows(MISMATCHED_AUTHORITY))
+                    HttpCompliance httpCompliance = httpConfiguration.getHttpCompliance();
+                    if (httpCompliance.allows(MISMATCHED_AUTHORITY))
                     {
-                        if (getHttpChannel() instanceof ComplianceViolation.Listener)
-                            ((ComplianceViolation.Listener)getHttpChannel()).onComplianceViolation(httpConfiguration.getHttpCompliance(), MISMATCHED_AUTHORITY, _uri.toString());
+                        if (httpChannel instanceof ComplianceViolation.Listener)
+                            ((ComplianceViolation.Listener)httpChannel).onComplianceViolation(httpCompliance, MISMATCHED_AUTHORITY, _uri.toString());
                     }
                     else
                     {

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -155,24 +155,24 @@ public class ForwardedRequestCustomizerTest
                 new Request("HTTP/1.0 - No Host header, with X-Forwarded-Host")
                     .headers(
                         "GET /example HTTP/1.0",
-                        "X-Forwarded-Host: alt.example.net:7070"
+                        "X-Forwarded-Host: alt.example.org:7070"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .scheme("http").serverName("alt.example.org").serverPort(7070)
                     .secure(false)
-                    .requestURL("http://alt.example.net:7070/example")
+                    .requestURL("http://alt.example.org:7070/example")
             ),
             Arguments.of(
                 new Request("HTTP/1.0 - Empty Host header, with X-Forwarded-Host")
                     .headers(
                         "GET /example HTTP/1.0",
                         "Host:",
-                        "X-Forwarded-Host: alt.example.net:7070"
+                        "X-Forwarded-Host: alt.example.org:7070"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .scheme("http").serverName("alt.example.org").serverPort(7070)
                     .secure(false)
-                    .requestURL("http://alt.example.net:7070/example")
+                    .requestURL("http://alt.example.org:7070/example")
             ),
             // Host IPv4
             Arguments.of(
@@ -199,7 +199,7 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("IPv4 in Request Line")
                     .headers(
                         "GET https://1.2.3.4:2222/ HTTP/1.1",
-                        "Host: wrong"
+                        "Host: 1.2.3.4:2222"
                     ),
                 new Expectations()
                     .scheme("https").serverName("1.2.3.4").serverPort(2222)
@@ -209,7 +209,7 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("IPv6 in Request Line")
                     .headers(
                         "GET http://[::1]:2222/ HTTP/1.1",
-                        "Host: wrong"
+                        "Host: [::1]:2222"
                     ),
                 new Expectations()
                     .scheme("http").serverName("[::1]").serverPort(2222)
@@ -749,12 +749,12 @@ public class ForwardedRequestCustomizerTest
                 new Request("RFC7239 - mixed with HTTP/1.0 - No Host header")
                     .headers(
                         "GET /example HTTP/1.0",
-                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.net:7070"
+                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.org:7070"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .scheme("http").serverName("alt.example.org").serverPort(7070)
                     .secure(false)
-                    .requestURL("http://alt.example.net:7070/example")
+                    .requestURL("http://alt.example.org:7070/example")
                     .remoteAddr("1.1.1.1").remotePort(6060)
             ),
             Arguments.of(
@@ -762,12 +762,12 @@ public class ForwardedRequestCustomizerTest
                     .headers(
                         "GET /example HTTP/1.0",
                         "Host:",
-                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.net:7070"
+                        "Forwarded: for=1.1.1.1:6060,proto=http;host=alt.example.org:7070"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(7070)
+                    .scheme("http").serverName("alt.example.org").serverPort(7070)
                     .secure(false)
-                    .requestURL("http://alt.example.net:7070/example")
+                    .requestURL("http://alt.example.org:7070/example")
                     .remoteAddr("1.1.1.1").remotePort(6060)
             ),
             // =================================================================
@@ -890,15 +890,15 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("https initial authority, X-Forwarded-Proto on http, Proxy-Ssl-Id exists (setSslIsSecure==false)")
                     .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
                     .headers(
-                        "GET https://alt.example.net/foo HTTP/1.1",
-                        "Host: myhost",
+                        "GET https://alt.example.org/foo HTTP/1.1",
+                        "Host: alt.example.org",
                         "X-Forwarded-Proto: http",
                         "Proxy-Ssl-Id: Wibble"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .scheme("http").serverName("alt.example.org").serverPort(80)
                     .secure(false)
-                    .requestURL("http://alt.example.net/foo")
+                    .requestURL("http://alt.example.org/foo")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
             ),
@@ -920,46 +920,46 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("Https initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==true)")
                     .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
                     .headers(
-                        "GET https://alt.example.net/foo HTTP/1.1",
-                        "Host: myhost",
+                        "GET https://alt.example.org/foo HTTP/1.1",
+                        "Host: alt.example.org",
                         "X-Proxied-Https: off", // this wins for scheme and secure
                         "Proxy-Ssl-Id: Wibble"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .scheme("http").serverName("alt.example.org").serverPort(80)
                     .secure(false)
-                    .requestURL("http://alt.example.net/foo")
+                    .requestURL("http://alt.example.org/foo")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
             ),
             Arguments.of(new Request("Https initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==true) (alt order)")
                     .configureCustomizer((customizer) -> customizer.setSslIsSecure(true))
                     .headers(
-                        "GET https://alt.example.net/foo HTTP/1.1",
-                        "Host: myhost",
+                        "GET https://alt.example.org/foo HTTP/1.1",
+                        "Host: alt.example.org",
                         "Proxy-Ssl-Id: Wibble",
                         "X-Proxied-Https: off" // this wins for scheme and secure
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .scheme("http").serverName("alt.example.org").serverPort(80)
                     .secure(false)
-                    .requestURL("http://alt.example.net/foo")
+                    .requestURL("http://alt.example.org/foo")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
             ),
             Arguments.of(new Request("Http initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==false)")
                     .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
                     .headers(
-                        "GET https://alt.example.net/foo HTTP/1.1",
-                        "Host: myhost",
+                        "GET https://alt.example.org/foo HTTP/1.1",
+                        "Host: alt.example.org",
                         "X-Proxied-Https: off",
                         "Proxy-Ssl-Id: Wibble",
                         "Proxy-auth-cert: 0123456789abcdef"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .scheme("http").serverName("alt.example.org").serverPort(80)
                     .secure(false)
-                    .requestURL("http://alt.example.net/foo")
+                    .requestURL("http://alt.example.org/foo")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
                     .sslCertificate("0123456789abcdef")
@@ -967,16 +967,16 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("Http initial authority, X-Proxied-Https off, Proxy-Ssl-Id exists (setSslIsSecure==false) (alt)")
                     .configureCustomizer((customizer) -> customizer.setSslIsSecure(false))
                     .headers(
-                        "GET https://alt.example.net/foo HTTP/1.1",
-                        "Host: myhost",
+                        "GET https://alt.example.org/foo HTTP/1.1",
+                        "Host: alt.example.org",
                         "Proxy-Ssl-Id: Wibble",
                         "Proxy-auth-cert: 0123456789abcdef",
                         "X-Proxied-Https: off"
                     ),
                 new Expectations()
-                    .scheme("http").serverName("alt.example.net").serverPort(80)
+                    .scheme("http").serverName("alt.example.org").serverPort(80)
                     .secure(false)
-                    .requestURL("http://alt.example.net/foo")
+                    .requestURL("http://alt.example.org/foo")
                     .remoteAddr("0.0.0.0").remotePort(0)
                     .sslSession("Wibble")
                     .sslCertificate("0123456789abcdef")
@@ -1026,38 +1026,38 @@ public class ForwardedRequestCustomizerTest
             Arguments.of(new Request("RFC7239 with https and h2")
                     .headers(
                         "GET /test/forwarded.jsp HTTP/1.1",
-                        "Host: web.example.net",
-                        "Forwarded: for=192.168.2.6;host=web.example.net;proto=https;proto-version=h2"
+                        "Host: web.example.org",
+                        "Forwarded: for=192.168.2.6;host=web.example.org;proto=https;proto-version=h2"
                     ),
                 new Expectations()
-                    .scheme("https").serverName("web.example.net").serverPort(443)
-                    .requestURL("https://web.example.net/test/forwarded.jsp")
+                    .scheme("https").serverName("web.example.org").serverPort(443)
+                    .requestURL("https://web.example.org/test/forwarded.jsp")
                     .remoteAddr("192.168.2.6").remotePort(0)
             ),
             // RFC7239 Tests with https and proxy provided port
             Arguments.of(new Request("RFC7239 with proxy provided port on https and h2")
                     .headers(
                         "GET /test/forwarded.jsp HTTP/1.1",
-                        "Host: web.example.net:9443",
-                        "Forwarded: for=192.168.2.6;host=web.example.net:9443;proto=https;proto-version=h2"
+                        "Host: web.example.org:9443",
+                        "Forwarded: for=192.168.2.6;host=web.example.org:9443;proto=https;proto-version=h2"
                     ),
                 new Expectations()
-                    .scheme("https").serverName("web.example.net").serverPort(9443)
-                    .requestURL("https://web.example.net:9443/test/forwarded.jsp")
+                    .scheme("https").serverName("web.example.org").serverPort(9443)
+                    .requestURL("https://web.example.org:9443/test/forwarded.jsp")
                     .remoteAddr("192.168.2.6").remotePort(0)
             ),
             // RFC7239 Tests with https, no port in Host, but proxy provided port
             Arguments.of(new Request("RFC7239 with client provided host and different proxy provided port on https and h2")
                     .headers(
                         "GET /test/forwarded.jsp HTTP/1.1",
-                        "Host: web.example.net",
-                        "Forwarded: for=192.168.2.6;host=new.example.net:7443;proto=https;proto-version=h2"
-                        // Client: https://web.example.net/test/forwarded.jsp
-                        // Proxy Requests: https://new.example.net/test/forwarded.jsp
+                        "Host: web.example.org",
+                        "Forwarded: for=192.168.2.6;host=new.example.org:7443;proto=https;proto-version=h2"
+                        // Client: https://web.example.org/test/forwarded.jsp
+                        // Proxy Requests: https://new.example.org/test/forwarded.jsp
                     ),
                 new Expectations()
-                    .scheme("https").serverName("new.example.net").serverPort(7443)
-                    .requestURL("https://new.example.net:7443/test/forwarded.jsp")
+                    .scheme("https").serverName("new.example.org").serverPort(7443)
+                    .requestURL("https://new.example.org:7443/test/forwarded.jsp")
                     .remoteAddr("192.168.2.6").remotePort(0)
             )
         );

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpParser;
@@ -47,6 +48,7 @@ public class PartialRFC2616Test
     {
         server = new Server();
         connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setHttpCompliance(HttpCompliance.RFC2616);
         connector.setIdleTimeout(10000);
         server.addConnector(connector);
 
@@ -403,12 +405,19 @@ public class PartialRFC2616Test
 
     }
 
+    /**
+     * @throws Exception
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc2616#section-5.2">RFC 2616 - Section 5.2 - The Resource Identified by a Request</a>
+     */
     @Test
     public void test521() throws Exception
     {
         // Default Host
         int offset = 0;
-        String response = connector.getResponse("GET http://VirtualHost:8888/path/R1 HTTP/1.1\n" + "Host: wronghost\n" + "Connection: close\n" + "\n");
+        String response = connector.getResponse(
+            "GET http://VirtualHost:8888/path/R1 HTTP/1.1\n" +
+            "Host: wronghost\n" +
+            "Connection: close\n" + "\n");
         offset = checkContains(response, offset, "HTTP/1.1 200", "Virtual host") + 1;
         offset = checkContains(response, offset, "Virtual Dump", "Virtual host") + 1;
         offset = checkContains(response, offset, "pathInfo=/path/R1", "Virtual host") + 1;

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -969,6 +969,15 @@ public class RequestTest
                 "Connection: close\n" +
                 "\n");
         i = 0;
+        assertThat(response, containsString("400 Bad Request"));
+
+        results.clear();
+        response = _connector.getResponse(
+            "GET http://myhost:8888/ HTTP/1.1\n" +
+                "Host: myhost:8888\n" +
+                "Connection: close\n" +
+                "\n");
+        i = 0;
         assertThat(response, containsString("200 OK"));
         assertEquals("http://myhost:8888/", results.get(i++));
         assertEquals("0.0.0.0", results.get(i++));

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/NcsaRequestLogTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/NcsaRequestLogTest.java
@@ -190,7 +190,7 @@ public class NcsaRequestLogTest
 
         _connector.getResponse(
             "GET http://hostname:8888/foo?name=value HTTP/1.1\n" +
-                "Host: servername\n" +
+                "Host: hostname:8888\n" +
                 "\n");
         String log = _entries.poll(5, TimeUnit.SECONDS);
         assertThat(log, containsString("GET http://hostname:8888/foo?name=value"));

--- a/tests/test-integration/src/test/resources/RFC2616Base.xml
+++ b/tests/test-integration/src/test/resources/RFC2616Base.xml
@@ -22,6 +22,12 @@
       <Set name="sendDateHeader">false</Set>
       <Set name="headerCacheSize">1024</Set>
 
+      <Set name="httpCompliance">
+        <Call class="org.eclipse.jetty.http.HttpCompliance" name="from">
+          <Arg>RFC2616</Arg>
+        </Call>
+      </Set>
+
       <!-- Uncomment to enable handling of X-Forwarded- style headers
       <Call name="addCustomizer">
         <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>


### PR DESCRIPTION
This is an alternative PR for #9312. This avoids changing the HttpParser and instead checks for a mismatched host only in the `Request.setMetaData` method.

