### PR TITLE
Issue #9497 allow jetty:effective-web-xml for jar projects

### DIFF
--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyEffectiveWebXml.java
@@ -63,12 +63,11 @@ public class JettyEffectiveWebXml extends AbstractUnassembledWebAppMojo
             }
         }
 
-        Path start = path.getName(0);
-        int count = path.getNameCount();
-        Path end = path.getName(count > 0 ? count - 1 : count);
-        //if the war is not assembled, we must configure it
-        if (start.startsWith("src") || !end.toString().endsWith(".war"))
+        
+        if ((path == null) || (path.startsWith("src") || !path.endsWith(".war")))
+        {
             super.configureUnassembledWebApp();
+        }
     }
     
     /**


### PR DESCRIPTION
Closes #9497 

Fix NPE to allow `jetty:effective-web-xml` to work with non-war projects.