### PR TITLE
Fixes #9438 - Jetty 12: Review JakartaWebSocketClientContainer use of…

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -99,6 +99,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
         return context == null ? (server == null ? null : server.getContext()) : context;
     }
 
+    // Do not remove, invoked via reflection.
     public static ContextHandler getCurrentContextHandler()
     {
         Context context = getCurrentContext();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
@@ -180,6 +180,17 @@ public interface Container
     }
 
     /**
+     * A utility method to unmanage a bean from a container.
+     * @param parent the parent container
+     * @param child the child bean
+     */
+    static void unmanage(Object parent, Object child)
+    {
+        if (parent instanceof Container container)
+            container.unmanage(child);
+    }
+
+    /**
      * A utility method to remove a bean from a container.
      * @param parent the parent container.
      * @param child the child bean.

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/JakartaWebSocketClientContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/JakartaWebSocketClientContainer.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketExtension
 import org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketFrameHandler;
 import org.eclipse.jetty.ee10.websocket.jakarta.common.JakartaWebSocketFrameHandlerFactory;
 import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.component.Container;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.thread.ShutdownThread;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
@@ -63,7 +64,7 @@ import org.slf4j.LoggerFactory;
 public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer implements jakarta.websocket.WebSocketContainer
 {
     private static final Logger LOG = LoggerFactory.getLogger(JakartaWebSocketClientContainer.class);
-    private static final Map<ClassLoader, ContainerLifeCycle> SHUTDOWN_MAP = new  ConcurrentHashMap<>();
+    private static final Map<ClassLoader, ContainerLifeCycle> SHUTDOWN_MAP = new ConcurrentHashMap<>();
 
     public static void setShutdownContainer(ContainerLifeCycle container)
     {
@@ -308,6 +309,25 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (LOG.isDebugEnabled())
             LOG.debug("doClientStart() {}", this);
 
+        // Mechanism 1.
+        // - When this class is used by a web app, and it is loaded from the server
+        //   class-path, so ContextHandler can be seen from this class' ClassLoader.
+        // - When this class is used on the server in embedded code, so the same
+        //   ClassLoader can load both this class and ContextHandler.
+        Object contextHandler = getContextHandler();
+        if (contextHandler != null)
+        {
+            Container.addBean(contextHandler, this, true);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} registered for ContextHandler shutdown to {}", this, contextHandler);
+            return;
+        }
+
+        // Mechanism 2.
+        // - When this class is used by a web app, and it is loaded from the web app
+        //   ClassLoader because all the necessary jars have been put in WEB-INF/lib.
+        //   In this case the ContextHandler class cannot be loaded by this class'
+        //   ClassLoader, and we rely on the JakartaWebSocketShutdownContainer.
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         ContainerLifeCycle container = SHUTDOWN_MAP.get(cl);
         if (container != null)
@@ -318,6 +338,8 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
             return;
         }
 
+        // Mechanism 3.
+        // - When this class is used on the client side.
         ShutdownThread.register(this);
         if (LOG.isDebugEnabled())
             LOG.debug("{} registered for JVM shutdown", this);
@@ -327,6 +349,16 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
     {
         if (LOG.isDebugEnabled())
             LOG.debug("doClientStop() {}", this);
+
+        Object contextHandler = getContextHandler();
+        if (contextHandler != null)
+        {
+            Container.unmanage(contextHandler, this);
+            Container.removeBean(contextHandler, this);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} deregistered for ContextHandler shutdown from {}", this, contextHandler);
+            return;
+        }
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         ContainerLifeCycle container = SHUTDOWN_MAP.get(cl);
@@ -346,5 +378,20 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         ShutdownThread.deregister(this);
         if (LOG.isDebugEnabled())
             LOG.debug("{} deregistered for JVM shutdown", this);
+    }
+
+    public Object getContextHandler()
+    {
+        try
+        {
+            return getClass().getClassLoader()
+                .loadClass("org.eclipse.jetty.server.handler.ContextHandler")
+                .getMethod("getCurrentContextHandler")
+                .invoke(null);
+        }
+        catch (Throwable x)
+        {
+            return null;
+        }
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee10.websocket.jakarta.tests;
 
 import java.net.URI;
-import java.util.Collection;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -97,11 +96,6 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         assertThat(container, instanceOf(JakartaWebSocketClientContainer.class));
         JakartaWebSocketClientContainer clientContainer = (JakartaWebSocketClientContainer)container;
         assertThat(clientContainer.isRunning(), is(true));
-
-        // The container should be a bean on the ContextHandler.
-        Collection<WebSocketContainer> containedBeans = contextHandler.getBeans(WebSocketContainer.class);
-        assertThat(containedBeans.size(), is(1));
-        assertThat(containedBeans.toArray()[0], is(container));
 
         // The client should be attached to the servers LifeCycle and should stop with it.
         server.stop();

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.websocket.jakarta.client.JakartaWebSocketClientContainer;
-import org.eclipse.jetty.ee10.websocket.jakarta.client.internal.JakartaWebSocketShutdownContainer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -67,10 +66,6 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         contextHandler.setContextPath("/");
         contextHandler.addServlet(new ServletHolder(new ContextHandlerShutdownServlet()), "/");
         server.setHandler(contextHandler);
-
-        // Because we are using embedded we must manually add the Jakarta WS Client Shutdown SCI.
-        JakartaWebSocketShutdownContainer jakartaWebSocketClientShutdown = new JakartaWebSocketShutdownContainer();
-        contextHandler.addServletContainerInitializer(jakartaWebSocketClientShutdown);
 
         server.start();
         serverUri = WSURI.toWebsocket(server.getURI());

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee10.websocket.jakarta.tests;
 
 import java.net.URI;
+import java.util.Collection;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -91,6 +92,11 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         assertThat(container, instanceOf(JakartaWebSocketClientContainer.class));
         JakartaWebSocketClientContainer clientContainer = (JakartaWebSocketClientContainer)container;
         assertThat(clientContainer.isRunning(), is(true));
+
+        // The container should be a bean on the ContextHandler.
+        Collection<WebSocketContainer> containedBeans = contextHandler.getBeans(WebSocketContainer.class);
+        assertThat(containedBeans.size(), is(1));
+        assertThat(containedBeans.toArray()[0], is(container));
 
         // The client should be attached to the servers LifeCycle and should stop with it.
         server.stop();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -166,14 +166,19 @@ public class ContextHandler extends ScopedHandler implements Attributes, Gracefu
         return __context.get();
     }
 
-    public static ContextHandler getContextHandler(ServletContext context)
+    public static ContextHandler getCurrentContextHandler()
     {
-        if (context instanceof APIContext)
-            return ((APIContext)context).getContextHandler();
         APIContext c = getCurrentContext();
         if (c != null)
             return c.getContextHandler();
         return null;
+    }
+
+    public static ContextHandler getContextHandler(ServletContext context)
+    {
+        if (context instanceof APIContext)
+            return ((APIContext)context).getContextHandler();
+        return getCurrentContextHandler();
     }
 
     public static ServletContext getServletContext(Context context)

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/JakartaWebSocketClientContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/JakartaWebSocketClientContainer.java
@@ -15,8 +15,10 @@ package org.eclipse.jetty.ee9.websocket.jakarta.client;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -44,7 +46,6 @@ import org.eclipse.jetty.ee9.websocket.jakarta.common.JakartaWebSocketFrameHandl
 import org.eclipse.jetty.ee9.websocket.jakarta.common.JakartaWebSocketFrameHandlerFactory;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.ShutdownThread;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
 import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
@@ -63,13 +64,15 @@ import org.slf4j.LoggerFactory;
 public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer implements jakarta.websocket.WebSocketContainer
 {
     private static final Logger LOG = LoggerFactory.getLogger(JakartaWebSocketClientContainer.class);
-    private static final AtomicReference<ContainerLifeCycle> SHUTDOWN_CONTAINER = new AtomicReference<>();
+    private static final AtomicReference<Map<ClassLoader, ContainerLifeCycle>> SHUTDOWN_MAP = new AtomicReference<>(new ConcurrentHashMap<>());
 
     public static void setShutdownContainer(ContainerLifeCycle container)
     {
-        SHUTDOWN_CONTAINER.set(container);
+        Map<ClassLoader, ContainerLifeCycle> map = SHUTDOWN_MAP.get();
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        map.compute(cl, (k, v) -> container);
         if (LOG.isDebugEnabled())
-            LOG.debug("initialized {} to {}", String.format("%s@%x", SHUTDOWN_CONTAINER.getClass().getSimpleName(), SHUTDOWN_CONTAINER.hashCode()), container);
+            LOG.debug("initialized shutdown map@{} to [{}={}]", SHUTDOWN_MAP.hashCode(), cl, container);
     }
 
     protected WebSocketCoreClient coreClient;
@@ -175,10 +178,8 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         JakartaClientUpgradeRequest upgradeRequest = new JakartaClientUpgradeRequest(this, getWebSocketCoreClient(), destURI, configuredEndpoint);
 
         EndpointConfig config = configuredEndpoint.getConfig();
-        if (config instanceof ClientEndpointConfig)
+        if (config instanceof ClientEndpointConfig clientEndpointConfig)
         {
-            ClientEndpointConfig clientEndpointConfig = (ClientEndpointConfig)config;
-
             JsrUpgradeListener jsrUpgradeListener = new JsrUpgradeListener(clientEndpointConfig.getConfigurator());
             upgradeRequest.addListener(jsrUpgradeListener);
 
@@ -309,27 +310,23 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (LOG.isDebugEnabled())
             LOG.debug("doClientStart() {}", this);
 
-        // If we are running in Jetty register shutdown with the ContextHandler.
-        if (addToContextHandler())
+        Map<ClassLoader, ContainerLifeCycle> shutdownMap = SHUTDOWN_MAP.get();
+        if (shutdownMap != null)
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Shutdown registered with ContextHandler");
-            return;
-        }
-
-        // If we are running inside a different ServletContainer we can register with the SHUTDOWN_CONTAINER static.
-        ContainerLifeCycle shutdownContainer = SHUTDOWN_CONTAINER.get();
-        if (shutdownContainer != null)
-        {
-            shutdownContainer.addManaged(this);
-            if (LOG.isDebugEnabled())
-                LOG.debug("Shutdown registered with ShutdownContainer {}", shutdownContainer);
-            return;
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ContainerLifeCycle container = shutdownMap.get(cl);
+            if (container != null)
+            {
+                container.addManaged(this);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} registered for Context shutdown to {}", this, container);
+                return;
+            }
         }
 
         ShutdownThread.register(this);
         if (LOG.isDebugEnabled())
-            LOG.debug("Shutdown registered with ShutdownThread");
+            LOG.debug("{} registered for JVM shutdown", this);
     }
 
     protected void doClientStop()
@@ -337,75 +334,27 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (LOG.isDebugEnabled())
             LOG.debug("doClientStop() {}", this);
 
-        // Remove from context handler if running in Jetty server.
-        removeFromContextHandler();
-
-        // Remove from the Shutdown Container.
-        ContainerLifeCycle shutdownContainer = SHUTDOWN_CONTAINER.get();
-        if (shutdownContainer != null && shutdownContainer.contains(this))
+        Map<ClassLoader, ContainerLifeCycle> shutdownMap = SHUTDOWN_MAP.get();
+        if (shutdownMap != null)
         {
-            // Un-manage first as we don't want to call stop again while in STOPPING state.
-            shutdownContainer.unmanage(this);
-            shutdownContainer.removeBean(this);
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ContainerLifeCycle container = shutdownMap.get(cl);
+            if (container != null)
+            {
+                // As we are already stopping this instance, un-manage first
+                // to avoid that removeBean() stops again this instance.
+                container.unmanage(this);
+                if (container.removeBean(this))
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("{} deregistered for Context shutdown from {}", this, container);
+                    return;
+                }
+            }
         }
 
-        // If not running in a server we need to de-register with the shutdown thread.
         ShutdownThread.deregister(this);
-    }
-
-    private boolean addToContextHandler()
-    {
-        try
-        {
-            Object context = getClass().getClassLoader()
-                .loadClass("org.eclipse.jetty.server.handler.ContextHandler")
-                .getMethod("getCurrentContext")
-                .invoke(null);
-
-            Object contextHandler = context.getClass()
-                .getMethod("getContextHandler")
-                .invoke(context);
-
-            contextHandler.getClass()
-                .getMethod("addManaged", LifeCycle.class)
-                .invoke(contextHandler, this);
-
-            return true;
-        }
-        catch (Throwable throwable)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("error from addToContextHandler() for {}", this, throwable);
-            return false;
-        }
-    }
-
-    private void removeFromContextHandler()
-    {
-        try
-        {
-            Object context = getClass().getClassLoader()
-                .loadClass("org.eclipse.jetty.server.handler.ContextHandler")
-                .getMethod("getCurrentContext")
-                .invoke(null);
-
-            Object contextHandler = context.getClass()
-                .getMethod("getContextHandler")
-                .invoke(context);
-
-            // Un-manage first as we don't want to call stop again while in STOPPING state.
-            contextHandler.getClass()
-                .getMethod("unmanage", Object.class)
-                .invoke(contextHandler, this);
-
-            contextHandler.getClass()
-                .getMethod("removeBean", Object.class)
-                .invoke(contextHandler, this);
-        }
-        catch (Throwable throwable)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("error from removeFromContextHandler() for {}", this, throwable);
-        }
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} deregistered for JVM shutdown", this);
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee9.websocket.jakarta.tests;
 
 import java.net.URI;
+import java.util.Collection;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -91,6 +92,11 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         assertThat(container, instanceOf(JakartaWebSocketClientContainer.class));
         JakartaWebSocketClientContainer clientContainer = (JakartaWebSocketClientContainer)container;
         assertThat(clientContainer.isRunning(), is(true));
+
+        // The container should be a bean on the ContextHandler.
+        Collection<WebSocketContainer> containedBeans = contextHandler.getBeans(WebSocketContainer.class);
+        assertThat(containedBeans.size(), is(1));
+        assertThat(containedBeans.toArray()[0], is(container));
 
         // The client should be attached to the servers LifeCycle and should stop with it.
         server.stop();

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee9.websocket.jakarta.tests;
 
 import java.net.URI;
-import java.util.Collection;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -97,11 +96,6 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         assertThat(container, instanceOf(JakartaWebSocketClientContainer.class));
         JakartaWebSocketClientContainer clientContainer = (JakartaWebSocketClientContainer)container;
         assertThat(clientContainer.isRunning(), is(true));
-
-        // The container should be a bean on the ContextHandler.
-        Collection<WebSocketContainer> containedBeans = contextHandler.getCoreContextHandler().getBeans(WebSocketContainer.class);
-        assertThat(containedBeans.size(), is(1));
-        assertThat(containedBeans.toArray()[0], is(container));
 
         // The client should be attached to the servers LifeCycle and should stop with it.
         server.stop();

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/JakartaClientShutdownWithServerEmbeddedTest.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.ee9.websocket.jakarta.client.JakartaWebSocketClientContainer;
-import org.eclipse.jetty.ee9.websocket.jakarta.client.internal.JakartaWebSocketShutdownContainer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -67,10 +66,6 @@ public class JakartaClientShutdownWithServerEmbeddedTest
         contextHandler.setContextPath("/");
         contextHandler.addServlet(new ServletHolder(new ContextHandlerShutdownServlet()), "/");
         server.setHandler(contextHandler);
-
-        // Because we are using embedded we must manually add the Jakarta WS Client Shutdown SCI.
-        JakartaWebSocketShutdownContainer jakartaWebSocketClientShutdown = new JakartaWebSocketShutdownContainer();
-        contextHandler.addServletContainerInitializer(jakartaWebSocketClientShutdown);
 
         server.start();
         serverUri = WSURI.toWebsocket(server.getURI());


### PR DESCRIPTION
… reflection

* Removed the use of reflection as it was unnecessary.
* Improved `setShutdownContainer()` to take into account multiple web applications, so it is now a `Map<ClassLoader, ContainerLifeCycle>` so that each web application has its own container to register `JakartaWebSocketClientContainer` instances.