### PR TITLE
Issue #9464 - Add optional configuration to log user out after OpenID idToken expires. (Jetty-10)

### DIFF
--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -38,6 +38,9 @@
         <Set name="authenticateNewUsers">
           <Property name="jetty.openid.authenticateNewUsers" default="false"/>
         </Set>
+        <Set name="respectIdTokenExpiry">
+          <Property name="jetty.openid.respectIdTokenExpiry" default="false"/>
+        </Set>
         <Call name="addScopes">
           <Arg>
             <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">

--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -38,8 +38,8 @@
         <Set name="authenticateNewUsers">
           <Property name="jetty.openid.authenticateNewUsers" default="false"/>
         </Set>
-        <Set name="respectIdTokenExpiry">
-          <Property name="jetty.openid.respectIdTokenExpiry" default="false"/>
+        <Set name="logoutWhenIdTokenIsExpired">
+          <Property name="jetty.openid.logoutWhenIdTokenIsExpired" default="false"/>
         </Set>
         <Call name="addScopes">
           <Arg>

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -45,3 +45,6 @@ etc/jetty-openid.xml
 
 ## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
 # jetty.openid.authMethod=client_secret_post
+
+## Whether the user should be logged out after the idToken expiry.
+# jetty.openid.respectIdTokenExpiry=false

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -46,5 +46,5 @@ etc/jetty-openid.xml
 ## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
 # jetty.openid.authMethod=client_secret_post
 
-## Whether the user should be logged out after the idToken expiry.
+## Whether the user should be logged out after the idToken expires.
 # jetty.openid.logoutWhenIdTokenIsExpired=false

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -47,4 +47,4 @@ etc/jetty-openid.xml
 # jetty.openid.authMethod=client_secret_post
 
 ## Whether the user should be logged out after the idToken expiry.
-# jetty.openid.respectIdTokenExpiry=false
+# jetty.openid.logoutWhenIdTokenIsExpired=false

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -464,10 +464,8 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("auth revoked {}", authentication);
-                    synchronized (session)
-                    {
-                        session.removeAttribute(SessionAuthentication.__J_AUTHENTICATED);
-                    }
+                    logout(req);
+                    return Authentication.SEND_CONTINUE;
                 }
                 else
                 {
@@ -499,10 +497,10 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                             }
                         }
                     }
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth {}", authentication);
+                    return authentication;
                 }
-                if (LOG.isDebugEnabled())
-                    LOG.debug("auth {}", authentication);
-                return authentication;
             }
 
             // If we can't send challenge.

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -402,12 +402,18 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             uri = URIUtil.SLASH;
 
         HttpSession session = request.getSession(false);
-        if (hasExpiredIdToken(session))
+        if (_openIdConfiguration.isRespectIdTokenExpiry() && hasExpiredIdToken(session))
+        {
             logoutWithoutRedirect(request);
-
-        mandatory |= isJSecurityCheck(uri);
-        if (!mandatory)
-            return new DeferredAuthentication(this);
+        }
+        else
+        {
+            // If we expired a valid authentication we do not want to defer authentication,
+            // we want to try re-authenticate the user.
+            mandatory |= isJSecurityCheck(uri);
+            if (!mandatory)
+                return new DeferredAuthentication(this);
+        }
 
         if (isErrorPage(baseRequest.getPathInContext()) && !DeferredAuthentication.isDeferred(response))
             return new DeferredAuthentication(this);

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -398,7 +398,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             uri = URIUtil.SLASH;
 
         HttpSession session = request.getSession(false);
-        if (_openIdConfiguration.isRespectIdTokenExpiry() && hasExpiredIdToken(session))
+        if (_openIdConfiguration.isLogoutWhenIdTokenIsExpired() && hasExpiredIdToken(session))
         {
             // After logout, fall through to the code below and send another login challenge.
             logoutWithoutRedirect(request);

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -55,6 +55,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     private String tokenEndpoint;
     private String endSessionEndpoint;
     private boolean authenticateNewUsers = false;
+    private boolean respectIdTokenExpiry = false;
 
     /**
      * Create an OpenID configuration for a specific OIDC provider.
@@ -273,6 +274,16 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     public void setAuthenticateNewUsers(boolean authenticateNewUsers)
     {
         this.authenticateNewUsers = authenticateNewUsers;
+    }
+
+    public boolean isRespectIdTokenExpiry()
+    {
+        return respectIdTokenExpiry;
+    }
+
+    public void setRespectIdTokenExpiry(boolean respectIdTokenExpiry)
+    {
+        this.respectIdTokenExpiry = respectIdTokenExpiry;
     }
 
     private static HttpClient newHttpClient()

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdConfiguration.java
@@ -55,7 +55,7 @@ public class OpenIdConfiguration extends ContainerLifeCycle
     private String tokenEndpoint;
     private String endSessionEndpoint;
     private boolean authenticateNewUsers = false;
-    private boolean respectIdTokenExpiry = false;
+    private boolean logoutWhenIdTokenIsExpired = false;
 
     /**
      * Create an OpenID configuration for a specific OIDC provider.
@@ -276,14 +276,14 @@ public class OpenIdConfiguration extends ContainerLifeCycle
         this.authenticateNewUsers = authenticateNewUsers;
     }
 
-    public boolean isRespectIdTokenExpiry()
+    public boolean isLogoutWhenIdTokenIsExpired()
     {
-        return respectIdTokenExpiry;
+        return logoutWhenIdTokenIsExpired;
     }
 
-    public void setRespectIdTokenExpiry(boolean respectIdTokenExpiry)
+    public void setLogoutWhenIdTokenIsExpired(boolean logoutWhenIdTokenIsExpired)
     {
-        this.respectIdTokenExpiry = respectIdTokenExpiry;
+        this.logoutWhenIdTokenIsExpired = logoutWhenIdTokenIsExpired;
     }
 
     private static HttpClient newHttpClient()

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -143,6 +143,11 @@ public class OpenIdCredentials implements Serializable
 
     public boolean isExpired()
     {
+        return checkExpiry(claims);
+    }
+
+    public static boolean checkExpiry(Map<String, Object> claims)
+    {
         if (claims == null)
             return true;
 

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.security.openid;
 
 import java.io.Serializable;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -152,9 +153,7 @@ public class OpenIdCredentials implements Serializable
             return true;
 
         // Check that the ID token has not expired by checking the exp claim.
-        long expiry = (Long)claims.get("exp");
-        long currentTimeSeconds = System.currentTimeMillis() / 1000;
-        return (currentTimeSeconds > expiry);
+        return Instant.ofEpochSecond((Long)claims.get("exp")).isBefore(Instant.now());
     }
 
     private void validateAudience(OpenIdConfiguration configuration) throws AuthenticationException

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -137,10 +137,19 @@ public class OpenIdCredentials implements Serializable
             throw new AuthenticationException("Authorized party claim value should be the client_id");
 
         // Check that the ID token has not expired by checking the exp claim.
-        long expiry = (Long)claims.get("exp");
-        long currentTimeSeconds = (long)(System.currentTimeMillis() / 1000F);
-        if (currentTimeSeconds > expiry)
+        if (isExpired())
             throw new AuthenticationException("ID Token has expired");
+    }
+
+    public boolean isExpired()
+    {
+        if (claims == null)
+            return true;
+
+        // Check that the ID token has not expired by checking the exp claim.
+        long expiry = (Long)claims.get("exp");
+        long currentTimeSeconds = System.currentTimeMillis() / 1000;
+        return (currentTimeSeconds > expiry);
     }
 
     private void validateAudience(OpenIdConfiguration configuration) throws AuthenticationException

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
@@ -137,7 +137,7 @@ public class OpenIdLoginService extends ContainerLifeCycle implements LoginServi
         if (!(user.getUserPrincipal() instanceof OpenIdUserPrincipal))
             return false;
         OpenIdUserPrincipal userPrincipal = (OpenIdUserPrincipal)user.getUserPrincipal();
-        if (userPrincipal.getCredentials().isExpired())
+        if (configuration.isRespectIdTokenExpiry() && userPrincipal.getCredentials().isExpired())
             return false;
         return loginService == null || loginService.validate(user);
     }

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
@@ -136,7 +136,9 @@ public class OpenIdLoginService extends ContainerLifeCycle implements LoginServi
     {
         if (!(user.getUserPrincipal() instanceof OpenIdUserPrincipal))
             return false;
-
+        OpenIdUserPrincipal userPrincipal = (OpenIdUserPrincipal)user.getUserPrincipal();
+        if (userPrincipal.getCredentials().isExpired())
+            return false;
         return loginService == null || loginService.validate(user);
     }
 

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdLoginService.java
@@ -137,7 +137,7 @@ public class OpenIdLoginService extends ContainerLifeCycle implements LoginServi
         if (!(user.getUserPrincipal() instanceof OpenIdUserPrincipal))
             return false;
         OpenIdUserPrincipal userPrincipal = (OpenIdUserPrincipal)user.getUserPrincipal();
-        if (configuration.isRespectIdTokenExpiry() && userPrincipal.getCredentials().isExpired())
+        if (configuration.isLogoutWhenIdTokenIsExpired() && userPrincipal.getCredentials().isExpired())
             return false;
         return loginService == null || loginService.validate(user);
     }

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -281,7 +281,7 @@ public class OpenIdAuthenticationTest
     @Test
     public void testExpiredIdToken() throws Exception
     {
-        setup(null, config -> config.setRespectIdTokenExpiry(true));
+        setup(null, config -> config.setLogoutWhenIdTokenIsExpired(true));
         long idTokenExpiryTime = 2000;
         openIdProvider.setIdTokenExpiry(idTokenExpiryTime);
         openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));
@@ -354,7 +354,7 @@ public class OpenIdAuthenticationTest
         assertThat(content, containsString("name: Alice"));
         assertThat(content, containsString("email: Alice@example.com"));
 
-        // After waiting past ID_Token expiry time we are still authenticated because respectIdTokenExpiry is false by default.
+        // After waiting past ID_Token expiry time we are still authenticated because logoutWhenIdTokenIsExpired is false by default.
         Thread.sleep(idTokenExpiryTime * 2);
         response = client.GET(appUriString + "/");
         assertThat(response.getStatus(), is(HttpStatus.OK_200));

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -283,7 +283,7 @@ public class OpenIdAuthenticationTest
     {
         setup(null, config -> config.setLogoutWhenIdTokenIsExpired(true));
         long idTokenExpiryTime = 2000;
-        openIdProvider.setIdTokenExpiry(idTokenExpiryTime);
+        openIdProvider.setIdTokenDuration(idTokenExpiryTime);
         openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));
 
         String appUriString = "http://localhost:" + connector.getLocalPort();
@@ -328,7 +328,7 @@ public class OpenIdAuthenticationTest
     {
         setup(null);
         long idTokenExpiryTime = 2000;
-        openIdProvider.setIdTokenExpiry(idTokenExpiryTime);
+        openIdProvider.setIdTokenDuration(idTokenExpiryTime);
         openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));
 
         String appUriString = "http://localhost:" + connector.getLocalPort();

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
@@ -63,7 +63,6 @@ public class OpenIdProvider extends ContainerLifeCycle
     private final CounterStatistic loggedInUsers = new CounterStatistic();
     private long _idTokenExpiry = 10000;
 
-
     public static void main(String[] args) throws Exception
     {
         String clientId = "CLIENT_ID123";

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
@@ -36,7 +36,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.slf4j.Logger;
@@ -68,7 +67,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         String clientId = "CLIENT_ID123";
         String clientSecret = "PASSWORD123";
         int port = 5771;
-        String redirectUri = "http://localhost:8080/openid/auth";
+        String redirectUri = "http://localhost:8080/j_security_check";
 
         OpenIdProvider openIdProvider = new OpenIdProvider(clientId, clientSecret);
         openIdProvider.addRedirectUri(redirectUri);
@@ -184,7 +183,7 @@ public class OpenIdProvider extends ContainerLifeCycle
             }
 
             String scopeString = req.getParameter("scope");
-            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(StringUtil.csvSplit(scopeString));
+            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(scopeString.split(" "));
             if (!scopes.contains("openid"))
             {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, "no openid scope");

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/openid/OpenIdProvider.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/openid/OpenIdProvider.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.tests.distribution.openid;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,8 +38,8 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,7 @@ public class OpenIdProvider extends ContainerLifeCycle
     private static final String CONFIG_PATH = "/.well-known/openid-configuration";
     private static final String AUTH_PATH = "/auth";
     private static final String TOKEN_PATH = "/token";
+    private static final String END_SESSION_PATH = "/end_session";
     private final Map<String, User> issuedAuthCodes = new HashMap<>();
 
     protected final String clientId;
@@ -59,13 +61,15 @@ public class OpenIdProvider extends ContainerLifeCycle
     private int port = 0;
     private String provider;
     private User preAuthedUser;
+    private final CounterStatistic loggedInUsers = new CounterStatistic();
+    private long _idTokenDuration = Duration.ofSeconds(10).toMillis();
 
     public static void main(String[] args) throws Exception
     {
         String clientId = "CLIENT_ID123";
         String clientSecret = "PASSWORD123";
         int port = 5771;
-        String redirectUri = "http://localhost:8080/openid/auth";
+        String redirectUri = "http://localhost:8080/j_security_check";
 
         OpenIdProvider openIdProvider = new OpenIdProvider(clientId, clientSecret);
         openIdProvider.addRedirectUri(redirectUri);
@@ -92,12 +96,23 @@ public class OpenIdProvider extends ContainerLifeCycle
 
         ServletContextHandler contextHandler = new ServletContextHandler();
         contextHandler.setContextPath("/");
-        contextHandler.addServlet(new ServletHolder(new OpenIdConfigServlet()), CONFIG_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdAuthEndpoint()), AUTH_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdTokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new ConfigServlet()), CONFIG_PATH);
+        contextHandler.addServlet(new ServletHolder(new AuthEndpoint()), AUTH_PATH);
+        contextHandler.addServlet(new ServletHolder(new TokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new EndSessionEndpoint()), END_SESSION_PATH);
         server.setHandler(contextHandler);
 
         addBean(server);
+    }
+
+    public void setIdTokenDuration(long duration)
+    {
+        _idTokenDuration = duration;
+    }
+
+    public long getIdTokenDuration()
+    {
+        return _idTokenDuration;
     }
 
     public void join() throws InterruptedException
@@ -111,6 +126,11 @@ public class OpenIdProvider extends ContainerLifeCycle
         String authEndpoint = provider + AUTH_PATH;
         String tokenEndpoint = provider + TOKEN_PATH;
         return new OpenIdConfiguration(provider, authEndpoint, tokenEndpoint, clientId, clientSecret, null);
+    }
+
+    public CounterStatistic getLoggedInUsers()
+    {
+        return loggedInUsers;
     }
 
     @Override
@@ -145,7 +165,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         redirectUris.add(uri);
     }
 
-    public class OpenIdAuthEndpoint extends HttpServlet
+    public class AuthEndpoint extends HttpServlet
     {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -165,7 +185,7 @@ public class OpenIdProvider extends ContainerLifeCycle
             }
 
             String scopeString = req.getParameter("scope");
-            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(StringUtil.csvSplit(scopeString));
+            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(scopeString.split(" "));
             if (!scopes.contains("openid"))
             {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, "no openid scope");
@@ -253,7 +273,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         }
     }
 
-    public class OpenIdTokenEndpoint extends HttpServlet
+    private class TokenEndpoint extends HttpServlet
     {
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
@@ -278,20 +298,53 @@ public class OpenIdProvider extends ContainerLifeCycle
             }
 
             String accessToken = "ABCDEFG";
-            long expiry = System.currentTimeMillis() + Duration.ofMinutes(10).toMillis();
+            long accessTokenDuration = Duration.ofMinutes(10).toSeconds();
             String response = "{" +
                 "\"access_token\": \"" + accessToken + "\"," +
-                "\"id_token\": \"" + JwtEncoder.encode(user.getIdToken(provider, clientId)) + "\"," +
-                "\"expires_in\": " + expiry + "," +
+                "\"id_token\": \"" + JwtEncoder.encode(user.getIdToken(provider, clientId, _idTokenDuration)) + "\"," +
+                "\"expires_in\": " + accessTokenDuration + "," +
                 "\"token_type\": \"Bearer\"" +
                 "}";
 
+            loggedInUsers.increment();
             resp.setContentType("text/plain");
             resp.getWriter().print(response);
         }
     }
 
-    public class OpenIdConfigServlet extends HttpServlet
+    private class EndSessionEndpoint extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            doPost(req, resp);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            String idToken = req.getParameter("id_token_hint");
+            if (idToken == null)
+            {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no id_token_hint");
+                return;
+            }
+
+            String logoutRedirect = req.getParameter("post_logout_redirect_uri");
+            if (logoutRedirect == null)
+            {
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.getWriter().println("logout success on end_session_endpoint");
+                return;
+            }
+
+            loggedInUsers.decrement();
+            resp.setContentType("text/plain");
+            resp.sendRedirect(logoutRedirect);
+        }
+    }
+
+    private class ConfigServlet extends HttpServlet
     {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -300,6 +353,7 @@ public class OpenIdProvider extends ContainerLifeCycle
                 "\"issuer\": \"" + provider + "\"," +
                 "\"authorization_endpoint\": \"" + provider + AUTH_PATH + "\"," +
                 "\"token_endpoint\": \"" + provider + TOKEN_PATH + "\"," +
+                "\"end_session_endpoint\": \"" + provider + END_SESSION_PATH + "\"," +
                 "}";
 
             resp.getWriter().write(discoveryDocument);
@@ -332,10 +386,24 @@ public class OpenIdProvider extends ContainerLifeCycle
             return subject;
         }
 
-        public String getIdToken(String provider, String clientId)
+        public String getIdToken(String provider, String clientId, long duration)
         {
-            long expiry = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
-            return JwtEncoder.createIdToken(provider, clientId, subject, name, expiry);
+            long expiryTime = Instant.now().plusMillis(duration).getEpochSecond();
+            return JwtEncoder.createIdToken(provider, clientId, subject, name, expiryTime);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof User))
+                return false;
+            return Objects.equals(subject, ((User)obj).subject) && Objects.equals(name, ((User)obj).name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(subject, name);
         }
     }
 }


### PR DESCRIPTION
## Issue #9464

Add new configuration parameter called `respectIdTokenExpiry` which if set to true will log the user out after the idToken has expired and attempt to redirect back to the OpenID provider to be re-authenticated.