### PR TITLE
Uncomment line in Symlink alias checker and add test for it.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AllowedResourceAliasChecker.java
@@ -164,7 +164,7 @@ public class AllowedResourceAliasChecker extends AbstractLifeCycle implements Al
 
     protected boolean isAllowed(Path path)
     {
-        // If the resource doesn't exist we cannot determine whether it is protected so we assume it is.
+        // If the resource doesn't exist we cannot determine whether it is protected, so we assume it is.
         if (path != null && Files.exists(path))
         {
             // Walk the path parent links looking for the base resource, but failing if any steps are protected

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SymlinkAllowedResourceAliasChecker.java
@@ -72,8 +72,7 @@ public class SymlinkAllowedResourceAliasChecker extends AllowedResourceAliasChec
                 // This allows symlinks like /other->/WEB-INF and /external->/var/lib/docroot
                 // This does not allow symlinks like /WeB-InF->/var/lib/other
                 if (Files.isSymbolicLink(fromBase))
-                    return true;
-                    // TODO: return !getContextHandler().isProtectedTarget(realURI.toString());
+                    return !getContextHandler().isProtectedTarget(realURI.toString());
 
                 // If the ancestor is not allowed then do not allow.
                 if (!isAllowed(fromBase))


### PR DESCRIPTION
This line was commented out early in the Jetty-12 development to make this compile. 
Re-add this line and add new test case for it.