### PR TITLE
fix missing request attributes when using auth-method CLIENT-CERT

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -363,7 +363,7 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
                     byte[] bytes = _sslSession.getId();
                     String idStr = StringUtil.toHexString(bytes);
 
-                    sslSessionData = new SslSessionData(idStr, keySize, certs);
+                    sslSessionData = new SslSessionData(idStr, keySize, certs, cipherSuite);
                     _sslSession.putValue(key, sslSessionData);
                 }
                 catch (Exception e)
@@ -411,7 +411,7 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
     /**
      * Simple bundle of data that is cached in the SSLSession.
      */
-    public record SslSessionData(String sessionId, int keySize, X509Certificate[] peerCertificates)
+    public record SslSessionData(String sessionId, int keySize, X509Certificate[] peerCertificates, String cipherSuite)
     {
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/authentication/SslClientCertAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/authentication/SslClientCertAuthenticator.java
@@ -72,7 +72,7 @@ public class SslClientCertAuthenticator extends LoginAuthenticator
             return Authentication.SEND_FAILURE;
         }
 
-        if(sslSessionData.cipherSuite()!=null)
+        if (sslSessionData.cipherSuite() != null)
         {
             req.setAttribute("jakarta.servlet.request.cipher_suite", sslSessionData.cipherSuite());
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/authentication/SslClientCertAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/authentication/SslClientCertAuthenticator.java
@@ -18,6 +18,7 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Objects;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee10.servlet.security.Authentication;
 import org.eclipse.jetty.ee10.servlet.security.Authentication.User;
@@ -70,15 +71,20 @@ public class SslClientCertAuthenticator extends LoginAuthenticator
             Response.writeError(req, res, callback, HttpServletResponse.SC_FORBIDDEN);
             return Authentication.SEND_FAILURE;
         }
-        
+
+        if(sslSessionData.cipherSuite()!=null)
+        {
+            req.setAttribute("jakarta.servlet.request.cipher_suite", sslSessionData.cipherSuite());
+        }
+        req.setAttribute("jakarta.servlet.request.key_size", sslSessionData.keySize());
         X509Certificate[] certs = sslSessionData.peerCertificates();
-        
+
         try
         {
             // Need certificates.
             if (certs != null && certs.length > 0)
             {
-
+                req.setAttribute("jakarta.servlet.request.X509Certificate", certs);
                 if (validateCerts)
                 {
                     sslContextFactory.validateCerts(certs);


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
