### PR TITLE
Fixing #9517 - bad url-pattern prefix match behavior

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -204,12 +204,19 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
             return exact.getPreMatched();
 
         // Try a prefix match
-        MappedResource<E> prefix = _prefixMap.getBest(path);
-        if (prefix != null)
+        if (!_prefixMap.isEmpty())
         {
-            MatchedPath matchedPath = prefix.getPathSpec().matched(path);
-            if (matchedPath != null)
-                return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
+            int i = path.length();
+            while (i >= 0)
+            {
+                MappedResource<E> candidate = _prefixMap.getBest(path, 0, i--);
+                if (candidate == null)
+                    continue;
+
+                MatchedPath matchedPath = candidate.getPathSpec().matched(path);
+                if (matchedPath != null)
+                    return new MatchedResource<>(candidate.getResource(), candidate.getPathSpec(), matchedPath);
+            }
         }
 
         // Try a suffix match
@@ -223,13 +230,13 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
             //  Loop 3: "foo"
             while ((i = path.indexOf('.', i + 1)) > 0)
             {
-                prefix = _suffixMap.get(path, i + 1, path.length() - i - 1);
-                if (prefix == null)
+                MappedResource<E> suffix = _suffixMap.get(path, i + 1, path.length() - i - 1);
+                if (suffix == null)
                     continue;
 
-                MatchedPath matchedPath = prefix.getPathSpec().matched(path);
+                MatchedPath matchedPath = suffix.getPathSpec().matched(path);
                 if (matchedPath != null)
-                    return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
+                    return new MatchedResource<>(suffix.getResource(), suffix.getPathSpec(), matchedPath);
             }
         }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -209,10 +209,11 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
         MappedResource<E> prefix = _prefixMap.getBest(path);
         while (prefix != null)
         {
-            MatchedPath matchedPath = prefix.getPathSpec().matched(path);
+            PathSpec pathSpec = prefix.getPathSpec();
+            MatchedPath matchedPath = pathSpec.matched(path);
             if (matchedPath != null)
-                return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
-            int specLength = prefix.getPathSpec().getSpecLength();
+                return new MatchedResource<>(prefix.getResource(), pathSpec, matchedPath);
+            int specLength = pathSpec.getSpecLength();
             prefix = specLength > PREFIX_TAIL_LEN ? _prefixMap.getBest(path, 0, specLength - PREFIX_TAIL_LEN) : null;
         }
 
@@ -293,11 +294,12 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
                             MappedResource<E> prefix = _prefixMap.getBest(path);
                             while (prefix != null)
                             {
-                                matchedPath = prefix.getPathSpec().matched(path);
+                                PathSpec pathSpec = prefix.getPathSpec();
+                                matchedPath = pathSpec.matched(path);
                                 if (matchedPath != null)
-                                    return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
-                                int specLength = prefix.getPathSpec().getSpecLength();
-                                prefix = specLength > 3 ? _prefixMap.getBest(path, 0, specLength - 3) : null;
+                                    return new MatchedResource<>(prefix.getResource(), pathSpec, matchedPath);
+                                int specLength = pathSpec.getSpecLength();
+                                prefix = specLength > PREFIX_TAIL_LEN ? _prefixMap.getBest(path, 0, specLength - PREFIX_TAIL_LEN) : null;
                             }
 
                             // If we reached here, there's NO optimized PREFIX Match possible, skip simple match below

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
 {
     private static final Logger LOG = LoggerFactory.getLogger(PathMappings.class);
+    // In prefix matches, this is the length ("/*".length() + 1) - used for the best prefix match loop
+    private static final int PREFIX_TAIL_LEN = 3;
     private final Set<MappedResource<E>> _mappings = new TreeSet<>(Comparator.comparing(MappedResource::getPathSpec));
 
     /**
@@ -211,7 +213,7 @@ public class PathMappings<E> implements Iterable<MappedResource<E>>, Dumpable
             if (matchedPath != null)
                 return new MatchedResource<>(prefix.getResource(), prefix.getPathSpec(), matchedPath);
             int specLength = prefix.getPathSpec().getSpecLength();
-            prefix = specLength > 3 ? _prefixMap.getBest(path, 0, specLength - 3) : null;
+            prefix = specLength > PREFIX_TAIL_LEN ? _prefixMap.getBest(path, 0, specLength - PREFIX_TAIL_LEN) : null;
         }
 
         // Try a suffix match

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -103,10 +103,10 @@ public class PathMappingsTest
         p.put(new ServletPathSpec("/*"), "any");
         p.put(new ServletPathSpec("/foo/*"), "foo");
 
-//        assertMatch(p, "/abs/path", "any");
-//        assertMatch(p, "/abs/foo/bar", "any");
-//        assertMatch(p, "/foo/bar", "foo");
-//        assertMatch(p, "/", "any");
+        assertMatch(p, "/abs/path", "any");
+        assertMatch(p, "/abs/foo/bar", "any");
+        assertMatch(p, "/foo/bar", "foo");
+        assertMatch(p, "/", "any");
         assertMatch(p, "/foobar", "any");
     }
 

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -111,7 +111,9 @@ public class PathMappingsTest
         assertMatch(p, "/foo/bar", "foo");
         assertMatch(p, "/", "any");
         assertMatch(p, "/foo", "foo");
+        assertMatch(p, "/fo", "any");
         assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/foob", "any");
         assertMatch(p, "/food", "food");
         assertMatch(p, "/food/zed", "food");
         assertMatch(p, "/foodie", "any");
@@ -127,7 +129,9 @@ public class PathMappingsTest
         assertMatch(p, "/foo/bar", "foo");
         assertMatch(p, "/", "any");
         assertMatch(p, "/foo", "foo");
+        assertMatch(p, "/fo", "any");
         assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/foob", "any");
         assertMatch(p, "/food", "food");
         assertMatch(p, "/food/zed", "food");
         assertMatch(p, "/foodie", "any");

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -102,6 +102,7 @@ public class PathMappingsTest
 
         p.put(new ServletPathSpec("/*"), "any");
         p.put(new ServletPathSpec("/foo/*"), "foo");
+        p.put(new ServletPathSpec("/food/*"), "food");
         p.put(new ServletPathSpec("/a/*"), "a");
         p.put(new ServletPathSpec("/a/b/*"), "ab");
 
@@ -109,7 +110,11 @@ public class PathMappingsTest
         assertMatch(p, "/abs/foo/bar", "any");
         assertMatch(p, "/foo/bar", "foo");
         assertMatch(p, "/", "any");
+        assertMatch(p, "/foo", "foo");
         assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/food", "food");
+        assertMatch(p, "/food/zed", "food");
+        assertMatch(p, "/foodie", "any");
         assertMatch(p, "/a/bc", "a");
         assertMatch(p, "/a/b/c", "ab");
         assertMatch(p, "/a/", "a");
@@ -121,7 +126,11 @@ public class PathMappingsTest
         assertMatch(p, "/abs/foo/bar", "any");
         assertMatch(p, "/foo/bar", "foo");
         assertMatch(p, "/", "any");
+        assertMatch(p, "/foo", "foo");
         assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/food", "food");
+        assertMatch(p, "/food/zed", "food");
+        assertMatch(p, "/foodie", "any");
         assertMatch(p, "/a/bc", "a");
         assertMatch(p, "/a/b/c", "ab");
         assertMatch(p, "/a/", "a");

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -93,6 +93,24 @@ public class PathMappingsTest
     }
 
     /**
+     * Test the match order rules imposed by the Servlet API (any vs specific sub-dir)
+     */
+    @Test
+    public void testServletMatchPrefix()
+    {
+        PathMappings<String> p = new PathMappings<>();
+
+        p.put(new ServletPathSpec("/*"), "any");
+        p.put(new ServletPathSpec("/foo/*"), "foo");
+
+//        assertMatch(p, "/abs/path", "any");
+//        assertMatch(p, "/abs/foo/bar", "any");
+//        assertMatch(p, "/foo/bar", "foo");
+//        assertMatch(p, "/", "any");
+        assertMatch(p, "/foobar", "any");
+    }
+
+    /**
      * Test the match order rules with a mixed Servlet and URI Template path specs
      *
      * <ul>

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/pathmap/PathMappingsTest.java
@@ -102,12 +102,30 @@ public class PathMappingsTest
 
         p.put(new ServletPathSpec("/*"), "any");
         p.put(new ServletPathSpec("/foo/*"), "foo");
+        p.put(new ServletPathSpec("/a/*"), "a");
+        p.put(new ServletPathSpec("/a/b/*"), "ab");
 
         assertMatch(p, "/abs/path", "any");
         assertMatch(p, "/abs/foo/bar", "any");
         assertMatch(p, "/foo/bar", "foo");
         assertMatch(p, "/", "any");
         assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/a/bc", "a");
+        assertMatch(p, "/a/b/c", "ab");
+        assertMatch(p, "/a/", "a");
+        assertMatch(p, "/a", "a");
+
+        // Try now with order important
+        p.put(new RegexPathSpec("/other.*/"), "other");
+        assertMatch(p, "/abs/path", "any");
+        assertMatch(p, "/abs/foo/bar", "any");
+        assertMatch(p, "/foo/bar", "foo");
+        assertMatch(p, "/", "any");
+        assertMatch(p, "/foobar", "any");
+        assertMatch(p, "/a/bc", "a");
+        assertMatch(p, "/a/b/c", "ab");
+        assertMatch(p, "/a/", "a");
+        assertMatch(p, "/a", "a");
     }
 
     /**


### PR DESCRIPTION
New testcase to ensure we don't have a regression on this behavior.
Restore a prefix matching loop that we previously had in Jetty 10.0.13
