### PR TITLE
Fixes #94890 - replace ISO-8859-1 fallback with UTF-8 Replacement Character

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -815,7 +815,7 @@ public class HttpParser
                                         checkVersion();
                                         _fieldCache.prepare();
                                         setState(State.HEADER);
-                                        _requestHandler.startRequest(_methodString, _uri.toString(), _version);
+                                        _requestHandler.startRequest(_methodString, _uri.getString(), _version);
                                         continue;
                                     }
                                 }
@@ -828,7 +828,7 @@ public class HttpParser
                             if (Violation.HTTP_0_9.isAllowedBy(_complianceMode))
                             {
                                 reportComplianceViolation(HTTP_0_9, HTTP_0_9.getDescription());
-                                _requestHandler.startRequest(_methodString, _uri.toString(), HttpVersion.HTTP_0_9);
+                                _requestHandler.startRequest(_methodString, _uri.getString(), HttpVersion.HTTP_0_9);
                                 setState(State.CONTENT);
                                 _endOfContent = EndOfContent.NO_CONTENT;
                                 BufferUtil.clear(buffer);
@@ -882,7 +882,7 @@ public class HttpParser
                             {
                                 // HTTP/0.9
                                 checkViolation(Violation.HTTP_0_9);
-                                _requestHandler.startRequest(_methodString, _uri.toString(), HttpVersion.HTTP_0_9);
+                                _requestHandler.startRequest(_methodString, _uri.getString(), HttpVersion.HTTP_0_9);
                                 setState(State.CONTENT);
                                 _endOfContent = EndOfContent.NO_CONTENT;
                                 BufferUtil.clear(buffer);
@@ -908,7 +908,7 @@ public class HttpParser
                             _fieldCache.prepare();
                             setState(State.HEADER);
 
-                            _requestHandler.startRequest(_methodString, _uri.toString(), _version);
+                            _requestHandler.startRequest(_methodString, _uri.getString(), _version);
                             continue;
 
                         case ALPHA:
@@ -1929,7 +1929,7 @@ public class HttpParser
                     info = _requestHandler == null ? _version.asString() : _methodString;
                     break;
                 case SPACE2:
-                    info = _requestHandler == null ? Integer.toString(_responseStatus) : _uri.toString();
+                    info = _requestHandler == null ? Integer.toString(_responseStatus) : _uri.getString();
                     break;
                 case CONTENT_END:
                 case TRAILER:

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -714,7 +714,7 @@ public class MultiPart
                     builder.append("\r\n");
 
                     // TODO: use a ByteBuffer pool and direct ByteBuffers?
-                    ByteBuffer byteBuffer = UTF_8.encode(builder.toString());
+                    ByteBuffer byteBuffer = UTF_8.encode(builder.getString());
                     state = State.CONTENT;
                     yield Content.Chunk.from(byteBuffer, false);
                 }
@@ -1178,7 +1178,7 @@ public class MultiPart
                     {
                         // End of field name.
                         incrementAndCheckPartHeadersLength();
-                        fieldName = text.toString();
+                        fieldName = text.getString();
                         trailingWhiteSpaces = 0;
                         text.reset();
                         return true;
@@ -1224,7 +1224,7 @@ public class MultiPart
                     {
                         // End of header value.
                         // Ignore trailing whitespace.
-                        fieldValue = text.toString().stripTrailing();
+                        fieldValue = text.getString().stripTrailing();
                         text.reset();
                         notifyPartHeader(fieldName, fieldValue);
                         fieldName = null;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -71,6 +71,8 @@ public final class UriCompliance implements ComplianceViolation.Mode
          */
         UTF16_ENCODINGS("https://www.w3.org/International/iri-edit/draft-duerst-iri.html#anchor29", "UTF16 encoding");
 
+        // TODO: BAD_UTF8_ENCODINGS
+
         private final String _url;
         private final String _description;
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/Huffman.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/Huffman.java
@@ -417,7 +417,7 @@ public class Huffman
         if (node != 0)
             throw new HpackException.CompressionException("Bad termination");
 
-        return utf8.toString();
+        return utf8.getString(true);
     }
 
     public static int octetsNeeded(String s)

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2CServerTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2CServerTest.java
@@ -148,7 +148,7 @@ public class HTTP2CServerTest extends AbstractServerTest
                     break;
             }
 
-            assertTrue(upgrade.toString().startsWith("HTTP/1.1 101 "));
+            assertTrue(upgrade.getString().startsWith("HTTP/1.1 101 "));
 
             bufferPool = new ArrayByteBufferPool();
             generator = new Generator(bufferPool);

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/util/HuffmanDecoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/util/HuffmanDecoder.java
@@ -105,7 +105,7 @@ public class HuffmanDecoder
             throw new EncodingException("bad_termination");
         }
 
-        String value = _utf8.toString();
+        String value = _utf8.getString(true);
         reset();
         return value;
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class InvalidURIRule extends Rule
 {
     private static final Logger LOG = LoggerFactory.getLogger(InvalidURIRule.class);
+    private static final int REPLACEMENT_CHAR_CODEPOINT = 65533; // UTF-8 Replacement Char as codepoint
 
     private int _code = HttpStatus.BAD_REQUEST_400;
     private String _message = "Illegal URI";
@@ -118,6 +119,9 @@ public class InvalidURIRule extends Rule
 
         if (LOG.isDebugEnabled())
             LOG.debug("{} {} {} {}", Character.charCount(codepoint), codepoint, block, Character.isISOControl(codepoint));
+
+        if (codepoint == REPLACEMENT_CHAR_CODEPOINT)
+            return false;
 
         return (!Character.isISOControl(codepoint)) && block != null && !Character.UnicodeBlock.SPECIALS.equals(block);
     }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/InvalidURIRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/InvalidURIRuleTest.java
@@ -218,6 +218,24 @@ public class InvalidURIRuleTest extends AbstractRuleTest
     }
 
     @Test
+    public void testInvalidPercentEncoding() throws Exception
+    {
+        InvalidURIRule rule = new InvalidURIRule();
+        rule.setCode(HttpStatus.NOT_ACCEPTABLE_406);
+        start(rule);
+
+        String request = """
+            GET /jsp/shamrock-%xx%zz.jsp HTTP/1.1
+            Host: localhost
+                        
+            """;
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        // The rule is not invoked because the UTF-8 sequence is invalid.
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
     public void testInvalidUTF8() throws Exception
     {
         InvalidURIRule rule = new InvalidURIRule();
@@ -231,8 +249,7 @@ public class InvalidURIRuleTest extends AbstractRuleTest
             """;
 
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
-        // The rule is not invoked because the UTF-8 sequence is invalid.
-        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+        assertEquals(HttpStatus.NOT_ACCEPTABLE_406, response.getStatus());
     }
 
     @Test
@@ -249,7 +266,6 @@ public class InvalidURIRuleTest extends AbstractRuleTest
             """;
 
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
-        // The rule is not invoked because the UTF-8 sequence is incomplete.
-        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+        assertEquals(HttpStatus.NOT_ACCEPTABLE_406, response.getStatus());
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/MultiPartParser.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/MultiPartParser.java
@@ -166,12 +166,12 @@ public class MultiPartParser
         _length = s.length();
     }
 
-    /*
+    /**
      * Mime Field strings are treated as UTF-8 as per https://tools.ietf.org/html/rfc7578#section-5.1
      */
     private String takeString()
     {
-        String s = _string.toString();
+        String s = _string.getString();
         // trim trailing whitespace.
         if (s.length() > _length)
             s = s.substring(0, _length);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/DumpHandler.java
@@ -179,7 +179,7 @@ public class DumpHandler extends Handler.Abstract
 
         writer.write("</pre>\n<h3>Content:</h3>\n<pre>");
         if (read != null)
-            writer.write(read.toString());
+            writer.write(read.getString());
         else
             writer.write(Content.Source.asString(request));
 

--- a/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java
+++ b/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java
@@ -773,7 +773,7 @@ public class AsyncJSON
                     }
                     else
                     {
-                        String string = stringBuilder.toString();
+                        String string = stringBuilder.takeFinishedString(false);
                         stringBuilder.reset();
                         stack.pop();
                         stack.peek().value(string);
@@ -1173,7 +1173,7 @@ public class AsyncJSON
         builder.append(indent);
         builder.append("^ ");
         builder.append(message);
-        return new IllegalArgumentException(builder.toString());
+        return new IllegalArgumentException(builder.takeFinishedString(false));
     }
 
     private static boolean isWhitespace(byte ws)

--- a/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java
+++ b/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java
@@ -773,7 +773,7 @@ public class AsyncJSON
                     }
                     else
                     {
-                        String string = stringBuilder.takeFinishedString(false);
+                        String string = stringBuilder.getString();
                         stringBuilder.reset();
                         stack.pop();
                         stack.peek().value(string);
@@ -1173,7 +1173,7 @@ public class AsyncJSON
         builder.append(indent);
         builder.append("^ ");
         builder.append(message);
-        return new IllegalArgumentException(builder.takeFinishedString(false));
+        return new IllegalArgumentException(builder.getString());
     }
 
     private static boolean isWhitespace(byte ws)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.stream.Stream;
 
-import org.eclipse.jetty.util.Utf8Appendable.NotUtf8Exception;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -552,12 +551,6 @@ public final class URIUtil
                 return path;
             return path.substring(offset, end);
         }
-        catch (NotUtf8Exception e)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} {}", path.substring(offset, offset + length), e.toString());
-            throw e;
-        }
         catch (IllegalArgumentException e)
         {
             throw e;
@@ -772,16 +765,6 @@ public final class URIUtil
 
             String canonical = (builder != null) ? builder.getString() : encodedPath;
             return normal ? canonical : normalizePath(canonical);
-        }
-        catch (NotUtf8Exception e)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} {}", encodedPath, e.toString());
-            throw e;
-        }
-        catch (IllegalArgumentException e)
-        {
-            throw e;
         }
         catch (Exception e)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -547,7 +547,7 @@ public final class URIUtil
             }
 
             if (builder != null)
-                return builder.takeFinishedString();
+                return builder.getString();
             if (offset == 0 && length == path.length())
                 return path;
             return path.substring(offset, end);
@@ -770,7 +770,7 @@ public final class URIUtil
                 slash = c == '/';
             }
 
-            String canonical = (builder != null) ? builder.takeFinishedString() : encodedPath;
+            String canonical = (builder != null) ? builder.getString() : encodedPath;
             return normal ? canonical : normalizePath(canonical);
         }
         catch (NotUtf8Exception e)
@@ -1624,7 +1624,7 @@ public final class URIUtil
             }
 
             if (builder != null)
-                return builder.takeFinishedString();
+                return builder.getString();
             return path;
         }
         catch (IllegalArgumentException e)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -413,7 +412,7 @@ public final class URIUtil
                 ret.append(c);
             }
         }
-        return ret.toString();
+        return ret.getString();
     }
 
     /**
@@ -492,7 +491,7 @@ public final class URIUtil
                     case '%':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(length, CodingErrorAction.REPLACE);
+                            builder = new Utf8StringBuilder(length);
                             builder.append(path, offset, i - offset);
                         }
                         if ((i + 2) < end)
@@ -525,7 +524,7 @@ public final class URIUtil
                     case ';':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(path.length(), CodingErrorAction.REPLACE);
+                            builder = new Utf8StringBuilder(path.length());
                             builder.append(path, offset, i - offset);
                         }
 
@@ -548,7 +547,7 @@ public final class URIUtil
             }
 
             if (builder != null)
-                return builder.toString();
+                return builder.takeFinishedString();
             if (offset == 0 && length == path.length())
                 return path;
             return path.substring(offset, end);
@@ -686,7 +685,7 @@ public final class URIUtil
                     case '%':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
+                            builder = new Utf8StringBuilder(encodedPath.length());
                             builder.append(encodedPath, 0, i);
                         }
                         if ((i + 2) < end)
@@ -730,7 +729,7 @@ public final class URIUtil
                     case ';':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
+                            builder = new Utf8StringBuilder(encodedPath.length());
                             builder.append(encodedPath, 0, i);
                         }
 
@@ -759,7 +758,7 @@ public final class URIUtil
                     default:
                         if (builder == null && !isSafe(c))
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
+                            builder = new Utf8StringBuilder(encodedPath.length());
                             builder.append(encodedPath, 0, i);
                         }
 
@@ -771,7 +770,7 @@ public final class URIUtil
                 slash = c == '/';
             }
 
-            String canonical = (builder != null) ? builder.toString() : encodedPath;
+            String canonical = (builder != null) ? builder.takeFinishedString() : encodedPath;
             return normal ? canonical : normalizePath(canonical);
         }
         catch (NotUtf8Exception e)
@@ -1625,7 +1624,7 @@ public final class URIUtil
             }
 
             if (builder != null)
-                return builder.toString();
+                return builder.takeFinishedString();
             return path;
         }
         catch (IllegalArgumentException e)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -491,7 +492,7 @@ public final class URIUtil
                     case '%':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(length);
+                            builder = new Utf8StringBuilder(length, CodingErrorAction.REPLACE);
                             builder.append(path, offset, i - offset);
                         }
                         if ((i + 2) < end)
@@ -524,7 +525,7 @@ public final class URIUtil
                     case ';':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(path.length());
+                            builder = new Utf8StringBuilder(path.length(), CodingErrorAction.REPLACE);
                             builder.append(path, offset, i - offset);
                         }
 
@@ -556,7 +557,7 @@ public final class URIUtil
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("{} {}", path.substring(offset, offset + length), e.toString());
-            return decodeISO88591Path(path, offset, length);
+            throw e;
         }
         catch (IllegalArgumentException e)
         {
@@ -685,7 +686,7 @@ public final class URIUtil
                     case '%':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length());
+                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
                             builder.append(encodedPath, 0, i);
                         }
                         if ((i + 2) < end)
@@ -729,7 +730,7 @@ public final class URIUtil
                     case ';':
                         if (builder == null)
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length());
+                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
                             builder.append(encodedPath, 0, i);
                         }
 
@@ -758,7 +759,7 @@ public final class URIUtil
                     default:
                         if (builder == null && !isSafe(c))
                         {
-                            builder = new Utf8StringBuilder(encodedPath.length());
+                            builder = new Utf8StringBuilder(encodedPath.length(), CodingErrorAction.REPLACE);
                             builder.append(encodedPath, 0, i);
                         }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -365,7 +365,8 @@ public class UrlEncoded
                     }
                     else
                     {
-                        throw new Utf8Appendable.NotUtf8Exception("Incomplete % encoding");
+                        // partial % encoding at end of string, this is a replacement
+                        throw new IllegalArgumentException("Invalid percent sequence");
                     }
                     break;
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -383,7 +383,6 @@ public class UrlEncoded
         }
         else if (buffer.length() > 0)
         {
-            buffer.finish();
             adder.accept(buffer.getString(), "");
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -329,7 +329,8 @@ public class UrlEncoded
             switch (c)
             {
                 case '&':
-                    value = buffer.takePartialString();
+                    value = buffer.getString();
+                    buffer.reset();
                     if (key != null)
                     {
                         adder.accept(key, value);
@@ -347,7 +348,8 @@ public class UrlEncoded
                         buffer.append(c);
                         break;
                     }
-                    key = buffer.takeFinishedString();
+                    key = buffer.getString();
+                    buffer.reset();
                     break;
 
                 case '+':
@@ -375,13 +377,13 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.takeFinishedString();
+            value = buffer.getString();
             adder.accept(key, value);
         }
         else if (buffer.length() > 0)
         {
             buffer.finish();
-            adder.accept(buffer.takeFinishedString(), "");
+            adder.accept(buffer.getString(), "");
         }
     }
 
@@ -487,7 +489,8 @@ public class UrlEncoded
             switch ((char)b)
             {
                 case '&':
-                    value = buffer.takeFinishedString();
+                    value = buffer.getString();
+                    buffer.reset();
                     if (key != null)
                     {
                         map.add(key, value);
@@ -506,7 +509,8 @@ public class UrlEncoded
                         buffer.append((byte)b);
                         break;
                     }
-                    key = buffer.takeFinishedString();
+                    key = buffer.getString();
+                    buffer.reset();
                     break;
 
                 case '+':
@@ -528,12 +532,12 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.takeFinishedString();
+            value = buffer.getString();
             map.add(key, value);
         }
         else if (buffer.length() > 0)
         {
-            map.add(buffer.takeFinishedString(), "");
+            map.add(buffer.getString(), "");
         }
         checkMaxKeys(map, maxKeys);
     }
@@ -782,7 +786,7 @@ public class UrlEncoded
                 return encoded.substring(offset, offset + length);
             }
 
-            return buffer.getString(false);
+            return buffer.getString();
         }
         else
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -318,7 +319,7 @@ public class UrlEncoded
 
     private static void decodeUtf8To(String query, int offset, int length, BiConsumer<String, String> adder)
     {
-        Utf8StringBuilder buffer = new Utf8StringBuilder();
+        Utf8StringBuilder buffer = new Utf8StringBuilder(CodingErrorAction.REPLACE);
         String key = null;
         String value;
 
@@ -329,7 +330,7 @@ public class UrlEncoded
             switch (c)
             {
                 case '&':
-                    value = buffer.toReplacedString();
+                    value = buffer.toString();
                     buffer.reset();
                     if (key != null)
                     {
@@ -348,7 +349,7 @@ public class UrlEncoded
                         buffer.append(c);
                         break;
                     }
-                    key = buffer.toReplacedString();
+                    key = buffer.toString();
                     buffer.reset();
                     break;
 
@@ -377,13 +378,13 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.toReplacedString();
+            value = buffer.toString();
             buffer.reset();
             adder.accept(key, value);
         }
         else if (buffer.length() > 0)
         {
-            adder.accept(buffer.toReplacedString(), "");
+            adder.accept(buffer.toString(), "");
         }
     }
 
@@ -477,7 +478,7 @@ public class UrlEncoded
     public static void decodeUtf8To(InputStream in, MultiMap<String> map, int maxLength, int maxKeys)
         throws IOException
     {
-        Utf8StringBuilder buffer = new Utf8StringBuilder();
+        Utf8StringBuilder buffer = new Utf8StringBuilder(CodingErrorAction.REPLACE);
         String key = null;
         String value;
 
@@ -489,7 +490,7 @@ public class UrlEncoded
             switch ((char)b)
             {
                 case '&':
-                    value = buffer.toReplacedString();
+                    value = buffer.toString();
                     buffer.reset();
                     if (key != null)
                     {
@@ -509,7 +510,7 @@ public class UrlEncoded
                         buffer.append((byte)b);
                         break;
                     }
-                    key = buffer.toReplacedString();
+                    key = buffer.toString();
                     buffer.reset();
                     break;
 
@@ -532,13 +533,13 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.toReplacedString();
+            value = buffer.toString();
             buffer.reset();
             map.add(key, value);
         }
         else if (buffer.length() > 0)
         {
-            map.add(buffer.toReplacedString(), "");
+            map.add(buffer.toString(), "");
         }
         checkMaxKeys(map, maxKeys);
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -98,7 +98,6 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
 
     private final CodingErrorAction _coderErrorAction;
     private int _codep;
-    private int _prev;
     private boolean _hasReplacements = false;
 
     public Utf8Appendable(Appendable appendable)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -132,8 +132,7 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
         {
             int state = _state;
             _state = UTF8_ACCEPT;
-            _appendable.append(REPLACEMENT);
-            _hasReplacements = true;
+            appendReplacement();
         }
     }
 
@@ -309,8 +308,7 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
 
                 case UTF8_REJECT ->
                 {
-                    _appendable.append(REPLACEMENT);
-                    _hasReplacements = true;
+                    appendReplacement();
                     _codep = 0; // it's a bad codepoint, don't use it
 
                     if (_state != UTF8_ACCEPT)
@@ -325,6 +323,19 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
                 }
             }
         }
+    }
+
+    public void appendReplacement()
+    {
+        try
+        {
+            _appendable.append(REPLACEMENT);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+        _hasReplacements = true;
     }
 
     public boolean isUtf8SequenceComplete()
@@ -343,15 +354,7 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
     {
         if (!isUtf8SequenceComplete())
         {
-            try
-            {
-                _appendable.append(REPLACEMENT);
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
-            _hasReplacements = true;
+            appendReplacement();
         }
         _codep = 0;
         _state = UTF8_ACCEPT;
@@ -458,7 +461,9 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
 
     /**
      * Default toString implementation
+     *
      * @return String representation of this object
+     * @see #getString()
      */
     public String toString()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -394,14 +394,14 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
      */
     public <X extends Throwable> String getString(boolean completeCodePoints, Supplier<? extends X> throwableOnReplacementsSupplier) throws X
     {
+        if (completeCodePoints)
+        {
+            finish();
+        }
         if (throwableOnReplacementsSupplier != null && hasReplacements())
         {
             X error = throwableOnReplacementsSupplier.get();
             throw error;
-        }
-        if (completeCodePoints)
-        {
-            finish();
         }
         return _appendable.toString();
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java
@@ -396,6 +396,10 @@ public abstract class Utf8Appendable implements CharsetStringBuilder
             X error = throwableOnReplacementsSupplier.get();
             throw error;
         }
+        if (completeCodePoints)
+        {
+            finish();
+        }
         return _appendable.toString();
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8LineParser.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8LineParser.java
@@ -56,7 +56,7 @@ public class Utf8LineParser
             if (parseByte(b))
             {
                 state = State.START;
-                return utf.toString();
+                return utf.getString();
             }
         }
         // have not reached end of line (yet)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.util;
 
 import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 
 /**
  * UTF-8 StringBuffer.
@@ -40,6 +41,12 @@ public class Utf8StringBuffer extends Utf8Appendable
     public Utf8StringBuffer(int capacity)
     {
         super(new StringBuffer(capacity));
+        _buffer = (StringBuffer)_appendable;
+    }
+
+    public Utf8StringBuffer(int capacity, CodingErrorAction codingErrorAction)
+    {
+        super(new StringBuffer(capacity), codingErrorAction);
         _buffer = (StringBuffer)_appendable;
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
@@ -53,12 +53,6 @@ public class Utf8StringBuffer extends Utf8Appendable
         _buffer.setLength(0);
     }
 
-    @Override
-    public String getPartialString()
-    {
-        return _buffer.toString();
-    }
-
     public StringBuffer getStringBuffer()
     {
         finish();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.jetty.util;
 
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CodingErrorAction;
-
 /**
  * UTF-8 StringBuffer.
  *
@@ -44,18 +41,6 @@ public class Utf8StringBuffer extends Utf8Appendable
         _buffer = (StringBuffer)_appendable;
     }
 
-    public Utf8StringBuffer(CodingErrorAction codingErrorAction)
-    {
-        super(new StringBuffer(), codingErrorAction);
-        _buffer = (StringBuffer)_appendable;
-    }
-
-    public Utf8StringBuffer(int capacity, CodingErrorAction codingErrorAction)
-    {
-        super(new StringBuffer(capacity), codingErrorAction);
-        _buffer = (StringBuffer)_appendable;
-    }
-
     @Override
     public int length()
     {
@@ -63,9 +48,8 @@ public class Utf8StringBuffer extends Utf8Appendable
     }
 
     @Override
-    public void reset()
+    public void clear()
     {
-        super.reset();
         _buffer.setLength(0);
     }
 
@@ -77,34 +61,7 @@ public class Utf8StringBuffer extends Utf8Appendable
 
     public StringBuffer getStringBuffer()
     {
-        checkState();
+        finish();
         return _buffer;
-    }
-
-    @Override
-    public String toString()
-    {
-        checkState();
-        return _buffer.toString();
-    }
-
-    @Override
-    public String takeString() throws CharacterCodingException
-    {
-        try
-        {
-            checkState();
-        }
-        catch (NotUtf8Exception e)
-        {
-            throw (CharacterCodingException)new CharacterCodingException().initCause(e);
-        }
-        catch (RuntimeException e)
-        {
-            throw (CharacterCodingException)new CharacterCodingException().initCause(e.getCause());
-        }
-        String s = _buffer.toString();
-        reset();
-        return s;
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuffer.java
@@ -44,6 +44,12 @@ public class Utf8StringBuffer extends Utf8Appendable
         _buffer = (StringBuffer)_appendable;
     }
 
+    public Utf8StringBuffer(CodingErrorAction codingErrorAction)
+    {
+        super(new StringBuffer(), codingErrorAction);
+        _buffer = (StringBuffer)_appendable;
+    }
+
     public Utf8StringBuffer(int capacity, CodingErrorAction codingErrorAction)
     {
         super(new StringBuffer(capacity), codingErrorAction);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -44,6 +44,12 @@ public class Utf8StringBuilder extends Utf8Appendable
         _buffer = (StringBuilder)_appendable;
     }
 
+    public Utf8StringBuilder(CodingErrorAction codingErrorAction)
+    {
+        super(new StringBuilder(), codingErrorAction);
+        _buffer = (StringBuilder)_appendable;
+    }
+
     public Utf8StringBuilder(int capacity, CodingErrorAction codingErrorAction)
     {
         super(new StringBuilder(capacity), codingErrorAction);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.util;
 
 import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 
 /**
  * UTF-8 StringBuilder.
@@ -40,6 +41,12 @@ public class Utf8StringBuilder extends Utf8Appendable
     public Utf8StringBuilder(int capacity)
     {
         super(new StringBuilder(capacity));
+        _buffer = (StringBuilder)_appendable;
+    }
+
+    public Utf8StringBuilder(int capacity, CodingErrorAction codingErrorAction)
+    {
+        super(new StringBuilder(capacity), codingErrorAction);
         _buffer = (StringBuilder)_appendable;
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -53,12 +53,6 @@ public class Utf8StringBuilder extends Utf8Appendable
         _buffer.setLength(0);
     }
 
-    @Override
-    public String getPartialString()
-    {
-        return _buffer.toString();
-    }
-
     public StringBuilder getStringBuilder()
     {
         finish();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.jetty.util;
 
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CodingErrorAction;
-
 /**
  * UTF-8 StringBuilder.
  *
@@ -44,18 +41,6 @@ public class Utf8StringBuilder extends Utf8Appendable
         _buffer = (StringBuilder)_appendable;
     }
 
-    public Utf8StringBuilder(CodingErrorAction codingErrorAction)
-    {
-        super(new StringBuilder(), codingErrorAction);
-        _buffer = (StringBuilder)_appendable;
-    }
-
-    public Utf8StringBuilder(int capacity, CodingErrorAction codingErrorAction)
-    {
-        super(new StringBuilder(capacity), codingErrorAction);
-        _buffer = (StringBuilder)_appendable;
-    }
-
     @Override
     public int length()
     {
@@ -63,9 +48,8 @@ public class Utf8StringBuilder extends Utf8Appendable
     }
 
     @Override
-    public void reset()
+    public void clear()
     {
-        super.reset();
         _buffer.setLength(0);
     }
 
@@ -77,34 +61,7 @@ public class Utf8StringBuilder extends Utf8Appendable
 
     public StringBuilder getStringBuilder()
     {
-        checkState();
+        finish();
         return _buffer;
-    }
-
-    @Override
-    public String toString()
-    {
-        checkState();
-        return _buffer.toString();
-    }
-
-    @Override
-    public String takeString() throws CharacterCodingException
-    {
-        try
-        {
-            checkState();
-        }
-        catch (NotUtf8Exception e)
-        {
-            throw (CharacterCodingException)new CharacterCodingException().initCause(e);
-        }
-        catch (RuntimeException e)
-        {
-            throw (CharacterCodingException)new CharacterCodingException().initCause(e.getCause());
-        }
-        String s = _buffer.toString();
-        reset();
-        return s;
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
@@ -261,13 +261,13 @@ public class URLEncodedTest
     {
         ArrayList<Arguments> data = new ArrayList<>();
         data.add(Arguments.of("Name=xx%zzyy", UTF_8, IllegalArgumentException.class));
-        data.add(Arguments.of("Name=%FF%FF%FF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        data.add(Arguments.of("Name=%EF%EF%EF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
+        // data.add(Arguments.of("Name=%FF%FF%FF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
+        // data.add(Arguments.of("Name=%EF%EF%EF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
         data.add(Arguments.of("Name=%E%F%F", UTF_8, IllegalArgumentException.class));
         data.add(Arguments.of("Name=x%", UTF_8, Utf8Appendable.NotUtf8Exception.class));
         data.add(Arguments.of("Name=x%2", UTF_8, Utf8Appendable.NotUtf8Exception.class));
         data.add(Arguments.of("Name=xxx%", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        data.add(Arguments.of("name=X%c0%afZ", UTF_8, Utf8Appendable.NotUtf8Exception.class));
+        // data.add(Arguments.of("name=X%c0%afZ", UTF_8, Utf8Appendable.NotUtf8Exception.class));
         return data.stream();
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
@@ -259,33 +259,30 @@ public class URLEncodedTest
 
     public static Stream<Arguments> invalidTestData()
     {
-        ArrayList<Arguments> data = new ArrayList<>();
-        data.add(Arguments.of("Name=xx%zzyy", UTF_8, IllegalArgumentException.class));
-        // data.add(Arguments.of("Name=%FF%FF%FF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        // data.add(Arguments.of("Name=%EF%EF%EF", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        data.add(Arguments.of("Name=%E%F%F", UTF_8, IllegalArgumentException.class));
-        data.add(Arguments.of("Name=x%", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        data.add(Arguments.of("Name=x%2", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        data.add(Arguments.of("Name=xxx%", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        // data.add(Arguments.of("name=X%c0%afZ", UTF_8, Utf8Appendable.NotUtf8Exception.class));
-        return data.stream();
+        return List.of(
+            "Name=xx%zzyy",
+            "Name=%E%F%F",
+            "Name=x%",
+            "Name=%x",
+            "Name=x%2",
+            "Name=xxx%").stream().map(Arguments::of);
     }
 
     @ParameterizedTest
     @MethodSource("invalidTestData")
-    public void testInvalidDecode(String inputString, Charset charset, Class<? extends Throwable> expectedThrowable)
+    public void testInvalidDecode(String inputString)
     {
-        assertThrows(expectedThrowable, () ->
+        assertThrows(IllegalArgumentException.class, () ->
         {
-            UrlEncoded.decodeTo(inputString, new MultiMap<>(), charset);
+            UrlEncoded.decodeTo(inputString, new MultiMap<>(), UTF_8);
         });
     }
 
     @ParameterizedTest
     @MethodSource("invalidTestData")
-    public void testInvalidDecodeUtf8ToMap(String inputString, Charset charset, Class<? extends Throwable> expectedThrowable)
+    public void testInvalidDecodeUtf8ToMap(String inputString)
     {
-        assertThrows(expectedThrowable, () ->
+        assertThrows(IllegalArgumentException.class, () ->
         {
             MultiMap<String> map = new MultiMap<>();
             UrlEncoded.decodeUtf8To(inputString, map);
@@ -294,12 +291,12 @@ public class URLEncodedTest
 
     @ParameterizedTest
     @MethodSource("invalidTestData")
-    public void testInvalidDecodeTo(String inputString, Charset charset, Class<? extends Throwable> expectedThrowable)
+    public void testInvalidDecodeTo(String inputString)
     {
-        assertThrows(expectedThrowable, () ->
+        assertThrows(IllegalArgumentException.class, () ->
         {
             MultiMap<String> map = new MultiMap<>();
-            UrlEncoded.decodeTo(inputString, map, charset);
+            UrlEncoded.decodeTo(inputString, map, UTF_8);
         });
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class UrlEncodedUtf8Test
 {
@@ -32,12 +31,12 @@ public class UrlEncodedUtf8Test
     @Test
     public void testIncompleteSequestAtTheEnd() throws Exception
     {
-        byte[] bytes = {97, 98, 61, 99, -50};
+        byte[] bytes = {'a', 'b', '=', 'c', -50};
         String test = new String(bytes, StandardCharsets.UTF_8);
         String expected = "c" + Utf8Appendable.REPLACEMENT;
 
-        fromString(test, test, "ab", expected, false);
-        fromInputStream(test, bytes, "ab", expected, false);
+        fromString(test, test, "ab", expected);
+        fromInputStream(test, bytes, "ab", expected);
     }
 
     @Test
@@ -47,8 +46,8 @@ public class UrlEncodedUtf8Test
         String test = new String(bytes, StandardCharsets.UTF_8);
         String expected = "" + Utf8Appendable.REPLACEMENT;
 
-        fromString(test, test, "ab", expected, false);
-        fromInputStream(test, bytes, "ab", expected, false);
+        fromString(test, test, "ab", expected);
+        fromInputStream(test, bytes, "ab", expected);
     }
 
     @Test
@@ -59,8 +58,8 @@ public class UrlEncodedUtf8Test
         String name = "e" + Utf8Appendable.REPLACEMENT;
         String value = "fg";
 
-        fromString(test, test, name, value, false);
-        fromInputStream(test, bytes, name, value, false);
+        fromString(test, test, name, value);
+        fromInputStream(test, bytes, name, value);
     }
 
     @Test
@@ -71,46 +70,22 @@ public class UrlEncodedUtf8Test
         String name = "ef";
         String value = "g" + Utf8Appendable.REPLACEMENT;
 
-        fromString(test, test, name, value, false);
-        fromInputStream(test, bytes, name, value, false);
+        fromString(test, test, name, value);
+        fromInputStream(test, bytes, name, value);
     }
 
-    // TODO: Split thrown/not-thrown
-    static void fromString(String test, String s, String field, String expected, boolean thrown) throws Exception
+    static void fromString(String test, String s, String field, String expected) throws Exception
     {
         MultiMap<String> values = new MultiMap<>();
-        try
-        {
-            UrlEncoded.decodeUtf8To(s, 0, s.length(), values);
-            if (thrown)
-                fail("Expected an exception");
-            assertThat(test, values.getString(field), is(expected));
-        }
-        catch (Exception e)
-        {
-            if (!thrown)
-                throw e;
-            LOG.trace("IGNORED", e);
-        }
+        UrlEncoded.decodeUtf8To(s, 0, s.length(), values);
+        assertThat(test, values.getString(field), is(expected));
     }
 
-    // TODO: Split thrown/not-thrown
-    static void fromInputStream(String test, byte[] b, String field, String expected, boolean thrown) throws Exception
+    static void fromInputStream(String test, byte[] b, String field, String expected) throws Exception
     {
         InputStream is = new ByteArrayInputStream(b);
         MultiMap<String> values = new MultiMap<>();
-        try
-        {
-            UrlEncoded.decodeUtf8To(is, values, 1000000, -1);
-            if (thrown)
-                fail("Expected an exception");
-            assertThat(test, values.getString(field), is(expected));
-        }
-        catch (Exception e)
-        {
-            if (!thrown)
-                throw e;
-            LOG.trace("IGNORED", e);
-        }
+        UrlEncoded.decodeUtf8To(is, values, 1000000, -1);
+        assertThat(test, values.getString(field), is(expected));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
@@ -70,12 +70,11 @@ public class Utf8AppendableTest
     {
         assertThrows(IllegalArgumentException.class, () ->
         {
-            String source = "abc\u10fb";
-            byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+            byte[] bytes = StringUtil.fromHexString("61626310FB");
             Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
-            for (int i = 0; i < bytes.length - 1; i++)
+            for (byte b: bytes)
             {
-                buffer.append(bytes[i]);
+                buffer.append(b);
             }
             buffer.getString(true, NOT_UTF8);
         });
@@ -87,11 +86,7 @@ public class Utf8AppendableTest
     {
         assertThrows(Utf8Appendable.NotUtf8Exception.class, () ->
         {
-            String source = "abcXX";
-            byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
-            bytes[3] = (byte)0xc0;
-            bytes[4] = (byte)0x00;
-
+            byte[] bytes = StringUtil.fromHexString("616263C000");
             Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
             for (byte aByte : bytes)
             {
@@ -263,9 +258,11 @@ public class Utf8AppendableTest
 
         utf8.append(BufferUtil.toBuffer(seq1, StandardCharsets.UTF_8));
         String ret1 = utf8.getString(false);
+        utf8.clear();
 
         utf8.append(BufferUtil.toBuffer(seq2, StandardCharsets.UTF_8));
         String ret2 = utf8.getString(false);
+        utf8.clear();
 
         assertThat("Seq1", ret1, is(seq1));
         assertThat("Seq2", ret2, is(seq2));
@@ -282,6 +279,7 @@ public class Utf8AppendableTest
 
         utf8.append(StringUtil.fromHexString(seq1));
         String ret1 = utf8.getString(false);
+        utf8.clear();
 
         utf8.append(StringUtil.fromHexString(seq2));
         String ret2 = utf8.getString(false);
@@ -301,7 +299,9 @@ public class Utf8AppendableTest
 
         utf8.append(StringUtil.fromHexString(seq1));
         String ret1 = utf8.getString(false);
+        utf8.clear();
         String ret2 = utf8.getString(false);
+        utf8.clear();
         utf8.append(StringUtil.fromHexString(seq2));
         String ret3 = utf8.getString(false);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
@@ -13,16 +13,18 @@
 
 package org.eclipse.jetty.util;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.eclipse.jetty.util.Utf8Appendable.NotUtf8Exception;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,31 +34,26 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class Utf8AppendableTest
 {
-    public static final List<Class<? extends Utf8Appendable>> APPENDABLE_IMPLS;
-
-    static
+    public static Stream<Arguments> defaultImplementations()
     {
-        APPENDABLE_IMPLS = new ArrayList<>();
-        APPENDABLE_IMPLS.add(Utf8StringBuilder.class);
-        APPENDABLE_IMPLS.add(Utf8StringBuffer.class);
-    }
-
-    public static Stream<Arguments> implementations()
-    {
-        return APPENDABLE_IMPLS.stream().map(Arguments::of);
+        return Stream.of(
+            Arguments.of(Utf8StringBuilder.class),
+            Arguments.of(Utf8StringBuffer.class)
+        );
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testUtf(Class<Utf8Appendable> impl) throws Exception
     {
         String source = "abcd012345\n\r\u0000\u00a4\u10fb\ufffdjetty";
         byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+        System.err.println("bytes = " + StringUtil.toHexString(bytes));
         Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
         for (byte aByte : bytes)
         {
@@ -67,7 +64,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testUtf8WithMissingByte(Class<Utf8Appendable> impl) throws Exception
     {
         assertThrows(IllegalArgumentException.class, () ->
@@ -79,12 +76,13 @@ public class Utf8AppendableTest
             {
                 buffer.append(bytes[i]);
             }
+            buffer.checkState();
             buffer.toString();
         });
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testUtf8WithAdditionalByte(Class<Utf8Appendable> impl) throws Exception
     {
         assertThrows(Utf8Appendable.NotUtf8Exception.class, () ->
@@ -103,7 +101,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testUTF32codes(Class<Utf8Appendable> impl) throws Exception
     {
         String source = "\uD842\uDF9F";
@@ -119,7 +117,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testGermanUmlauts(Class<Utf8Appendable> impl) throws Exception
     {
         byte[] bytes = new byte[6];
@@ -139,8 +137,32 @@ public class Utf8AppendableTest
         assertEquals("\u00FC\u00F6\u00E4", buffer.toString());
     }
 
+    /**
+     * Test of ARABIC LETTER TEH MARBUTA.
+     * (hex code point 0629, decimal code point 1577, hex utf-8 bytes D8 A9)
+     * (bidi note, this is a right to left character as well)
+     */
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
+    public void testArabicTehMarbuta(Class<Utf8Appendable> impl) throws Exception
+    {
+        byte[] bytes = new byte[4];
+        bytes[0] = (byte)0xD8;
+        bytes[1] = (byte)0xA9;
+        bytes[2] = (byte)0xD8;
+        bytes[3] = (byte)0xA9;
+
+        Utf8Appendable buffer = impl.getDeclaredConstructor().newInstance();
+        for (int i = 0; i < bytes.length; i++)
+        {
+            buffer.append(bytes[i]);
+        }
+
+        assertEquals("ةة", buffer.toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("defaultImplementations")
     public void testInvalidUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException
     {
         assertThrows(Utf8Appendable.NotUtf8Exception.class, () ->
@@ -152,7 +174,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testInvalidZeroUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException
     {
         // From https://datatracker.ietf.org/doc/html/rfc3629#section-10
@@ -165,7 +187,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testInvalidAlternateDotEncodingUTF8(Class<Utf8Appendable> impl) throws UnsupportedEncodingException
     {
         // From https://datatracker.ietf.org/doc/html/rfc3629#section-10
@@ -181,7 +203,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testFastFail1(Class<Utf8Appendable> impl) throws Exception
     {
         byte[] part1 = TypeUtil.fromHexString("cebae1bdb9cf83cebcceb5");
@@ -201,7 +223,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testFastFail2(Class<Utf8Appendable> impl) throws Exception
     {
         byte[] part1 = TypeUtil.fromHexString("cebae1bdb9cf83cebcceb5f4");
@@ -221,7 +243,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testPartialUnsplitCodepoint(Class<Utf8Appendable> impl) throws Exception
     {
         Utf8Appendable utf8 = impl.getDeclaredConstructor().newInstance();
@@ -240,7 +262,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testPartialSplitCodepoint(Class<Utf8Appendable> impl) throws Exception
     {
         Utf8Appendable utf8 = impl.getDeclaredConstructor().newInstance();
@@ -259,7 +281,7 @@ public class Utf8AppendableTest
     }
 
     @ParameterizedTest
-    @MethodSource("implementations")
+    @MethodSource("defaultImplementations")
     public void testPartialSplitCodepointWithNoBuf(Class<Utf8Appendable> impl) throws Exception
     {
         Utf8Appendable utf8 = impl.getDeclaredConstructor().newInstance();
@@ -278,40 +300,93 @@ public class Utf8AppendableTest
         assertThat("Seq3", ret3, is("\uC3A4\uC3BC\uC3A0\uC3A1-UTF-8!!"));
     }
 
-    @TestFactory
-    public Iterator<DynamicTest> testBadUtf8()
+    public static Stream<Arguments> appendWithReplacementSource()
     {
-        String[] samples = new String[]{
-            "c0af",
-            "EDA080",
-            "f08080af",
-            "f8808080af",
-            "e080af",
-            "F4908080",
-            "fbbfbfbfbf",
-            "10FFFF",
-            "CeBaE1BdB9Cf83CeBcCeB5EdA080656469746564",
-            // use of UTF-16 High Surrogates (in codepoint form)
-            "da07",
-            "d807",
-            // decoded UTF-16 High Surrogate "\ud807" (in UTF-8 form)
-            "EDA087"
-        };
+        List<Arguments> sources = new ArrayList<>();
 
-        List<DynamicTest> tests = new ArrayList<>();
+        boolean matchJavaBehavior = true;
 
-        for (Class<? extends Utf8Appendable> impl : APPENDABLE_IMPLS)
+        sources.add(Arguments.of("00", "\u0000", matchJavaBehavior)); // null control char
+        sources.add(Arguments.of("E282AC", "€", matchJavaBehavior)); // euro symbol
+        sources.add(Arguments.of("EFBFBD", "�", matchJavaBehavior)); // the replacement character itself
+        // "overlong" UTF-8 sequences - (the utf-8 codepage specifies that C0/C1 should be rejected for "overlong" encoding)
+        // "hi" (ascii) is bytes 0x68 0x69, which can be represented in overlong encoding of
+        // C1 (11000001) + A8 (10101000) = 'h'
+        // C1 (11000001) + A9 (10101001) = 'i'
+        sources.add(Arguments.of("C1A8C1A9", "����", matchJavaBehavior));
+        // "()" (ascii) is bytes 0x28 0x29, which can be represented in overlong encoding of
+        // C0 (11000001) + A8 (10101000) = '('
+        // C0 (11000001) + A9 (10101001) = ')'
+        sources.add(Arguments.of("C0A8C0A9", "����", matchJavaBehavior));
+        // the following expected results are gathered from URI.create(input).getPath()
+        // which is consistent with StandardCharsets.UTF_8.newDecoder().onMalformed(REPLACE).decode()
+        sources.add(Arguments.of("D8002F", "�\u0000/", matchJavaBehavior));
+        sources.add(Arguments.of("D82F", "�/", matchJavaBehavior)); // incomplete sequence followed by normal char
+        sources.add(Arguments.of("C328", "�(", matchJavaBehavior)); // incomplete sequence followed by normal char
+        sources.add(Arguments.of("A0A1", "��", matchJavaBehavior)); // invalid 2 octet sequence
+        sources.add(Arguments.of("E228A1", "�(�", matchJavaBehavior)); // incomplete + normal + incomplete
+        sources.add(Arguments.of("E28228", "�(", matchJavaBehavior));  // invalid 3 octet sequence
+        sources.add(Arguments.of("F0288CBC", "�(��", matchJavaBehavior)); // invalid 4 octet sequence
+        sources.add(Arguments.of("F09028BC", "�(�", matchJavaBehavior)); // invalid 4 octet sequence
+        sources.add(Arguments.of("F0288C28", "�(�(", matchJavaBehavior));  // invalid 4 octet sequence
+        sources.add(Arguments.of("F8A1A1A1A1", "�����", matchJavaBehavior));  // valid sequence, but not unicode
+        sources.add(Arguments.of("FCA1A1A1A1A1", "������", matchJavaBehavior));  // valid sequence, but not unicode
+        sources.add(Arguments.of("F8A1A1A1", "����", matchJavaBehavior)); // F8 codepage not supported
+        sources.add(Arguments.of("C0AF", "��", matchJavaBehavior));
+        sources.add(Arguments.of("F08080AF", "����", matchJavaBehavior));
+        sources.add(Arguments.of("FFFFFF", "���", matchJavaBehavior)); // FF codepage never assigned meaning in utf-8
+        sources.add(Arguments.of("f8808080af", "�����", matchJavaBehavior)); // F8 codepage not supported
+        sources.add(Arguments.of("e080af", "���", matchJavaBehavior));
+        sources.add(Arguments.of("F4908080", "����", matchJavaBehavior));
+        sources.add(Arguments.of("fbbfbfbfbf", "�����", matchJavaBehavior)); // FB codepage not supported
+        sources.add(Arguments.of("10FFFF", "\u0010��", matchJavaBehavior));
+        // use of UTF-16 High Surrogates (in codepoint form)
+        sources.add(Arguments.of("da07", "�\u0007", matchJavaBehavior));
+        sources.add(Arguments.of("d807", "�\u0007", matchJavaBehavior));
+
+        // The following are outliers, and produce extra replacement characters when
+        // compared the Java replacement character behaviors.
+        sources.add(Arguments.of("EDA080", "���", !matchJavaBehavior));
+        sources.add(Arguments.of("CeBaE1BdB9Cf83CeBcCeB5EdA080656469746564", "κόσμε���edited", !matchJavaBehavior));
+        // decoded UTF-16 High Surrogate "\ud807" (in UTF-8 form)
+        sources.add(Arguments.of("EDA087", "���", !matchJavaBehavior));
+        return sources.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendWithReplacementSource")
+    public void testBadUtf8(String inputHex, String expectedResult, boolean compareWithJavaCharsetDecoder)
+    {
+        byte[] inputBytes = StringUtil.fromHexString(inputHex);
+        if (compareWithJavaCharsetDecoder)
         {
-            for (String hex : samples)
+            CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder();
+            utf8Decoder.onMalformedInput(CodingErrorAction.REPLACE);
+            try
             {
-                tests.add(dynamicTest(impl.getSimpleName() + " : " + hex, () ->
-                {
-                    Utf8Appendable utf8 = impl.getDeclaredConstructor().newInstance();
-                    assertThrows(NotUtf8Exception.class, () -> utf8.append(TypeUtil.fromHexString(hex)));
-                }));
+                CharBuffer charBuffer = utf8Decoder.decode(ByteBuffer.wrap(inputBytes));
+                String charsetDecoderResult = charBuffer.toString();
+                assertThat("CharsetDecoder result", charsetDecoderResult, is(expectedResult));
+            }
+            catch (CharacterCodingException e)
+            {
+                fail("Should not have thrown while in REPLACE mode", e);
             }
         }
 
-        return tests.iterator();
+        Utf8StringBuilder utf8Builder = new Utf8StringBuilder(20, CodingErrorAction.REPLACE);
+        for (byte b: inputBytes)
+        {
+            try
+            {
+                utf8Builder.appendByte(b);
+            }
+            catch (IOException e)
+            {
+                fail("Should not have thrown while in REPLACE mode", e);
+            }
+        }
+        String ourResult = utf8Builder.toReplacedString();
+        assertThat("Utf8Appendable with REPLACE mode", ourResult, is(expectedResult));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.eclipse.jetty.util.Utf8Appendable.NOT_UTF8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,8 +77,7 @@ public class Utf8AppendableTest
             {
                 buffer.append(bytes[i]);
             }
-            buffer.finish();
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -98,7 +98,7 @@ public class Utf8AppendableTest
                 buffer.append(aByte);
             }
 
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -173,7 +173,7 @@ public class Utf8AppendableTest
             buffer.append((byte)0xC2);
             buffer.append((byte)0xC2);
 
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -188,7 +188,7 @@ public class Utf8AppendableTest
             buffer.append((byte)0xC0);
             buffer.append((byte)0x80);
 
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -206,7 +206,7 @@ public class Utf8AppendableTest
             buffer.append((byte)0x2e);
             buffer.append((byte)0x2f);
 
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -227,7 +227,7 @@ public class Utf8AppendableTest
         {
             // Part 2 is invalid
             buffer.append(part2, 0, part2.length);
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -248,7 +248,7 @@ public class Utf8AppendableTest
         {
             // Part 2 is invalid
             buffer.append(part2, 0, part2.length);
-            buffer.getString(true);
+            buffer.getString(true, NOT_UTF8);
         });
     }
 
@@ -262,10 +262,10 @@ public class Utf8AppendableTest
         String seq2 = "\uC3BC\uC3A0\uC3A1-UTF-8!!";
 
         utf8.append(BufferUtil.toBuffer(seq1, StandardCharsets.UTF_8));
-        String ret1 = utf8.takePartialString();
+        String ret1 = utf8.getString(false);
 
         utf8.append(BufferUtil.toBuffer(seq2, StandardCharsets.UTF_8));
-        String ret2 = utf8.takePartialString();
+        String ret2 = utf8.getString(false);
 
         assertThat("Seq1", ret1, is(seq1));
         assertThat("Seq2", ret2, is(seq2));
@@ -281,10 +281,10 @@ public class Utf8AppendableTest
         String seq2 = "A4EC8EBCEC8EA0EC8EA12D5554462D382121";
 
         utf8.append(StringUtil.fromHexString(seq1));
-        String ret1 = utf8.takePartialString();
+        String ret1 = utf8.getString(false);
 
         utf8.append(StringUtil.fromHexString(seq2));
-        String ret2 = utf8.takePartialString();
+        String ret2 = utf8.getString(false);
 
         assertThat("Seq1", ret1, is("Hello-\uC2B5@\uC39F"));
         assertThat("Seq2", ret2, is("\uC3A4\uC3BC\uC3A0\uC3A1-UTF-8!!"));
@@ -300,10 +300,10 @@ public class Utf8AppendableTest
         String seq2 = "A4EC8EBCEC8EA0EC8EA12D5554462D382121";
 
         utf8.append(StringUtil.fromHexString(seq1));
-        String ret1 = utf8.takePartialString();
-        String ret2 = utf8.takePartialString();
+        String ret1 = utf8.getString(false);
+        String ret2 = utf8.getString(false);
         utf8.append(StringUtil.fromHexString(seq2));
-        String ret3 = utf8.takePartialString();
+        String ret3 = utf8.getString(false);
 
         assertThat("Seq1", ret1, is("Hello-\uC2B5@\uC39F"));
         assertThat("Seq2", ret2, is(""));

--- a/jetty-core/jetty-util/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-util/src/test/resources/jetty-logging.properties
@@ -1,4 +1,5 @@
 #org.eclipse.jetty.util.LEVEL=DEBUG
+#org.eclipse.jetty.util.Utf8Appendable.LEVEL=DEBUG
 #org.eclipse.jetty.util.PathWatcher.LEVEL=DEBUG
 #org.eclipse.jetty.util.thread.QueuedThreadPool.LEVEL=DEBUG
 #org.eclipse.jetty.util.thread.ReservedThreadExecutor.LEVEL=DEBUG

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -173,7 +173,7 @@ public class CloseStatus
                     Utf8StringBuilder utf = new Utf8StringBuilder();
                     // if this throws, we know we have bad UTF8
                     utf.append(reasonBytes, 0, reasonBytes.length);
-                    String reason = utf.toString();
+                    String reason = utf.takeFinishedString(true);
 
                     this.code = statusCode;
                     this.reason = reason;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/CloseStatus.java
@@ -18,7 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Utf8Appendable;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.exception.ProtocolException;
@@ -168,21 +167,14 @@ public class CloseStatus
                 data.get(reasonBytes, 0, len);
 
                 // Spec Requirement : throw BadPayloadException on invalid UTF8
-                try
-                {
-                    Utf8StringBuilder utf = new Utf8StringBuilder();
-                    // if this throws, we know we have bad UTF8
-                    utf.append(reasonBytes, 0, reasonBytes.length);
-                    String reason = utf.takeFinishedString(true);
+                Utf8StringBuilder utf = new Utf8StringBuilder();
+                // if this throws, we know we have bad UTF8
+                utf.append(reasonBytes, 0, reasonBytes.length);
+                String reason = utf.getString(true, () -> new BadPayloadException("Invalid CLOSE Reason: Bad UTF-8"));
 
-                    this.code = statusCode;
-                    this.reason = reason;
-                    return;
-                }
-                catch (Utf8Appendable.NotUtf8Exception e)
-                {
-                    throw new BadPayloadException("Invalid CLOSE Reason", e);
-                }
+                this.code = statusCode;
+                this.reason = reason;
+                return;
             }
         }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
@@ -207,7 +207,6 @@ public class MessageHandler implements FrameHandler
 
             if (frame.isFin())
             {
-                textBuffer.finish();
                 onText(textBuffer.getString(true, () -> new BadPayloadException("Invalid UTF-8")), callback);
                 textBuffer.reset();
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
@@ -20,7 +20,6 @@ import java.util.function.Consumer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingNestedCallback;
-import org.eclipse.jetty.util.Utf8Appendable;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.CoreSession;
@@ -209,7 +208,7 @@ public class MessageHandler implements FrameHandler
             if (frame.isFin())
             {
                 textBuffer.finish();
-                onText(textBuffer.takeFinishedString(true), callback);
+                onText(textBuffer.getString(true, () -> new BadPayloadException("Invalid UTF-8")), callback);
                 textBuffer.reset();
             }
             else
@@ -220,10 +219,6 @@ public class MessageHandler implements FrameHandler
         catch (BadPayloadException e)
         {
             callback.failed(e);
-        }
-        catch (Utf8Appendable.NotUtf8Exception e)
-        {
-            callback.failed(new BadPayloadException(e));
         }
         catch (Throwable t)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/MessageHandler.java
@@ -202,17 +202,24 @@ public class MessageHandler implements FrameHandler
                     throw new MessageTooLargeException("Message larger than " + maxSize + " bytes");
 
                 textBuffer.append(frame.getPayload());
+                if (textBuffer.hasReplacements())
+                    throw new BadPayloadException("Invalid UTF-8 sequence");
             }
 
             if (frame.isFin())
             {
-                onText(textBuffer.toString(), callback);
+                textBuffer.finish();
+                onText(textBuffer.takeFinishedString(true), callback);
                 textBuffer.reset();
             }
             else
             {
                 callback.succeeded();
             }
+        }
+        catch (BadPayloadException e)
+        {
+            callback.failed(e);
         }
         catch (Utf8Appendable.NotUtf8Exception e)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/NullAppendable.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/NullAppendable.java
@@ -48,6 +48,12 @@ public class NullAppendable extends Utf8Appendable
     }
 
     @Override
+    public void clear()
+    {
+        // do nothing
+    }
+
+    @Override
     public String getPartialString()
     {
         return null;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/NullAppendable.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/NullAppendable.java
@@ -54,12 +54,6 @@ public class NullAppendable extends Utf8Appendable
     }
 
     @Override
-    public String getPartialString()
-    {
-        return null;
-    }
-
-    @Override
     public String takeString()
     {
         return null;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ValidationExtension.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/ValidationExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.websocket.core.internal;
 import java.util.Map;
 
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Utf8Appendable;
 import org.eclipse.jetty.websocket.core.AbstractExtension;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
 import org.eclipse.jetty.websocket.core.Frame;
@@ -137,7 +138,11 @@ public class ValidationExtension extends AbstractExtension
                     appendable.append(frame.getPayload().slice());
 
                 if (frame.isFin())
-                    appendable.checkState();
+                {
+                    appendable.finish();
+                    if (appendable.hasReplacements())
+                        throw new Utf8Appendable.NotUtf8Exception("Invalid UTF-8 encountered");
+                }
             }
         }
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
@@ -42,7 +42,6 @@ public class PartialStringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                out.finish();
                 methodHandle.invoke(out.getString(true), true);
                 out = null;
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
@@ -42,12 +42,14 @@ public class PartialStringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                methodHandle.invoke(out.toString(), true);
+                out.finish();
+                methodHandle.invoke(out.getString(true), true);
                 out = null;
             }
             else
             {
-                methodHandle.invoke(out.takePartialString(), false);
+                methodHandle.invoke(out.getString(true), false);
+                out.clear();
             }
 
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/PartialStringMessageSink.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 
 public class PartialStringMessageSink extends AbstractMessageSink
 {
@@ -42,12 +43,12 @@ public class PartialStringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                methodHandle.invoke(out.getString(true), true);
+                methodHandle.invoke(out.getString(true, () -> new BadPayloadException("Not UTF-8")), true);
                 out = null;
             }
             else
             {
-                methodHandle.invoke(out.getString(true), false);
+                methodHandle.invoke(out.getString(false, () -> new BadPayloadException("Not UTF-8")), false);
                 out.clear();
             }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
@@ -50,7 +50,9 @@ public class StringMessageSink extends AbstractMessageSink
 
             out.append(frame.getPayload());
             if (frame.isFin())
-                methodHandle.invoke(out.toString());
+            {
+                methodHandle.invoke(out.takeFinishedString(true));
+            }
 
             callback.succeeded();
             session.demand(1);

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
@@ -21,6 +21,8 @@ import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
 
+import static org.eclipse.jetty.util.Utf8Appendable.NOT_UTF8;
+
 public class StringMessageSink extends AbstractMessageSink
 {
     private Utf8StringBuilder out;
@@ -51,7 +53,7 @@ public class StringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                methodHandle.invoke(out.takeFinishedString(true));
+                methodHandle.invoke(out.getString(true, NOT_UTF8));
             }
 
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/StringMessageSink.java
@@ -19,9 +19,8 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
-
-import static org.eclipse.jetty.util.Utf8Appendable.NOT_UTF8;
 
 public class StringMessageSink extends AbstractMessageSink
 {
@@ -53,7 +52,7 @@ public class StringMessageSink extends AbstractMessageSink
             out.append(frame.getPayload());
             if (frame.isFin())
             {
-                methodHandle.invoke(out.getString(true, NOT_UTF8));
+                methodHandle.invoke(out.getString(true, () -> new BadPayloadException("Not valid UTF-8")));
             }
 
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/MessageWriterTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/MessageWriterTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.messages.MessageWriter;
 import org.junit.jupiter.api.Test;
 
@@ -234,7 +235,7 @@ public class MessageWriterTest
 
             if (frame.isFin())
             {
-                messages.offer(activeMessage.takeFinishedString(true));
+                messages.offer(activeMessage.getString(true, () -> new BadPayloadException("Not UTF-8")));
                 activeMessage = null;
             }
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/MessageWriterTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/MessageWriterTest.java
@@ -234,7 +234,7 @@ public class MessageWriterTest
 
             if (frame.isFin())
             {
-                messages.offer(activeMessage.toString());
+                messages.offer(activeMessage.takeFinishedString(true));
                 activeMessage = null;
             }
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/PartialStringMessageSinkTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/PartialStringMessageSinkTest.java
@@ -25,10 +25,10 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.FutureCallback;
-import org.eclipse.jetty.util.Utf8Appendable;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.messages.PartialStringMessageSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +95,7 @@ public class PartialStringMessageSinkTest
 
         // Callback should fail and we don't receive the message in the sink.
         RuntimeException error = assertThrows(RuntimeException.class, () -> callback.block(5, TimeUnit.SECONDS));
-        assertThat(error.getCause(), instanceOf(Utf8Appendable.NotUtf8Exception.class));
+        assertThat(error.getCause(), instanceOf(BadPayloadException.class));
         List<String> message = Objects.requireNonNull(endpoint.messages.poll(5, TimeUnit.SECONDS));
         assertTrue(message.isEmpty());
     }
@@ -115,7 +115,7 @@ public class PartialStringMessageSinkTest
 
         // Callback should fail and we only received the first frame which had no full character.
         RuntimeException error = assertThrows(RuntimeException.class, () -> continuationCallback.block(5, TimeUnit.SECONDS));
-        assertThat(error.getCause(), instanceOf(Utf8Appendable.NotUtf8Exception.class));
+        assertThat(error.getCause(), instanceOf(BadPayloadException.class));
         List<String> message = Objects.requireNonNull(endpoint.messages.poll(5, TimeUnit.SECONDS));
         assertThat(message.size(), is(1));
         assertThat(message.get(0), is(""));

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/StringMessageSinkTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/util/StringMessageSinkTest.java
@@ -22,10 +22,10 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.FutureCallback;
-import org.eclipse.jetty.util.Utf8Appendable;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
 import org.eclipse.jetty.websocket.core.messages.StringMessageSink;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,7 @@ public class StringMessageSinkTest
 
         // Callback should fail and we don't receive the message in the sink.
         RuntimeException error = assertThrows(RuntimeException.class, () -> callback.block(5, TimeUnit.SECONDS));
-        assertThat(error.getCause(), instanceOf(Utf8Appendable.NotUtf8Exception.class));
+        assertThat(error.getCause(), instanceOf(BadPayloadException.class));
         assertNull(endpoint.messages.poll());
     }
 
@@ -119,7 +119,7 @@ public class StringMessageSinkTest
 
         // Callback should fail and we don't receive the message in the sink.
         RuntimeException error = assertThrows(RuntimeException.class, () -> continuationCallback.block(5, TimeUnit.SECONDS));
-        assertThat(error.getCause(), instanceOf(Utf8Appendable.NotUtf8Exception.class));
+        assertThat(error.getCause(), instanceOf(BadPayloadException.class));
         assertNull(endpoint.messages.poll());
     }
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/src/main/java/org/eclipse/jetty/ee10/demos/AsyncRestServlet.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/src/main/java/org/eclipse/jetty/ee10/demos/AsyncRestServlet.java
@@ -181,7 +181,7 @@ public class AsyncRestServlet extends AbstractRestServlet
         {
             // extract auctions from the results
             @SuppressWarnings("unchecked")
-            Map<String, Object> query = (Map<String, Object>)new JSON().fromJSON(_content.toString());
+            Map<String, Object> query = (Map<String, Object>)new JSON().fromJSON(_content.getString());
             Object[] auctions = (Object[])query.get("Item");
             if (auctions != null)
             {

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -1607,7 +1607,7 @@ public class AsyncMiddleManServletTest
                         {
                             builder.append(buffer);
                         }
-                        String transformed = transform(builder.toString());
+                        String transformed = transform(builder.getString());
                         output.add(ByteBuffer.wrap(transformed.getBytes(StandardCharsets.UTF_8)));
                         output.add(slice);
                     }

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ForwardProxyServerTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ForwardProxyServerTest.java
@@ -171,7 +171,7 @@ public class ForwardProxyServerTest
                             }
                             Utf8StringBuilder builder = new Utf8StringBuilder();
                             builder.append(buffer);
-                            String request = builder.toString();
+                            String request = builder.getString();
 
                             // ProxyServlet will receive an absolute URI from
                             // the client, and convert it to a relative URI.

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -329,7 +329,7 @@ public class DispatcherTest
             assertThat(rawResponse, containsString(" 500 "));
 
             rawResponse = _connector.getResponse("""
-                GET /context/forward/?echo=badclient&bad=%88%A4 HTTP/1.1\r
+                GET /context/forward/?echo=badclient&bad=%xx%zz HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
@@ -337,7 +337,7 @@ public class DispatcherTest
             assertThat(rawResponse, containsString(" 400 "));
 
             rawResponse = _connector.getResponse("""
-                GET /context/forward/params?echo=badclient&bad=%88%A4 HTTP/1.1\r
+                GET /context/forward/params?echo=badclient&bad=%xx%zz HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
@@ -345,7 +345,7 @@ public class DispatcherTest
             assertThat(rawResponse, containsString(" 400 "));
 
             rawResponse = _connector.getResponse("""
-                GET /context/forward/badparams?echo=badclientandparam&bad=%88%A4 HTTP/1.1\r
+                GET /context/forward/badparams?echo=badclientandparam&bad=%xx%zz HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
@@ -874,7 +874,7 @@ public class DispatcherTest
             if ("/params".equals(request.getPathInfo()))
                 getServletContext().getRequestDispatcher("/echo?echo=forward").forward(request, response);
             else if ("/badparams".equals(request.getPathInfo()))
-                getServletContext().getRequestDispatcher("/echo?echo=forward&fbad=%88%A4").forward(request, response);
+                getServletContext().getRequestDispatcher("/echo?echo=forward&fbad=%xx%zz").forward(request, response);
             else
                 getServletContext().getRequestDispatcher("/echo").forward(request, response);
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -388,7 +388,7 @@ public class ErrorPageTest
     {
         try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
         {
-            String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
+            String response = _connector.getResponse("GET /app?baa=%xx%zz HTTP/1.0\r\n\r\n");
             assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad Request"));
             assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
             assertThat(response, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/common/messages/MessageWriterTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/common/messages/MessageWriterTest.java
@@ -171,7 +171,7 @@ public class MessageWriterTest
 
             if (frame.isFin())
             {
-                messages.offer(activeMessage.toString());
+                messages.offer(activeMessage.getString(true));
                 activeMessage = null;
             }
             callback.succeeded();

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/src/main/java/org/eclipse/jetty/ee9/demos/AsyncRestServlet.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/src/main/java/org/eclipse/jetty/ee9/demos/AsyncRestServlet.java
@@ -181,7 +181,7 @@ public class AsyncRestServlet extends AbstractRestServlet
         {
             // extract auctions from the results
             @SuppressWarnings("unchecked")
-            Map<String, Object> query = (Map<String, Object>)new JSON().fromJSON(_content.toString());
+            Map<String, Object> query = (Map<String, Object>)new JSON().fromJSON(_content.getString());
             Object[] auctions = (Object[])query.get("Item");
             if (auctions != null)
             {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartParser.java
@@ -169,7 +169,7 @@ public class MultiPartParser
      */
     private String takeString()
     {
-        String s = _string.toString();
+        String s = _string.takeFinishedString();
         // trim trailing whitespace.
         if (s.length() > _length)
             s = s.substring(0, _length);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartParser.java
@@ -164,12 +164,12 @@ public class MultiPartParser
         _length = s.length();
     }
 
-    /*
+    /**
      * Mime Field strings are treated as UTF-8 as per https://tools.ietf.org/html/rfc7578#section-5.1
      */
     private String takeString()
     {
-        String s = _string.takeFinishedString();
+        String s = _string.getString();
         // trim trailing whitespace.
         if (s.length() > _length)
             s = s.substring(0, _length);

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpWriterTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpWriterTest.java
@@ -110,7 +110,7 @@ public class HttpWriterTest
 
         Utf8StringBuilder buf = new Utf8StringBuilder();
         buf.append(BufferUtil.toArray(_bytes), 0, _bytes.remaining());
-        assertEquals(data, buf.toString());
+        assertEquals(data, buf.getString());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -580,19 +580,18 @@ public class RequestTest
             {
                 // Should still be able to get the raw query.
                 String rawQuery = request.getQueryString();
-                return rawQuery.equals("param=aaa%E7bbb");
+                return rawQuery.equals("param=aaa%xxbbb");
             }
         };
 
         //Send a request with query string with illegal hex code to cause
         //an exception parsing the params
-        String request = "GET /?param=aaa%E7bbb HTTP/1.1\r\n" +
+        String request = "GET /?param=aaa%xxbbb HTTP/1.1\r\n" +
             "Host: whatever\r\n" +
             "Content-Type: text/html;charset=utf8\n" +
             "Connection: close\n" +
             "\n";
 
-        LOG.info("Expecting NotUtf8Exception in state 36...");
         String responses = _connector.getResponse(request);
         assertThat(responses, startsWith("HTTP/1.1 200"));
     }

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -1607,7 +1607,7 @@ public class AsyncMiddleManServletTest
                         {
                             builder.append(buffer);
                         }
-                        String transformed = transform(builder.toString());
+                        String transformed = transform(builder.takeFinishedString());
                         output.add(ByteBuffer.wrap(transformed.getBytes(StandardCharsets.UTF_8)));
                         output.add(slice);
                     }

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -1607,7 +1607,7 @@ public class AsyncMiddleManServletTest
                         {
                             builder.append(buffer);
                         }
-                        String transformed = transform(builder.takeFinishedString());
+                        String transformed = transform(builder.getString());
                         output.add(ByteBuffer.wrap(transformed.getBytes(StandardCharsets.UTF_8)));
                         output.add(slice);
                     }

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ForwardProxyServerTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ForwardProxyServerTest.java
@@ -171,7 +171,7 @@ public class ForwardProxyServerTest
                             }
                             Utf8StringBuilder builder = new Utf8StringBuilder();
                             builder.append(buffer);
-                            String request = builder.toString();
+                            String request = builder.takeFinishedString();
 
                             // ProxyServlet will receive an absolute URI from
                             // the client, and convert it to a relative URI.

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ForwardProxyServerTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ForwardProxyServerTest.java
@@ -171,7 +171,7 @@ public class ForwardProxyServerTest
                             }
                             Utf8StringBuilder builder = new Utf8StringBuilder();
                             builder.append(buffer);
-                            String request = builder.takeFinishedString();
+                            String request = builder.getString();
 
                             // ProxyServlet will receive an absolute URI from
                             // the client, and convert it to a relative URI.

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DispatcherTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DispatcherTest.java
@@ -64,14 +64,12 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -388,13 +386,13 @@ public class DispatcherTest
             response = _connector.getResponse("GET /context/forward/badparams?echo=badparams HTTP/1.0\n\n");
             assertThat(response, containsString(" 500 "));
 
-            response = _connector.getResponse("GET /context/forward/?echo=badclient&bad=%88%A4 HTTP/1.0\n\n");
+            response = _connector.getResponse("GET /context/forward/?echo=badclient&bad=%xx%zz HTTP/1.0\n\n");
             assertThat(response, containsString(" 400 "));
 
-            response = _connector.getResponse("GET /context/forward/params?echo=badclient&bad=%88%A4 HTTP/1.0\n\n");
+            response = _connector.getResponse("GET /context/forward/params?echo=badclient&bad=%xx%zz HTTP/1.0\n\n");
             assertThat(response, containsString(" 400 "));
 
-            response = _connector.getResponse("GET /context/forward/badparams?echo=badclientandparam&bad=%88%A4 HTTP/1.0\n\n");
+            response = _connector.getResponse("GET /context/forward/badparams?echo=badclientandparam&bad=%xx%zz HTTP/1.0\n\n");
             assertThat(response, containsString(" 500 "));
         }
     }
@@ -824,7 +822,7 @@ public class DispatcherTest
             if ("/params".equals(request.getPathInfo()))
                 getServletContext().getRequestDispatcher("/echo?echo=forward").forward(request, response);
             else if ("/badparams".equals(request.getPathInfo()))
-                getServletContext().getRequestDispatcher("/echo?echo=forward&fbad=%88%A4").forward(request, response);
+                getServletContext().getRequestDispatcher("/echo?echo=forward&fbad=%xx%zz").forward(request, response);
             else
                 getServletContext().getRequestDispatcher("/echo").forward(request, response);
         }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
@@ -29,7 +29,6 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -52,7 +51,6 @@ import org.eclipse.jetty.server.Server;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +62,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-//@Disabled // TODO
 public class ErrorPageTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(ErrorPageTest.class);
@@ -380,7 +377,7 @@ public class ErrorPageTest
     {
         try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
         {
-            String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
+            String response = _connector.getResponse("GET /app?baa=%xx%zz HTTP/1.0\r\n\r\n");
             assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad Request"));
             assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
             assertThat(response, Matchers.containsString("ERROR_MESSAGE: Bad query encoding"));

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/common/messages/MessageWriterTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/common/messages/MessageWriterTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.websocket.core.CoreSession;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.core.exception.BadPayloadException;
 import org.eclipse.jetty.websocket.core.messages.MessageWriter;
 import org.junit.jupiter.api.Test;
 
@@ -171,7 +172,7 @@ public class MessageWriterTest
 
             if (frame.isFin())
             {
-                messages.offer(activeMessage.takeFinishedString(true));
+                messages.offer(activeMessage.getString(true, () -> new BadPayloadException("Not UTF-8")));
                 activeMessage = null;
             }
             callback.succeeded();

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/common/messages/MessageWriterTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/common/messages/MessageWriterTest.java
@@ -171,7 +171,7 @@ public class MessageWriterTest
 
             if (frame.isFin())
             {
-                messages.offer(activeMessage.toString());
+                messages.offer(activeMessage.takeFinishedString(true));
                 activeMessage = null;
             }
             callback.succeeded();


### PR DESCRIPTION
Fixes #9489 

+ Removes ISO-8859-1 fallback behavior from URIUtil.decodePath()
+ Introduces Replacement Character behaviors to Utf8Appendable
+ New constructors for Utf8StringBuilder and Utf8StringBuffer to allow specifying malformed behavior