### PR TITLE
BadMessage interface

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -24,7 +24,7 @@ import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpResponse;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpParser;
@@ -539,7 +539,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     }
 
     @Override
-    public void badMessage(BadMessageException failure)
+    public void badMessage(HttpException failure)
     {
         HttpExchange exchange = getHttpExchange();
         if (exchange == null || unsolicited)
@@ -550,7 +550,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         {
             HttpResponse response = exchange.getResponse();
             response.status(failure.getCode()).reason(failure.getReason());
-            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response, failure));
+            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response, HttpException.asThrowable(failure)));
         }
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -550,7 +550,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         {
             HttpResponse response = exchange.getResponse();
             response.status(failure.getCode()).reason(failure.getReason());
-            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response, HttpException.asThrowable(failure)));
+            failAndClose(new HttpResponseException("HTTP protocol violation: bad response on " + getHttpConnection(), response, (Throwable)failure));
         }
     }
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -45,8 +45,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
@@ -1281,7 +1281,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         ExecutionException e = assertThrows(ExecutionException.class, () ->
             testContentDelimitedByEOFWithSlowRequest(scenario, HttpVersion.HTTP_1_0, 1024));
 
-        assertThat(e.getCause(), instanceOf(BadMessageException.class));
+        assertThat(e.getCause(), instanceOf(HttpException.class));
         assertThat(e.getCause().getMessage(), containsString("Unknown content"));
     }
 
@@ -1292,7 +1292,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         ExecutionException e = assertThrows(ExecutionException.class, () ->
             testContentDelimitedByEOFWithSlowRequest(scenario, HttpVersion.HTTP_1_0, 128 * 1024));
 
-        assertThat(e.getCause(), instanceOf(BadMessageException.class));
+        assertThat(e.getCause(), instanceOf(HttpException.class));
         assertThat(e.getCause().getMessage(), containsString("Unknown content"));
     }
 

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.fcgi.FCGI;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -306,9 +306,9 @@ public class ResponseContentParser extends StreamContentParser
         }
 
         @Override
-        public void badMessage(BadMessageException failure)
+        public void badMessage(HttpException failure)
         {
-            fail(failure);
+            fail(HttpException.asThrowable(failure));
         }
 
         protected void fail(Throwable failure)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
@@ -308,7 +308,7 @@ public class ResponseContentParser extends StreamContentParser
         @Override
         public void badMessage(HttpException failure)
         {
-            fail(HttpException.asThrowable(failure));
+            fail((Throwable)failure);
         }
 
         protected void fail(Throwable failure)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.fcgi.generator.ServerGenerator;
 import org.eclipse.jetty.fcgi.parser.ServerParser;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -401,7 +400,7 @@ public class ServerFCGIConnection extends AbstractConnection implements Connecti
             if (LOG.isDebugEnabled())
                 LOG.debug("Request {} failure on {}: {}", request, stream, failure);
             if (stream != null)
-                stream.getHttpChannel().onFailure(new BadMessageException(HttpStatus.BAD_REQUEST_400, null, failure));
+                stream.getHttpChannel().onFailure(new BadMessageException(null, failure));
             stream = null;
         }
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -16,17 +16,24 @@ package org.eclipse.jetty.http;
 /**
  * <p>Exception thrown to indicate a Bad HTTP Message has either been received
  * or attempted to be generated.  Typically these are handled with either 400
- * or 500 responses.</p>
+ * responses.</p>
  */
 @SuppressWarnings("serial")
-public class BadMessageException extends RuntimeException
+public class BadMessageException extends HttpException.RuntimeException
 {
-    final int _code;
-    final String _reason;
-
     public BadMessageException()
     {
-        this(400, null, null);
+        this(null, null);
+    }
+
+    public BadMessageException(String reason)
+    {
+        this(reason, null);
+    }
+
+    public BadMessageException(String reason, Throwable cause)
+    {
+        this(HttpStatus.BAD_REQUEST_400, reason, cause);
     }
 
     public BadMessageException(int code)
@@ -34,38 +41,24 @@ public class BadMessageException extends RuntimeException
         this(code, null, null);
     }
 
-    public BadMessageException(String reason)
-    {
-        this(400, reason);
-    }
-
-    public BadMessageException(String reason, Throwable cause)
-    {
-        this(400, reason, cause);
-    }
-
     public BadMessageException(int code, String reason)
     {
         this(code, reason, null);
     }
 
-    public BadMessageException(int code, Throwable cause)
-    {
-        this(code, null, cause);
-    }
-
     public BadMessageException(int code, String reason, Throwable cause)
     {
-        super(code + ": " + reason, cause);
-        _code = code;
-        _reason = reason;
+        super(code, reason, cause);
+        assert code >= 400 && code < 500;
     }
 
+    @Override
     public int getCode()
     {
         return _code;
     }
 
+    @Override
     public String getReason()
     {
         return _reason;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -51,16 +51,4 @@ public class BadMessageException extends HttpException.RuntimeException
         super(code, reason, cause);
         assert code >= 400 && code < 500;
     }
-
-    @Override
-    public int getCode()
-    {
-        return _code;
-    }
-
-    @Override
-    public String getReason()
-    {
-        return _reason;
-    }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -137,7 +137,7 @@ public class CookieCache implements CookieParser.Handler
             }
             catch (CookieParser.InvalidCookieException invalidCookieException)
             {
-                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, invalidCookieException.getMessage(), invalidCookieException);
+                throw new BadMessageException(invalidCookieException.getMessage(), invalidCookieException);
             }
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
@@ -38,7 +38,7 @@ public class HostPortHttpField extends HttpField
         }
         catch (Exception e)
         {
-            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad HostPort", e);
+            throw new BadMessageException("Bad HostPort", e);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -28,15 +28,10 @@ public interface HttpException extends QuietException
 
     String getReason();
 
-    static Throwable asThrowable(HttpException httpException)
-    {
-        return httpException instanceof Throwable throwable ? throwable : null;
-    }
-
-    static void rethrowRuntime(HttpException httpException)
+    static void throwAsUnchecked(HttpException httpException)
     {
         if (httpException instanceof Throwable throwable)
-            ExceptionUtil.ifExceptionThrowRuntime(throwable);
+            ExceptionUtil.ifExceptionThrowUnchecked(throwable);
     }
 
     /**
@@ -47,8 +42,8 @@ public interface HttpException extends QuietException
     @SuppressWarnings("serial")
     class RuntimeException extends java.lang.RuntimeException implements HttpException
     {
-        final int _code;
-        final String _reason;
+        private final int _code;
+        private final String _reason;
 
         public RuntimeException(int code)
         {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -88,8 +88,8 @@ public interface HttpException extends QuietException
     @SuppressWarnings("serial")
     class IllegalArgumentException extends java.lang.IllegalArgumentException implements HttpException
     {
-        final int _code;
-        final String _reason;
+        private final int _code;
+        private final String _reason;
 
         public IllegalArgumentException(int code)
         {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -1,0 +1,128 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+import org.eclipse.jetty.io.QuietException;
+import org.eclipse.jetty.util.ExceptionUtil;
+
+/**
+ * <p>A tagging interface for Exceptions that carry a HTTP response code and reason.</p>
+ * <p>Exception sub-classes that implement this interface will be caught by the container
+ * and the {@link #getCode()} used to send a response.</p>
+ */
+@SuppressWarnings("serial")
+public interface HttpException extends QuietException
+{
+    int getCode();
+
+    String getReason();
+
+    static Throwable asThrowable(HttpException httpException)
+    {
+        return httpException instanceof Throwable throwable ? throwable : null;
+    }
+
+    static void rethrowRuntime(HttpException httpException)
+    {
+        if (httpException instanceof Throwable throwable)
+            ExceptionUtil.ifExceptionThrowRuntime(throwable);
+    }
+
+    /**
+     * <p>Exception thrown to indicate a Bad HTTP Message has either been received
+     * or attempted to be generated.  Typically these are handled with either 400
+     * or 500 responses.</p>
+     */
+    @SuppressWarnings("serial")
+    class RuntimeException extends java.lang.RuntimeException implements HttpException
+    {
+        final int _code;
+        final String _reason;
+
+        public RuntimeException(int code)
+        {
+            this(code, null, null);
+        }
+
+        public RuntimeException(int code, String reason)
+        {
+            this(code, reason, null);
+        }
+
+        public RuntimeException(int code, Throwable cause)
+        {
+            this(code, null, cause);
+        }
+
+        public RuntimeException(int code, String reason, Throwable cause)
+        {
+            super(code + ": " + reason, cause);
+            _code = code;
+            _reason = reason;
+        }
+
+        @Override
+        public int getCode()
+        {
+            return _code;
+        }
+
+        @Override
+        public String getReason()
+        {
+            return _reason;
+        }
+    }
+
+    /**
+     * <p>Exception thrown to indicate a Bad HTTP Message has either been received
+     * or attempted to be generated.  Typically these are handled with either 400
+     * or 500 responses.</p>
+     */
+    @SuppressWarnings("serial")
+    class IllegalArgumentException extends java.lang.IllegalArgumentException implements HttpException
+    {
+        final int _code;
+        final String _reason;
+
+        public IllegalArgumentException(int code)
+        {
+            this(code, null, null);
+        }
+
+        public IllegalArgumentException(int code, String reason)
+        {
+            this(code, reason, null);
+        }
+
+        public IllegalArgumentException(int code, String reason, Throwable cause)
+        {
+            super(code + ": " + reason, cause);
+            _code = code;
+            _reason = reason;
+        }
+
+        @Override
+        public int getCode()
+        {
+            return _code;
+        }
+
+        @Override
+        public String getReason()
+        {
+            return _reason;
+        }
+    }
+}

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.util.ExceptionUtil;
  * <p>Exception sub-classes that implement this interface will be caught by the container
  * and the {@link #getCode()} used to send a response.</p>
  */
-@SuppressWarnings("serial")
 public interface HttpException extends QuietException
 {
     int getCode();
@@ -30,8 +29,7 @@ public interface HttpException extends QuietException
 
     static void throwAsUnchecked(HttpException httpException)
     {
-        if (httpException instanceof Throwable throwable)
-            ExceptionUtil.ifExceptionThrowUnchecked(throwable);
+        ExceptionUtil.ifExceptionThrowUnchecked((Throwable)httpException);
     }
 
     /**
@@ -39,7 +37,6 @@ public interface HttpException extends QuietException
      * or attempted to be generated.  Typically these are handled with either 400
      * or 500 responses.</p>
      */
-    @SuppressWarnings("serial")
     class RuntimeException extends java.lang.RuntimeException implements HttpException
     {
         private final int _code;
@@ -85,7 +82,6 @@ public interface HttpException extends QuietException
      * or attempted to be generated.  Typically these are handled with either 400
      * or 500 responses.</p>
      */
-    @SuppressWarnings("serial")
     class IllegalArgumentException extends java.lang.IllegalArgumentException implements HttpException
     {
         private final int _code;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -436,10 +436,10 @@ public class HttpGenerator
                 }
                 catch (Exception e)
                 {
-                    if (e instanceof HttpException httpException)
-                        HttpException.rethrowRuntime(httpException);
-                    else
-                        throw new HttpException.RuntimeException(INTERNAL_SERVER_ERROR_500, e.getMessage(), e);
+                    if (e instanceof HttpException)
+                        throw e;
+
+                    throw new HttpException.RuntimeException(INTERNAL_SERVER_ERROR_500, e.getMessage(), e);
                 }
                 finally
                 {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -438,7 +438,6 @@ public class HttpGenerator
                 {
                     if (e instanceof HttpException)
                         throw e;
-
                     throw new HttpException.RuntimeException(INTERNAL_SERVER_ERROR_500, e.getMessage(), e);
                 }
                 finally

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -340,7 +340,7 @@ public class HttpParser
         if (violation.isAllowedBy(_complianceMode))
             reportComplianceViolation(violation, violation.getDescription());
         else
-            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
+            throw new BadMessageException(violation.getDescription());
     }
 
     protected void reportComplianceViolation(Violation violation)
@@ -701,7 +701,7 @@ public class HttpParser
                             break;
                         case CR:
                         case LF:
-                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "No Status");
+                            throw new BadMessageException("No Status");
                         default:
                             throw new IllegalCharacterException(_state, t, buffer);
                     }
@@ -758,7 +758,7 @@ public class HttpParser
                             break;
 
                         default:
-                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, _requestHandler != null ? "No URI" : "No Status");
+                            throw new BadMessageException(_requestHandler != null ? "No URI" : "No Status");
                     }
                     break;
 
@@ -966,10 +966,10 @@ public class HttpParser
     private void checkVersion()
     {
         if (_version == null)
-            throw new BadMessageException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "Unknown Version");
+            throw new HttpException.RuntimeException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "Unknown Version");
 
         if (_version.getVersion() < 10 || _version.getVersion() > 20)
-            throw new BadMessageException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "Unsupported Version");
+            throw new HttpException.RuntimeException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "Unsupported Version");
     }
 
     private void parsedHeader()
@@ -991,7 +991,7 @@ public class HttpParser
                         {
                             checkViolation(MULTIPLE_CONTENT_LENGTHS);
                             if (convertContentLength(_valueString) != _contentLength)
-                                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, MULTIPLE_CONTENT_LENGTHS.getDescription());
+                                throw new BadMessageException(MULTIPLE_CONTENT_LENGTHS.getDescription());
                         }
                         _hasContentLength = true;
 
@@ -1013,7 +1013,7 @@ public class HttpParser
 
                         // we encountered another Transfer-Encoding header, but chunked was already set
                         if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
-                            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
+                            throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
 
                         if (HttpHeaderValue.CHUNKED.is(_valueString))
                         {
@@ -1030,7 +1030,7 @@ public class HttpParser
                                 if (HttpHeaderValue.CHUNKED.is(values.get(i)))
                                 {
                                     if (chunked != -1)
-                                        throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, multiple chunked tokens");
+                                        throw new BadMessageException("Bad Transfer-Encoding, multiple chunked tokens");
                                     chunked = i;
                                     // declared chunked
                                     _endOfContent = EndOfContent.CHUNKED_CONTENT;
@@ -1039,7 +1039,7 @@ public class HttpParser
                                 // we have a non-chunked token after a declared chunked token
                                 else if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
                                 {
-                                    throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
+                                    throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
                                 }
                             }
                         }
@@ -1134,7 +1134,7 @@ public class HttpParser
         catch (NumberFormatException e)
         {
             LOG.trace("IGNORED", e);
-            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Invalid Content-Length Value", e);
+            throw new BadMessageException("Invalid Content-Length Value", e);
         }
     }
 
@@ -1212,14 +1212,14 @@ public class HttpParser
                                 {
                                     // Transfer-Encoding chunked not specified
                                     // https://tools.ietf.org/html/rfc7230#section-3.3.1
-                                    throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
+                                    throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
                                 }
                             }
 
                             // Was there a required host header?
                             if (_parsedHost == null && _version == HttpVersion.HTTP_1_1 && _requestHandler != null)
                             {
-                                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "No Host");
+                                throw new BadMessageException("No Host");
                             }
 
                             // is it a response that cannot have a body?
@@ -1637,20 +1637,18 @@ public class HttpParser
                 }
             }
         }
-        catch (BadMessageException x)
-        {
-            BufferUtil.clear(buffer);
-            badMessage(x);
-        }
         catch (Throwable x)
         {
             BufferUtil.clear(buffer);
-            badMessage(new BadMessageException(HttpStatus.BAD_REQUEST_400, _requestHandler != null ? "Bad Request" : "Bad Response", x));
+            HttpException bad = x instanceof HttpException http
+                ? http
+                : new BadMessageException(_requestHandler != null ? "Bad Request" : "Bad Response", x);
+            badMessage(bad);
         }
         return false;
     }
 
-    protected void badMessage(BadMessageException x)
+    protected void badMessage(HttpException x)
     {
         if (debugEnabled)
             LOG.debug("Parse exception: {} for {}", this, _handler, x);
@@ -2020,7 +2018,7 @@ public class HttpParser
          *
          * @param failure the failure with the bad message information
          */
-        default void badMessage(BadMessageException failure)
+        default void badMessage(HttpException failure)
         {
         }
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -836,7 +836,7 @@ public class HttpParser
                             }
                             else
                             {
-                                throw new BadMessageException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "HTTP/0.9 not supported");
+                                throw new HttpException.RuntimeException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "HTTP/0.9 not supported");
                             }
                             break;
 
@@ -2052,7 +2052,7 @@ public class HttpParser
     {
         private IllegalCharacterException(State state, HttpTokens.Token token, ByteBuffer buffer)
         {
-            super(400, String.format("Illegal character %s", token));
+            super(String.format("Illegal character %s", token));
             if (LOG.isDebugEnabled())
                 LOG.debug(String.format("Illegal character %s in state=%s for buffer %s", token, state, BufferUtil.toDetailString(buffer)));
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
@@ -428,9 +428,9 @@ public class HttpTester
         }
 
         @Override
-        public void badMessage(BadMessageException failure)
+        public void badMessage(HttpException failure)
         {
-            throw failure;
+            HttpException.rethrowRuntime(failure);
         }
 
         public ByteBuffer generate()

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
@@ -430,7 +430,7 @@ public class HttpTester
         @Override
         public void badMessage(HttpException failure)
         {
-            HttpException.rethrowRuntime(failure);
+            HttpException.throwAsUnchecked(failure);
         }
 
         public ByteBuffer generate()

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
@@ -256,9 +256,9 @@ public class HttpGeneratorServerHTTPTest
         }
 
         @Override
-        public void badMessage(BadMessageException failure)
+        public void badMessage(HttpException failure)
         {
-            throw failure;
+            HttpException.rethrowRuntime(failure);
         }
     }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
@@ -258,7 +258,7 @@ public class HttpGeneratorServerHTTPTest
         @Override
         public void badMessage(HttpException failure)
         {
-            HttpException.rethrowRuntime(failure);
+            HttpException.throwAsUnchecked(failure);
         }
     }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
@@ -281,11 +281,9 @@ public class HttpGeneratorServerTest
         result = gen.generateResponse(info, false, null, null, null, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
 
-        BadMessageException e = assertThrows(BadMessageException.class, () ->
-        {
-            gen.generateResponse(info, false, header, null, null, true);
-        });
-        assertEquals(500, e._code);
+        HttpException e = assertThrows(HttpException.RuntimeException.class, () ->
+            gen.generateResponse(info, false, header, null, null, true));
+        assertEquals(500, e.getCode());
     }
 
     @Test

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -3330,7 +3330,7 @@ public class HttpParserTest
         }
 
         @Override
-        public void badMessage(BadMessageException failure)
+        public void badMessage(HttpException failure)
         {
             String reason = failure.getReason();
             _bad = reason == null ? String.valueOf(failure.getCode()) : reason;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -19,9 +19,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -337,10 +337,10 @@ public interface Response extends Content.Sink
             cause = new Throwable("unknown cause");
         int status = HttpStatus.INTERNAL_SERVER_ERROR_500;
         String message = cause.toString();
-        if (cause instanceof BadMessageException bad)
+        if (cause instanceof HttpException httpException)
         {
-            status = bad.getCode();
-            message = bad.getReason();
+            status = httpException.getCode();
+            message = httpException.getReason();
         }
         writeError(request, response, callback, status, message, cause);
     }
@@ -399,7 +399,7 @@ public interface Response extends Content.Sink
         // Let's be less verbose with BadMessageExceptions & QuietExceptions
         if (logger.isDebugEnabled())
             logger.debug("writeError: status={}, message={}, response={}", status, message, response, cause);
-        else if (cause instanceof BadMessageException || cause instanceof QuietException || cause instanceof TimeoutException)
+        else if (cause instanceof QuietException || cause instanceof TimeoutException)
             logger.debug("writeError: status={}, message={}, response={} {}", status, message, response, cause.toString());
         else if (cause != null)
             logger.warn("writeError: status={}, message={}, response={}", status, message, response, cause);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -92,12 +92,12 @@ public class ErrorHandler implements Request.Handler
         int code = response.getStatus();
         String message = (String)request.getAttribute(ERROR_MESSAGE);
         Throwable cause = (Throwable)request.getAttribute(ERROR_EXCEPTION);
-        if (cause instanceof BadMessageException bad)
+        if (cause instanceof HttpException httpException)
         {
-            code = bad.getCode();
+            code = httpException.getCode();
             response.setStatus(code);
             if (message == null)
-                message = bad.getReason();
+                message = httpException.getReason();
         }
 
         if (!errorPageForMethod(request.getMethod()) || HttpStatus.hasNoBody(code))

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1059,7 +1059,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
             if (LOG.isDebugEnabled())
                 LOG.debug("badMessage {} {}", HttpConnection.this, failure);
 
-            _failure = HttpException.asThrowable(failure);
+            _failure = (Throwable)failure;
             _generator.setPersistent(false);
 
             HttpStreamOverHTTP1 stream = _stream.get();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpGenerator;
@@ -830,7 +831,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
                     case HEADER_OVERFLOW:
                     {
                         if (_header.capacity() >= _configuration.getResponseHeaderSize())
-                            throw new BadMessageException(INTERNAL_SERVER_ERROR_500, "Response header too large");
+                            throw new HttpException.RuntimeException(INTERNAL_SERVER_ERROR_500, "Response header too large");
                         releaseHeader();
                         _header = _bufferPool.acquire(_configuration.getResponseHeaderSize(), useDirectByteBuffers);
                         continue;
@@ -1053,12 +1054,12 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
         }
 
         @Override
-        public void badMessage(BadMessageException failure)
+        public void badMessage(HttpException failure)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("badMessage {} {}", HttpConnection.this, failure);
 
-            _failure = failure;
+            _failure = HttpException.asThrowable(failure);
             _generator.setPersistent(false);
 
             HttpStreamOverHTTP1 stream = _stream.get();
@@ -1077,7 +1078,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
                 _httpChannel.onRequest(new MetaData.Request(stream._method, uri, stream._version, HttpFields.EMPTY));
             }
 
-            Runnable task = _httpChannel.onFailure(failure);
+            Runnable task = _httpChannel.onFailure(_failure);
             if (task != null)
                 getServer().getThreadPool().execute(task);
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
@@ -91,15 +91,15 @@ public class ExceptionUtil
      * @throws Error If the passed {@link Throwable} is an {@link Error}.
      * @throws RuntimeException Otherwise, if the passed {@link Throwable} is not null.
      */
-    public static void ifExceptionThrowRuntime(Throwable throwable)
+    public static void ifExceptionThrowUnchecked(Throwable throwable)
         throws Error, RuntimeException
     {
         if (throwable == null)
             return;
-        if (throwable instanceof Error error)
-            throw error;
         if (throwable instanceof RuntimeException runtimeException)
             throw runtimeException;
+        if (throwable instanceof Error error)
+            throw error;
         throw new RuntimeException(throwable);
     }
 
@@ -231,7 +231,7 @@ public class ExceptionUtil
 
         public void ifExceptionThrowRuntime()
         {
-            ExceptionUtil.ifExceptionThrowRuntime(_multiException);
+            ExceptionUtil.ifExceptionThrowUnchecked(_multiException);
         }
 
         public <T extends Throwable> void ifExceptionThrowAs(Class<T> type) throws T

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ExceptionUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ExceptionUtilTest.java
@@ -104,7 +104,7 @@ public class ExceptionUtilTest
     public void testEmpty() throws Exception
     {
         ExceptionUtil.ifExceptionThrow(null);
-        ExceptionUtil.ifExceptionThrowRuntime(null);
+        ExceptionUtil.ifExceptionThrowUnchecked(null);
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -44,8 +44,8 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.CompressedContentFormat;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -1027,10 +1027,10 @@ public class DefaultServlet extends HttpServlet
 
             int statusCode = HttpStatus.INTERNAL_SERVER_ERROR_500;
             String reason = null;
-            if (cause instanceof BadMessageException badMessageException)
+            if (cause instanceof HttpException httpException)
             {
-                statusCode = badMessageException.getCode();
-                reason = badMessageException.getReason();
+                statusCode = httpException.getCode();
+                reason = httpException.getReason();
             }
             writeHttpError(coreRequest, coreResponse, callback, statusCode, reason, cause);
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletRequestState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletRequestState.java
@@ -21,7 +21,7 @@ import jakarta.servlet.AsyncListener;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Request;
@@ -819,16 +819,16 @@ public class ServletRequestState
         final Request request = _servletChannel.getServletContextRequest();
         final int code;
         final String message;
-        Throwable cause = _servletChannel.unwrap(th, BadMessageException.class, UnavailableException.class);
+        Throwable cause = _servletChannel.unwrap(th, HttpException.class, UnavailableException.class);
         if (cause == null)
         {
             code = HttpStatus.INTERNAL_SERVER_ERROR_500;
             message = th.toString();
         }
-        else if (cause instanceof BadMessageException bme)
+        else if (cause instanceof HttpException httpException)
         {
-            code = bme.getCode();
-            message = bme.getReason();
+            code = httpException.getCode();
+            message = httpException.getReason();
         }
         else if (cause instanceof UnavailableException)
         {

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CloseableDoSFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CloseableDoSFilter.java
@@ -15,7 +15,7 @@ package org.eclipse.jetty.ee10.servlets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 
 /**
  * This is an extension to {@link DoSFilter} that uses Jetty APIs to
@@ -27,7 +27,7 @@ public class CloseableDoSFilter extends DoSFilter
     @Override
     protected void onRequestTimeout(HttpServletRequest request, HttpServletResponse response, Thread handlingThread)
     {
-        throw new BadMessageException(503);
+        throw new HttpException.RuntimeException(503);
         //TODO: need to change visibility of getServletChannel to make this work
 //        ServletContextRequest baseRequest = ServletContextRequest.getBaseRequest(request);
 //        baseRequest.getServletChannel().getEndPoint().close();

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
@@ -37,7 +37,7 @@ import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http2.FlowControlStrategy;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
@@ -325,9 +325,10 @@ public class ServerTimeoutsTest extends AbstractTest
                             break;
                     }
                 }
-                catch (BadMessageException x)
+                catch (Throwable x)
                 {
-                    handlerLatch.countDown();
+                    if (x instanceof HttpException)
+                        handlerLatch.countDown();
                     throw x;
                 }
             }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -574,7 +574,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         }
         _configurations = null;
         super.destroy();
-        ExceptionUtil.ifExceptionThrowRuntime(multiException);
+        ExceptionUtil.ifExceptionThrowUnchecked(multiException);
     }
 
     /*

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Cookies.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Cookies.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.CookieParser;
-import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +102,7 @@ public class Cookies implements CookieParser.Handler
         }
         catch (CookieParser.InvalidCookieException invalidCookieException)
         {
-            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, invalidCookieException.getMessage(), invalidCookieException);
+            throw new BadMessageException(invalidCookieException.getMessage(), invalidCookieException);
         }
         _cookies = _cookieList.toArray(new Cookie[0]);
         _cookieList.clear();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
@@ -199,7 +199,7 @@ public class Dispatcher implements RequestDispatcher
                     catch (Throwable e)
                     {
                         // Only throw HttpException if not in Error Dispatch Mode
-                        // This allows application ErrorPageErrorHandler to handle BME messages
+                        // This allows application ErrorPageErrorHandler to handle HttpException messages
                         if (e instanceof HttpException && dispatch == DispatcherType.ERROR)
                         {
                             LOG.warn("Ignoring Original Bad Request Query String: {}", old_uri, e);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
@@ -26,7 +26,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.util.Attributes;
@@ -196,17 +196,17 @@ public class Dispatcher implements RequestDispatcher
                     {
                         baseRequest.mergeQueryParameters(old_uri.getQuery(), _uri.getQuery());
                     }
-                    catch (BadMessageException e)
+                    catch (Throwable e)
                     {
-                        // Only throw BME if not in Error Dispatch Mode
+                        // Only throw HttpException if not in Error Dispatch Mode
                         // This allows application ErrorPageErrorHandler to handle BME messages
-                        if (dispatch != DispatcherType.ERROR)
+                        if (e instanceof HttpException && dispatch == DispatcherType.ERROR)
                         {
-                            throw e;
+                            LOG.warn("Ignoring Original Bad Request Query String: {}", old_uri, e);
                         }
                         else
                         {
-                            LOG.warn("Ignoring Original Bad Request Query String: {}", old_uri, e);
+                            throw e;
                         }
                     }
                 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -21,7 +21,7 @@ import jakarta.servlet.AsyncListener;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.UnavailableException;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -853,17 +853,16 @@ public class HttpChannelState
         final Request request = _channel.getRequest();
         final int code;
         final String message;
-        Throwable cause = _channel.unwrap(th, BadMessageException.class, UnavailableException.class);
+        Throwable cause = _channel.unwrap(th, HttpException.class, UnavailableException.class);
         if (cause == null)
         {
             code = HttpStatus.INTERNAL_SERVER_ERROR_500;
             message = th.toString();
         }
-        else if (cause instanceof BadMessageException)
+        else if (cause instanceof HttpException httpException)
         {
-            BadMessageException bme = (BadMessageException)cause;
-            code = bme.getCode();
-            message = bme.getReason();
+            code = httpException.getCode();
+            message = httpException.getReason();
         }
         else if (cause instanceof UnavailableException)
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
@@ -488,7 +488,7 @@ public class MultiPartFormInputStream
             }
         }
         _parts.clear();
-        ExceptionUtil.ifExceptionThrowRuntime(err);
+        ExceptionUtil.ifExceptionThrowUnchecked(err);
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2102,7 +2102,7 @@ public class Request implements HttpServletRequest
             catch (Throwable th)
             {
                 _queryParameters = BAD_PARAMS;
-                throw new BadMessageException(400, "Bad query encoding", th);
+                throw new BadMessageException("Bad query encoding", th);
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -55,6 +55,7 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -220,7 +221,7 @@ public class RequestTest
                 request.getParameterMap();
                 return false;
             }
-            catch (BadMessageException e)
+            catch (Exception e)
             {
                 // Should be able to retrieve the raw query
                 String rawQuery = request.getQueryString();
@@ -575,7 +576,7 @@ public class RequestTest
                 request.getParameter("param");
                 return false;
             }
-            catch (BadMessageException e)
+            catch (Exception e)
             {
                 // Should still be able to get the raw query.
                 String rawQuery = request.getQueryString();
@@ -607,9 +608,11 @@ public class RequestTest
                 request.getParameter("param");
                 return false;
             }
-            catch (BadMessageException e)
+            catch (Throwable e)
             {
-                return e.getCode() == 415;
+                if (e instanceof HttpException httpException)
+                    return httpException.getCode() == 415;
+                throw e;
             }
         };
 

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -221,7 +221,7 @@ public class RequestTest
                 request.getParameterMap();
                 return false;
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 // Should be able to retrieve the raw query
                 String rawQuery = request.getQueryString();
@@ -398,7 +398,7 @@ public class RequestTest
                 assertTrue(e.getMessage().startsWith("No multipart config"));
                 return true;
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 return false;
             }
@@ -576,7 +576,7 @@ public class RequestTest
                 request.getParameter("param");
                 return false;
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 // Should still be able to get the raw query.
                 String rawQuery = request.getQueryString();
@@ -1324,7 +1324,7 @@ public class RequestTest
                 {
                     //expected
                 }
-                catch (Exception e)
+                catch (Throwable e)
                 {
                     fail("Session creation after response commit should throw IllegalStateException");
                 }
@@ -2229,7 +2229,7 @@ public class RequestTest
                 assertTrue(e.getMessage().startsWith("No multipart config"));
                 response.setStatus(200);
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 response.sendError(500);
             }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/ServerTimeoutsTest.java
@@ -37,7 +37,7 @@ import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http2.FlowControlStrategy;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
@@ -325,9 +325,10 @@ public class ServerTimeoutsTest extends AbstractTest
                             break;
                     }
                 }
-                catch (BadMessageException x)
+                catch (Exception x)
                 {
-                    handlerLatch.countDown();
+                    if (x instanceof HttpException)
+                        handlerLatch.countDown();
                     throw x;
                 }
             }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -578,7 +578,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         }
         _configurations = null;
         super.destroy();
-        ExceptionUtil.ifExceptionThrowRuntime(multiException);
+        ExceptionUtil.ifExceptionThrowUnchecked(multiException);
     }
 
     /*


### PR DESCRIPTION
Convert class BadMessageException to BadMessage interface that allows different types of BadMessage exceptions. This follows the pattern of the QuietException interface.