### PR TITLE
Fixes #7608 - Jetty-12 MetaData cleanup needed

### DIFF
--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http2/HTTP2ClientDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http2/HTTP2ClientDocs.java
@@ -236,7 +236,7 @@ public class HTTP2ClientDocs
                 }
                 else
                 {
-                    System.getLogger("http2").log(INFO, "Received trailers {0}", metaData.getFields());
+                    System.getLogger("http2").log(INFO, "Received trailers {0}", metaData.getHttpFields());
                 }
             }
 
@@ -328,9 +328,9 @@ public class HTTP2ClientDocs
                 // The "request" the client would make for the pushed resource.
                 MetaData.Request pushedRequest = frame.getMetaData();
                 // The pushed "request" URI.
-                HttpURI pushedURI = pushedRequest.getURI();
+                HttpURI pushedURI = pushedRequest.getHttpURI();
                 // The pushed "request" headers.
-                HttpFields pushedRequestHeaders = pushedRequest.getFields();
+                HttpFields pushedRequestHeaders = pushedRequest.getHttpFields();
 
                 // If needed, retrieve the primary stream that triggered the push.
                 Stream primaryStream = pushedStream.getSession().getStream(frame.getStreamId());
@@ -347,7 +347,7 @@ public class HTTP2ClientDocs
                         if (metaData.isResponse())
                         {
                             // The pushed "response" headers.
-                            HttpFields pushedResponseHeaders = metaData.getFields();
+                            HttpFields pushedResponseHeaders = metaData.getHttpFields();
 
                             // Typically a pushed stream has data, so demand for data.
                             stream.demand();

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http2/HTTP2ServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http2/HTTP2ServerDocs.java
@@ -230,7 +230,7 @@ public class HTTP2ServerDocs
                 // Prepare the response HEADERS frame.
 
                 // The response HTTP status and HTTP headers.
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
 
                 if (HttpMethod.GET.is(request.getMethod()))
                 {
@@ -322,17 +322,17 @@ public class HTTP2ServerDocs
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                if (pushEnabled && request.getURIString().endsWith("/index.html"))
+                if (pushEnabled && request.getHttpURI().toString().endsWith("/index.html"))
                 {
                     // Push the favicon.
-                    HttpURI pushedURI = HttpURI.build(request.getURI()).path("/favicon.ico");
+                    HttpURI pushedURI = HttpURI.build(request.getHttpURI()).path("/favicon.ico");
                     MetaData.Request pushedRequest = new MetaData.Request("GET", pushedURI, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     PushPromiseFrame promiseFrame = new PushPromiseFrame(stream.getId(), 0, pushedRequest);
                     stream.push(promiseFrame, null)
                         .thenCompose(pushedStream ->
                         {
                             // Send the favicon "response".
-                            MetaData.Response pushedResponse = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response pushedResponse = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             return pushedStream.headers(new HeadersFrame(pushedStream.getId(), pushedResponse, null, false))
                                 .thenCompose(pushed -> pushed.data(new DataFrame(pushed.getId(), faviconBuffer, true)));
                         });

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http3/HTTP3ServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http3/HTTP3ServerDocs.java
@@ -221,7 +221,7 @@ public class HTTP3ServerDocs
                 // Prepare the response HEADERS frame.
 
                 // The response HTTP status and HTTP headers.
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
 
                 if (HttpMethod.GET.is(request.getMethod()))
                 {

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -109,7 +109,7 @@ public class HttpStreamOverFCGI implements HttpStream
     {
         String pathQuery = URIUtil.addPathQuery(_path, _query);
         // TODO https?
-        MetaData.Request request = new MetaData.Request(_method, HttpScheme.HTTP.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, Long.MIN_VALUE);
+        MetaData.Request request = new MetaData.Request(_method, HttpScheme.HTTP.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, -1);
         Runnable task = _httpChannel.onRequest(request);
         _allHeaders.forEach(field -> _httpChannel.getRequest().setAttribute(field.getName(), field.getValue()));
         // TODO: here we just execute the task.
@@ -258,7 +258,7 @@ public class HttpStreamOverFCGI implements HttpStream
 
         _committed = true;
 
-        boolean shutdown = _shutdown = info.getFields().contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString());
+        boolean shutdown = _shutdown = info.getHttpFields().contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString());
 
         ByteBufferPool bufferPool = _generator.getByteBufferPool();
         ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator();
@@ -290,7 +290,7 @@ public class HttpStreamOverFCGI implements HttpStream
 
     private void generateResponseHeaders(ByteBufferPool.Accumulator accumulator, MetaData.Response info)
     {
-        _generator.generateResponseHeaders(accumulator, _id, info.getStatus(), info.getReason(), info.getFields());
+        _generator.generateResponseHeaders(accumulator, _id, info.getStatus(), info.getReason(), info.getHttpFields());
     }
 
     private void generateResponseContent(ByteBufferPool.Accumulator accumulator, boolean last, ByteBuffer buffer)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -45,12 +45,12 @@ public class HttpGenerator
     public static final boolean __STRICT = Boolean.getBoolean("org.eclipse.jetty.http.HttpGenerator.STRICT");
 
     private static final byte[] __colon_space = new byte[]{':', ' '};
-    public static final MetaData.Response CONTINUE_100_INFO = new MetaData.Response(HttpVersion.HTTP_1_1, 100, null, HttpFields.EMPTY, -1);
-    public static final MetaData.Response PROGRESS_102_INFO = new MetaData.Response(HttpVersion.HTTP_1_1, 102, null, HttpFields.EMPTY, -1);
+    public static final MetaData.Response CONTINUE_100_INFO = new MetaData.Response(100, null, HttpVersion.HTTP_1_1, HttpFields.EMPTY);
+    public static final MetaData.Response PROGRESS_102_INFO = new MetaData.Response(102, null, HttpVersion.HTTP_1_1, HttpFields.EMPTY);
     public static final MetaData.Response RESPONSE_400_INFO =
-        new MetaData.Response(HttpVersion.HTTP_1_1, HttpStatus.BAD_REQUEST_400, null, HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
+        new MetaData.Response(HttpStatus.BAD_REQUEST_400, null, HttpVersion.HTTP_1_1, HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
     public static final MetaData.Response RESPONSE_500_INFO =
-        new MetaData.Response(HttpVersion.HTTP_1_1, INTERNAL_SERVER_ERROR_500, null, HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
+        new MetaData.Response(INTERNAL_SERVER_ERROR_500, null, HttpVersion.HTTP_1_1, HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
 
     // states
     public enum State
@@ -224,7 +224,7 @@ public class HttpGenerator
 
                     generateHeaders(header, content, last);
 
-                    boolean expect100 = info.getFields().contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString());
+                    boolean expect100 = info.getHttpFields().contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString());
 
                     if (expect100)
                     {
@@ -527,7 +527,7 @@ public class HttpGenerator
     {
         header.put(StringUtil.getBytes(request.getMethod()));
         header.put((byte)' ');
-        header.put(StringUtil.getBytes(request.getURIString()));
+        header.put(StringUtil.getBytes(request.getHttpURI().toString()));
         header.put((byte)' ');
         header.put(request.getHttpVersion().toBytes());
         header.put(HttpTokens.CRLF);
@@ -591,7 +591,7 @@ public class HttpGenerator
         if (LOG.isDebugEnabled())
         {
             LOG.debug("generateHeaders {} last={} content={}", _info, last, BufferUtil.toDetailString(content));
-            LOG.debug(_info.getFields().toString());
+            LOG.debug(_info.getHttpFields().toString());
         }
 
         // default field values
@@ -605,7 +605,7 @@ public class HttpGenerator
         boolean contentLengthField = false;
 
         // Generate fields
-        HttpFields fields = _info.getFields();
+        HttpFields fields = _info.getHttpFields();
         if (fields != null)
         {
             int n = fields.size();

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
@@ -590,7 +590,7 @@ public class HttpTester
         @Override
         public MetaData.Response getInfo()
         {
-            return new MetaData.Response(_version, _status, _reason, this, _content == null ? -1 : _content.size());
+            return new MetaData.Response(_status, _reason, _version, this, _content == null ? -1 : _content.size());
         }
 
         @Override

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
@@ -32,12 +32,12 @@ public class HttpGeneratorClientTest
     {
         RequestInfo(String method, String uri, HttpFields fields)
         {
-            super(method, HttpURI.from(method, uri), HttpVersion.HTTP_1_1, fields, -1);
+            super(method, HttpURI.from(method, uri), HttpVersion.HTTP_1_1, fields);
         }
 
         RequestInfo(String method, String uri, HttpVersion version, HttpFields fields)
         {
-            super(method, HttpURI.from(method, uri), version, fields, -1);
+            super(method, HttpURI.from(method, uri), version, fields);
         }
 
         RequestInfo(String method, String uri, int contentLength, HttpFields fields)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerHTTPTest.java
@@ -144,7 +144,7 @@ public class HttpGeneratorServerHTTPTest
                 switch (result)
                 {
                     case NEED_INFO:
-                        info = new MetaData.Response(HttpVersion.fromVersion(version), _code, reason, _fields, _contentLength);
+                        info = new MetaData.Response(_code, reason, HttpVersion.fromVersion(version), _fields, _contentLength);
                         continue;
 
                     case NEED_HEADER:

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
@@ -44,7 +44,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Content-Type", "test/data");
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_0_9, 200, null, fields, 10);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_0_9, fields, 10);
 
         result = gen.generateResponse(info, false, null, null, content, true);
         assertEquals(HttpGenerator.Result.FLUSH, result);
@@ -81,7 +81,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Content-Type", "test/data");
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, 10);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, 10);
 
         result = gen.generateResponse(info, false, null, null, content, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -113,7 +113,7 @@ public class HttpGeneratorServerTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Location", "http://somewhere/else");
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 302, null, fields, 0);
+        MetaData.Response info = new MetaData.Response(302, null, HttpVersion.HTTP_1_1, fields, 0);
 
         HttpGenerator.Result result = gen.generateResponse(info, false, null, null, null, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -150,7 +150,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Content-Type", "test/data");
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 204, "Foo", fields, 10);
+        MetaData.Response info = new MetaData.Response(204, "Foo", HttpVersion.HTTP_1_1, fields, 10);
 
         HttpGenerator.Result result = gen.generateResponse(info, false, header, null, content, true);
 
@@ -187,7 +187,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Content-Type", "test/data;\r\nextra=value");
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, "ØÆ", fields, 10);
+        MetaData.Response info = new MetaData.Response(200, "ØÆ", HttpVersion.HTTP_1_1, fields, 10);
 
         result = gen.generateResponse(info, false, null, null, content, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -218,11 +218,11 @@ public class HttpGeneratorServerTest
     {
         ByteBuffer header = BufferUtil.allocate(8096);
         HttpFields.Mutable fields1 = HttpFields.build();
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields1, -1);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields1);
         HttpFields.Mutable fields2 = HttpFields.build();
         fields2.add(HttpHeader.SERVER, "SomeServer");
         fields2.add(HttpHeader.X_POWERED_BY, "SomePower");
-        MetaData.Response infoF = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields2, -1);
+        MetaData.Response infoF = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields2);
         String head;
 
         HttpGenerator gen = new HttpGenerator(true, true);
@@ -276,7 +276,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add("Content-Length", "11");
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, 10);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, 10);
 
         result = gen.generateResponse(info, false, null, null, null, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -299,7 +299,7 @@ public class HttpGeneratorServerTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, 0);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, 0);
 
         result = gen.generateResponse(info, false, null, null, null, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -334,7 +334,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add("Connection", "close");
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, 0);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, 0);
 
         result = gen.generateResponse(info, false, null, null, null, true);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
@@ -370,7 +370,7 @@ public class HttpGeneratorServerTest
         fields.add("Upgrade", "WebSocket");
         fields.add("Connection", "Upgrade");
         fields.add("Sec-WebSocket-Accept", "123456789==");
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 101, null, fields, -1);
+        MetaData.Response info = new MetaData.Response(101, null, HttpVersion.HTTP_1_1, fields);
 
         result = gen.generateResponse(info, false, header, null, null, true);
         assertEquals(HttpGenerator.Result.FLUSH, result);
@@ -404,7 +404,7 @@ public class HttpGeneratorServerTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, -1);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields);
         result = gen.generateResponse(info, false, null, null, content0, false);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
         assertEquals(HttpGenerator.State.START, gen.getState());
@@ -471,7 +471,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add(HttpHeader.TRANSFER_ENCODING, HttpHeaderValue.CHUNKED);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, -1);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields);
         result = gen.generateResponse(info, false, null, null, content0, false);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
         assertEquals(HttpGenerator.State.START, gen.getState());
@@ -542,7 +542,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add(HttpHeader.TRANSFER_ENCODING, HttpHeaderValue.CHUNKED);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, -1,
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, -1,
             () ->
             {
                 HttpFields.Mutable trailer1 = HttpFields.build();
@@ -629,7 +629,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add(HttpHeader.TRANSFER_ENCODING, HttpHeaderValue.CHUNKED);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, -1,
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, -1,
             () ->
             {
                 HttpFields.Mutable trailer1 = HttpFields.build();
@@ -697,7 +697,7 @@ public class HttpGeneratorServerTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, 59);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, 59);
         result = gen.generateResponse(info, false, null, null, content0, false);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
         assertEquals(HttpGenerator.State.START, gen.getState());
@@ -747,7 +747,7 @@ public class HttpGeneratorServerTest
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
         fields.add("Content-Length", "" + (content0.remaining() + content1.remaining()));
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, -1);
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields);
         result = gen.generateResponse(info, false, null, null, content0, false);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
         assertEquals(HttpGenerator.State.START, gen.getState());
@@ -811,7 +811,7 @@ public class HttpGeneratorServerTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Last-Modified", DateGenerator.__01Jan1970);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_1, 200, null, fields, BufferUtil.length(content0) + BufferUtil.length(content1));
+        MetaData.Response info = new MetaData.Response(200, null, HttpVersion.HTTP_1_1, fields, BufferUtil.length(content0) + BufferUtil.length(content1));
         result = gen.generateResponse(info, false, null, null, content0, false);
         assertEquals(HttpGenerator.Result.NEED_HEADER, result);
         assertEquals(HttpGenerator.State.START, gen.getState());
@@ -855,7 +855,7 @@ public class HttpGeneratorServerTest
         fields.put(HttpHeader.CONNECTION, HttpHeaderValue.KEEP_ALIVE);
         String customValue = "test";
         fields.add(HttpHeader.CONNECTION, customValue);
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_0, 200, "OK", fields, -1);
+        MetaData.Response info = new MetaData.Response(200, "OK", HttpVersion.HTTP_1_0, fields);
         ByteBuffer header = BufferUtil.allocate(4096);
         HttpGenerator.Result result = generator.generateResponse(info, false, header, null, null, true);
         assertSame(HttpGenerator.Result.FLUSH, result);
@@ -870,7 +870,7 @@ public class HttpGeneratorServerTest
         HttpGenerator generator = new HttpGenerator();
         HttpFields.Mutable fields = HttpFields.build();
         fields.put(HttpHeader.CONNECTION, HttpHeaderValue.KEEP_ALIVE.asString() + ", other, " + HttpHeaderValue.CLOSE.asString());
-        MetaData.Response info = new MetaData.Response(HttpVersion.HTTP_1_0, 200, "OK", fields, -1);
+        MetaData.Response info = new MetaData.Response(200, "OK", HttpVersion.HTTP_1_0, fields);
         ByteBuffer header = BufferUtil.allocate(4096);
         HttpGenerator.Result result = generator.generateResponse(info, false, header, null, null, true);
         assertSame(HttpGenerator.Result.FLUSH, result);

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -119,7 +119,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
 
         responseBegin(exchange);
 
-        HttpFields headers = response.getFields();
+        HttpFields headers = response.getHttpFields();
         for (HttpField header : headers)
         {
             responseHeader(exchange, header);
@@ -151,7 +151,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         if (exchange == null)
             return;
 
-        HttpFields trailers = frame.getMetaData().getFields();
+        HttpFields trailers = frame.getMetaData().getHttpFields();
         trailers.forEach(exchange.getResponse()::trailer);
     }
 
@@ -175,7 +175,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
 
         HttpRequest request = exchange.getRequest();
         MetaData.Request metaData = frame.getMetaData();
-        HttpRequest pushRequest = (HttpRequest)getHttpDestination().getHttpClient().newRequest(metaData.getURIString());
+        HttpRequest pushRequest = (HttpRequest)getHttpDestination().getHttpClient().newRequest(metaData.getHttpURI().toString());
         // TODO: copy PUSH_PROMISE headers into pushRequest.
 
         BiFunction<Request, Request, Response.CompleteListener> pushListener = request.getPushHandler();

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -88,7 +88,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         this.streamId = streamId;
         this.request = request;
         this.local = local;
-        this.dataLength = Long.MIN_VALUE;
+        this.dataLength = -1;
         this.dataStalled = true;
     }
 
@@ -375,11 +375,11 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         MetaData metaData = frame.getMetaData();
         if (metaData.isRequest() || metaData.isResponse())
         {
-            HttpFields fields = metaData.getFields();
+            HttpFields fields = metaData.getHttpFields();
             long length = -1;
             if (fields != null && !HttpMethod.CONNECT.is(request.getMethod()))
                 length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
-            dataLength = length >= 0 ? length : Long.MIN_VALUE;
+            dataLength = length;
         }
 
         boolean offered = false;
@@ -425,7 +425,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
             return;
         }
 
-        if (dataLength != Long.MIN_VALUE)
+        if (dataLength >= 0)
         {
             DataFrame frame = data.frame();
             dataLength -= frame.remaining();

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
@@ -145,11 +145,11 @@ public class ContinuationParseTest
             assertTrue(frame.isEndStream());
             MetaData.Request request = (MetaData.Request)frame.getMetaData();
             assertEquals(metaData.getMethod(), request.getMethod());
-            assertEquals(metaData.getURI(), request.getURI());
+            assertEquals(metaData.getHttpURI(), request.getHttpURI());
             for (int j = 0; j < fields.size(); ++j)
             {
                 HttpField field = fields.getField(j);
-                assertTrue(request.getFields().contains(field));
+                assertTrue(request.getHttpFields().contains(field));
             }
             PriorityFrame priority = frame.getPriority();
             assertNull(priority);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
@@ -72,7 +72,14 @@ public class FrameFloodTest
     public void testInvalidHeadersFrameFlood() throws Exception
     {
         // Invalid MetaData (no method, no scheme, etc).
-        MetaData.Request metadata = new MetaData.Request(null, null, null, null, HttpVersion.HTTP_2, null, -1);
+        MetaData.Request metadata = new MetaData.Request("NULL", null, null, null, HttpVersion.HTTP_2, null, -1)
+        {
+            @Override
+            public String getMethod()
+            {
+                return null;
+            }
+        };
         HpackEncoder encoder = new HpackEncoder();
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         encoder.encode(buffer, metadata);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/HeadersGenerateParseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/HeadersGenerateParseTest.java
@@ -84,11 +84,11 @@ public class HeadersGenerateParseTest
             assertTrue(frame.isEndStream());
             MetaData.Request request = (MetaData.Request)frame.getMetaData();
             assertEquals(metaData.getMethod(), request.getMethod());
-            assertEquals(metaData.getURI(), request.getURI());
+            assertEquals(metaData.getHttpURI(), request.getHttpURI());
             for (int j = 0; j < fields.size(); ++j)
             {
                 HttpField field = fields.getField(j);
-                assertTrue(request.getFields().contains(field));
+                assertTrue(request.getHttpFields().contains(field));
             }
             PriorityFrame priority = frame.getPriority();
             assertNotNull(priority);
@@ -144,11 +144,11 @@ public class HeadersGenerateParseTest
             assertTrue(frame.isEndStream());
             MetaData.Request request = (MetaData.Request)frame.getMetaData();
             assertEquals(metaData.getMethod(), request.getMethod());
-            assertEquals(metaData.getURI(), request.getURI());
+            assertEquals(metaData.getHttpURI(), request.getHttpURI());
             for (int j = 0; j < fields.size(); ++j)
             {
                 HttpField field = fields.getField(j);
-                assertTrue(request.getFields().contains(field));
+                assertTrue(request.getHttpFields().contains(field));
             }
             PriorityFrame priority = frame.getPriority();
             assertNotNull(priority);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/PushPromiseGenerateParseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/PushPromiseGenerateParseTest.java
@@ -83,11 +83,11 @@ public class PushPromiseGenerateParseTest
             assertEquals(promisedStreamId, frame.getPromisedStreamId());
             MetaData.Request request = (MetaData.Request)frame.getMetaData();
             assertEquals(metaData.getMethod(), request.getMethod());
-            assertEquals(metaData.getURI(), request.getURI());
+            assertEquals(metaData.getHttpURI(), request.getHttpURI());
             for (int j = 0; j < fields.size(); ++j)
             {
                 HttpField field = fields.getField(j);
-                assertTrue(request.getFields().contains(field));
+                assertTrue(request.getHttpFields().contains(field));
             }
         }
     }
@@ -136,11 +136,11 @@ public class PushPromiseGenerateParseTest
             assertEquals(promisedStreamId, frame.getPromisedStreamId());
             MetaData.Request request = frame.getMetaData();
             assertEquals(metaData.getMethod(), request.getMethod());
-            assertEquals(metaData.getURI(), request.getURI());
+            assertEquals(metaData.getHttpURI(), request.getHttpURI());
             for (int j = 0; j < fields.size(); ++j)
             {
                 HttpField field = fields.getField(j);
-                assertTrue(request.getFields().contains(field));
+                assertTrue(request.getHttpFields().contains(field));
             }
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -166,7 +166,7 @@ public class HpackEncoder
             if (LOG.isDebugEnabled())
                 LOG.debug(String.format("CtxTbl[%x] encoding", _context.hashCode()));
 
-            HttpFields fields = metadata.getFields();
+            HttpFields fields = metadata.getHttpFields();
             // Verify that we can encode without errors.
             if (isValidateEncoding() && fields != null)
             {
@@ -196,14 +196,14 @@ public class HpackEncoder
                 HttpMethod httpMethod = method == null ? null : HttpMethod.fromString(method);
                 HttpField methodField = C_METHODS.get(httpMethod);
                 encode(buffer, methodField == null ? new HttpField(HttpHeader.C_METHOD, method) : methodField);
-                encode(buffer, new HttpField(HttpHeader.C_AUTHORITY, request.getURI().getAuthority()));
+                encode(buffer, new HttpField(HttpHeader.C_AUTHORITY, request.getHttpURI().getAuthority()));
                 boolean isConnect = HttpMethod.CONNECT.is(request.getMethod());
                 String protocol = request.getProtocol();
                 if (!isConnect || protocol != null)
                 {
-                    String scheme = request.getURI().getScheme();
+                    String scheme = request.getHttpURI().getScheme();
                     encode(buffer, HttpScheme.HTTPS.is(scheme) ? C_SCHEME_HTTPS : C_SCHEME_HTTP);
-                    encode(buffer, new HttpField(HttpHeader.C_PATH, request.getURI().getPathQuery()));
+                    encode(buffer, new HttpField(HttpHeader.C_PATH, request.getHttpURI().getPathQuery()));
                     if (protocol != null)
                         encode(buffer, new HttpField(HttpHeader.C_PROTOCOL, protocol));
                 }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -35,7 +35,7 @@ public class MetaDataBuilder
     private HostPortHttpField _authority;
     private String _path;
     private String _protocol;
-    private long _contentLength = Long.MIN_VALUE;
+    private long _contentLength = -1;
     private HpackException.StreamException _streamException;
     private boolean _request;
     private boolean _response;
@@ -260,7 +260,7 @@ public class MetaDataBuilder
             {
                 if (_status == null)
                     throw new HpackException.StreamException("No Status");
-                return new MetaData.Response(HttpVersion.HTTP_2, _status, fields, _contentLength);
+                return new MetaData.Response(_status, null, HttpVersion.HTTP_2, fields, _contentLength);
             }
 
             return new MetaData(HttpVersion.HTTP_2, fields, _contentLength);
@@ -277,7 +277,7 @@ public class MetaDataBuilder
             _path = null;
             _protocol = null;
             _size = 0;
-            _contentLength = Long.MIN_VALUE;
+            _contentLength = -1;
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
@@ -67,9 +67,9 @@ public class HpackDecoderTest
         MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         assertFalse(request.iterator().hasNext());
 
         // Second request
@@ -79,9 +79,9 @@ public class HpackDecoderTest
         request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         Iterator<HttpField> iterator = request.iterator();
         assertTrue(iterator.hasNext());
         assertEquals(new HttpField("cache-control", "no-cache"), iterator.next());
@@ -94,9 +94,9 @@ public class HpackDecoderTest
         request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTPS.asString(), request.getURI().getScheme());
-        assertEquals("/index.html", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTPS.asString(), request.getHttpURI().getScheme());
+        assertEquals("/index.html", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         iterator = request.iterator();
         assertTrue(iterator.hasNext());
         assertEquals(new HttpField("custom-key", "custom-value"), iterator.next());
@@ -115,9 +115,9 @@ public class HpackDecoderTest
         MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         assertFalse(request.iterator().hasNext());
 
         // Second request
@@ -127,9 +127,9 @@ public class HpackDecoderTest
         request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         Iterator<HttpField> iterator = request.iterator();
         assertTrue(iterator.hasNext());
         assertEquals(new HttpField("cache-control", "no-cache"), iterator.next());
@@ -151,10 +151,10 @@ public class HpackDecoderTest
         MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
-        assertEquals(1, request.getFields().size());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
+        assertEquals(1, request.getHttpFields().size());
         HttpField field = request.iterator().next();
         assertEquals(HttpHeader.AUTHORIZATION, field.getHeader());
         assertEquals(value, field.getValue());
@@ -174,9 +174,9 @@ public class HpackDecoderTest
         MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("www.example.com", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("www.example.com", request.getHttpURI().getHost());
         assertFalse(request.iterator().hasNext());
     }
 
@@ -191,13 +191,13 @@ public class HpackDecoderTest
         MetaData.Response response = (MetaData.Response)decoder.decode(buffer);
 
         assertThat(response.getStatus(), is(200));
-        assertThat(response.getFields().size(), is(6));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.DATE, "Fri, 15 Jul 2016 02:36:20 GMT"));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.CONTENT_TYPE, "text/html"));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.CONTENT_ENCODING, ""));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.CONTENT_LENGTH, "42"));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.SERVER, "nghttpx nghttp2/1.12.0"));
-        assertThat(response.getFields(), containsHeaderValue(HttpHeader.VIA, "1.1 nghttpx"));
+        assertThat(response.getHttpFields().size(), is(6));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.DATE, "Fri, 15 Jul 2016 02:36:20 GMT"));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.CONTENT_TYPE, "text/html"));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.CONTENT_ENCODING, ""));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.CONTENT_LENGTH, "42"));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.SERVER, "nghttpx nghttp2/1.12.0"));
+        assertThat(response.getHttpFields(), containsHeaderValue(HttpHeader.VIA, "1.1 nghttpx"));
     }
 
     @Test
@@ -207,8 +207,8 @@ public class HpackDecoderTest
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
         HpackDecoder decoder = new HpackDecoder(4096, 8192);
         MetaData metaData = decoder.decode(buffer);
-        assertThat(metaData.getFields().get(HttpHeader.HOST), is("localhost0"));
-        assertThat(metaData.getFields().get(HttpHeader.COOKIE), is("abcdefghij"));
+        assertThat(metaData.getHttpFields().get(HttpHeader.HOST), is("localhost0"));
+        assertThat(metaData.getHttpFields().get(HttpHeader.COOKIE), is("abcdefghij"));
         assertThat(decoder.getHpackContext().getMaxDynamicTableSize(), is(50));
         assertThat(decoder.getHpackContext().size(), is(1));
     }
@@ -249,7 +249,7 @@ public class HpackDecoderTest
         MetaData metaData = decoder.decode(buffer);
 
         assertThat(decoder.getHpackContext().getDynamicTableSize(), is(0));
-        assertThat(metaData.getFields().get("host"), Matchers.startsWith("This is a very large field"));
+        assertThat(metaData.getHttpFields().get("host"), Matchers.startsWith("This is a very large field"));
     }
 
     @Test
@@ -451,9 +451,9 @@ public class HpackDecoderTest
         MetaData.Request request = (MetaData.Request)decoder.decode(buffer);
 
         assertEquals("GET", request.getMethod());
-        assertEquals(HttpScheme.HTTP.asString(), request.getURI().getScheme());
-        assertEquals("/", request.getURI().getPath());
-        assertEquals("test", request.getURI().getHost());
+        assertEquals(HttpScheme.HTTP.asString(), request.getHttpURI().getScheme());
+        assertEquals("/", request.getHttpURI().getPath());
+        assertEquals("test", request.getHttpURI().getHost());
         assertFalse(request.iterator().hasNext());
     }
 
@@ -538,8 +538,8 @@ public class HpackDecoderTest
         String encoded = "00016800";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
         MetaData metaData = decoder.decode(buffer);
-        assertThat(metaData.getFields().size(), is(1));
-        assertThat(metaData.getFields().get("h"), is(""));
+        assertThat(metaData.getHttpFields().size(), is(1));
+        assertThat(metaData.getHttpFields().get("h"), is(""));
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
@@ -46,23 +46,24 @@ public class HpackTest
         HpackDecoder decoder = new HpackDecoder(4096, 8192);
         ByteBuffer buffer = BufferUtil.allocateDirect(16 * 1024);
 
+        long contentLength = 1024;
         HttpFields.Mutable fields0 = HttpFields.build()
             .add(HttpHeader.CONTENT_TYPE, "text/html")
-            .add(HttpHeader.CONTENT_LENGTH, "1024")
+            .add(HttpHeader.CONTENT_LENGTH, String.valueOf(contentLength))
             .add(new HttpField(HttpHeader.CONTENT_ENCODING, (String)null))
             .add(ServerJetty)
             .add(XPowerJetty)
             .add(Date)
             .add(HttpHeader.SET_COOKIE, "abcdefghijklmnopqrstuvwxyz")
             .add("custom-key", "custom-value");
-        Response original0 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0);
+        Response original0 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0, contentLength);
 
         BufferUtil.clearToFill(buffer);
         encoder.encode(buffer, original0);
         BufferUtil.flipToFlush(buffer, 0);
         Response decoded0 = (Response)decoder.decode(buffer);
         
-        Response nullToEmpty = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0.put(new HttpField(HttpHeader.CONTENT_ENCODING, "")));
+        Response nullToEmpty = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0.put(new HttpField(HttpHeader.CONTENT_ENCODING, "")), contentLength);
         assertMetaDataResponseSame(nullToEmpty, decoded0);
 
         // Same again?
@@ -73,15 +74,16 @@ public class HpackTest
 
         assertMetaDataResponseSame(nullToEmpty, decoded0b);
 
+        contentLength = 1234;
         HttpFields.Mutable fields1 = HttpFields.build()
             .add(HttpHeader.CONTENT_TYPE, "text/plain")
-            .add(HttpHeader.CONTENT_LENGTH, "1234")
+            .add(HttpHeader.CONTENT_LENGTH, String.valueOf(contentLength))
             .add(HttpHeader.CONTENT_ENCODING, " ")
             .add(ServerJetty)
             .add(XPowerJetty)
             .add(Date)
             .add("Custom-Key", "Other-Value");
-        Response original1 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields1);
+        Response original1 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields1, contentLength);
 
         // Same again?
         BufferUtil.clearToFill(buffer);

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
@@ -55,15 +55,14 @@ public class HpackTest
             .add(Date)
             .add(HttpHeader.SET_COOKIE, "abcdefghijklmnopqrstuvwxyz")
             .add("custom-key", "custom-value");
-        Response original0 = new MetaData.Response(HttpVersion.HTTP_2, 200, fields0);
+        Response original0 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0);
 
         BufferUtil.clearToFill(buffer);
         encoder.encode(buffer, original0);
         BufferUtil.flipToFlush(buffer, 0);
         Response decoded0 = (Response)decoder.decode(buffer);
         
-        Response nullToEmpty = new MetaData.Response(HttpVersion.HTTP_2, 200, 
-            fields0.put(new HttpField(HttpHeader.CONTENT_ENCODING, "")));
+        Response nullToEmpty = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0.put(new HttpField(HttpHeader.CONTENT_ENCODING, "")));
         assertMetaDataResponseSame(nullToEmpty, decoded0);
 
         // Same again?
@@ -82,7 +81,7 @@ public class HpackTest
             .add(XPowerJetty)
             .add(Date)
             .add("Custom-Key", "Other-Value");
-        Response original1 = new MetaData.Response(HttpVersion.HTTP_2, 200, fields1);
+        Response original1 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields1);
 
         // Same again?
         BufferUtil.clearToFill(buffer);
@@ -91,7 +90,7 @@ public class HpackTest
         Response decoded1 = (Response)decoder.decode(buffer);
 
         assertMetaDataResponseSame(original1, decoded1);
-        assertEquals("custom-key", decoded1.getFields().getField("Custom-Key").getName());
+        assertEquals("custom-key", decoded1.getHttpFields().getField("Custom-Key").getName());
     }
 
     @Test
@@ -144,7 +143,7 @@ public class HpackTest
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
             .add("Cookie", "[\uD842\uDF9F]")
             .add("custom-key", "[\uD842\uDF9F]");
-        Response original0 = new MetaData.Response(HttpVersion.HTTP_2, 200, fields0);
+        Response original0 = new MetaData.Response(200, null, HttpVersion.HTTP_2, fields0);
 
         BufferUtil.clearToFill(buffer);
         encoder.encode(buffer, original0);
@@ -218,7 +217,7 @@ public class HpackTest
         encoder.encode(buffer, new MetaData(HttpVersion.HTTP_2, input));
         BufferUtil.flipToFlush(buffer, 0);
         MetaData metaData = decoder.decode(buffer);
-        HttpFields output = metaData.getFields();
+        HttpFields output = metaData.getHttpFields();
 
         assertEquals(1, output.size());
         assertEquals("*", output.get(HttpHeader.ACCEPT));
@@ -242,7 +241,7 @@ public class HpackTest
         encoder.encode(buffer, new MetaData(HttpVersion.HTTP_2, input));
         BufferUtil.flipToFlush(buffer, 0);
         MetaData metaData = decoder.decode(buffer);
-        HttpFields output = metaData.getFields();
+        HttpFields output = metaData.getHttpFields();
 
         assertEquals(2, output.size());
         assertEquals(teValue, output.get(HttpHeader.TE));
@@ -281,7 +280,7 @@ public class HpackTest
     {
         assertThat("Metadata.contentLength", actual.getContentLength(), is(expected.getContentLength()));
         assertThat("Metadata.version" + ".version", actual.getHttpVersion(), is(expected.getHttpVersion()));
-        assertHttpFieldsSame(expected.getFields(), actual.getFields());
+        assertHttpFieldsSame(expected.getHttpFields(), actual.getHttpFields());
     }
 
     private void assertHttpFieldsSame(HttpFields expected, HttpFields actual)

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2CServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2CServerConnectionFactory.java
@@ -65,7 +65,7 @@ public class HTTP2CServerConnectionFactory extends HTTP2ServerConnectionFactory 
     public Connection upgradeConnection(Connector connector, EndPoint endPoint, Request request, HttpFields.Mutable response101) throws BadMessageException
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{} upgrading {}{}{}", this, request, System.lineSeparator(), request.getFields());
+            LOG.debug("{} upgrading {}{}{}", this, request, System.lineSeparator(), request.getHttpFields());
 
         if (request.getContentLength() > 0)
             return null;

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -305,7 +305,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         }
         else
         {
-            HttpField settingsField = request.getFields().getField(HttpHeader.HTTP2_SETTINGS);
+            HttpField settingsField = request.getHttpFields().getField(HttpHeader.HTTP2_SETTINGS);
             if (settingsField == null)
                 throw new BadMessageException("Missing " + HttpHeader.HTTP2_SETTINGS + " header");
             String value = settingsField.getValue();

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -103,7 +103,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 }
             }
 
-            HttpFields fields = _requestMetaData.getFields();
+            HttpFields fields = _requestMetaData.getHttpFields();
 
             _expects100Continue = fields.contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString());
 
@@ -114,7 +114,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             {
                 LOG.debug("HTTP2 request #{}/{}, {} {} {}{}{}",
                     _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()),
-                    _requestMetaData.getMethod(), _requestMetaData.getURI(), _requestMetaData.getHttpVersion(),
+                    _requestMetaData.getMethod(), _requestMetaData.getHttpURI(), _requestMetaData.getHttpVersion(),
                     System.lineSeparator(), fields);
             }
 
@@ -242,7 +242,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onTrailer(HeadersFrame frame)
     {
-        HttpFields trailers = frame.getMetaData().getFields().asImmutable();
+        HttpFields trailers = frame.getMetaData().getHttpFields().asImmutable();
         try (AutoLock ignored = lock.lock())
         {
             _demand = false;
@@ -322,10 +322,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 if (contentLength < 0)
                 {
                     _responseMetaData = new MetaData.Response(
-                        response.getHttpVersion(),
-                        response.getStatus(),
-                        response.getReason(),
-                        response.getFields(),
+                        response.getStatus(), response.getReason(), response.getHttpVersion(),
+                        response.getHttpFields(),
                         realContentLength,
                         response.getTrailersSupplier()
                     );
@@ -392,7 +390,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             LOG.debug("HTTP2 Response #{}/{}:{}{} {}{}{}",
                 _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()),
                 System.lineSeparator(), HttpVersion.HTTP_2, response.getStatus(),
-                System.lineSeparator(), response.getFields());
+                System.lineSeparator(), response.getHttpFields());
         }
 
         _stream.send(new HTTP2Stream.FrameList(headersFrame, dataFrame, trailersFrame), callback);
@@ -495,8 +493,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             {
                 LOG.debug("HTTP/2 push request #{}/{}:{}{} {} {}{}{}",
                     _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()), System.lineSeparator(),
-                    request.getMethod(), request.getURI(), request.getHttpVersion(),
-                    System.lineSeparator(), request.getFields());
+                    request.getMethod(), request.getHttpURI(), request.getHttpVersion(),
+                    System.lineSeparator(), request.getHttpFields());
             }
 
             return task;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BlockedWritesWithSmallThreadPoolTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BlockedWritesWithSmallThreadPoolTest.java
@@ -209,7 +209,7 @@ public class BlockedWritesWithSmallThreadPoolTest
                             data.release();
                             if (data.frame().isEndStream())
                             {
-                                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                             }
                             else

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/CloseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/CloseTest.java
@@ -61,7 +61,7 @@ public class CloseTest extends AbstractServerTest
                 try
                 {
                     sessionRef.set(stream.getSession());
-                    MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                    MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     // Reply with HEADERS.
                     stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     closeLatch.await(5, TimeUnit.SECONDS);
@@ -129,7 +129,7 @@ public class CloseTest extends AbstractServerTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 sessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -194,7 +194,7 @@ public class CloseTest extends AbstractServerTest
             {
                 stream.setIdleTimeout(10 * idleTimeout);
                 sessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 stream.getSession().close(ErrorCode.NO_ERROR.code, "OK", Callback.NOOP);
                 return null;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentStreamCreationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentStreamCreationTest.java
@@ -50,7 +50,7 @@ public class ConcurrentStreamCreationTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 serverLatch.countDown();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConnectTunnelTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConnectTunnelTest.java
@@ -53,11 +53,11 @@ public class ConnectTunnelTest extends AbstractTest
                 // Verifies that the CONNECT request is well formed.
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
                 assertEquals(HttpMethod.CONNECT.asString(), request.getMethod());
-                HttpURI uri = request.getURI();
+                HttpURI uri = request.getHttpURI();
                 assertNull(uri.getScheme());
                 assertNull(uri.getPath());
                 assertNotNull(uri.getAuthority());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(stream::demand));
                 return new Stream.Listener()
                 {
@@ -109,12 +109,12 @@ public class ConnectTunnelTest extends AbstractTest
                 // Verifies that the CONNECT request is well formed.
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
                 assertEquals(HttpMethod.CONNECT.asString(), request.getMethod());
-                HttpURI uri = request.getURI();
+                HttpURI uri = request.getHttpURI();
                 assertNotNull(uri.getScheme());
                 assertNotNull(uri.getPath());
                 assertNotNull(uri.getAuthority());
                 assertNotNull(request.getProtocol());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(stream::demand));
                 return new Stream.Listener()
                 {

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/DataDemandTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/DataDemandTest.java
@@ -64,7 +64,7 @@ public class DataDemandTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 serverStreamRef.set(stream);
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(stream::demand));
                 return new Stream.Listener()
                 {
@@ -177,7 +177,7 @@ public class DataDemandTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(() -> sendData(stream), x -> {}));
                 return null;
             }
@@ -233,7 +233,7 @@ public class DataDemandTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(() -> sendData(stream), x -> {}));
                 return null;
             }
@@ -272,7 +272,7 @@ public class DataDemandTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), Callback.from(() -> sendData(stream), x -> {}));
                 return null;
             }
@@ -331,7 +331,7 @@ public class DataDemandTest extends AbstractTest
                         data.release();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                         else

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStalledTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStalledTest.java
@@ -134,9 +134,9 @@ public class FlowControlStalledTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
 
-                if (request.getURIString().endsWith("/stall"))
+                if (request.getHttpURI().toString().endsWith("/stall"))
                 {
                     stream.headers(new HeadersFrame(stream.getId(), response, null, false), new Callback()
                     {
@@ -230,9 +230,9 @@ public class FlowControlStalledTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
 
-                if (request.getURIString().endsWith("/stall"))
+                if (request.getHttpURI().toString().endsWith("/stall"))
                 {
                     stream.headers(new HeadersFrame(stream.getId(), response, null, false), new Callback()
                     {

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStrategyTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStrategyTest.java
@@ -237,7 +237,7 @@ public abstract class FlowControlStrategyTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 stream.demand();
@@ -323,7 +323,7 @@ public abstract class FlowControlStrategyTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, false);
                 CompletableFuture<Void> completable = new CompletableFuture<>();
                 stream.headers(responseFrame, Callback.from(completable));
@@ -423,7 +423,7 @@ public abstract class FlowControlStrategyTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 stream.demand();
@@ -522,7 +522,7 @@ public abstract class FlowControlStrategyTest
                 MetaData.Request request = (MetaData.Request)requestFrame.getMetaData();
                 if (HttpMethod.POST.is(request.getMethod()))
                 {
-                    MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                    MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     stream.headers(new HeadersFrame(stream.getId(), metaData, null, false))
                         .thenCompose(s ->
                         {
@@ -536,7 +536,7 @@ public abstract class FlowControlStrategyTest
                 else
                 {
                     // For every stream, send down half the window size of data.
-                    MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                    MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     stream.headers(new HeadersFrame(stream.getId(), metaData, null, false))
                         .thenCompose(s ->
                         {
@@ -644,7 +644,7 @@ public abstract class FlowControlStrategyTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, false);
                 stream.headers(responseFrame)
                     .thenAccept(s -> s.data(new DataFrame(s.getId(), ByteBuffer.wrap(data), true)));
@@ -689,7 +689,7 @@ public abstract class FlowControlStrategyTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, false);
                 CompletableFuture<Stream> completable = stream.headers(responseFrame);
                 stream.demand();
@@ -1052,7 +1052,7 @@ public abstract class FlowControlStrategyTest
                         {
                             // Release the Data when the stream is already remotely closed.
                             dataList.forEach(Stream.Data::release);
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                         else

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -73,7 +73,7 @@ public class GoAwayTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -128,7 +128,7 @@ public class GoAwayTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -212,7 +212,7 @@ public class GoAwayTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -368,7 +368,7 @@ public class GoAwayTest extends AbstractTest
 
         // Previous streams must complete successfully.
         Stream serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
         serverStream.headers(new HeadersFrame(serverStream.getId(), response, null, true), Callback.NOOP);
 
         assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
@@ -417,7 +417,7 @@ public class GoAwayTest extends AbstractTest
                         // Only send the response after reading the first DATA frame.
                         if (dataFrames.incrementAndGet() == 1)
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                     }
@@ -595,7 +595,7 @@ public class GoAwayTest extends AbstractTest
 
         // Complete the stream.
         Stream serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
         serverStream.headers(new HeadersFrame(serverStream.getId(), response, null, true), Callback.NOOP);
 
         assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
@@ -680,7 +680,7 @@ public class GoAwayTest extends AbstractTest
 
         // Complete the stream, the server should send the non-graceful GOAWAY.
         Stream serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
         serverStream.headers(new HeadersFrame(serverStream.getId(), response, null, true), Callback.NOOP);
 
         // The server already received the client GOAWAY,
@@ -717,7 +717,7 @@ public class GoAwayTest extends AbstractTest
                         data.release();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                     }
@@ -1165,7 +1165,7 @@ public class GoAwayTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                String path = request.getURI().getPath();
+                String path = request.getHttpURI().getPath();
 
                 if ("/prime".equals(path))
                 {
@@ -1223,7 +1223,7 @@ public class GoAwayTest extends AbstractTest
             {
                 long remotePort = ((InetSocketAddress)stream.getSession().getRemoteSocketAddress()).getPort();
                 HttpFields responseHeaders = HttpFields.build().putLongField("X-Remote-Port", remotePort);
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, responseHeaders);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, responseHeaders);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true));
             }
         });

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
@@ -59,7 +59,7 @@ public class GracefulShutdownTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -125,7 +125,7 @@ public class GracefulShutdownTest extends AbstractTest
                         data.release();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                         else
@@ -198,7 +198,7 @@ public class GracefulShutdownTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2ServerTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2ServerTest.java
@@ -580,7 +580,7 @@ public class HTTP2ServerTest extends AbstractServerTest
 
                 serverLatch.countDown();
 
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -115,7 +115,7 @@ public class HTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, false), new Callback()
                 {
                     @Override
@@ -429,7 +429,7 @@ public class HTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY, 0);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY, 0);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }
@@ -546,7 +546,7 @@ public class HTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 CompletableFuture<Stream> completable = stream.headers(new HeadersFrame(stream.getId(), response, null, false));
                 stream.demand();
                 return new Stream.Listener()
@@ -645,7 +645,7 @@ public class HTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 DataFrame dataFrame = new DataFrame(stream.getId(), BufferUtil.EMPTY_BUFFER, true);
                 // The call to headers() is legal, but slow.
                 new Thread(() ->
@@ -710,7 +710,7 @@ public class HTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame response = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(response, Callback.NOOP);
                 // Close cleanly.
@@ -882,7 +882,7 @@ public class HTTP2Test extends AbstractTest
                         dataLatch.countDown();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         }
                         else

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -159,7 +159,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), metaData, null, false), new Callback()
                 {
                     @Override
@@ -312,7 +312,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
                 }
                 else
                 {
-                    MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                    MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 }
                 return null;
@@ -576,7 +576,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
                         try
                         {
                             // Response.
-                            MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response metaData = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             HeadersFrame response = new HeadersFrame(request.getStreamId(), metaData, null, true);
                             generator.control(accumulator, response);
                             writeFrames();
@@ -649,7 +649,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.NO_CONTENT_204, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.NO_CONTENT_204, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
                 stream.headers(responseFrame)
                     .thenAccept(s -> s.data(new DataFrame(s.getId(), ByteBuffer.wrap(bytes), true)));
@@ -679,7 +679,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
                 // Produce an invalid HPACK block by adding a request pseudo-header to the response.
                 HttpFields fields = HttpFields.build()
                     .put(":method", "get");
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, fields, 0);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, fields, 0);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
                 byte[] bytes = "hello".getBytes(StandardCharsets.US_ASCII);
                 stream.headers(responseFrame)
@@ -710,7 +710,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 int streamId = stream.getId();
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(streamId, response, null, false);
                 stream.headers(responseFrame)
                     .thenAccept(s -> s.data(new DataFrame(s.getId(), ByteBuffer.wrap(new byte[bytes]), true)));

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -68,7 +68,7 @@ public class IdleTimeoutTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
                 stream.setIdleTimeout(10 * idleTimeout);
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -155,7 +155,7 @@ public class IdleTimeoutTest extends AbstractTest
                 // to avoid a race where the idle timeout fires
                 // again before we can send the headers to the client.
                 sleep(idleTimeout + idleTimeout / 2);
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -209,7 +209,7 @@ public class IdleTimeoutTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 stream.setIdleTimeout(10 * idleTimeout);
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -287,7 +287,7 @@ public class IdleTimeoutTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 stream.setIdleTimeout(10 * idleTimeout);
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -536,7 +536,7 @@ public class IdleTimeoutTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                 return null;
             }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/InterleavingTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/InterleavingTest.java
@@ -110,7 +110,7 @@ public class InterleavingTest extends AbstractTest
 
         Stream serverStream1 = serverStreams.get(0);
         Stream serverStream2 = serverStreams.get(1);
-        MetaData.Response response1 = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response1 = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
         serverStream1.headers(new HeadersFrame(serverStream1.getId(), response1, null, false), Callback.NOOP);
 
         Random random = new Random();
@@ -119,7 +119,7 @@ public class InterleavingTest extends AbstractTest
         byte[] content2 = new byte[2 * ((HTTP2Session)serverStream2.getSession()).updateSendWindow(0)];
         random.nextBytes(content2);
 
-        MetaData.Response response2 = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response2 = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
         serverStream2.headers(new HeadersFrame(serverStream2.getId(), response2, null, false), new Callback()
         {
             @Override

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxConcurrentStreamsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxConcurrentStreamsTest.java
@@ -467,23 +467,23 @@ public class MaxConcurrentStreamsTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                switch (request.getURI().getPath())
+                switch (request.getHttpURI().getPath())
                 {
                     case "/1" ->
                     {
                         // Do not return to cause TCP congestion.
                         assertTrue(awaitLatch(request1Latch, 15, TimeUnit.SECONDS));
-                        MetaData.Response response1 = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response1 = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response1, null, true), Callback.NOOP);
                     }
                     case "/3" ->
                     {
-                        MetaData.Response response3 = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response3 = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response3, null, true), Callback.NOOP);
                     }
                     default ->
                     {
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.INTERNAL_SERVER_ERROR_500, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.INTERNAL_SERVER_ERROR_500, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
                 }
@@ -578,7 +578,7 @@ public class MaxConcurrentStreamsTest extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                switch (request.getURI().getPath())
+                switch (request.getHttpURI().getPath())
                 {
                     case "/prime" ->
                     {
@@ -586,14 +586,14 @@ public class MaxConcurrentStreamsTest extends AbstractTest
                         // Send another request from here to force the opening of the 2nd connection.
                         httpClient.newRequest("localhost", connector.getLocalPort()).path("/prime2").send(result ->
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, result.getResponse().getStatus(), HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(result.getResponse().getStatus(), null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         });
                     }
                     case "/prime2" ->
                     {
                         session2 = stream.getSession();
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
                     case "/update_max_streams" ->
@@ -602,13 +602,13 @@ public class MaxConcurrentStreamsTest extends AbstractTest
                         Map<Integer, Integer> settings = new HashMap<>();
                         settings.put(SettingsFrame.MAX_CONCURRENT_STREAMS, 2);
                         session.settings(new SettingsFrame(settings, false), Callback.NOOP);
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
                     default ->
                     {
                         sleep(processing);
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
                 }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxPushedStreamsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxPushedStreamsTest.java
@@ -102,7 +102,7 @@ public class MaxPushedStreamsTest extends AbstractTest
                     // ... then send the response.
                     .thenRun(() ->
                     {
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true));
                     });
                 return null;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PrefaceTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PrefaceTest.java
@@ -85,7 +85,7 @@ public class PrefaceTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -238,7 +238,7 @@ public class PrefaceTest extends AbstractTest
                     @Override
                     public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
                     {
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                         return null;
                     }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PriorityTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PriorityTest.java
@@ -43,7 +43,7 @@ public class PriorityTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;
@@ -91,7 +91,7 @@ public class PriorityTest extends AbstractTest
                 try
                 {
                     beforeRequests.await(5, TimeUnit.SECONDS);
-                    MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                    MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                     HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                     stream.headers(responseFrame, Callback.NOOP);
                     afterRequests.countDown();
@@ -157,7 +157,7 @@ public class PriorityTest extends AbstractTest
                 assertEquals(priorityFrame.isExclusive(), priority.isExclusive());
                 latch.countDown();
 
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PushedResourcesTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/PushedResourcesTest.java
@@ -70,7 +70,7 @@ public class PushedResourcesTest extends AbstractTest
                     public void succeeded(Stream pushStream)
                     {
                         // Just send the normal response and wait for the reset.
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
                 }, new Stream.Listener()
@@ -124,9 +124,9 @@ public class PushedResourcesTest extends AbstractTest
                 }
                 else
                 {
-                    MetaData.Request push1 = new MetaData.Request(null, HttpURI.build(request.getHttpURI()).path(path1), HttpVersion.HTTP_2, HttpFields.EMPTY);
+                    MetaData.Request push1 = new MetaData.Request("GET", HttpURI.build(request.getHttpURI()).path(path1), HttpVersion.HTTP_2, HttpFields.EMPTY);
                     request.push(push1);
-                    MetaData.Request push2 = new MetaData.Request(null, HttpURI.build(request.getHttpURI()).path(path2), HttpVersion.HTTP_2, HttpFields.EMPTY);
+                    MetaData.Request push2 = new MetaData.Request("GET", HttpURI.build(request.getHttpURI()).path(path2), HttpVersion.HTTP_2, HttpFields.EMPTY);
                     request.push(push2);
                     response.write(true, ByteBuffer.wrap(bytes), callback);
                 }
@@ -189,7 +189,7 @@ public class PushedResourcesTest extends AbstractTest
                 }
                 else
                 {
-                    request.push(new MetaData.Request(null, HttpURI.build(request.getHttpURI()).path(oldPath), HttpVersion.HTTP_2, HttpFields.EMPTY));
+                    request.push(new MetaData.Request("GET", HttpURI.build(request.getHttpURI()).path(oldPath), HttpVersion.HTTP_2, HttpFields.EMPTY));
                     callback.succeeded();
                 }
                 return true;
@@ -260,7 +260,7 @@ public class PushedResourcesTest extends AbstractTest
         // Request for the primary and secondary resource to build the cache.
         HttpFields.Mutable primaryFields = HttpFields.build();
         MetaData.Request primaryRequest = newRequest("GET", primaryResource, primaryFields);
-        String referrerURI = primaryRequest.getURIString();
+        String referrerURI = primaryRequest.getHttpURI().toString();
         CountDownLatch warmupLatch = new CountDownLatch(1);
         session.newStream(new HeadersFrame(primaryRequest, null, true), new Stream.Listener()
         {

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RawHTTP2ProxyTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RawHTTP2ProxyTest.java
@@ -128,7 +128,7 @@ public class RawHTTP2ProxyTest
                             LOGGER.debug("SERVER1 received {}", frame);
                         if (frame.isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             HeadersFrame reply = new HeadersFrame(stream.getId(), response, null, false);
                             if (LOGGER.isDebugEnabled())
                                 LOGGER.debug("SERVER1 sending {}", reply);
@@ -166,7 +166,7 @@ public class RawHTTP2ProxyTest
                         if (LOGGER.isDebugEnabled())
                             LOGGER.debug("SERVER2 received {}", data);
                         data.release();
-                        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         HeadersFrame reply = new HeadersFrame(stream.getId(), response, null, false);
                         if (LOGGER.isDebugEnabled())
                             LOGGER.debug("SERVER2 sending {}", reply);
@@ -287,7 +287,7 @@ public class RawHTTP2ProxyTest
                 LOGGER.debug("Received {} for {} on {}: {}", frame, stream, stream.getSession(), frame.getMetaData());
             // Forward to the right server.
             MetaData metaData = frame.getMetaData();
-            HttpFields fields = metaData.getFields();
+            HttpFields fields = metaData.getHttpFields();
             int port = Integer.parseInt(fields.get("X-Target"));
             ClientToProxyToServer clientToProxyToServer = forwarders.computeIfAbsent(port, p -> new ClientToProxyToServer("localhost", p, client));
             clientToProxyToServer.offer(stream, frame, Callback.NOOP);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RequestTrailersTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RequestTrailersTest.java
@@ -58,7 +58,7 @@ public class RequestTrailersTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, true);
                 stream.headers(responseFrame, Callback.NOOP);
                 return new Stream.Listener()
@@ -105,7 +105,7 @@ public class RequestTrailersTest extends AbstractTest
                         // trailers, but instead a DATA frame with endStream=true.
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, true);
                             stream.headers(responseFrame, Callback.NOOP);
                         }
@@ -160,7 +160,7 @@ public class RequestTrailersTest extends AbstractTest
                         // trailers, but instead a DATA frame with endStream=true.
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, true);
                             stream.headers(responseFrame, Callback.NOOP);
                         }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCloseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCloseTest.java
@@ -81,7 +81,7 @@ public class StreamCloseTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame response = new HeadersFrame(stream.getId(), metaData, null, true);
                 stream.headers(response, new Callback()
                 {
@@ -123,7 +123,7 @@ public class StreamCloseTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame response = new HeadersFrame(stream.getId(), metaData, null, false);
                 CompletableFuture<Stream> completable = stream.headers(response);
                 stream.demand();
@@ -218,7 +218,7 @@ public class StreamCloseTest extends AbstractTest
                         });
                     }
                 }, null);
-                HeadersFrame response = new HeadersFrame(stream.getId(), new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY), null, true);
+                HeadersFrame response = new HeadersFrame(stream.getId(), new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY), null, true);
                 stream.headers(response, Callback.NOOP);
                 return null;
             }
@@ -269,7 +269,7 @@ public class StreamCloseTest extends AbstractTest
                     {
                         assertTrue(pushedStream.isReset());
                         assertTrue(pushedStream.isClosed());
-                        HeadersFrame response = new HeadersFrame(stream.getId(), new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY), null, true);
+                        HeadersFrame response = new HeadersFrame(stream.getId(), new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY), null, true);
                         stream.headers(response, Callback.NOOP);
                         serverLatch.countDown();
                         callback.succeeded();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCountTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCountTest.java
@@ -71,7 +71,7 @@ public class StreamCountTest extends AbstractTest
                         data.release();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                            MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), metaData, null, true), Callback.NOOP);
                         }
                     }
@@ -137,7 +137,7 @@ public class StreamCountTest extends AbstractTest
                         data.release();
                         if (data.frame().isEndStream())
                         {
-                            MetaData.Response metaData = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                            MetaData.Response metaData = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                             stream.headers(new HeadersFrame(stream.getId(), metaData, null, true), Callback.NOOP);
                         }
                     }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -165,7 +165,7 @@ public class StreamResetTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame requestFrame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
                 CompletableFuture<Stream> completable = stream.headers(responseFrame);
                 stream.demand();
@@ -1053,7 +1053,7 @@ public class StreamResetTest extends AbstractTest
             @Override
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, 200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
                 stream.headers(responseFrame, Callback.NOOP);
                 return null;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/TrailersTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/TrailersTest.java
@@ -68,7 +68,7 @@ public class TrailersTest extends AbstractTest
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
                 assertFalse(frame.isEndStream());
-                assertTrue(request.getFields().contains("X-Request"));
+                assertTrue(request.getHttpFields().contains("X-Request"));
                 return new Stream.Listener()
                 {
                     @Override
@@ -76,7 +76,7 @@ public class TrailersTest extends AbstractTest
                     {
                         MetaData trailer = frame.getMetaData();
                         assertTrue(frame.isEndStream());
-                        assertTrue(trailer.getFields().contains("X-Trailer"));
+                        assertTrue(trailer.getHttpFields().contains("X-Trailer"));
                         latch.countDown();
                     }
                 };
@@ -205,7 +205,7 @@ public class TrailersTest extends AbstractTest
             {
                 HttpFields.Mutable responseFields = HttpFields.build();
                 responseFields.put("X-Response", "true");
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_2, HttpStatus.OK_200, responseFields);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, responseFields);
                 HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
                 stream.headers(responseFrame, new Callback()
                 {
@@ -238,14 +238,14 @@ public class TrailersTest extends AbstractTest
                 {
                     MetaData.Response response = (MetaData.Response)frame.getMetaData();
                     assertEquals(HttpStatus.OK_200, response.getStatus());
-                    assertTrue(response.getFields().contains("X-Response"));
+                    assertTrue(response.getHttpFields().contains("X-Response"));
                     assertFalse(frame.isEndStream());
                     responded = true;
                 }
                 else
                 {
                     MetaData trailer = frame.getMetaData();
-                    assertTrue(trailer.getFields().contains("X-Trailer"));
+                    assertTrue(trailer.getHttpFields().contains("X-Trailer"));
                     assertTrue(frame.isEndStream());
                     latch.countDown();
                 }
@@ -316,7 +316,7 @@ public class TrailersTest extends AbstractTest
         assertFalse(data.isEndStream());
         assertTrue(trailers.isEndStream());
         assertTrue(eof.isEndStream());
-        assertEquals(trailers.getMetaData().getFields().get(trailerName), trailerValue);
+        assertEquals(trailers.getMetaData().getHttpFields().get(trailerName), trailerValue);
     }
 
     @Test
@@ -464,6 +464,6 @@ public class TrailersTest extends AbstractTest
         assertEquals(HttpStatus.OK_200, responseMetaData.getStatus());
 
         MetaData trailerMetaData = trailersRef.get();
-        assertEquals(trailerValue, trailerMetaData.getFields().get(trailerName));
+        assertEquals(trailerValue, trailerMetaData.getHttpFields().get(trailerName));
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -97,7 +97,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
 
         responseBegin(exchange);
 
-        HttpFields headers = response.getFields();
+        HttpFields headers = response.getHttpFields();
         for (HttpField header : headers)
         {
             responseHeader(exchange, header);
@@ -128,7 +128,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
         if (exchange == null)
             return;
 
-        HttpFields trailers = frame.getMetaData().getFields();
+        HttpFields trailers = frame.getMetaData().getHttpFields();
         trailers.forEach(exchange.getResponse()::trailer);
 
         responseSuccess(exchange, null);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
@@ -74,7 +74,7 @@ public class HeadersGenerateParseTest
         MetaData.Request inputMetaData = (MetaData.Request)input.getMetaData();
         MetaData.Request outputMetaData = (MetaData.Request)output.getMetaData();
         assertEquals(inputMetaData.getMethod(), outputMetaData.getMethod());
-        assertEquals(inputMetaData.getURIString(), outputMetaData.getURIString());
-        assertEquals(inputMetaData.getFields(), outputMetaData.getFields());
+        assertEquals(inputMetaData.getHttpURI().toString(), outputMetaData.getHttpURI().toString());
+        assertEquals(inputMetaData.getHttpFields(), outputMetaData.getHttpFields());
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
@@ -165,9 +165,9 @@ public class QpackEncoder implements Dumpable
                 LOG.debug("Encoding: streamId={}, metadata={}", streamId, metadata);
 
             // Verify that we can encode without errors.
-            if (metadata.getFields() != null)
+            if (metadata.getHttpFields() != null)
             {
-                for (HttpField field : metadata.getFields())
+                for (HttpField field : metadata.getHttpFields())
                 {
                     String name = field.getName();
                     char firstChar = name.charAt(0);

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/Http3Fields.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/Http3Fields.java
@@ -61,7 +61,7 @@ public class Http3Fields implements HttpFields
 
     public Http3Fields(MetaData metadata)
     {
-        httpFields = metadata.getFields();
+        httpFields = metadata.getHttpFields();
         if (metadata.isRequest())
         {
             MetaData.Request request = (MetaData.Request)metadata;
@@ -69,14 +69,14 @@ public class Http3Fields implements HttpFields
             HttpMethod httpMethod = method == null ? null : HttpMethod.fromString(method);
             HttpField methodField = C_METHODS.get(httpMethod);
             pseudoHeaders.add(methodField == null ? new HttpField(HttpHeader.C_METHOD, method) : methodField);
-            pseudoHeaders.add(new HttpField(HttpHeader.C_AUTHORITY, request.getURI().getAuthority()));
+            pseudoHeaders.add(new HttpField(HttpHeader.C_AUTHORITY, request.getHttpURI().getAuthority()));
 
             boolean isConnect = HttpMethod.CONNECT.is(request.getMethod());
             String protocol = request.getProtocol();
             if (!isConnect || protocol != null)
             {
-                pseudoHeaders.add(HttpScheme.HTTPS.is(request.getURI().getScheme()) ? C_SCHEME_HTTPS : C_SCHEME_HTTP);
-                pseudoHeaders.add(new HttpField(HttpHeader.C_PATH, request.getURI().getPathQuery()));
+                pseudoHeaders.add(HttpScheme.HTTPS.is(request.getHttpURI().getScheme()) ? C_SCHEME_HTTPS : C_SCHEME_HTTP);
+                pseudoHeaders.add(new HttpField(HttpHeader.C_PATH, request.getHttpURI().getPathQuery()));
 
                 if (protocol != null)
                     pseudoHeaders.add(new HttpField(HttpHeader.C_PROTOCOL, protocol));

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/MetaDataBuilder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/MetaDataBuilder.java
@@ -36,7 +36,7 @@ public class MetaDataBuilder
     private HostPortHttpField _authority;
     private String _path;
     private String _protocol;
-    private long _contentLength = Long.MIN_VALUE;
+    private long _contentLength = -1;
     private QpackException.StreamException _streamException;
     private boolean _request;
     private boolean _response;
@@ -262,7 +262,7 @@ public class MetaDataBuilder
             {
                 if (_status == null)
                     throw new QpackException.StreamException(H3_GENERAL_PROTOCOL_ERROR, "No Status");
-                return new MetaData.Response(HttpVersion.HTTP_3, _status, fields, _contentLength);
+                return new MetaData.Response(_status, null, HttpVersion.HTTP_3, fields, _contentLength);
             }
 
             return new MetaData(HttpVersion.HTTP_3, fields, _contentLength);
@@ -279,7 +279,7 @@ public class MetaDataBuilder
             _path = null;
             _protocol = null;
             _size = 0;
-            _contentLength = Long.MIN_VALUE;
+            _contentLength = -1;
         }
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/BlockedStreamsTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/BlockedStreamsTest.java
@@ -108,8 +108,8 @@ public class BlockedStreamsTest
         // Give first instruction to get first metadata.
         _decoder.parseInstructions(QpackTestUtil.toBuffer(instruction1));
         MetaData metaData = _decoderHandler.getMetaData();
-        assertThat(metaData.getFields().size(), equalTo(1));
-        assertThat(metaData.getFields().get(entry1.getHeader()), equalTo(entry1.getValue()));
+        assertThat(metaData.getHttpFields().size(), equalTo(1));
+        assertThat(metaData.getHttpFields().get(entry1.getHeader()), equalTo(entry1.getValue()));
 
         Instruction inc1 = _decoderHandler.getInstruction();
         assertThat(inc1, instanceOf(InsertCountIncrementInstruction.class));
@@ -125,8 +125,8 @@ public class BlockedStreamsTest
         // Give second instruction to get second metadata.
         _decoder.parseInstructions(QpackTestUtil.toBuffer(instruction2));
         metaData = _decoderHandler.getMetaData();
-        assertThat(metaData.getFields().size(), equalTo(1));
-        assertThat(metaData.getFields().get(entry2.getHeader()), equalTo(entry2.getValue()));
+        assertThat(metaData.getHttpFields().size(), equalTo(1));
+        assertThat(metaData.getHttpFields().get(entry2.getHeader()), equalTo(entry2.getValue()));
 
         Instruction inc2 = _decoderHandler.getInstruction();
         assertThat(inc2, instanceOf(InsertCountIncrementInstruction.class));
@@ -152,8 +152,8 @@ public class BlockedStreamsTest
         decoded = _decoder.decode(3, buffer, _decoderHandler);
         assertTrue(decoded);
         metaData = _decoderHandler.getMetaData();
-        assertThat(metaData.getFields().size(), equalTo(1));
-        assertThat(metaData.getFields().get(entry3.getHeader()), equalTo(entry3.getValue()));
+        assertThat(metaData.getHttpFields().size(), equalTo(1));
+        assertThat(metaData.getHttpFields().get(entry3.getHeader()), equalTo(entry3.getValue()));
 
         // No longer referencing any streams that have been acknowledged.
         buffer = toBuffer(inc1, ack1, inc2, ack2);

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncodeDecodeTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncodeDecodeTest.java
@@ -90,7 +90,7 @@ public class EncodeDecodeTest
 
         _decoder.decode(streamId, buffer, _decoderHandler);
         MetaData result = _decoderHandler.getMetaData();
-        assertThat(result.getFields(), is(httpFields));
+        assertThat(result.getHttpFields(), is(httpFields));
         assertThat(_decoderHandler.getInstruction(), instanceOf(SectionAcknowledgmentInstruction.class));
         assertTrue(_decoderHandler.isEmpty());
 

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EvictionTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EvictionTest.java
@@ -84,7 +84,7 @@ public class EvictionTest
 //            System.err.println("====================");
 //            System.err.println();
 
-            assertTrue(result.getFields().isEqualTo(httpFields));
+            assertTrue(result.getHttpFields().isEqualTo(httpFields));
             encodedFields.clear();
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -94,7 +94,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
                 }
             }
 
-            HttpFields fields = requestMetaData.getFields();
+            HttpFields fields = requestMetaData.getHttpFields();
 
             expects100Continue = fields.contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString());
 
@@ -107,7 +107,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
             {
                 LOG.debug("HTTP3 request #{}/{}, {} {} {}{}{}",
                     stream.getId(), Integer.toHexString(stream.getSession().hashCode()),
-                    requestMetaData.getMethod(), requestMetaData.getURI(), requestMetaData.getHttpVersion(),
+                    requestMetaData.getMethod(), requestMetaData.getHttpURI(), requestMetaData.getHttpVersion(),
                     System.lineSeparator(), fields);
             }
 
@@ -237,7 +237,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
 
     public Runnable onTrailer(HeadersFrame frame)
     {
-        HttpFields trailers = frame.getMetaData().getFields().asImmutable();
+        HttpFields trailers = frame.getMetaData().getHttpFields().asImmutable();
         if (LOG.isDebugEnabled())
         {
             LOG.debug("HTTP3 Request #{}/{}, trailer:{}{}",
@@ -312,10 +312,8 @@ public class HttpStreamOverHTTP3 implements HttpStream
                 if (contentLength < 0)
                 {
                     this.responseMetaData = new MetaData.Response(
-                        response.getHttpVersion(),
-                        response.getStatus(),
-                        response.getReason(),
-                        response.getFields(),
+                        response.getStatus(), response.getReason(), response.getHttpVersion(),
+                        response.getHttpFields(),
                         realContentLength,
                         response.getTrailersSupplier()
                     );
@@ -382,7 +380,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
             LOG.debug("HTTP3 Response #{}/{}:{}{} {}{}{}",
                 stream.getId(), Integer.toHexString(stream.getSession().hashCode()),
                 System.lineSeparator(), HttpVersion.HTTP_3, response.getStatus(),
-                System.lineSeparator(), response.getFields());
+                System.lineSeparator(), response.getHttpFields());
         }
 
         CompletableFuture<Stream> cf = stream.respond(headersFrame);

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
@@ -161,7 +161,7 @@ public class ClientServerTest extends AbstractClientServerTest
                 serverSessionRef.set((HTTP3Session)stream.getSession());
                 serverRequestLatch.countDown();
                 // Send the response.
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), true));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), true));
                 // Not interested in request data.
                 return null;
             }
@@ -208,7 +208,7 @@ public class ClientServerTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 // Send the response.
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), false));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), false));
                 stream.demand();
                 return new Stream.Server.Listener()
                 {
@@ -278,7 +278,7 @@ public class ClientServerTest extends AbstractClientServerTest
             {
                 serverSessionRef.set((HTTP3Session)stream.getSession());
                 // Send the response headers.
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), false));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), false));
                 stream.demand();
                 return new Stream.Server.Listener()
                 {
@@ -371,7 +371,7 @@ public class ClientServerTest extends AbstractClientServerTest
             @Override
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), true));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), true));
                 return null;
             }
         });
@@ -422,10 +422,10 @@ public class ClientServerTest extends AbstractClientServerTest
             {
                 serverSessionRef.set(stream.getSession());
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                if ("/large".equals(request.getURI().getPath()))
+                if ("/large".equals(request.getHttpURI().getPath()))
                 {
                     HttpFields largeHeaders = HttpFields.build().put("too-large", "x".repeat(2 * maxResponseHeadersSize));
-                    stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, largeHeaders), true))
+                    stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, largeHeaders), true))
                         .whenComplete((s, x) ->
                         {
                             // The response could not be generated, but the stream is still valid.
@@ -441,7 +441,7 @@ public class ClientServerTest extends AbstractClientServerTest
                 }
                 else
                 {
-                    stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), true));
+                    stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), true));
                 }
                 return null;
             }

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
@@ -61,7 +61,7 @@ public class GoAwayTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 serverSessionRef.set((HTTP3SessionServer)stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                 stream.respond(new HeadersFrame(response, true));
                 return null;
             }
@@ -141,7 +141,7 @@ public class GoAwayTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                 stream.respond(new HeadersFrame(response, true));
                 return null;
             }
@@ -220,7 +220,7 @@ public class GoAwayTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 serverSessionRef.set(stream.getSession());
-                MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                 stream.respond(new HeadersFrame(response, true));
                 return null;
             }
@@ -365,7 +365,7 @@ public class GoAwayTest extends AbstractClientServerTest
 
         // Previous streams must complete successfully.
         Stream.Server serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
         serverStream.respond(new HeadersFrame(response, true));
 
         assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
@@ -452,7 +452,7 @@ public class GoAwayTest extends AbstractClientServerTest
 
         // Complete the stream.
         Stream.Server serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
         serverStream.respond(new HeadersFrame(response, true));
 
         assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
@@ -540,7 +540,7 @@ public class GoAwayTest extends AbstractClientServerTest
 
         // Complete the stream, the server should send the non-graceful GOAWAY.
         Stream.Server serverStream = serverStreamRef.get();
-        MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+        MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
         serverStream.respond(new HeadersFrame(response, true));
 
         // The server already received the client GOAWAY,
@@ -581,7 +581,7 @@ public class GoAwayTest extends AbstractClientServerTest
                             data.release();
                         if (data != null && data.isLast())
                         {
-                            MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                            MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                             serverStream.respond(new HeadersFrame(response, true));
                         }
                         else
@@ -1254,7 +1254,7 @@ public class GoAwayTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 serverStreamRef.set((HTTP3Stream)stream);
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), false));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), false));
                 return null;
             }
         });
@@ -1312,7 +1312,7 @@ public class GoAwayTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 serverStreamRef.set((HTTP3Stream)stream);
-                stream.respond(new HeadersFrame(new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY), false));
+                stream.respond(new HeadersFrame(new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY), false));
                 return null;
             }
         });

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/StreamIdleTimeoutTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/StreamIdleTimeoutTest.java
@@ -53,7 +53,7 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                if ("/idle".equals(request.getURI().getPath()))
+                if ("/idle".equals(request.getHttpURI().getPath()))
                 {
                     assertFalse(frame.isLast());
                     stream.demand();
@@ -68,7 +68,7 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
                 }
                 else
                 {
-                    MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                    MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                     stream.respond(new HeadersFrame(response, true));
                     return null;
                 }
@@ -134,7 +134,7 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
             public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {
                 MetaData.Request request = (MetaData.Request)frame.getMetaData();
-                if ("/idle".equals(request.getURI().getPath()))
+                if ("/idle".equals(request.getHttpURI().getPath()))
                 {
                     return new Stream.Server.Listener()
                     {
@@ -148,7 +148,7 @@ public class StreamIdleTimeoutTest extends AbstractClientServerTest
                 }
                 else
                 {
-                    MetaData.Response response = new MetaData.Response(HttpVersion.HTTP_3, HttpStatus.OK_200, HttpFields.EMPTY);
+                    MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_3, HttpFields.EMPTY);
                     stream.respond(new HeadersFrame(response, true));
                     return null;
                 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -803,7 +803,7 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public HttpURI getHttpURI()
         {
-            return _metaData.getURI();
+            return _metaData.getHttpURI();
         }
 
         @Override
@@ -815,7 +815,7 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public HttpFields getHeaders()
         {
-            return _metaData.getFields();
+            return _metaData.getHttpFields();
         }
 
         @Override
@@ -1193,7 +1193,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 HttpChannelState channel = _request.getHttpChannel();
                 HttpVersion version = channel.getConnectionMetaData().getHttpVersion();
-                MetaData.Response response = new MetaData.Response(version, status, headers);
+                MetaData.Response response = new MetaData.Response(status, null, version, headers);
                 channel._stream.send(_request._metaData, response, false, null, completable);
             }
             else
@@ -1224,9 +1224,7 @@ public class HttpChannelState implements HttpChannel, Components
             httpChannel._stream.prepareResponse(mutableHeaders);
 
             return new MetaData.Response(
-                httpChannel.getConnectionMetaData().getHttpVersion(),
-                _status,
-                null,
+                _status, null, httpChannel.getConnectionMetaData().getHttpVersion(),
                 httpChannel._responseHeaders,
                 httpChannel._committedContentLength,
                 getTrailersSupplier()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1502,7 +1502,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
             // Prior knowledge HTTP/2 does not need a 101 response (it will directly be
             // in HTTP/2 format) while HTTP/1.1 to HTTP/2 upgrade needs a 101 response.
             if (!isPriorKnowledgeH2C)
-                send(_request, new MetaData.Response(HttpVersion.HTTP_1_1, HttpStatus.SWITCHING_PROTOCOLS_101, response101, 0), false, null, Callback.NOOP);
+                send(_request, new MetaData.Response(HttpStatus.SWITCHING_PROTOCOLS_101, null, HttpVersion.HTTP_1_1, response101, 0), false, null, Callback.NOOP);
 
             if (LOG.isDebugEnabled())
                 LOG.debug("Upgrading from {} to {}", getEndPoint().getConnection(), upgradeConnection);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1131,7 +1131,7 @@ public class HttpChannelTest
         HttpFields fields = HttpFields.build()
             .add(HttpHeader.HOST, "localhost")
             .asImmutable();
-        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, -1);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields);
 
         Runnable task = channel.onRequest(request);
         task.run();
@@ -1270,7 +1270,7 @@ public class HttpChannelTest
             .add(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN_8859_1.asString())
             .add(HttpHeader.CONTENT_LENGTH, "12")
             .asImmutable();
-        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, -1);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields);
 
         Runnable todo = channel.onRequest(request);
         todo.run();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
@@ -180,7 +180,7 @@ public class MockHttpStream implements HttpStream
         {
             MetaData.Response r = _response.getAndSet(response);
 
-            _responseHeaders.add(response.getFields());
+            _responseHeaders.add(response.getHttpFields());
 
             if (r != null && r.getStatus() >= 200)
             {
@@ -188,7 +188,7 @@ public class MockHttpStream implements HttpStream
                 return;
             }
 
-            if (response.getFields().contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString()) &&
+            if (response.getHttpFields().contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString()) &&
                 _channel.getConnectionMetaData() instanceof MockConnectionMetaData mock)
                 mock.notPersistent();
         }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -160,7 +160,7 @@ public class ContextHandlerTest
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
         // The original fields have been recycled.
-        assertThat(stream.getResponse().getFields().size(), equalTo(0));
+        assertThat(stream.getResponse().getHttpFields().size(), equalTo(0));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(helloHandler.getMessage()));
     }
 
@@ -198,7 +198,7 @@ public class ContextHandlerTest
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
         // The original fields have been recycled.
-        assertThat(stream.getResponse().getFields().size(), equalTo(0));
+        assertThat(stream.getResponse().getHttpFields().size(), equalTo(0));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(helloHandler.getMessage()));
     }
 
@@ -587,7 +587,7 @@ public class ContextHandlerTest
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(500));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_HTML_8859_1.asString()));
-        assertThat(stream.getResponse().getFields().size(), equalTo(0));
+        assertThat(stream.getResponse().getHttpFields().size(), equalTo(0));
         assertThat(BufferUtil.toString(stream.getResponseContent()), containsString("<h1>Context: /ctx</h1>"));
         assertThat(BufferUtil.toString(stream.getResponseContent()), containsString("java.lang.RuntimeException: Testing"));
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/DebugListener.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/DebugListener.java
@@ -251,7 +251,7 @@ public class DebugListener extends AbstractLifeCycle implements ServletContextLi
             {
                 Request br = Request.getBaseRequest(r);
 
-                String headers = _showHeaders ? ("\n" + br.getMetaData().getFields().toString()) : "";
+                String headers = _showHeaders ? ("\n" + br.getMetaData().getHttpFields().toString()) : "";
 
                 StringBuffer url = r.getRequestURL();
                 if (r.getQueryString() != null)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -936,9 +936,9 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (LOG.isDebugEnabled())
         {
             MetaData.Request metaData = _request.getMetaData();
-            LOG.debug("onRequest for {} on {}{}{} {} {}{}{}", metaData.getURIString(), this, System.lineSeparator(),
-                metaData.getMethod(), metaData.getURIString(), metaData.getHttpVersion(), System.lineSeparator(),
-                metaData.getFields());
+            LOG.debug("onRequest for {} on {}{}{} {} {}{}{}", metaData.getHttpURI().toString(), this, System.lineSeparator(),
+                metaData.getMethod(), metaData.getHttpURI().toString(), metaData.getHttpVersion(), System.lineSeparator(),
+                metaData.getHttpFields());
         }
     }
 
@@ -955,9 +955,9 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (LOG.isDebugEnabled())
         {
             MetaData.Request metaData = _request.getMetaData();
-            LOG.debug("onProcess for {} on {}{}{} {} {}{}{}", metaData.getURIString(), this, System.lineSeparator(),
-                metaData.getMethod(), metaData.getURIString(), metaData.getHttpVersion(), System.lineSeparator(),
-                metaData.getFields());
+            LOG.debug("onProcess for {} on {}{}{} {} {}{}{}", metaData.getHttpURI().toString(), this, System.lineSeparator(),
+                metaData.getMethod(), metaData.getHttpURI().toString(), metaData.getHttpVersion(), System.lineSeparator(),
+                metaData.getHttpFields());
         }
     }
 
@@ -1068,7 +1068,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                 if (handler != null)
                     content = handler.badMessageError(status, reason, fields);
 
-                sendResponse(new MetaData.Response(HttpVersion.HTTP_1_1, status, null, fields, BufferUtil.length(content)), content, true);
+                sendResponse(new MetaData.Response(status, null, HttpVersion.HTTP_1_1, fields, BufferUtil.length(content)), content, true);
             }
         }
         catch (IOException e)
@@ -1140,7 +1140,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             // TODO: why can't we just do _coreResponse.setMetaData(response), without copying?
             _coreResponse.setStatus(response.getStatus());
             // TODO: at least avoid copying the headers?
-            _coreResponse.getHeaders().add(response.getFields());
+            _coreResponse.getHeaders().add(response.getHttpFields());
             _coreResponse.setTrailersSupplier(response.getTrailersSupplier());
         }
         _coreResponse.write(complete, content, callback);
@@ -1169,7 +1169,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (LOG.isDebugEnabled())
             LOG.debug("COMMIT for {} on {}{}{} {} {}{}{}", getRequest().getRequestURI(), this, System.lineSeparator(),
                 info.getStatus(), info.getReason(), info.getHttpVersion(), System.lineSeparator(),
-                info.getFields());
+                info.getHttpFields());
     }
 
     public boolean isCommitted()
@@ -1529,7 +1529,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
 
             if (x instanceof HttpException httpException)
             {
-                MetaData.Response responseMeta = new MetaData.Response(HttpVersion.HTTP_1_1, httpException.getCode(), httpException.getReason(), HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
+                MetaData.Response responseMeta = new MetaData.Response(httpException.getCode(), httpException.getReason(), HttpVersion.HTTP_1_1, HttpFields.build().add(HttpFields.CONNECTION_CLOSE), 0);
                 send(_request.getMetaData(), responseMeta, null, true, new Nested(this)
                 {
                     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/InetAccessHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/InetAccessHandler.java
@@ -234,7 +234,7 @@ public class InetAccessHandler extends HandlerWrapper
     protected boolean isAllowed(InetAddress addr, Request baseRequest, HttpServletRequest request)
     {
         String connectorName = baseRequest.getHttpChannel().getConnector().getName();
-        String path = baseRequest.getMetaData().getURI().getCanonicalPath();
+        String path = baseRequest.getMetaData().getHttpURI().getCanonicalPath();
         return _set.test(new InetAccessSet.AccessTuple(connectorName, addr, path));
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -704,7 +704,7 @@ public class Request implements HttpServletRequest
         if (_contentType == null)
         {
             MetaData.Request metadata = _metaData;
-            _contentType = metadata == null ? null : metadata.getFields().get(HttpHeader.CONTENT_TYPE);
+            _contentType = metadata == null ? null : metadata.getHttpFields().get(HttpHeader.CONTENT_TYPE);
         }
         return _contentType;
     }
@@ -775,7 +775,7 @@ public class Request implements HttpServletRequest
 
         _cookiesExtracted = true;
 
-        for (HttpField field : metadata.getFields())
+        for (HttpField field : metadata.getHttpFields())
         {
             if (field.getHeader() == HttpHeader.COOKIE)
             {
@@ -1380,7 +1380,7 @@ public class Request implements HttpServletRequest
         MetaData.Request metadata = _metaData;
         if (metadata == null)
             return null;
-        HttpURI uri = metadata.getURI();
+        HttpURI uri = metadata.getHttpURI();
         if (uri == null)
             return null;
         return uri.isAbsolute() && metadata.getHttpVersion() == HttpVersion.HTTP_2 ? uri.getPathQuery() : uri.toString();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -1270,7 +1270,7 @@ public class Response implements HttpServletResponse
 
     protected MetaData.Response newResponseMetaData()
     {
-        return new MetaData.Response(_channel.getRequest().getHttpVersion(), getStatus(), getReason(), _fields, getLongContentLength(), getTrailers());
+        return new MetaData.Response(getStatus(), getReason(), _channel.getRequest().getHttpVersion(), _fields, getLongContentLength(), getTrailers());
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ResponseTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ResponseTest.java
@@ -2316,7 +2316,7 @@ public class ResponseTest
         @Override
         public HttpURI getHttpURI()
         {
-            return _reqMeta.getURI();
+            return _reqMeta.getHttpURI();
         }
 
         @Override
@@ -2328,7 +2328,7 @@ public class ResponseTest
         @Override
         public HttpFields getHeaders()
         {
-            return _reqMeta.getFields();
+            return _reqMeta.getHttpFields();
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/authentication/SpnegoAuthenticatorTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/authentication/SpnegoAuthenticatorTest.java
@@ -80,7 +80,7 @@ public class SpnegoAuthenticatorTest
         };
         Request req = channel.getRequest();
         Response res = channel.getResponse();
-        MetaData.Request metadata = new MetaData.Request(null, HttpURI.build("http://localhost"), null, HttpFields.EMPTY);
+        MetaData.Request metadata = new MetaData.Request("GET", HttpURI.build("http://localhost"), null, HttpFields.EMPTY);
         req.setMetaData(metadata);
 
         assertThat(channel.getState().handling(), is(HttpChannelState.Action.DISPATCH));
@@ -148,7 +148,7 @@ public class SpnegoAuthenticatorTest
 
         // Create a bogus Authorization header. We don't care about the actual credentials.
 
-        MetaData.Request metadata = new MetaData.Request(null, HttpURI.build("http://localhost"), null,
+        MetaData.Request metadata = new MetaData.Request("GET", HttpURI.build("http://localhost"), null,
             HttpFields.build().add(HttpHeader.AUTHORIZATION, "Basic asdf"));
         req.setMetaData(metadata);
 


### PR DESCRIPTION
* Removed unnecessary constructors from MetaData, MetaData.Request and MetaData.Response.
* Removed MetaData.Request.getURIString() (available as getHttpURI().toString()).
* Renamed MetaData.getFields() -> getHttpFields(), as they can be headers or trailers.
* Renamed MetaData.Request.getURI() -> getHttpURI().
* Normalized handling of contentLength, now always -1 (rather than Long.MIN_VALUE) if unknown.
* Permutated MetaData.Response constructor parameters to be consistent with MetaData.Request.
* MetaData.Request's method and httpURI must be non-null.