### PR TITLE
upgrade json-smart to 2.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
     <jolokia.version>1.7.1</jolokia.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <json-smart.version>2.4.8</json-smart.version>
+    <json-smart.version>2.4.9</json-smart.version>
     <jsp.impl.version>9.0.52</jsp.impl.version>
     <junit.version>5.9.1</junit.version>
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
