### PR TITLE
Jetty 9.4.x - Dependabot Rollup (2023 April)

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.4.8</version>
+      <version>2.4.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -17,7 +17,7 @@
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
-    <osgi-util-version>3.7.100</osgi-util-version>
+    <osgi-util-version>3.7.200</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>
     <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
     <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <osgi-version>3.18.200</osgi-version>
+    <osgi-version>3.18.300</osgi-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -19,7 +19,7 @@
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
     <osgi-util-version>3.7.200</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>
-    <osgi-util-promise-version>1.2.0</osgi-util-promise-version>
+    <osgi-util-promise-version>1.3.0</osgi-util-promise-version>
     <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>
     <osgi-util-position-version>1.0.1</osgi-util-position-version>
     <osgi-util-tracker-version>1.5.4</osgi-util-tracker-version>
@@ -225,6 +225,11 @@
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.util.tracker</artifactId>
         <version>${osgi-util-tracker-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.promise</artifactId>
+        <version>${osgi-util-promise-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -9,7 +9,7 @@
   <name>Example :: Jetty Spring</name>
 
   <properties>
-    <spring-version>5.3.25</spring-version>
+    <spring-version>5.3.26</spring-version>
     <dependencies>target/dependencies</dependencies>
     <bundle-symbolic-name>${project.groupId}.spring</bundle-symbolic-name>
     <jacoco.skip>true</jacoco.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
     <maven.jxr.plugin.version>3.3.1</maven.jxr.plugin.version>
     <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
-    <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+    <maven.release.plugin.version>3.0.0</maven.release.plugin.version>
     <maven.remote-resources.plugin.version>3.0.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <logback.version>1.2.11</logback.version>
     <maven.plugin-tools.version>3.8.1</maven.plugin-tools.version>
-    <maven.resolver.version>1.9.5</maven.resolver.version>
+    <maven.resolver.version>1.9.7</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
     <mongodb.version>2.14.3</mongodb.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <maven.install.plugin.version>3.1.0</maven.install.plugin.version>
-    <maven.deploy.plugin.version>3.1.0</maven.deploy.plugin.version>
+    <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
     <servicemix-depends.plugin.version>1.4.0</servicemix-depends.plugin.version>
     <versions.plugin.version>2.11.0</versions.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <xmemcached.version>2.4.7</xmemcached.version>
 
     <!-- some maven plugins versions -->
-    <asciidoctor.plugin.version>2.2.2</asciidoctor.plugin.version>
+    <asciidoctor.plugin.version>2.2.3</asciidoctor.plugin.version>
     <appassembler.plugin.version>2.1.0</appassembler.plugin.version>
     <build-helper.plugin.version>3.3.0</build-helper.plugin.version>
     <buildnumber.plugin.version>3.0.0</buildnumber.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <jsp.version>8.5.70</jsp.version>
     <junit.version>5.9.1</junit.version>
     <log4j2.version>2.17.1</log4j2.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.2.12</logback.version>
     <maven.plugin-tools.version>3.8.1</maven.plugin-tools.version>
     <maven.resolver.version>1.9.5</maven.resolver.version>
     <maven.version>3.9.0</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>9.3</checkstyle.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons.compress.version>1.22</commons.compress.version>
+    <commons.compress.version>1.23.0</commons.compress.version>
     <commons.io.version>2.11.0</commons.io.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <ant.version>1.10.13</ant.version>
     <apache.avro.version>1.11.1</apache.avro.version>
     <mina.core.version>2.2.1</mina.core.version>
-    <asm.version>9.4</asm.version>
+    <asm.version>9.5</asm.version>
     <bndlib.version>6.3.1</bndlib.version>
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>9.3</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
-    <maven.install.plugin.version>3.1.0</maven.install.plugin.version>
+    <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
     <maven.deploy.plugin.version>3.1.0</maven.deploy.plugin.version>
     <servicemix-depends.plugin.version>1.4.0</servicemix-depends.plugin.version>
     <versions.plugin.version>2.11.0</versions.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <license.plugin.version>4.1</license.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.5.0</maven.assembly.plugin.version>
-    <maven.invoker.plugin.version>3.5.0</maven.invoker.plugin.version>
+    <maven.invoker.plugin.version>3.5.1</maven.invoker.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M9</maven.surefire.plugin.version>
     <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>
     <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.remote-resources.plugin.version>3.0.0</maven.remote-resources.plugin.version>
-    <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
+    <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.source.plugin.version>3.2.1</maven.source.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.5.0</maven.assembly.plugin.version>
     <maven.invoker.plugin.version>3.5.0</maven.invoker.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M9</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.0.0</maven.surefire.plugin.version>
     <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>
     <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <osgi.util.function.version>1.2.0</osgi.util.function.version>
     <osgi.util.promise.version>1.2.0</osgi.util.promise.version>
     <plexus-container.version>2.1.1</plexus-container.version>
-    <plexus-utils.version>3.5.0</plexus-utils.version>
+    <plexus-utils.version>3.5.1</plexus-utils.version>
     <slf4j.version>1.7.36</slf4j.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>


### PR DESCRIPTION
rollup of various dependabot PRs for `jetty-9.4.x`