### PR TITLE
Improved `URIUtil.safeDecodePath(String)`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -509,14 +509,6 @@ public final class URIUtil
 
     private static void safePathAppend(Utf8StringBuilder builder, byte b)
     {
-        // control characters
-        if (((b >= 0x00) && (b <= 0x1F)) || (b == 0x7F))
-        {
-            // TODO: perhaps we should just ensure these are encoded instead?
-            builder.append("�"); // unicode replacement character
-            return;
-        }
-
         switch (b)
         {
             case '/' -> builder.append("%2F");

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -81,6 +81,7 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
     };
 
     private int _codep;
+    private boolean _throwOnInvalid = true;
 
     public Utf8Appendable(Appendable appendable)
     {
@@ -88,6 +89,16 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
     }
 
     public abstract int length();
+
+    public boolean isThrowOnInvalid()
+    {
+        return _throwOnInvalid;
+    }
+
+    public void setThrowOnInvalid(boolean throwOnInvalid)
+    {
+        _throwOnInvalid = throwOnInvalid;
+    }
 
     protected void reset()
     {
@@ -101,7 +112,8 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
             _appendable.append(REPLACEMENT);
             int state = _state;
             _state = UTF8_ACCEPT;
-            throw new NotUtf8Exception("char appended in state " + state);
+            if (_throwOnInvalid)
+                throw new NotUtf8Exception("char appended in state " + state);
         }
     }
 
@@ -250,7 +262,9 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
                     _codep = 0;
                     _state = UTF8_ACCEPT;
                     _appendable.append(REPLACEMENT);
-                    throw new NotUtf8Exception(reason);
+                    if (_throwOnInvalid)
+                        throw new NotUtf8Exception(reason);
+                    break;
 
                 default:
                     _state = next;
@@ -286,7 +300,8 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
             {
                 throw new RuntimeException(e);
             }
-            throw new NotUtf8Exception("incomplete UTF8 sequence");
+            if (_throwOnInvalid)
+                throw new NotUtf8Exception("incomplete UTF8 sequence");
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -268,7 +268,7 @@ public class URIUtilTest
             Arguments.of("/abc%f8%a1%a1%a1", "/abc����"), // incomplete sequence
 
             // Test for null character (real world ugly test case)
-            Arguments.of("/%00/", "/�/"), // null is not in the unreserved characters list and should not be decoded
+            Arguments.of("/%00/", "/\u0000/"), // null is not in the unreserved characters list and should not be decoded
 
             // Deprecated Microsoft Percent-U encoding
             Arguments.of("/abc%u3040", "/abc\u3040"),

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -256,13 +256,14 @@ public class URIUtilTest
 
             // Invalid UTF-8 - replacement characters should be present on invalid sequences
             // URI paths do not support ISO8859-1, so this should not be a fallback of our safeDecodePath implementation
-            Arguments.of("/abc%C3%28", "/abc�"), // invalid 2 octext sequence
-            Arguments.of("/abc%A0%A1", "/abc��"), // invalid 2 octext sequence
-            Arguments.of("/abc%e2%28%a1", "/abc��"), // invalid 3 octext sequence
-            Arguments.of("/abc%e2%82%28", "/abc�"), // invalid 3 octext sequence
-            Arguments.of("/abc%f0%28%8c%bc", "/abc���"), // invalid 4 octext sequence
-            Arguments.of("/abc%f0%90%28%bc", "/abc��"), // invalid 4 octext sequence
-            Arguments.of("/abc%f0%28%8c%28", "/abc��("), // invalid 4 octext sequence
+            Arguments.of("/a%D8%2fbar", "/a�%2Fbar"), // invalid 2 octet sequence
+            Arguments.of("/abc%C3%28", "/abc�"), // invalid 2 octet sequence
+            Arguments.of("/abc%A0%A1", "/abc��"), // invalid 2 octet sequence
+            Arguments.of("/abc%e2%28%a1", "/abc��"), // invalid 3 octet sequence
+            Arguments.of("/abc%e2%82%28", "/abc�"), // invalid 3 octet sequence
+            Arguments.of("/abc%f0%28%8c%bc", "/abc���"), // invalid 4 octet sequence
+            Arguments.of("/abc%f0%90%28%bc", "/abc��"), // invalid 4 octet sequence
+            Arguments.of("/abc%f0%28%8c%28", "/abc��("), // invalid 4 octet sequence
             Arguments.of("/abc%f8%a1%a1%a1%a1", "/abc�����"), // valid sequence, but not unicode
             Arguments.of("/abc%fc%a1%a1%a1%a1%a1", "/abc������"), // valid sequence, but not unicode
             Arguments.of("/abc%f8%a1%a1%a1", "/abc����"), // incomplete sequence

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
@@ -139,6 +139,30 @@ public class Utf8AppendableTest
         assertEquals("\u00FC\u00F6\u00E4", buffer.toString());
     }
 
+    /**
+     * Test of ARABIC LETTER TEH MARBUTA.
+     * (hex code point 0629, decimal code point 1577, hex utf-8 bytes D8 A9)
+     * (bidi note, this is a right to left character as well)
+     */
+    @ParameterizedTest
+    @MethodSource("implementations")
+    public void testArabicTehMarbuta(Class<Utf8Appendable> impl) throws Exception
+    {
+        byte[] bytes = new byte[4];
+        bytes[0] = (byte)0xD8;
+        bytes[1] = (byte)0xA9;
+        bytes[2] = (byte)0xD8;
+        bytes[3] = (byte)0xA9;
+
+        Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
+        for (int i = 0; i < bytes.length; i++)
+        {
+            buffer.append(bytes[i]);
+        }
+
+        assertEquals("ةة", buffer.toString());
+    }
+
     @ParameterizedTest
     @MethodSource("implementations")
     public void testInvalidUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException


### PR DESCRIPTION
More testing of Issue #9444 revealed other cases where we should be safer with our decoding.

This includes new tests for `URIUtil.safeDecodePath(String)`, along with the ability to configure `Utf8Appendable` instances to use a replacement character instead of always throwing an exception in the case of bad UTF-8 sequences.