### PR TITLE
Issue #9459 empty session path in cookie

### DIFF
--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -239,9 +239,9 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         _context = ContextHandler.getCurrentContext();
         _loader = Thread.currentThread().getContextClassLoader();
 
-        // ensure a session path is set for non root contexts
+        // ensure a session path is set
         String contextPath = _context == null ? "/" : _context.getContextPath();
-        if (!"/".equals(contextPath) && getSessionPath() == null)
+        if (getSessionPath() == null)
             setSessionPath(contextPath);
 
         // Use a coarser lock to serialize concurrent start of many contexts.

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/SessionHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/SessionHandlerTest.java
@@ -299,7 +299,7 @@ public class SessionHandlerTest
     @Test
     public void testSimpleSessionCreation() throws Exception
     {
-        String contextPath = "";
+        String contextPath = "/";
         String servletMapping = "/server";
 
         Server server = new Server();
@@ -339,7 +339,8 @@ public class SessionHandlerTest
             client.start();
 
             //make a session
-            String url = "http://localhost:" + port + contextPath + servletMapping + "?action=create";
+            String path = contextPath + (contextPath.endsWith("/") && servletMapping.startsWith("/") ? servletMapping.substring(1) : servletMapping);
+            String url = "http://localhost:" + port + path + "?action=create";
 
             //make a request to set up a session on the server
             ContentResponse response = client.GET(url);
@@ -347,8 +348,9 @@ public class SessionHandlerTest
 
             String sessionCookie = response.getHeaders().get("Set-Cookie");
             assertTrue(sessionCookie != null);
+            assertThat(sessionCookie, containsString("Path=/"));
 
-            ContentResponse response2 = client.GET("http://localhost:" + port + contextPath + servletMapping + "?action=test");
+            ContentResponse response2 = client.GET("http://localhost:" + port + path + "?action=test");
             assertEquals(HttpServletResponse.SC_OK, response2.getStatus());
         }
         finally


### PR DESCRIPTION
Closes #9459 

Commit  https://github.com/eclipse/jetty.project/commit/50a88187fa26bf558c092bd59fce67dcf28acd7e only set the session cookie path iff the context path was not the root context.