### PR TITLE
Moved implementation methods ensure*() from the Response interface

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResponseUtils.java
@@ -1,0 +1,86 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpHeaderValue;
+import org.eclipse.jetty.util.StringUtil;
+
+public class ResponseUtils
+{
+    public static void ensureConsumeAvailableOrNotPersistent(Request request, Response response)
+    {
+        if (request.consumeAvailable())
+            return;
+        ensureNotPersistent(request, response);
+    }
+
+    public static void ensureNotPersistent(Request request, Response response)
+    {
+        switch (request.getConnectionMetaData().getHttpVersion())
+        {
+            case HTTP_1_0 ->
+                // Remove any keep-alive value in Connection headers
+                response.getHeaders().computeField(HttpHeader.CONNECTION, (h, fields) ->
+                {
+                    if (fields == null || fields.isEmpty())
+                        return null;
+                    String v = fields.stream()
+                        .flatMap(field -> Stream.of(field.getValues()).filter(s -> !HttpHeaderValue.KEEP_ALIVE.is(s)))
+                        .collect(Collectors.joining(", "));
+                    if (StringUtil.isEmpty(v))
+                        return null;
+
+                    return new HttpField(HttpHeader.CONNECTION, v);
+                });
+
+            case HTTP_1_1 ->
+                // Add close value to Connection headers
+                response.getHeaders().computeField(HttpHeader.CONNECTION, (h, fields) ->
+                {
+                    if (fields == null || fields.isEmpty())
+                        return HttpFields.CONNECTION_CLOSE;
+
+                    if (fields.stream().anyMatch(f -> f.contains(HttpHeaderValue.CLOSE.asString())))
+                    {
+                        if (fields.size() == 1)
+                        {
+                            HttpField f = fields.get(0);
+                            if (HttpFields.CONNECTION_CLOSE.equals(f))
+                                return f;
+                        }
+
+                        return new HttpField(HttpHeader.CONNECTION, fields.stream()
+                            .flatMap(field -> Stream.of(field.getValues()).filter(s -> !HttpHeaderValue.KEEP_ALIVE.is(s)))
+                            .collect(Collectors.joining(", ")));
+                    }
+
+                    return new HttpField(HttpHeader.CONNECTION,
+                        Stream.concat(fields.stream()
+                                    .flatMap(field -> Stream.of(field.getValues()).filter(s -> !HttpHeaderValue.KEEP_ALIVE.is(s))),
+                                Stream.of(HttpHeaderValue.CLOSE.asString()))
+                            .collect(Collectors.joining(", ")));
+                });
+        }
+    }
+
+    private ResponseUtils()
+    {
+    }
+}

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -43,7 +43,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.ResponseUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Blocker;
@@ -490,7 +490,7 @@ public class ServletChannel
                             // Connection:close.  This can't be deferred to COMPLETE as the response will be committed
                             // by then.
                             if (!_httpInput.consumeAvailable())
-                                Response.ensureNotPersistent(_servletContextRequest, _servletContextRequest.getResponse());
+                                ResponseUtils.ensureNotPersistent(_servletContextRequest, _servletContextRequest.getResponse());
 
                             ContextHandler.ScopedContext context = (ContextHandler.ScopedContext)_servletContextRequest.getAttribute(ErrorHandler.ERROR_CONTEXT);
                             Request.Handler errorHandler = ErrorHandler.getErrorHandler(getServer(), context == null ? null : context.getContextHandler());
@@ -574,7 +574,7 @@ public class ServletChannel
 
                             // Indicate Connection:close if we can't consume all.
                             if (getResponse().getStatus() >= 200)
-                                Response.ensureConsumeAvailableOrNotPersistent(_servletContextRequest, _servletContextRequest.getResponse());
+                                ResponseUtils.ensureConsumeAvailableOrNotPersistent(_servletContextRequest, _servletContextRequest.getResponse());
                         }
 
 


### PR DESCRIPTION
to ResponseUtils to avoid cluttering the main Response interface.