### PR TITLE
Dependency Rollup (and fixes) for `jetty-9.4.x`

### DIFF
--- a/jetty-cdi/pom.xml
+++ b/jetty-cdi/pom.xml
@@ -46,6 +46,16 @@
       <artifactId>weld-servlet-core</artifactId>
       <version>${weld.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerb-simplekdc</artifactId>
-      <version>2.0.2</version>
+      <version>2.0.3</version>
       <scope>test</scope>
     </dependency>
     <!-- transitive dependency defined as a range and we don't want that -->

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -43,6 +43,10 @@
           <groupId>org.wildfly.common</groupId>
           <artifactId>wildfly-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -51,6 +55,16 @@
       <version>${infinispan.protostream.version}</version>
       <optional>true</optional>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -67,12 +81,22 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-remote-query-client</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/jetty-infinispan/infinispan-embedded-query/pom.xml
+++ b/jetty-infinispan/infinispan-embedded-query/pom.xml
@@ -89,11 +89,16 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-query</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-test-helper</artifactId>
-      <scope>test</scope>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/jetty-infinispan/infinispan-embedded/pom.xml
+++ b/jetty-infinispan/infinispan-embedded/pom.xml
@@ -78,15 +78,5 @@
       <artifactId>infinispan-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-core</artifactId>
-      <exclusions>
-          <exclusion>
-              <groupId>org.wildfly.common</groupId>
-              <artifactId>wildfly-common</artifactId>
-          </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 </project>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -99,6 +99,12 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-query</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
@@ -109,11 +115,21 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-remote-query-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -88,6 +88,10 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -100,6 +104,12 @@
       <artifactId>protostream</artifactId>
       <version>${infinispan.protostream.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <jetty-version-txt.plugin.version>2.7</jetty-version-txt.plugin.version>
     <license.plugin.version>4.1</license.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
-    <maven.assembly.plugin.version>3.4.2</maven.assembly.plugin.version>
+    <maven.assembly.plugin.version>3.5.0</maven.assembly.plugin.version>
     <maven.invoker.plugin.version>3.5.0</maven.invoker.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M9</maven.surefire.plugin.version>
     <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <guice.version>5.1.0</guice.version>
     <hawtio.version>2.15.0</hawtio.version>
     <hazelcast.version>3.12.12</hazelcast.version>
-    <infinispan.protostream.version>4.6.1.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.4.4.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.annotations.version>2.14.2</jackson.annotations.version>
     <jackson.core.version>2.14.2</jackson.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <javax.transaction.api.version>1.3</javax.transaction.api.version>
     <javax.websocket.api.version>1.0</javax.websocket.api.version>
-    <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
-    <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
+    <jboss.logging.annotations.version>3.4.3.Final</jboss.logging.annotations.version>
+    <jboss.logging.processor.version>3.4.3.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.4.3.Final</jboss.logging.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
     <jetty.schemas.version>3.1.2</jetty.schemas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,8 @@
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <javax.transaction.api.version>1.3</javax.transaction.api.version>
     <javax.websocket.api.version>1.0</javax.websocket.api.version>
-    <jboss.logging.annotations.version>3.4.3.Final</jboss.logging.annotations.version>
-    <jboss.logging.processor.version>3.4.3.Final</jboss.logging.processor.version>
-    <jboss.logging.version>3.4.3.Final</jboss.logging.version>
+    <jboss.logging.version>3.5.0.Final</jboss.logging.version>
+    <jboss.threads.version>3.5.0.Final</jboss.threads.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
     <jetty.schemas.version>3.1.2</jetty.schemas.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
@@ -151,7 +150,6 @@
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <testcontainers.version>1.16.1</testcontainers.version>
     <unix.socket.tmp></unix.socket.tmp>
-
   </properties>
 
   <licenses>
@@ -1041,22 +1039,22 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-processor</artifactId>
-        <version>2.2.1.Final</version>
+        <version>${jboss.logging.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-annotations</artifactId>
-        <version>2.2.1.Final</version>
+        <version>${jboss.logging.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logmanager</groupId>
         <artifactId>jboss-logmanager</artifactId>
-        <version>2.1.19.Final</version>
+        <version>${jboss.logging.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.threads</groupId>
         <artifactId>jboss-threads</artifactId>
-        <version>3.5.0.Final</version>
+        <version>${jboss.threads.version}</version>
       </dependency>
       <!-- Old Deps -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <guice.version>5.1.0</guice.version>
     <hawtio.version>2.15.0</hawtio.version>
     <hazelcast.version>3.12.12</hazelcast.version>
-    <infinispan.protostream.version>4.4.4.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.6.1.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.annotations.version>2.13.3</jackson.annotations.version>
     <jackson.core.version>2.13.3</jackson.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
-    <wildfly.common.version>1.6.0.Final</wildfly.common.version>
     <wildfly.elytron.version>2.1.0.Final</wildfly.elytron.version>
     <xmemcached.version>2.4.7</xmemcached.version>
 
@@ -1123,11 +1122,6 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.annotations.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.common</groupId>
-        <artifactId>wildfly-common</artifactId>
-        <version>${wildfly.common.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <logback.version>1.2.11</logback.version>
     <maven.plugin-tools.version>3.7.1</maven.plugin-tools.version>
-    <maven.resolver.version>1.9.4</maven.resolver.version>
+    <maven.resolver.version>1.9.5</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
     <mongodb.version>2.14.3</mongodb.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     <javax.transaction.api.version>1.3</javax.transaction.api.version>
     <javax.websocket.api.version>1.0</javax.websocket.api.version>
-    <jboss.logging.version>3.5.0.Final</jboss.logging.version>
-    <jboss.threads.version>3.5.0.Final</jboss.threads.version>
+    <jboss.logging.version>3.4.3.Final</jboss.logging.version>
+    <jboss.threads.version>3.4.3.Final</jboss.threads.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
     <jetty.schemas.version>3.1.2</jetty.schemas.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
@@ -149,6 +149,7 @@
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
     <testcontainers.version>1.16.1</testcontainers.version>
     <unix.socket.tmp></unix.socket.tmp>
+
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <testcontainers.version>1.17.6</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
-    <wildfly.elytron.version>2.0.0.Final</wildfly.elytron.version>
+    <wildfly.elytron.version>2.1.0.Final</wildfly.elytron.version>
     <xmemcached.version>2.4.7</xmemcached.version>
 
     <!-- some maven plugins versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
     <hazelcast.version>3.12.12</hazelcast.version>
     <infinispan.protostream.version>4.6.1.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
-    <jackson.annotations.version>2.13.3</jackson.annotations.version>
-    <jackson.core.version>2.13.3</jackson.core.version>
-    <jackson.databind.version>2.13.3</jackson.databind.version>
+    <jackson.annotations.version>2.14.2</jackson.annotations.version>
+    <jackson.core.version>2.14.2</jackson.core.version>
+    <jackson.databind.version>2.14.2</jackson.databind.version>
     <jamon.version>2.82</jamon.version>
     <javax.activation.version>1.1.0.v201105071233</javax.activation.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>


### PR DESCRIPTION
Rollup of various dependencies in branch `jetty-9.4.x`