### PR TITLE
Fixed flaky test `StreamResetTest.testClientResetConsumesQueuedData()`.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -259,7 +259,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 }
                 else
                 {
-                    stream.process(new StreamData(data, stream, flowControlLength));
+                    // StreamData has its own reference count (that starts at 1),
+                    // so since we create it here, we release it after stream.process().
+                    StreamData streamData = new StreamData(data, stream, flowControlLength);
+                    stream.process(streamData);
+                    streamData.release();
                 }
             }
         }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -444,8 +444,8 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     private boolean offer(Data data)
     {
-        // No need to retain the Data object because it
-        // has already been retained when it was created.
+        // Retain the data because it is stored for later use.
+        data.retain();
         boolean process;
         try (AutoLock ignored = lock.lock())
         {

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -82,11 +82,9 @@ import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -424,7 +422,6 @@ public class StreamResetTest extends AbstractTest
     }
 
     @Test
-    @Tag("Flaky")
     public void testClientResetConsumesQueuedData() throws Exception
     {
         CountDownLatch dataLatch = new CountDownLatch(1);
@@ -457,9 +454,8 @@ public class StreamResetTest extends AbstractTest
 
         // Wait for the server to receive the reset and process
         // it, and for the client to process the window updates.
-        Thread.sleep(1000);
-
-        assertThat(((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
+        await().atMost(5, TimeUnit.SECONDS)
+            .until(() -> ((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
     }
 
     @Test
@@ -587,13 +583,14 @@ public class StreamResetTest extends AbstractTest
     {
         try (StacklessLogging ignored = new StacklessLogging(Response.class))
         {
+            long delay = 1000;
             start(new Handler.Abstract()
             {
                 @Override
                 public boolean handle(Request request, Response response, Callback callback) throws Exception
                 {
                     // Wait to let the data sent by the client to be queued.
-                    Thread.sleep(1000);
+                    Thread.sleep(delay);
                     throw new IllegalStateException("explicitly_thrown_by_test");
                 }
             });
@@ -621,9 +618,8 @@ public class StreamResetTest extends AbstractTest
 
             // Wait for the server process the exception, and
             // for the client to process the window updates.
-            Thread.sleep(2000);
-
-            assertThat(((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
+            await().atMost(2 * delay, TimeUnit.MILLISECONDS)
+                .until(() -> ((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
         }
     }
 


### PR DESCRIPTION
The problem was that the retain/release idiom in HTTP2Session.onData() was not respected.
Now after the call to HTTP2Stream.process(), the Data object is released.