### PR TITLE
Jetty 12.0.x improve multiversion annotations test

### DIFF
--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationParser.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -655,7 +656,7 @@ public class AnnotationParser
             ClassReader reader = new ClassReader(in);
             reader.accept(new MyClassVisitor(handlers, containingResource, _asmVersion), ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
 
-            String classname = reader.getClassName();
+            String classname = normalize(reader.getClassName());
             URI existing = _parsedClassNames.putIfAbsent(classname, location);
             if (existing != null)
                 LOG.warn("{} scanned from multiple locations: {}, {}", classname, existing, location);
@@ -664,5 +665,14 @@ public class AnnotationParser
         {
             throw new IOException("Unable to parse class: " + classFile.toUri(), e);
         }
+    }
+    
+    /**
+     * Useful mostly for testing to expose the list of parsed classes.
+     * @return the map of classnames to their URIs
+     */
+    Map<String, URI> getParsedClassNames()
+    {
+        return Collections.unmodifiableMap(_parsedClassNames);
     }
 }

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.annotations;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -217,12 +220,16 @@ public class TestAnnotationParser
     {
         Path badClassesJar = MavenTestingUtils.getTestResourcePathFile("jdk9/log4j-api-2.9.0.jar");
         AnnotationParser parser = new AnnotationParser();
-        Set<AnnotationParser.Handler> emptySet = Collections.emptySet();
-
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            parser.parse(emptySet, resourceFactory.newResource(badClassesJar));
             // Should throw no exceptions and work with the META-INF/versions without incident
+            parser.parse(Collections.emptySet(), resourceFactory.newResource(badClassesJar));
+
+            //check for a class that is only in versions 9
+            Map<String, URI> parsed = parser.getParsedClassNames();
+            URI processIdUtilURI = parsed.get("org.apache.logging.log4j.util.ProcessIdUtil");
+            assertNotNull(processIdUtilURI);
+            assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
         }
     }
 
@@ -231,13 +238,16 @@ public class TestAnnotationParser
     {
         Path jdk10Jar = MavenTestingUtils.getTestResourcePathFile("jdk10/multirelease-10.jar");
         AnnotationParser parser = new AnnotationParser();
-        DuplicateClassScanHandler handler = new DuplicateClassScanHandler();
-        Set<AnnotationParser.Handler> handlers = Collections.singleton(handler);
 
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            parser.parse(handlers, resourceFactory.newResource(jdk10Jar));
             // Should throw no exceptions
+            parser.parse(Collections.emptySet(), resourceFactory.newResource(jdk10Jar));
+
+            Map<String, URI> parsed = parser.getParsedClassNames();
+            assertEquals(3, parsed.size());           
+            assertThat(parsed.keySet(), containsInAnyOrder("hello.DetailedVer", "hello.Greetings", "hello.Hello"));
+            assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
         }
     }
 

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
@@ -229,7 +229,8 @@ public class TestAnnotationParser
             Map<String, URI> parsed = parser.getParsedClassNames();
             URI processIdUtilURI = parsed.get("org.apache.logging.log4j.util.ProcessIdUtil");
             assertNotNull(processIdUtilURI);
-            assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
+            if (Runtime.version().feature() > 17)
+                assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
         }
     }
 
@@ -247,7 +248,8 @@ public class TestAnnotationParser
             Map<String, URI> parsed = parser.getParsedClassNames();
             assertEquals(3, parsed.size());           
             assertThat(parsed.keySet(), containsInAnyOrder("hello.DetailedVer", "hello.Greetings", "hello.Hello"));
-            assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
+            if (Runtime.version().feature() > 17)
+                assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
         }
     }
 

--- a/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/AnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/AnnotationParser.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -652,7 +653,7 @@ public class AnnotationParser
             ClassReader reader = new ClassReader(in);
             reader.accept(new MyClassVisitor(handlers, containingResource, _asmVersion), ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
 
-            String classname = reader.getClassName();
+            String classname = normalize(reader.getClassName());
             URI existing = _parsedClassNames.putIfAbsent(classname, location);
             if (existing != null)
                 LOG.warn("{} scanned from multiple locations: {}, {}", classname, existing, location);
@@ -661,5 +662,14 @@ public class AnnotationParser
         {
             throw new IOException("Unable to parse class: " + classFile.toUri(), e);
         }
+    }
+
+    /**
+     * Useful mostly for testing to expose the list of parsed classes.
+     * @return the map of classnames to their URIs
+     */
+    Map<String, URI> getParsedClassNames()
+    {
+        return Collections.unmodifiableMap(_parsedClassNames);
     }
 }

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
@@ -217,7 +217,8 @@ public class TestAnnotationParser
     @Test
     public void testJep238MultiReleaseInJar() throws Exception
     {
-        Path badClassesJar = MavenTestingUtils.getTestResourcePathFile("jdk9/log4j-api-2.9.0.jar");
+       Path badClassesJar = MavenTestingUtils.getTargetPath("test-classes/jdk9/log4j-api-2.9.0.jar");
+
         AnnotationParser parser = new AnnotationParser();
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -228,16 +229,16 @@ public class TestAnnotationParser
             Map<String, URI> parsed = parser.getParsedClassNames();
             URI processIdUtilURI = parsed.get("org.apache.logging.log4j.util.ProcessIdUtil");
             assertNotNull(processIdUtilURI);
-            assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
+            if (Runtime.version().feature() > 17)
+                assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
         }
     }
 
     @Test
     public void testJep238MultiReleaseInJarJDK10() throws Exception
     {
-        Path jdk10Jar = MavenTestingUtils.getTestResourcePathFile("jdk10/multirelease-10.jar");
+        Path jdk10Jar = MavenTestingUtils.getTargetPath("test-classes/jdk10/multirelease-10.jar");
         AnnotationParser parser = new AnnotationParser();
-
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
             // Should throw no exceptions
@@ -246,7 +247,8 @@ public class TestAnnotationParser
             Map<String, URI> parsed = parser.getParsedClassNames();
             assertEquals(3, parsed.size());           
             assertThat(parsed.keySet(), containsInAnyOrder("hello.DetailedVer", "hello.Greetings", "hello.Hello"));
-            assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
+            if (Runtime.version().feature() > 17)
+                assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
         }
     }
 

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee9.annotations;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -214,29 +217,36 @@ public class TestAnnotationParser
     @Test
     public void testJep238MultiReleaseInJar() throws Exception
     {
-        Path badClassesJar = MavenTestingUtils.getTargetPath("test-classes/jdk9/log4j-api-2.9.0.jar");
+        Path badClassesJar = MavenTestingUtils.getTestResourcePathFile("jdk9/log4j-api-2.9.0.jar");
         AnnotationParser parser = new AnnotationParser();
-        Set<AnnotationParser.Handler> emptySet = Collections.emptySet();
-
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            parser.parse(emptySet, resourceFactory.newResource(badClassesJar));
             // Should throw no exceptions and work with the META-INF/versions without incident
+            parser.parse(Collections.emptySet(), resourceFactory.newResource(badClassesJar));
+
+            //check for a class that is only in versions 9
+            Map<String, URI> parsed = parser.getParsedClassNames();
+            URI processIdUtilURI = parsed.get("org.apache.logging.log4j.util.ProcessIdUtil");
+            assertNotNull(processIdUtilURI);
+            assertThat(processIdUtilURI.toString(), containsString("META-INF/versions/9"));
         }
     }
 
     @Test
     public void testJep238MultiReleaseInJarJDK10() throws Exception
     {
-        Path jdk10Jar = MavenTestingUtils.getTargetPath("test-classes/jdk10/multirelease-10.jar");
+        Path jdk10Jar = MavenTestingUtils.getTestResourcePathFile("jdk10/multirelease-10.jar");
         AnnotationParser parser = new AnnotationParser();
-        DuplicateClassScanHandler handler = new DuplicateClassScanHandler();
-        Set<AnnotationParser.Handler> handlers = Collections.singleton(handler);
 
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            parser.parse(handlers, resourceFactory.newResource(jdk10Jar));
             // Should throw no exceptions
+            parser.parse(Collections.emptySet(), resourceFactory.newResource(jdk10Jar));
+
+            Map<String, URI> parsed = parser.getParsedClassNames();
+            assertEquals(3, parsed.size());           
+            assertThat(parsed.keySet(), containsInAnyOrder("hello.DetailedVer", "hello.Greetings", "hello.Hello"));
+            assertThat(parsed.get("hello.Greetings").toString(), containsString("META-INF/versions/10"));
         }
     }
 


### PR DESCRIPTION
The tests for multiversion jar annotation parsing really weren't doing much testing, so this PR ensures some testing is actually done and verified. Also minor fix in AnnotationParser to use the normalized class name, not the internal class name.