### PR TITLE
Fixes #9556 - Better prompt for input on Password

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -236,7 +236,7 @@ public class Password extends Credential
 
     public static void main(String[] args) throws IOException
     {
-        boolean promptUser = false;
+        boolean promptArgs = false;
         String argUser = null;
         String argPassword = null;
 
@@ -244,7 +244,7 @@ public class Password extends Credential
         {
             if (arg.equals("--prompt"))
             {
-                promptUser = true;
+                promptArgs = true;
                 // ignore any other args
                 break;
             }
@@ -252,17 +252,17 @@ public class Password extends Credential
             if (argUser == null)
             {
                 argUser = arg;
-                promptUser = true;
+                promptArgs = true;
             }
             else
             {
                 if (!arg.equals("?"))
-                    promptUser = false;
+                    promptArgs = false;
                 argPassword = arg;
             }
         }
 
-        if (promptUser)
+        if (promptArgs)
         {
             System.out.print("Username");
             if (StringUtil.isNotBlank(argUser))

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -276,6 +276,11 @@ public class Password extends Credential
 
             System.out.print("Password: ");
             argPassword = input.readLine();
+            if (StringUtil.isBlank(argPassword))
+            {
+                System.err.println("ERROR: blank passwords not supported");
+                System.exit(1);
+            }
         }
         else if (StringUtil.isBlank(argUser))
         {

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -13,9 +13,13 @@
 
 package org.eclipse.jetty.util.security;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * Password utility class.
@@ -230,21 +234,68 @@ public class Password extends Credential
         return new Password(passwd);
     }
 
-    public static void main(String[] arg)
+    public static void main(String[] args) throws IOException
     {
-        if (arg.length != 1 && arg.length != 2)
+        boolean promptUser = false;
+        String argUser = null;
+        String argPassword = null;
+
+        for (String arg: args)
         {
-            System.err.println("Usage - java " + Password.class.getName() + " [<user>] <password>");
-            System.err.println("If the password is ?, the user will be prompted for the password");
+            if (arg.equals("--prompt"))
+            {
+                promptUser = true;
+                // ignore any other args
+                break;
+            }
+
+            if (argUser == null)
+            {
+                argUser = arg;
+                promptUser = true;
+            }
+            else
+            {
+                if (!arg.equals("?"))
+                    promptUser = false;
+                argPassword = arg;
+            }
+        }
+
+        if (promptUser)
+        {
+            System.out.print("Username");
+            if (StringUtil.isNotBlank(argUser))
+                System.out.printf("[%s]", argUser);
+            System.out.print(": ");
+
+            BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+            argUser = input.readLine();
+
+            System.out.print("Password: ");
+            argPassword = input.readLine();
+        }
+        else if (StringUtil.isBlank(argUser))
+        {
+            System.err.printf("Usage - java %s [<user>] <password> --prompt%n", Password.class.getName());
+            System.err.printf("Argument options:%n");
+            System.err.printf("  %s%n", Password.class.getName());
+            System.err.printf("     No arguments, will show this help%n");
+            System.err.printf("  %s myusername%n", Password.class.getName());
+            System.err.printf("     username only, will prompt for entries%n");
+            System.err.printf("  %s myusername ?%n", Password.class.getName());
+            System.err.printf("     username with question mark password, will prompt for entries%n");
+            System.err.printf("  %s myusername secretpassword%n", Password.class.getName());
+            System.err.printf("     username with password, will produce obfuscation results%n");
+            System.err.printf("  %s --prompt%n", Password.class.getName());
+            System.err.printf("     will prompt for entries%n");
             System.exit(1);
         }
-        String p = arg[arg.length == 1 ? 0 : 1];
-        Password pw = new Password(p);
-        System.err.println(pw.toString());
+
+        Password pw = new Password(argPassword);
         System.err.println(obfuscate(pw.toString()));
-        System.err.println(Credential.MD5.digest(p));
-        if (arg.length == 2)
-            System.err.println(Credential.Crypt.crypt(arg[0], pw.toString()));
+        System.err.println(Credential.MD5.digest(argPassword));
+        System.err.println(Credential.Crypt.crypt(argUser, pw.toString()));
         System.exit(0);
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -270,7 +270,9 @@ public class Password extends Credential
             System.out.print(": ");
 
             BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
-            argUser = input.readLine();
+            String inputUser = input.readLine();
+            if (StringUtil.isNotBlank(inputUser))
+                argUser = inputUser;
 
             System.out.print("Password: ");
             argPassword = input.readLine();
@@ -295,7 +297,8 @@ public class Password extends Credential
         Password pw = new Password(argPassword);
         System.err.println(obfuscate(pw.toString()));
         System.err.println(Credential.MD5.digest(argPassword));
-        System.err.println(Credential.Crypt.crypt(argUser, pw.toString()));
+        if (StringUtil.isNotBlank(argUser))
+            System.err.println(Credential.Crypt.crypt(argUser, pw.toString()));
         System.exit(0);
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java
@@ -284,18 +284,18 @@ public class Password extends Credential
         }
         else if (StringUtil.isBlank(argUser))
         {
-            System.err.printf("Usage - java %s [<user>] <password> --prompt%n", Password.class.getName());
+            System.err.printf("Usage - java %s [<username>] [<password>] --prompt%n", Password.class.getName());
             System.err.printf("Argument options:%n");
             System.err.printf("  %s%n", Password.class.getName());
             System.err.printf("     No arguments, will show this help%n");
-            System.err.printf("  %s myusername%n", Password.class.getName());
-            System.err.printf("     username only, will prompt for entries%n");
-            System.err.printf("  %s myusername ?%n", Password.class.getName());
-            System.err.printf("     username with question mark password, will prompt for entries%n");
-            System.err.printf("  %s myusername secretpassword%n", Password.class.getName());
+            System.err.printf("  %s <username>%n", Password.class.getName());
+            System.err.printf("     username only, will prompt for arguments%n");
+            System.err.printf("  %s <username> ?%n", Password.class.getName());
+            System.err.printf("     username with question mark password, will prompt for arguments%n");
+            System.err.printf("  %s <username> <password>%n", Password.class.getName());
             System.err.printf("     username with password, will produce obfuscation results%n");
             System.err.printf("  %s --prompt%n", Password.class.getName());
-            System.err.printf("     will prompt for entries%n");
+            System.err.printf("     will prompt for arguments%n");
             System.exit(1);
         }
 

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/security/PasswordTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/security/PasswordTest.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.Test;
 
@@ -62,7 +63,7 @@ public class PasswordTest
     public void testCommandLineUsage() throws IOException, InterruptedException
     {
         ProcessBuilder passwordBuilder = new ProcessBuilder()
-            .directory(MavenTestingUtils.getTargetDir())
+            .directory(MavenPaths.targetDir().toFile())
             .command("java",
                 "-cp", MavenTestingUtils.getTargetPath("classes").toString(),
                 Password.class.getName(),
@@ -79,7 +80,6 @@ public class PasswordTest
                 assertThat("Non-error exit code: " + output, exitCode, is(0));
                 assertThat("Output", output, not(containsString("Exception")));
                 assertThat("Output", output, allOf(
-                    containsString("password"),
                     containsString("OBF:"),
                     containsString("MD5:"),
                     containsString("CRYPT:")


### PR DESCRIPTION
Fixes how we prompt user for inputs on the `org.eclipse.jetty.util.security.Password` command line tool.

This PR (initially) shows the following results ...

_Usage text_

``` shell
$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password 
Usage - java org.eclipse.jetty.util.security.Password [<user>] <password> --prompt
Argument options:
  org.eclipse.jetty.util.security.Password
     No arguments, will show this help
  org.eclipse.jetty.util.security.Password myusername
     username only, will prompt for entries
  org.eclipse.jetty.util.security.Password myusername ?
     username with question mark password, will prompt for entries
  org.eclipse.jetty.util.security.Password myusername secretpassword
     username with password, will produce obfuscation results
  org.eclipse.jetty.util.security.Password --prompt
     will prompt for entries
```

_Specifically asking for input prompts_

``` shell
$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password --prompt
Username: user⏎ 
Password: pass⏎ 
OBF:1y0s1v1p1v2p1y0y
MD5:1a1dC91c907325C69271DdF0C944Bc72
CRYPT:usGhvISzyaLuU
```

_Username provided, no password, prompt user_

``` shell
$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password ?
Username[?]: user⏎ 
Password: pass⏎ 
OBF:1y0s1v1p1v2p1y0y
MD5:1a1dC91c907325C69271DdF0C944Bc72
CRYPT:usGhvISzyaLuU

$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password myusername
Username[myusername]: ⏎ 
Password: mypassword⏎ 
OBF:1uh41zly1x8g1vu11ym71ym71vv91x8e1zlk1ugm
MD5:34819d7bEeAbB9260a5c854bC85b3e44
CRYPT:..slnl7JMUqP.

$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password myusername ?
Username[myusername]: ⏎
Password: mypassword⏎
OBF:1uh41zly1x8g1vu11ym71ym71vv91x8e1zlk1ugm
MD5:34819d7bEeAbB9260a5c854bC85b3e44
CRYPT:..slnl7JMUqP.
```

_Prompt for input, no username provided, output doesn't contain CRYPT_

``` shell
$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password --prompt
Username: ⏎
Password: mypass⏎
OBF:1xfd1zt11uha1ugg1zsp1xfp
MD5:A029D0Df84Eb5549C641E04a9eF389E5

```

_Username and password provided as arguments, no prompt for input_

``` shell
$ java -cp target/jetty-util-10.0.15-SNAPSHOT.jar org.eclipse.jetty.util.security.Password user pass
OBF:1y0s1v1p1v2p1y0y
MD5:1a1dC91c907325C69271DdF0C944Bc72
CRYPT:usGhvISzyaLuU
```