### PR TITLE
Jetty 12 - Move `org.eclipse.jetty.server.context.ManagedAttributes` to core `jetty-server`

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -74,6 +74,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
     private static final Logger LOG = LoggerFactory.getLogger(ContextHandler.class);
     private static final ThreadLocal<Context> __context = new ThreadLocal<>();
 
+    public static final String MANAGED_ATTRIBUTES = "org.eclipse.jetty.server.context.ManagedAttributes";
+
     /**
      * Get the current Context if any.
      *

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -137,7 +137,6 @@ public class ServletContextHandler extends ContextHandler implements Graceful
 
     public static final int DEFAULT_LISTENER_TYPE_INDEX = 1;
     public static final int EXTENDED_LISTENER_TYPE_INDEX = 0;
-    public static final String MANAGED_ATTRIBUTES = "org.eclipse.jetty.server.context.ManagedAttributes";
     public static final String MAX_FORM_KEYS_KEY = "org.eclipse.jetty.server.Request.maxFormKeys";
     public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
     public static final int DEFAULT_MAX_FORM_KEYS = 1000;

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/DoSFilterJMXTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/DoSFilterJMXTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +55,7 @@ public class DoSFilterJMXTest
         holder.setName(name);
         holder.setInitParameter(DoSFilter.MANAGED_ATTR_INIT_PARAM, "true");
         context.addFilter(holder, "/*", EnumSet.of(DispatcherType.REQUEST));
-        context.setInitParameter(ServletContextHandler.MANAGED_ATTRIBUTES, name);
+        context.setInitParameter(ContextHandler.MANAGED_ATTRIBUTES, name);
 
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -150,8 +150,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
 
     private static String __serverInfo = "jetty/" + Server.getVersion();
 
-    public static final String MANAGED_ATTRIBUTES = "org.eclipse.jetty.server.context.ManagedAttributes";
-
     public static final String MAX_FORM_KEYS_KEY = "org.eclipse.jetty.server.Request.maxFormKeys";
     public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
     public static final int DEFAULT_MAX_FORM_KEYS = 1000;
@@ -717,7 +715,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
      */
     protected void startContext() throws Exception
     {
-        String managedAttributes = _initParams.get(MANAGED_ATTRIBUTES);
+        String managedAttributes = _initParams.get(org.eclipse.jetty.server.handler.ContextHandler.MANAGED_ATTRIBUTES);
         if (managedAttributes != null)
             addEventListener(new ManagedAttributeListener(this, StringUtil.csvSplit(managedAttributes)));
 

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/DoSFilterJMXTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/DoSFilterJMXTest.java
@@ -54,7 +54,7 @@ public class DoSFilterJMXTest
         holder.setName(name);
         holder.setInitParameter(DoSFilter.MANAGED_ATTR_INIT_PARAM, "true");
         context.addFilter(holder, "/*", EnumSet.of(DispatcherType.REQUEST));
-        context.setInitParameter(ServletContextHandler.MANAGED_ATTRIBUTES, name);
+        context.setInitParameter(org.eclipse.jetty.server.handler.ContextHandler.MANAGED_ATTRIBUTES, name);
 
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);


### PR DESCRIPTION
Fixes #8740