### PR TITLE
introduce ShrinkManager

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/LinearShrinkManager.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/LinearShrinkManager.java
@@ -1,0 +1,151 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.thread;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jetty.util.NanoTime;
+
+/**
+ * <p>Encapsulates logic for shrinking {@link QueuedThreadPool}. Tracks pool-level idle baseline
+ * timestamps as a deque. Upon idle, threads push to the head of the deque by calling {@link #onIdle()},
+ * and when an idle thread becomes non-idle (i.e., runs a job), it pops from the head of the deque
+ * by calling {@link #onBusy()}.
+ *
+ * <p>Shrinking proceeds by polling the <i>tail</i> of the deque via {@link #shrinkIfNeeded(long, int)};
+ * the pool thus determines eligibility to shrink based on the longest-standing idle capacity at the pool
+ * level.
+ *
+ * <p>The repeated lifecycle methods {@link #onIdle()} and {@link #onBusy()} return <code>true</code>
+ * and <code>false</code> (respectively) as a convenience, indicating whether the calling thread is
+ * registered with this {@link LinearShrinkManager} following the associated method call. It is the
+ * responsibility of the calling thread to ensure (e.g., via conditional call to {@link #prune()}
+ * in a <code>finally</code> block) that any outstanding entries in this {@link LinearShrinkManager} are
+ * removed if the calling thread exits unexpectedly (i.e., throws an exception).
+ */
+public class LinearShrinkManager implements QueuedThreadPool.ShrinkManager
+{
+    private final int mask;
+    private final long[] timestamps;
+    private final AtomicInteger head = new AtomicInteger();
+    private final AtomicInteger tail = new AtomicInteger();
+    private final AtomicLong lastShrink = new AtomicLong();
+
+    /**
+     * This is the number of times that CaS will retry. Non-configurable default is to never retry.
+     * This variable only exists to be set in tests to achieve more precise/reliable behavior, and
+     * even at that it should only make a difference for the case where `idleTimeoutDecay > 1`, and
+     * only when there are a handful of threads -- &gt; 1 (enough to generate contention), but not
+     * so many as that another thread would simply pick up the missed CaS "reservation".
+     */
+    static int RETRY_LIMIT = 0;
+
+    public LinearShrinkManager(int maxSize)
+    {
+        // We make size a power of two for easy mask/circular operation.
+        // NOTE: it's perfectly fine for `head`/`tail` to overflow/wrap around.
+        int size = Integer.highestOneBit(maxSize + 1) << 1;
+        this.mask = size - 1;
+        this.timestamps = new long[size];
+    }
+
+    /**
+     * Called by a thread that is newly idle, either because it just completed a job, or because
+     * it has just been created. Returns <code>true</code>, indicating that an entry has been added
+     * to this {@link LinearShrinkManager} for the calling thread.
+     */
+    @Override
+    public boolean onIdle()
+    {
+        timestamps[head.getAndIncrement() & mask] = NanoTime.now();
+        return true;
+    }
+
+    /**
+     * Called by a thread just before it performs work. Returns <code>false</code>, indicating that
+     * an entry (corresponding to the calling thread) has been removed from this {@link LinearShrinkManager}.
+     */
+    @Override
+    public boolean onBusy()
+    {
+        head.getAndDecrement();
+        return false;
+    }
+
+    /**
+     * Check to see if this pool has idle capacity and is eligible to shrink. If this method returns
+     * <code>false</code>, it has no side-effects. If this method returns <code>true</code>, the
+     * {@link LinearShrinkManager} has been updated to record the removal of the thread, and it is the
+     * responsibility of the caller to ensure that exactly one corresponding thread (the calling
+     * thread) exits, <i>without</i> calling {@link #prune()}.
+     *
+     * @param itNanos time (in nanos) that pool capacity must be idle in order to be eligible to shrink
+     * @param idleTimeoutMaxShrinkCount max threads to shrink per itNanos interval
+     * @return <code>true</code> if the pool should shrink, otherwise <code>false</code>.
+     */
+    @Override
+    public boolean shrinkIfNeeded(long itNanos, int idleTimeoutMaxShrinkCount)
+    {
+        long now = NanoTime.now();
+        final long idleBaseline = timestamps[tail.getAndIncrement() & mask];
+        if (NanoTime.elapsed(idleBaseline, now) > itNanos)
+        {
+            long last = lastShrink.get();
+            int retries = 0;
+            long siNanos = itNanos / idleTimeoutMaxShrinkCount;
+            while (NanoTime.elapsed(last, now) > siNanos)
+            {
+                // shrinkInterval is satisfied
+                if (lastShrink.compareAndSet(last, Math.max(last, idleBaseline) + siNanos))
+                {
+                    // NOTE: attempted CaS may fail, _very_ infrequently. If it does, that's fine.
+                    // This is a "best effort" approach to shrinking, and even if our CaS fails,
+                    // the missed "shrink reservation" will very likely simply be picked up by
+                    // another thread.
+                    return true;
+                }
+                else if (++retries > RETRY_LIMIT)
+                {
+                    break;
+                }
+                last = lastShrink.get();
+            }
+        }
+        tail.getAndDecrement();
+        return false;
+    }
+
+    /**
+     * Must be called by any thread with an outstanding entry in this {@link LinearShrinkManager} that exits for any
+     * reason <i>other than</i> {@link #shrinkIfNeeded(long, int)} returning <code>true</code>. This method will
+     * normally not be called except (conditionally) in a <code>finally</code> block if a registered thread exits
+     * unexpectedly with an exception.
+     */
+    @Override
+    public void prune()
+    {
+        tail.getAndIncrement();
+    }
+
+    /**
+     * Initializes the baseline timestamp against which idle timestamps are compared to determine eligibility for
+     * shrinkage. This should be called to prevent premature idling of threads created early in the life of a pool.
+     */
+    @Override
+    public void init()
+    {
+        lastShrink.set(NanoTime.now());
+    }
+}

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/LinearShrinkManager.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/LinearShrinkManager.java
@@ -24,7 +24,7 @@ import org.eclipse.jetty.util.NanoTime;
  * and when an idle thread becomes non-idle (i.e., runs a job), it pops from the head of the deque
  * by calling {@link #onBusy()}.
  *
- * <p>Shrinking proceeds by polling the <i>tail</i> of the deque via {@link #shrinkIfNeeded(long, int)};
+ * <p>Shrinking proceeds by polling the <i>tail</i> of the deque via {@link #evict(long, int)};
  * the pool thus determines eligibility to shrink based on the longest-standing idle capacity at the pool
  * level.
  *
@@ -92,11 +92,11 @@ public class LinearShrinkManager implements QueuedThreadPool.ShrinkManager
      * thread) exits, <i>without</i> calling {@link #prune()}.
      *
      * @param itNanos time (in nanos) that pool capacity must be idle in order to be eligible to shrink
-     * @param idleTimeoutMaxShrinkCount max threads to shrink per itNanos interval
+     * @param maxEvictCount max threads to shrink per itNanos interval
      * @return <code>true</code> if the pool should shrink, otherwise <code>false</code>.
      */
     @Override
-    public boolean shrinkIfNeeded(long itNanos, int idleTimeoutMaxShrinkCount)
+    public boolean evict(long itNanos, int maxEvictCount)
     {
         long now = NanoTime.now();
         final long idleBaseline = timestamps[tail.getAndIncrement() & mask];
@@ -104,7 +104,7 @@ public class LinearShrinkManager implements QueuedThreadPool.ShrinkManager
         {
             long last = lastShrink.get();
             int retries = 0;
-            long siNanos = itNanos / idleTimeoutMaxShrinkCount;
+            long siNanos = itNanos / maxEvictCount;
             while (NanoTime.elapsed(last, now) > siNanos)
             {
                 // shrinkInterval is satisfied
@@ -129,7 +129,7 @@ public class LinearShrinkManager implements QueuedThreadPool.ShrinkManager
 
     /**
      * Must be called by any thread with an outstanding entry in this {@link LinearShrinkManager} that exits for any
-     * reason <i>other than</i> {@link #shrinkIfNeeded(long, int)} returning <code>true</code>. This method will
+     * reason <i>other than</i> {@link #evict(long, int)} returning <code>true</code>. This method will
      * normally not be called except (conditionally) in a <code>finally</code> block if a registered thread exits
      * unexpectedly with an exception.
      */

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -1260,7 +1260,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
                             pruneIdle = shrinkManager.onIdle();
                         }
 
-                        if (shrinkManager.shrink(idleTimeoutNanos, getMaxShrinkCount()))
+                        if (getThreads() > getMinThreads() && shrinkManager.shrink(idleTimeoutNanos, getMaxShrinkCount()))
                         {
                             pruneIdle = false;
                             break;

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolShrinkTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolShrinkTest.java
@@ -1,0 +1,570 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.thread;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class QueuedThreadPoolShrinkTest
+{
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueuedThreadPoolShrinkTest.class);
+
+    @Test
+    public void testSustainedActivity() throws Exception
+    {
+        // We need a floor on `idleTimeout` because when set too low, we run into issues with threads
+        // not being able to accept new jobs immediately after triggering the countdown latch. This is
+        // just an artifact of the limitations of testing, and the `idleTimeoutFloor` is absurdly low
+        // anyway, wrt what we'd expect it to be set to in practice.
+        final int idleTimeoutFloor = 100;
+        final int maxThreads = 1000;
+        final long seed = new Random().nextLong();
+        Random r = new Random(seed);
+        final int idleTimeout = r.nextInt(2000 - idleTimeoutFloor) + idleTimeoutFloor;
+        final int idleTimeoutDecay = r.nextInt(maxThreads) + 1; // the point of this test is that `idleTimoutDecay` doesn't matter.
+        final String configMsg = "idleTimeout=" + idleTimeout + ", idleTimeoutDecay=" + idleTimeoutDecay + ", seed=" + Long.toUnsignedString(seed, 16);
+        QueuedThreadPool qtp = new QueuedThreadPool(maxThreads, 0);
+        qtp.setIdleTimeout(idleTimeout);
+        qtp.setIdleTimeoutMaxShrinkCount(idleTimeoutDecay);
+        qtp.start();
+        AtomicBoolean abortPing = new AtomicBoolean();
+        try
+        {
+            // set up a background job to keep a target number of threads organically alive
+            int targetThreadCount = 500;
+            Set<String> threads = new HashSet<>(targetThreadCount);
+            Random subR = new Random(r.nextLong());
+            qtp.execute(() ->
+            {
+                try
+                {
+                    keepPoolAlive(qtp, idleTimeout, targetThreadCount, abortPing, threads, new CountDownLatch(targetThreadCount), 1, subR);
+                }
+                catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            // Let it run long enough to give threads a chance to idle out (they should
+            // _not_ actually idle out -- that's what we're testing).
+            Thread.sleep(10000);
+
+            // We expect all requests to be served by the exact same batch of threads (i.e., no
+            // threads idled out, which would have necessitated the creation of replacement
+            // threads)
+            assertEquals(targetThreadCount, threads.size(), configMsg);
+
+            // The overall pool size should account for our requests, plus the background job that
+            // issues the requests
+            assertEquals(targetThreadCount + 1, qtp.getThreads(), configMsg);
+        }
+        finally
+        {
+            abortPing.set(true);
+            qtp.stop();
+        }
+    }
+
+    @Test
+    public void testShrinkToSustainedBaseline() throws Exception
+    {
+        String overrideSeed = null; //"786feaa41a735314";
+        final long seed;
+        if (overrideSeed == null)
+        {
+            seed = new Random().nextLong();
+        }
+        else
+        {
+            seed = Long.parseUnsignedLong(overrideSeed, 16);
+        }
+        Random r = new Random(seed);
+        final boolean busy = r.nextBoolean();
+        final int maxThreads = 1000;
+        final int baselineTargetThreadCount = r.nextInt(r.nextBoolean() ? maxThreads : (maxThreads >> 1)) + 1;
+        final int expectStableThreadCount = baselineTargetThreadCount + (busy ? 10 : 1);
+        final int idleTimeout = 1000;
+        final int idleTimeoutDecayFloor = 10;
+        final int idleTimeoutDecay;
+        if (r.nextBoolean())
+        {
+            // fast decay
+            idleTimeoutDecay = r.nextInt((Math.max(1, (maxThreads - baselineTargetThreadCount) - idleTimeoutDecayFloor))) + idleTimeoutDecayFloor + 1;
+        }
+        else
+        {
+            // slow decay
+            idleTimeoutDecay = r.nextInt(Math.max(2, (maxThreads - baselineTargetThreadCount) - idleTimeoutDecayFloor) >> 1) + idleTimeoutDecayFloor + 1;
+        }
+        QueuedThreadPool qtp = new QueuedThreadPool(maxThreads + 1, 0);
+        qtp.setIdleTimeout(idleTimeout);
+        qtp.setIdleTimeoutMaxShrinkCount(idleTimeoutDecay);
+        qtp.start();
+        AtomicBoolean abortPing = new AtomicBoolean();
+        try
+        {
+            // spin up the highWaterMark number of threads
+            CountDownLatch initCdl = new CountDownLatch(maxThreads);
+            for (int i = 0; i < maxThreads; i++)
+            {
+                int delay = r.nextInt(idleTimeout) + 1;
+                qtp.execute(() ->
+                {
+                    initCdl.countDown();
+                    try
+                    {
+                        initCdl.await();
+                        Thread.sleep(delay);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+            initCdl.await();
+            assertEquals(maxThreads, qtp.getThreads());
+
+            // set up a background job to keep a baseline target number of threads organically alive
+            final int shift = r.nextInt(3) + 1;
+            final String configMsg = "baselineTargetThreadCount=" + baselineTargetThreadCount + ", expectStableThreadCount=" + expectStableThreadCount + ", idleTimeoutDecay=" + idleTimeoutDecay + ", busy=" + busy + ", shift=" + shift + ", seed=" + Long.toUnsignedString(seed, 16);
+            LOG.info("CONFIG: " + configMsg);
+
+            final CountDownLatch pingCdl = new CountDownLatch(baselineTargetThreadCount);
+            Random subR = new Random(r.nextLong());
+            qtp.execute(() ->
+            {
+                try
+                {
+                    if (busy)
+                    {
+                        keepPoolBusy(qtp, idleTimeout, baselineTargetThreadCount, abortPing, new HashSet<>(baselineTargetThreadCount), pingCdl, subR);
+                    }
+                    else
+                    {
+                        keepPoolAlive(qtp, idleTimeout, baselineTargetThreadCount, abortPing, new HashSet<>(baselineTargetThreadCount), pingCdl, shift, subR);
+                    }
+                }
+                catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            pingCdl.await();
+
+            // If we don't wait here, there will be threads that have already decided to die, but not yet updated
+            // thread pool size count, which will skew results.
+            Thread.sleep(idleTimeout << 1);
+
+            final long start = System.nanoTime();
+            final int initialThreadCount = qtp.getThreads();
+            double expectExpired;
+            int threadCount = initialThreadCount;
+            final int waitForStableCount = 5;
+            int stableCount = 0;
+            int samplePeriod = idleTimeout >> 1;
+            long precisionCorrect = TimeUnit.MILLISECONDS.toNanos(samplePeriod);
+            long tolerance = TimeUnit.MILLISECONDS.toNanos(idleTimeout);
+            long expectDurationNanos = (initialThreadCount - baselineTargetThreadCount) * (TimeUnit.MILLISECONDS.toNanos(idleTimeout) / idleTimeoutDecay);
+            long requireFinish = start + expectDurationNanos + precisionCorrect + tolerance;
+            int consecutiveVarianceFaults = 0;
+            while (threadCount > expectStableThreadCount || stableCount < waitForStableCount)
+            {
+                Thread.sleep(samplePeriod);
+                long finishedTime;
+                if (threadCount < expectStableThreadCount && !busy)
+                {
+                    fail("dropped below expected count of " + expectStableThreadCount + "; found " + threadCount);
+                }
+                else if (threadCount <= expectStableThreadCount)
+                {
+                    if (stableCount++ == 0)
+                    {
+                        long now = System.nanoTime();
+                        long duration = now - start;
+                        // we must correct the expected value for the imprecision of the `idleTimeout` window
+                        long actualMillis = TimeUnit.NANOSECONDS.toMillis(duration);
+                        if (busy)
+                        {
+                            long expectMillis = TimeUnit.NANOSECONDS.toMillis(expectDurationNanos + precisionCorrect + tolerance);
+                            assertTrue(actualMillis <= expectMillis, configMsg + ", expect=" + expectMillis + ", actual=" + actualMillis);
+                        }
+                        else
+                        {
+                            long expectMillis = TimeUnit.NANOSECONDS.toMillis(expectDurationNanos);
+                            long delta = TimeUnit.NANOSECONDS.toMillis(precisionCorrect + tolerance);
+                            assertEquals(expectMillis, actualMillis, delta, configMsg);
+                        }
+                    }
+                    LOG.info("OK finished threshold=" + expectStableThreadCount + ", actual=" + threadCount);
+                    continue;
+                }
+                else if ((finishedTime = System.nanoTime()) > requireFinish)
+                {
+                    fail("exceeded expected finish time by " + TimeUnit.NANOSECONDS.toMillis(finishedTime - requireFinish) + " millis");
+                }
+                threadCount = qtp.getThreads();
+                expectExpired = ((double)idleTimeoutDecay / TimeUnit.MILLISECONDS.toNanos(idleTimeout)) * (System.nanoTime() - start);
+                long expectThreadCount = Math.round(initialThreadCount - expectExpired);
+                double variance = ((double)(initialThreadCount - threadCount) / expectExpired) - 1;
+                if (threadCount > expectStableThreadCount && Math.abs(variance) > 0.05)
+                {
+                    if (consecutiveVarianceFaults++ > 5)
+                    {
+                        fail("too many consecutive variance faults; expect=" + expectThreadCount + ", actual=" + threadCount + ", variance=" + variance + " (" + configMsg + ")");
+                    }
+                }
+                else
+                {
+                    consecutiveVarianceFaults = 0;
+                }
+                LOG.info("OK threadCount expect=" + expectThreadCount + ", actual=" + threadCount + ", variance=" + variance);
+            }
+        }
+        finally
+        {
+            abortPing.set(true);
+            qtp.stop();
+        }
+    }
+
+    @Test
+    public void testPrecise() throws Exception
+    {
+        final int restoreRetryLimit = LinearShrinkManager.RETRY_LIMIT;
+        LinearShrinkManager.RETRY_LIMIT = 10;
+        try
+        {
+            testShrinkRatePrecise(5, 5, 5);
+            testShrinkRatePrecise(10, 10);
+            testShrinkRatePrecise(2, 2, 2, 2, 2, 2);
+        }
+        finally
+        {
+            LinearShrinkManager.RETRY_LIMIT = restoreRetryLimit;
+        }
+    }
+
+    private void testShrinkRatePrecise(int idleTimeoutDecay, int... expectExpirations) throws Exception
+    {
+        Map<Integer, Integer> expected = new HashMap<>();
+        for (int i = 0; i < expectExpirations.length; i++)
+        {
+            expected.put(3 + i, expectExpirations[i]);
+        }
+        QueuedThreadPool qtp = new QueuedThreadPool(1000, 0);
+        qtp.setIdleTimeout(1000);
+        qtp.setIdleTimeoutMaxShrinkCount(idleTimeoutDecay);
+        qtp.start();
+        final int count = 10;
+        final int taskMillis = 2000;
+        try
+        {
+            CountDownLatch cdl = new CountDownLatch(count);
+            for (int i = 0; i < count; i++)
+            {
+                qtp.execute(() ->
+                {
+                    try
+                    {
+                        Thread.sleep(taskMillis);
+                        cdl.countDown();
+                        cdl.await();
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+            long start = System.nanoTime();
+            cdl.await();
+            assertEquals(count, qtp.getThreads());
+            int size = count;
+            Map<Integer, Integer> timeoutGroups = new HashMap<>();
+            while (size != 0)
+            {
+                int newSize = qtp.getThreads();
+                if (newSize != size)
+                {
+                    double seconds = (double)(System.nanoTime() - start) / 1000000000;
+                    int secondsRounded = (int)Math.round(seconds);
+                    int diff = size - newSize;
+                    timeoutGroups.compute(secondsRounded, (k, v) -> v == null ? diff : v + diff);
+                }
+                size = newSize;
+            }
+            assertEquals(expected, timeoutGroups);
+        }
+        finally
+        {
+            qtp.stop();
+        }
+    }
+
+    @Test
+    public void testGeneral() throws Exception
+    {
+        // NOTE: this test takes a long time, but given that we're evaluating pool shrinkage at varying
+        // rates over time, I'm not sure how else to do it.
+        testGeneralLoop(1);
+        testGeneralLoop(10);
+        testGeneralLoop(20);
+        testGeneralLoop(30);
+        testGeneralLoop(40);
+        testGeneralLoop(50);
+        testGeneralLoop(60);
+        testGeneralLoop(70);
+        testGeneralLoop(80);
+        testGeneralLoop(90);
+        testGeneralLoop(100);
+        testGeneralLoop(200);
+    }
+
+    private void testGeneralLoop(int idleTimeoutDecay) throws Exception
+    {
+        for (int idleTimeout = 100; idleTimeout <= 400; idleTimeout += 100)
+        {
+            double[] actual = new double[1];
+            int iterations = testShrinkRateGeneral(idleTimeout, idleTimeoutDecay, actual);
+            LOG.info("OK idleTimeoutDecay=" + idleTimeoutDecay + " idleTimeout=" + idleTimeout + ", iterations=" + iterations + ", actual=" + actual[0]);
+        }
+    }
+
+    private int testShrinkRateGeneral(final int idleTimeout, int idleTimeoutDecay, double[] actual) throws Exception
+    {
+        final double expected = idleTimeoutDecay;
+
+        final int count = 5000;
+        AtomicBoolean abortPing = new AtomicBoolean();
+        QueuedThreadPool qtp = new QueuedThreadPool(count << 1, 0);
+        qtp.setIdleTimeout(idleTimeout);
+        qtp.setIdleTimeoutMaxShrinkCount(idleTimeoutDecay);
+        qtp.start();
+        final int taskMillis = idleTimeout << 1;
+        // The outcome of how this Random is used will not be deterministic anyway, so for our purposes a
+        // a static seed would be fine.
+        long seed = new Random().nextLong();
+        Random r = new Random(seed);
+        try
+        {
+            for (int i = 0; i < count; i++)
+            {
+                int delay1 = r.nextInt(taskMillis);
+                int delay2 = r.nextInt(taskMillis);
+                qtp.execute(() ->
+                {
+                    try
+                    {
+                        Thread.sleep(delay1);
+                        qtp.execute(() ->
+                        {
+                            try
+                            {
+                                Thread.sleep(taskMillis + delay2);
+                            }
+                            catch (InterruptedException e)
+                            {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+
+            // wait until we expect all threads to be idle.
+            Thread.sleep((long)taskMillis << 1);
+
+            // very short idleTimeout or minimal idleTimeoutDecay may take a little longer to converge
+            int maxIterations = idleTimeout < 200 || idleTimeoutDecay == 1 ? 64 : 32;
+
+            // set up a background job to keep a target number of threads organically alive
+            int targetThreadCount = 500;
+            if ((qtp.getThreads() - targetThreadCount) / idleTimeoutDecay > maxIterations)
+            {
+                Set<String> threads = new HashSet<>();
+                CountDownLatch latch = new CountDownLatch(targetThreadCount);
+                Random subR = new Random(r.nextLong());
+                qtp.execute(() ->
+                {
+                    try
+                    {
+                        keepPoolAlive(qtp, idleTimeout, targetThreadCount, abortPing, threads, latch, 1, subR);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+                latch.await(); // spin up sending threads before `start` baseline
+                Thread.sleep(taskMillis);
+            }
+
+            long start = System.nanoTime();
+            int origSize = qtp.getThreads();
+            int size = origSize;
+            final int minIterations = 3;
+            double ratio = Double.NaN;
+            double deviation = Double.NaN;
+            final int requireWithinTolerance = 4;
+            int countWithinTolerance = 0;
+
+            final double tolerance = 0.05;
+
+            for (int i = 0; i < maxIterations && size > 0; i++)
+            {
+                Thread.sleep(idleTimeout);
+                long now = System.nanoTime();
+                int nextSize = qtp.getThreads();
+                ratio = ((double)(origSize - nextSize) / (now - start)) * (idleTimeout * 1000000);
+                deviation = (ratio / expected) - 1;
+                if (i > minIterations && Math.abs(deviation) < tolerance && ++countWithinTolerance >= requireWithinTolerance)
+                {
+                    actual[0] = ratio;
+                    return i;
+                }
+                size = nextSize;
+            }
+            fail("expected=" + expected + ", ratio=" + ratio + ", last-deviation " + deviation + ", count=" + countWithinTolerance + ", seed=" + Long.toUnsignedString(seed, 16));
+            return maxIterations;
+        }
+        finally
+        {
+            abortPing.set(true);
+            qtp.stop();
+        }
+    }
+
+    private static void keepPoolAlive(QueuedThreadPool qtp, long idleTimeout, int targetThreadCount, AtomicBoolean abort, Set<String> threads, CountDownLatch cdl, int shift, Random r) throws InterruptedException
+    {
+        ExecutorService exec = Executors.newFixedThreadPool(targetThreadCount);
+        try
+        {
+            long pauseMillis = idleTimeout >> shift; // pause some ratio of `idleTimeout` between pinging threads
+            do
+            {
+                Thread.sleep(pauseMillis);
+                CountDownLatch latch = cdl;
+                for (int i = 0; i < targetThreadCount; i++)
+                {
+                    long delay = r.nextInt((int)pauseMillis >> 1) + 1;
+                    exec.submit(() ->
+                    {
+                        qtp.execute(() ->
+                        {
+                            threads.add(Thread.currentThread().getName());
+                            latch.countDown();
+                            try
+                            {
+                                latch.await();
+                                Thread.sleep(delay);
+                            }
+                            catch (InterruptedException e)
+                            {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                    });
+                }
+                latch.await();
+                cdl = new CountDownLatch(targetThreadCount);
+            }
+            while (!abort.get());
+        }
+        finally
+        {
+            exec.shutdown();
+        }
+    }
+
+    private static void keepPoolBusy(QueuedThreadPool qtp, long idleTimeout, int targetThreadCount, AtomicBoolean abort, Set<String> threads, CountDownLatch cdl, Random r) throws InterruptedException
+    {
+        ExecutorService exec = Executors.newFixedThreadPool(targetThreadCount);
+        int count = (int)cdl.getCount();
+        CountDownLatch postCdl = new CountDownLatch(count);
+        try
+        {
+            for (int i = 0; i < targetThreadCount; i++)
+            {
+                Random subR = new Random(r.nextLong());
+                exec.submit(() ->
+                {
+                    boolean initial = true;
+                    while (!abort.get())
+                    {
+                        CountDownLatch innerLatch = new CountDownLatch(1);
+                        qtp.execute(() ->
+                        {
+                            threads.add(Thread.currentThread().getName());
+                            long delay = subR.nextInt((int)idleTimeout);
+                            try
+                            {
+                                Thread.sleep(delay);
+                            }
+                            catch (InterruptedException e)
+                            {
+                                throw new RuntimeException(e);
+                            }
+                            finally
+                            {
+                                innerLatch.countDown();
+                            }
+                        });
+                        try
+                        {
+                            innerLatch.await();
+                        }
+                        catch (InterruptedException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                        if (initial)
+                        {
+                            cdl.countDown();
+                            initial = false;
+                        }
+                    }
+                    postCdl.countDown();
+                });
+            }
+            postCdl.await();
+        }
+        finally
+        {
+            exec.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Leverages new organization of logic in #9498 for performant min TTL idleTimeout and separately configured linear shrink rate. Basically rebases #9354 onto #9498, but ends up much cleaner/more performant.