### PR TITLE
Fixes #9550 - Jetty 12 - Flaky test WebSocketProxyTest.testEcho

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -285,7 +285,7 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
      * it is known that application code in the listener methods or annotated methods
      * of the WebSocket endpoint does not use blocking APIs.</p>
      * <p>Setting the invocation type to {@link InvocationType#NON_BLOCKING}, but then
-     * use blocking APIs in the WebSocket endpoint may result in a server lockup.</p>
+     * using blocking APIs in the WebSocket endpoint may result in a server lockup.</p>
      * <p>By default {@link InvocationType#BLOCKING} is returned, assuming that
      * application code in the WebSocket endpoint uses blocking APIs.</p>
      *

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
@@ -116,4 +116,13 @@ public class WebSocketUpgradeHandler extends Handler.Wrapper
             return true;
         return super.handle(request, response, callback);
     }
+
+    @Override
+    public InvocationType getInvocationType()
+    {
+        // Must be BLOCKING because EndPoint.upgrade() ends up invoking
+        // application code in the WebSocket "connect" event handler,
+        // e.g. a method annotated with @OnWebSocketConnect, that may block.
+        return InvocationType.NON_BLOCKING;
+    }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
@@ -123,6 +123,6 @@ public class WebSocketUpgradeHandler extends Handler.Wrapper
         // Must be BLOCKING because EndPoint.upgrade() ends up invoking
         // application code in the WebSocket "connect" event handler,
         // e.g. a method annotated with @OnWebSocketConnect, that may block.
-        return InvocationType.NON_BLOCKING;
+        return InvocationType.BLOCKING;
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/WebSocketUpgradeHandler.java
@@ -124,7 +124,7 @@ public class WebSocketUpgradeHandler extends Handler.Wrapper
         if (isDynamic())
             return InvocationType.BLOCKING;
         Handler handler = getHandler();
-        InvocationType result = handler == null ? InvocationType.NON_BLOCKING : handler.getInvocationType();
-        return Invocable.combine(result, container.getInvocationType());
+        InvocationType handlerInvocationType = handler == null ? InvocationType.NON_BLOCKING : handler.getInvocationType();
+        return Invocable.combine(handlerInvocationType, container.getInvocationType());
     }
 }


### PR DESCRIPTION
Unfortunately the fix is to make WebSocketUpgradeHandler.invocationType=BLOCKING, because the current semantic of the Jetty WebSocket APIs is that it is possible to call blocking APIs from within WebSocket event handler methods.