### PR TITLE
Jetty-12.0.x tests in parallel (down build time on CI from 1h25 to 55min) some modules are still not parallel due to some static usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ This is configurable using the following properties:
     # number of tests executed in parallel
     -Djunit.jupiter.execution.parallel.config.fixed.parallelism=2
 ```
+If a test cannot be runned in parallel because accessing/modifying some static fields or for any other reasons, the test should be marked with the annotation
+```java
+@Isolated("Access static field of Configurations")
+```
+
 
 Professional Services
 ---------------------

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ all            | `jetty-home/target/jetty-home-<ver>.tar.gz`                    
 Note: The build tests do a lot of stress testing, and on some machines it is necessary to set the 
 file descriptor limit to greater than 2048 for the tests to all pass successfully (check your `ulimit -n` value).
 
+Note: The tests are running in parallel using [Junit5 parallel execution](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution).
+This is configurable using the following properties:
+```
+    # to enable/disable the parallel execution
+    -Djunit.jupiter.execution.parallel.enabled=true/false
+    # number of tests executed in parallel
+    -Djunit.jupiter.execution.parallel.config.fixed.parallelism=2
+```
+
 Professional Services
 ---------------------
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
@@ -39,7 +39,6 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 
-import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
@@ -609,7 +610,7 @@ public class HttpClientTLSTest
                     latch.countDown();
             });
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
     @Test

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -95,7 +95,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class HttpClientTest extends AbstractHttpClientServerTest
 {
-    public WorkDir testdir;
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
@@ -546,8 +545,9 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
-    public void testExchangeIsCompleteOnlyWhenBothRequestAndResponseAreComplete(Scenario scenario) throws Exception
+    public void testExchangeIsCompleteOnlyWhenBothRequestAndResponseAreComplete(Scenario scenario, WorkDir workDir) throws Exception
     {
+        Path targetTestsDir = workDir.getEmptyPathDir();
         start(scenario, new EmptyServerHandler()
         {
             @Override
@@ -561,7 +561,6 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         });
 
         // Prepare a big file to upload
-        Path targetTestsDir = testdir.getEmptyPathDir();
         Files.createDirectories(targetTestsDir);
         Path file = Paths.get(targetTestsDir.toString(), "http_client_conversation.big");
         try (OutputStream output = Files.newOutputStream(file, StandardOpenOption.CREATE))

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/AppLifeCycleTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/AppLifeCycleTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.deploy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,11 +36,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(WorkDirExtension.class)
 public class AppLifeCycleTest
 {
-    public WorkDir testdir;
-
     private void assertNoPath(String from, String to)
     {
-        assertPath(from, to, new ArrayList<String>());
+        assertPath(from, to, new ArrayList<>());
     }
 
     private void assertPath(AppLifeCycle lifecycle, String from, String to, List<String> expected)
@@ -89,30 +88,21 @@ public class AppLifeCycleTest
     @Test
     public void testFindPathDeployedStarted()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("deployed");
-        expected.add("starting");
-        expected.add("started");
+        List<String> expected = List.of("deployed", "starting", "started");
         assertPath("deployed", "started", expected);
     }
 
     @Test
     public void testFindPathDeployedUndeployed()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("deployed");
-        expected.add("undeploying");
-        expected.add("undeployed");
+        List<String> expected = List.of("deployed", "undeploying", "undeployed");
         assertPath("deployed", "undeployed", expected);
     }
 
     @Test
     public void testFindPathStartedDeployed()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("started");
-        expected.add("stopping");
-        expected.add("deployed");
+        List<String> expected = List.of("started", "stopping", "deployed");
         assertPath("started", "deployed", expected);
     }
 
@@ -125,34 +115,21 @@ public class AppLifeCycleTest
     @Test
     public void testFindPathStartedUndeployed()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("started");
-        expected.add("stopping");
-        expected.add("deployed");
-        expected.add("undeploying");
-        expected.add("undeployed");
+        List<String> expected = List.of("started", "stopping", "deployed", "undeploying", "undeployed");
         assertPath("started", "undeployed", expected);
     }
 
     @Test
     public void testFindPathUndeployedDeployed()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("undeployed");
-        expected.add("deploying");
-        expected.add("deployed");
+        List<String> expected = List.of("undeployed", "deploying", "deployed");
         assertPath("undeployed", "deployed", expected);
     }
 
     @Test
     public void testFindPathUndeployedStarted()
     {
-        List<String> expected = new ArrayList<String>();
-        expected.add("undeployed");
-        expected.add("deploying");
-        expected.add("deployed");
-        expected.add("starting");
-        expected.add("started");
+        List<String> expected = List.of("undeployed", "deploying", "deployed", "starting", "started");
         assertPath("undeployed", "started", expected);
     }
 
@@ -169,12 +146,13 @@ public class AppLifeCycleTest
      * @throws IOException on test failure
      */
     @Test
-    public void testFindPathMultiple() throws IOException
+    public void testFindPathMultiple(WorkDir workDir) throws IOException
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         AppLifeCycle lifecycle = new AppLifeCycle();
-        List<String> expected = new ArrayList<String>();
+        List<String> expected = new ArrayList<>();
 
-        File outputDir = testdir.getEmptyPathDir().toFile();
+        File outputDir = tmpPath.toFile();
 
         // Modify graph to add new 'staging' -> 'staged' between 'deployed' and 'started'
         GraphOutputDot.write(lifecycle, new File(outputDir, "multiple-1.dot")); // before change

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentManagerTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentManagerTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.deploy;
 
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Set;
 
@@ -34,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(WorkDirExtension.class)
 public class DeploymentManagerTest
 {
-    public WorkDir testdir;
 
     @Test
     public void testReceiveApp() throws Exception
@@ -135,12 +135,13 @@ public class DeploymentManagerTest
     }
 
     @Test
-    public void testXmlConfigured() throws Exception
+    public void testXmlConfigured(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         XmlConfiguredJetty jetty = null;
         try
         {
-            jetty = new XmlConfiguredJetty(testdir.getEmptyPathDir());
+            jetty = new XmlConfiguredJetty(testdir);
             jetty.addConfiguration("jetty.xml");
             jetty.addConfiguration("jetty-http.xml");
             jetty.addConfiguration("jetty-deploymgr-contexts.xml");

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ContextProviderRuntimeUpdatesTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ContextProviderRuntimeUpdatesTest.java
@@ -44,15 +44,13 @@ public class ContextProviderRuntimeUpdatesTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(ContextProviderRuntimeUpdatesTest.class);
 
-    public WorkDir testdir;
     private static XmlConfiguredJetty jetty;
     private final AtomicInteger _scans = new AtomicInteger();
     private int _providerCount;
 
-    public void createJettyBase() throws Exception
+    public void createJettyBase(Path testdir) throws Exception
     {
-        testdir.ensureEmpty();
-        jetty = new XmlConfiguredJetty(testdir.getEmptyPathDir());
+        jetty = new XmlConfiguredJetty(testdir);
 
         Path resourceBase = jetty.getJettyBasePath().resolve("resourceBase");
         FS.ensureDirExists(resourceBase);
@@ -118,9 +116,10 @@ public class ContextProviderRuntimeUpdatesTest
      * @throws IOException on test failure
      */
     @Test
-    public void testAfterStartupContext() throws Exception
+    public void testAfterStartupContext(WorkDir workDir) throws Exception
     {
-        createJettyBase();
+        Path testdir = workDir.getEmptyPathDir();
+        createJettyBase(testdir);
         startJetty();
 
         jetty.copyWebapp("bar-core-context.xml", "bar.xml");
@@ -134,9 +133,10 @@ public class ContextProviderRuntimeUpdatesTest
      * @throws IOException on test failure
      */
     @Test
-    public void testAfterStartupThenRemoveContext() throws Exception
+    public void testAfterStartupThenRemoveContext(WorkDir workDir) throws Exception
     {
-        createJettyBase();
+        Path testdir = workDir.getEmptyPathDir();
+        createJettyBase(testdir);
         startJetty();
 
         jetty.copyWebapp("bar-core-context.xml", "bar.xml");
@@ -154,9 +154,10 @@ public class ContextProviderRuntimeUpdatesTest
      * @throws Exception on test failure
      */
     @Test
-    public void testAfterStartupThenUpdateContext() throws Exception
+    public void testAfterStartupThenUpdateContext(WorkDir workDir) throws Exception
     {
-        createJettyBase();
+        Path testdir = workDir.getEmptyPathDir();
+        createJettyBase(testdir);
 
         startJetty();
 

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ContextProviderStartupTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/ContextProviderStartupTest.java
@@ -32,13 +32,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirExtension.class)
 public class ContextProviderStartupTest
 {
-    public WorkDir testdir;
+    public WorkDir workDir;
+    public Path testdir;
     private static XmlConfiguredJetty jetty;
 
     @BeforeEach
     public void setupEnvironment() throws Exception
     {
-        jetty = new XmlConfiguredJetty(testdir.getEmptyPathDir());
+        testdir = workDir.getEmptyPathDir();
+        jetty = new XmlConfiguredJetty(testdir);
 
         Path resourceBase = jetty.getJettyBasePath().resolve("resourceBase");
         FS.ensureDirExists(resourceBase);

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
@@ -74,7 +74,6 @@ public class XmlConfiguredJetty
 
     public XmlConfiguredJetty(Path testDir) throws IOException
     {
-        FS.ensureEmpty(testDir);
         _jettyBase = testDir.resolve("base");
         FS.ensureDirExists(_jettyBase);
 
@@ -261,7 +260,7 @@ public class XmlConfiguredJetty
         }
 
         this._server = server;
-        this._server.setStopTimeout(10);
+        this._server.setStopTimeout(10000);
         this._contexts = (ContextHandlerCollection)ids.get("Contexts");
     }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/EtagUtilsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/EtagUtilsTest.java
@@ -38,13 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class EtagUtilsTest
 {
-    public WorkDir workDir;
 
     @Test
-    public void testCalcWeakETag() throws IOException
+    public void testCalcWeakETag(WorkDir workDir) throws IOException
     {
-        Path root = workDir.getEmptyPathDir();
-        Path testFile = root.resolve("test.dat");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testFile = tmpPath.resolve("test.dat");
+        System.out.println("testFile" + testFile.toString());
         Files.writeString(testFile, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
         String weakEtag = EtagUtils.computeWeakEtag(testFile);
@@ -53,13 +53,13 @@ public class EtagUtilsTest
     }
 
     @Test
-    public void testCalcWeakETagSameFileDifferentLocations() throws IOException
+    public void testCalcWeakETagSameFileDifferentLocations(WorkDir workDir) throws IOException
     {
-        Path root = workDir.getEmptyPathDir();
-        Path testFile = root.resolve("test.dat");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testFile = tmpPath.resolve("test.dat");
         Files.writeString(testFile, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
-        Path altDir = root.resolve("alt");
+        Path altDir = tmpPath.resolve("alt");
         FS.ensureDirExists(altDir);
         Path altFile = altDir.resolve("test.dat");
         Files.copy(testFile, altFile);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpScheme;
@@ -500,7 +501,7 @@ public class HTTP2Test extends AbstractTest
             }
         });
         assertTrue(exchangeLatch2.await(5, TimeUnit.SECONDS));
-        assertEquals(1, session.getStreams().size());
+        await().atMost(Duration.ofSeconds(5)).until(() -> session.getStreams().size(), is(1));
 
         // Create a fourth stream.
         MetaData.Request request4 = newRequest("GET", HttpFields.EMPTY);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MultiplexedConnectionPoolTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MultiplexedConnectionPoolTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Sibling of ConnectionPoolTest, but using H2 to multiplex connections.
@@ -337,7 +338,7 @@ public class MultiplexedConnectionPoolTest
             assertThat(response.getStatus(), Matchers.is(200));
 
             // Check that the pool never grows above 1.
-            assertThat(poolRef.get().size(), is(1));
+            assertThat(poolRef.get().size(), lessThan(2));
 
             Thread.sleep(maxDuration * 2);
         }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -454,7 +454,7 @@ public class StreamResetTest extends AbstractTest
 
         // Wait for the server to receive the reset and process
         // it, and for the client to process the window updates.
-        await().atMost(5, TimeUnit.SECONDS)
+        await().atMost(10, TimeUnit.SECONDS)
             .until(() -> ((HTTP2Session)client).updateSendWindow(0), Matchers.greaterThan(0));
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
@@ -11,6 +11,9 @@
   <name>Core :: HTTP3 :: Tests</name>
 
   <properties>
+    <!-- too flaky to support parallel tests in CI -->
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+    <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
@@ -103,7 +103,7 @@ public class AbstractClientServerTest
     protected Session.Client newSession(Session.Client.Listener listener) throws Exception
     {
         InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
-        return http3Client.connect(address, listener).get(5, TimeUnit.SECONDS);
+        return http3Client.connect(address, listener).get(30, TimeUnit.SECONDS);
     }
 
     protected MetaData.Request newRequest(String path)

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
@@ -1232,13 +1232,13 @@ public class GoAwayTest extends AbstractClientServerTest
             }
         });
 
-        assertTrue(settingsLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(settingsLatch.await(10, TimeUnit.SECONDS));
 
         server.stop();
 
-        assertTrue(clientGoAwayLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(clientDisconnectLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(serverDisconnectLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientGoAwayLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(clientDisconnectLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(serverDisconnectLatch.await(10, TimeUnit.SECONDS));
 
         await().atMost(1, TimeUnit.SECONDS).until(() -> serverSessionRef.get().getProtocolSession().getQuicSession().getQuicConnection().getEndPoint().isOpen(), is(false));
         await().atMost(1, TimeUnit.SECONDS).until(() -> clientSession.getProtocolSession().getQuicSession().getQuicConnection().getEndPoint().isOpen(), is(false));

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
@@ -77,7 +77,7 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
         });
 
         ContentResponse response = httpClient.newRequest("https://localhost:" + connector.getLocalPort())
-            .timeout(5, TimeUnit.SECONDS)
+            .timeout(10, TimeUnit.SECONDS)
             .send();
         assertEquals(content, response.getContentAsString());
     }
@@ -179,7 +179,7 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
                 latch.countDown();
             });
 
-        assertTrue(beforeContentLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(beforeContentLatch.await(10, TimeUnit.SECONDS));
 
         // Verify that the response is not completed yet.
         assertFalse(latch.await(1, TimeUnit.SECONDS));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -57,10 +57,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(WorkDirExtension.class)
+@ExtendWith(WorkDirExtension.class) 
 public class IOTest
 {
-    public WorkDir workDir;
 
     @Test
     public void testIO() throws Exception
@@ -428,10 +427,10 @@ public class IOTest
     }
 
     @Test
-    public void testGatherWrite() throws Exception
+    public void testGatherWrite(WorkDir workDir) throws Exception
     {
-        Path dir = workDir.getEmptyPathDir();
-        Path file = Files.createTempFile(dir, "test", ".txt");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path file = Files.createTempFile(tmpPath, "test", ".txt");
         FileChannel out = FileChannel.open(file,
             StandardOpenOption.CREATE,
             StandardOpenOption.READ,
@@ -604,4 +603,5 @@ public class IOTest
         assertFalse(Files.isSymbolicLink(realPath));
         assertFalse(Files.isSymbolicLink(linkPath));
     }
+
 }

--- a/jetty-core/jetty-keystore/src/test/java/org/eclipse/jetty/test/keystore/KeystoreGeneratorTest.java
+++ b/jetty-core/jetty-keystore/src/test/java/org/eclipse/jetty/test/keystore/KeystoreGeneratorTest.java
@@ -33,17 +33,20 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class KeystoreGeneratorTest
 {
     private Server _server;
@@ -57,9 +60,10 @@ public class KeystoreGeneratorTest
     @BeforeEach
     public void before(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         // Generate a test keystore.
         String password = "myKeystorePassword";
-        Path outputFile = workDir.getEmptyPathDir().resolve("keystore-test.p12");
+        Path outputFile = tmpPath.resolve("keystore-test.p12");
         File myPassword = KeystoreGenerator.generateTestKeystore(outputFile.toString(), password);
         assertTrue(myPassword.exists());
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -233,6 +233,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
      * Feed a full header method
      */
     @Test
+    @Tag("flaky")
     public void testFullMethod() throws Exception
     {
         // TODO this test is flakey

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceListingTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResourceListingTest.java
@@ -33,10 +33,12 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.toolchain.xhtml.CatalogXHTML;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Document;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -50,13 +52,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class ResourceListingTest
 {
     @Test
     public void testBasicResourceXHtmlListingRoot(WorkDir workDir) throws IOException
     {
         Path root = workDir.getEmptyPathDir();
-
         FS.touch(root.resolve("entry1.txt"));
         FS.touch(root.resolve("entry2.dat"));
         Files.createDirectory(root.resolve("dirFoo"));
@@ -86,7 +88,6 @@ public class ResourceListingTest
     public void testBasicResourceXHtmlListingDeep(WorkDir workDir) throws IOException
     {
         Path root = workDir.getEmptyPathDir();
-
         FS.touch(root.resolve("entry1.txt"));
         FS.touch(root.resolve("entry2.dat"));
         Files.createDirectory(root.resolve("dirFoo"));
@@ -116,7 +117,6 @@ public class ResourceListingTest
     public void testResourceCollectionXHtmlListingContext(WorkDir workDir) throws IOException
     {
         Path root = workDir.getEmptyPathDir();
-
         Path docrootA = root.resolve("docrootA");
         Files.createDirectory(docrootA);
         FS.touch(docrootA.resolve("entry1.txt"));
@@ -180,7 +180,6 @@ public class ResourceListingTest
     public void testListingFilenamesOnly(WorkDir workDir) throws Exception
     {
         Path docRoot = workDir.getEmptyPathDir();
-
         /* create some content in the docroot */
         FS.ensureDirExists(docRoot);
         Path one = docRoot.resolve("one");
@@ -209,9 +208,8 @@ public class ResourceListingTest
     @Test
     public void testListingProperUrlEncoding(WorkDir workDir) throws Exception
     {
-        Path docRoot = workDir.getEmptyPathDir();
         /* create some content in the docroot */
-
+        Path docRoot = workDir.getEmptyPathDir();
         Path wackyDir = docRoot.resolve("dir;"); // this should not be double-encoded.
         FS.ensureDirExists(wackyDir);
 
@@ -255,7 +253,6 @@ public class ResourceListingTest
     public void testListingWithQuestionMarks(WorkDir workDir) throws Exception
     {
         Path docRoot = workDir.getEmptyPathDir();
-
         /* create some content in the docroot */
         FS.ensureDirExists(docRoot.resolve("one"));
         FS.ensureDirExists(docRoot.resolve("two"));
@@ -279,7 +276,6 @@ public class ResourceListingTest
     public void testListingEncoding(WorkDir workDir) throws Exception
     {
         Path docRoot = workDir.getEmptyPathDir();
-
         /* create some content in the docroot */
         Path one = docRoot.resolve("one");
         FS.ensureDirExists(one);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/FileBufferedResponseHandlerTest.java
@@ -32,8 +32,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ExtendWith(WorkDirExtension.class)
 @Disabled // TODO
+@ExtendWith(WorkDirExtension.class)
 public class FileBufferedResponseHandlerTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(FileBufferedResponseHandlerTest.class);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MultiPartFormDataHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MultiPartFormDataHandlerTest.java
@@ -34,11 +34,13 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class MultiPartFormDataHandlerTest
 {
     private Server server;
@@ -246,8 +249,9 @@ public class MultiPartFormDataHandlerTest
     }
 
     @Test
-    public void testAsyncMultiPartResponse(@TempDir Path tempDir) throws Exception
+    public void testAsyncMultiPartResponse(WorkDir workDir) throws Exception
     {
+        Path tempDir = workDir.getEmptyPathDir();
         start(new Handler.Abstract.NonBlocking()
         {
             @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -59,6 +59,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
@@ -70,6 +71,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -104,6 +106,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 /**
  * Resource Handler test
  */
+@ExtendWith(WorkDirExtension.class)
 public class ResourceHandlerTest
 {
     public WorkDir workDir;
@@ -117,39 +120,39 @@ public class ResourceHandlerTest
     private static void addBasicWelcomeScenarios(Scenarios scenarios)
     {
         scenarios.addScenario(
-            "GET /context/one/ (index.htm match)",
-            """
-                GET /context/one/ HTTP/1.1\r
-                Host: local\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response.getContent(), containsString("<h1>Hello Inde</h1>"))
+                "GET /context/one/ (index.htm match)",
+                """
+                    GET /context/one/ HTTP/1.1\r
+                    Host: local\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.OK_200,
+                (response) -> assertThat(response.getContent(), containsString("<h1>Hello Inde</h1>"))
         );
 
         scenarios.addScenario(
-            "GET /context/two/ (index.html match)",
-            """
-                GET /context/two/ HTTP/1.1\r
-                Host: local\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response.getContent(), containsString("<h1>Hello Index</h1>"))
+                "GET /context/two/ (index.html match)",
+                """
+                    GET /context/two/ HTTP/1.1\r
+                    Host: local\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.OK_200,
+                (response) -> assertThat(response.getContent(), containsString("<h1>Hello Index</h1>"))
         );
 
         scenarios.addScenario(
-            "GET /context/three/ (index.html wins over index.htm)",
-            """
-                GET /context/three/ HTTP/1.1\r
-                Host: local\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response.getContent(), containsString("<h1>Three Index</h1>"))
+                "GET /context/three/ (index.html wins over index.htm)",
+                """
+                    GET /context/three/ HTTP/1.1\r
+                    Host: local\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.OK_200,
+                (response) -> assertThat(response.getContent(), containsString("<h1>Three Index</h1>"))
         );
     }
 
@@ -191,8 +194,8 @@ public class ResourceHandlerTest
                 Connection: close\r
                 \r
                 """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response.getContent(), containsString("<h1>Hello Index</h1>"))
+                HttpStatus.OK_200,
+                (response) -> assertThat(response.getContent(), containsString("<h1>Hello Index</h1>"))
         );
 
         scenarios.addScenario("""
@@ -201,8 +204,8 @@ public class ResourceHandlerTest
                 Connection: close\r
                 \r
                 """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response.getContent(), containsString("Hello Index"))
+                HttpStatus.OK_200,
+                (response) -> assertThat(response.getContent(), containsString("Hello Index"))
         );
 
         List<String> notEncodedPrefixes = new ArrayList<>();
@@ -216,7 +219,7 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.NOT_FOUND_404
+                    HttpStatus.NOT_FOUND_404
             );
 
             scenarios.addScenario("""
@@ -225,7 +228,7 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX", prefix),
-                HttpStatus.NOT_FOUND_404
+                    HttpStatus.NOT_FOUND_404
             );
 
             scenarios.addScenario("""
@@ -234,8 +237,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX", prefix),
-                HttpStatus.NOT_FOUND_404,
-                (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
+                    HttpStatus.NOT_FOUND_404,
+                    (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
             );
 
             scenarios.addScenario("""
@@ -244,8 +247,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.BAD_REQUEST_400,
-                (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
+                    HttpStatus.BAD_REQUEST_400,
+                    (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
             );
 
             scenarios.addScenario("""
@@ -254,8 +257,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.BAD_REQUEST_400,
-                (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
+                    HttpStatus.BAD_REQUEST_400,
+                    (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
             );
 
             scenarios.addScenario("""
@@ -264,8 +267,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.NOT_FOUND_404,
-                (response) -> assertThat(response.getContent(), not(containsString("Hello Index")))
+                    HttpStatus.NOT_FOUND_404,
+                    (response) -> assertThat(response.getContent(), not(containsString("Hello Index")))
             );
 
             scenarios.addScenario("""
@@ -274,7 +277,7 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.BAD_REQUEST_400
+                    HttpStatus.BAD_REQUEST_400
             );
 
             scenarios.addScenario("""
@@ -283,12 +286,12 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.NOT_FOUND_404,
-                (response) ->
-                {
-                    String body = response.getContent();
-                    assertThat(body, not(containsString("Directory: ")));
-                }
+                    HttpStatus.NOT_FOUND_404,
+                    (response) ->
+                    {
+                        String body = response.getContent();
+                        assertThat(body, not(containsString("Directory: ")));
+                    }
             );
         }
 
@@ -308,8 +311,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.MOVED_TEMPORARILY_302,
-                (response) -> assertThat("Location header", response.get(HttpHeader.LOCATION), endsWith(prefix + "/"))
+                    HttpStatus.MOVED_TEMPORARILY_302,
+                    (response) -> assertThat("Location header", response.get(HttpHeader.LOCATION), endsWith(prefix + "/"))
             );
 
             scenarios.addScenario("""
@@ -318,7 +321,7 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.OK_200
+                    HttpStatus.OK_200
             );
 
             scenarios.addScenario("""
@@ -327,8 +330,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.OK_200,
-                (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
+                    HttpStatus.OK_200,
+                    (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
             );
 
             scenarios.addScenario("""
@@ -337,8 +340,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.OK_200,
-                (response) -> assertThat(response.getContent(), containsString("Hello Index"))
+                    HttpStatus.OK_200,
+                    (response) -> assertThat(response.getContent(), containsString("Hello Index"))
             );
 
             scenarios.addScenario("""
@@ -347,13 +350,13 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.NOT_FOUND_404,
-                (response) ->
-                {
-                    String body = response.getContent();
-                    assertThat(body, containsString("Not Found"));
-                    assertThat(body, not(containsString("Directory: ")));
-                }
+                    HttpStatus.NOT_FOUND_404,
+                    (response) ->
+                    {
+                        String body = response.getContent();
+                        assertThat(body, containsString("Not Found"));
+                        assertThat(body, not(containsString("Directory: ")));
+                    }
             );
 
             scenarios.addScenario("""
@@ -362,8 +365,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.NOT_FOUND_404,
-                (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
+                    HttpStatus.NOT_FOUND_404,
+                    (response) -> assertThat(response.getContent(), not(containsString("Sssh")))
             );
 
             scenarios.addScenario("""
@@ -372,8 +375,8 @@ public class ResourceHandlerTest
                     Connection: close\r
                     \r
                     """.replace("@PREFIX@", prefix),
-                HttpStatus.OK_200,
-                (response) -> assertThat(response.getContent(), containsString("Hello Index"))
+                    HttpStatus.OK_200,
+                    (response) -> assertThat(response.getContent(), containsString("Hello Index"))
             );
         }
 
@@ -398,228 +401,228 @@ public class ResourceHandlerTest
         Scenarios scenarios = new Scenarios();
 
         scenarios.addScenario(
-            "No range requested",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response, containsHeaderValue(HttpHeader.ACCEPT_RANGES, "bytes"))
+                "No range requested",
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.OK_200,
+                (response) -> assertThat(response, containsHeaderValue(HttpHeader.ACCEPT_RANGES, "bytes"))
         );
 
         scenarios.addScenario(
-            "Simple range request (no-close)",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                assertThat(response, containsHeaderValue("Content-Type", "text/plain"));
-                assertThat(response, containsHeaderValue("Content-Length", "10"));
-                assertThat(response, containsHeaderValue("Content-Range", "bytes 0-9/80"));
-            }
+                "Simple range request (no-close)",
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    assertThat(response, containsHeaderValue("Content-Type", "text/plain"));
+                    assertThat(response, containsHeaderValue("Content-Length", "10"));
+                    assertThat(response, containsHeaderValue("Content-Range", "bytes 0-9/80"));
+                }
         );
 
         scenarios.addScenario(
-            "Simple range request w/close",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                assertThat(response, containsHeaderValue("Content-Type", "text/plain"));
-                assertThat(response, containsHeaderValue("Content-Range", "bytes 0-9/80"));
-            });
+                "Simple range request w/close",
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    assertThat(response, containsHeaderValue("Content-Type", "text/plain"));
+                    assertThat(response, containsHeaderValue("Content-Range", "bytes 0-9/80"));
+                });
 
         scenarios.addScenario(
-            "Multiple ranges (x3)",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9,20-29,40-49\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                String body = response.getContent();
+                "Multiple ranges (x3)",
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9,20-29,40-49\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    String body = response.getContent();
 
-                assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
-                assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
+                    assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
+                    assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
 
-                HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
-                String boundary = getContentTypeBoundary(contentType);
+                    HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
+                    String boundary = getContentTypeBoundary(contentType);
 
-                assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
+                    assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
 
-                assertThat(body, containsString("Content-Range: bytes 0-9/80"));
-                assertThat(body, containsString("Content-Range: bytes 20-29/80"));
+                    assertThat(body, containsString("Content-Range: bytes 0-9/80"));
+                    assertThat(body, containsString("Content-Range: bytes 20-29/80"));
 
-                assertThat(response.getContent(), startsWith("--" + boundary));
-                assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
-            }
+                    assertThat(response.getContent(), startsWith("--" + boundary));
+                    assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
+                }
         );
 
         scenarios.addScenario("Multiple ranges (x4)",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9,20-29,40-49,70-79\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                String body = response.getContent();
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9,20-29,40-49,70-79\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    String body = response.getContent();
 
-                assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
-                assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
+                    assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
+                    assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
 
-                HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
-                String boundary = getContentTypeBoundary(contentType);
+                    HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
+                    String boundary = getContentTypeBoundary(contentType);
 
-                assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
+                    assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
 
-                assertThat(body, containsString("Content-Range: bytes 0-9/80"));
-                assertThat(body, containsString("Content-Range: bytes 20-29/80"));
-                assertThat(body, containsString("Content-Range: bytes 70-79/80"));
+                    assertThat(body, containsString("Content-Range: bytes 0-9/80"));
+                    assertThat(body, containsString("Content-Range: bytes 20-29/80"));
+                    assertThat(body, containsString("Content-Range: bytes 70-79/80"));
 
-                assertThat(response.getContent(), startsWith("--" + boundary));
-                assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
-            }
+                    assertThat(response.getContent(), startsWith("--" + boundary));
+                    assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
+                }
         );
 
         scenarios.addScenario(
-            "Multiple ranges (x4) with empty range request",
-            """
-                GET /context/data.txt HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9,20-29,40-49,60-60,70-79\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                String body = response.getContent();
+                "Multiple ranges (x4) with empty range request",
+                """
+                    GET /context/data.txt HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9,20-29,40-49,60-60,70-79\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    String body = response.getContent();
 
-                assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
-                assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
+                    assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
+                    assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
 
-                HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
-                String boundary = getContentTypeBoundary(contentType);
+                    HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
+                    String boundary = getContentTypeBoundary(contentType);
 
-                assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
+                    assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
 
-                assertThat(body, containsString("Content-Range: bytes 0-9/80"));
-                assertThat(body, containsString("Content-Range: bytes 20-29/80"));
-                assertThat(body, containsString("Content-Range: bytes 60-60/80")); // empty range request
-                assertThat(body, containsString("Content-Range: bytes 70-79/80"));
+                    assertThat(body, containsString("Content-Range: bytes 0-9/80"));
+                    assertThat(body, containsString("Content-Range: bytes 20-29/80"));
+                    assertThat(body, containsString("Content-Range: bytes 60-60/80")); // empty range request
+                    assertThat(body, containsString("Content-Range: bytes 70-79/80"));
 
-                assertThat(response.getContent(), startsWith("--" + boundary));
-                assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
-            }
+                    assertThat(response.getContent(), startsWith("--" + boundary));
+                    assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
+                }
         );
 
         // test a range request with a file with no suffix, therefore no mimetype
 
         scenarios.addScenario(
-            "No mimetype resource - no range requested",
-            """
-                GET /context/nofilesuffix HTTP/1.1\r
-                Host: localhost\r
-                \r
-                """,
-            HttpStatus.OK_200,
-            (response) -> assertThat(response, containsHeaderValue(HttpHeader.ACCEPT_RANGES, "bytes"))
+                "No mimetype resource - no range requested",
+                """
+                    GET /context/nofilesuffix HTTP/1.1\r
+                    Host: localhost\r
+                    \r
+                    """,
+                HttpStatus.OK_200,
+                (response) -> assertThat(response, containsHeaderValue(HttpHeader.ACCEPT_RANGES, "bytes"))
         );
 
         scenarios.addScenario(
-            "No mimetype resource - simple range request",
-            """
-                GET /context/nofilesuffix HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                assertThat(response, containsHeaderValue(HttpHeader.CONTENT_LENGTH, "10"));
-                assertThat(response, containsHeaderValue(HttpHeader.CONTENT_RANGE, "bytes 0-9/80"));
-                assertThat(response, not(containsHeader(HttpHeader.CONTENT_TYPE)));
-            }
+                "No mimetype resource - simple range request",
+                """
+                    GET /context/nofilesuffix HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    assertThat(response, containsHeaderValue(HttpHeader.CONTENT_LENGTH, "10"));
+                    assertThat(response, containsHeaderValue(HttpHeader.CONTENT_RANGE, "bytes 0-9/80"));
+                    assertThat(response, not(containsHeader(HttpHeader.CONTENT_TYPE)));
+                }
         );
 
         scenarios.addScenario(
-            "No mimetype resource - multiple ranges (x3)",
-            """
-                GET /context/nofilesuffix HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9,20-29,40-49\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                String body = response.getContent();
+                "No mimetype resource - multiple ranges (x3)",
+                """
+                    GET /context/nofilesuffix HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9,20-29,40-49\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    String body = response.getContent();
 
-                assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
-                assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
+                    assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
+                    assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
 
-                HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
-                String boundary = getContentTypeBoundary(contentType);
+                    HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
+                    String boundary = getContentTypeBoundary(contentType);
 
-                assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
+                    assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
 
-                assertThat(body, containsString("Content-Range: bytes 0-9/80"));
-                assertThat(body, containsString("Content-Range: bytes 20-29/80"));
+                    assertThat(body, containsString("Content-Range: bytes 0-9/80"));
+                    assertThat(body, containsString("Content-Range: bytes 20-29/80"));
 
-                assertThat(response.getContent(), startsWith("--" + boundary));
-                assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
-            }
+                    assertThat(response.getContent(), startsWith("--" + boundary));
+                    assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
+                }
         );
 
         scenarios.addScenario(
-            "No mimetype resource - multiple ranges (x5) with empty range request",
-            """
-                GET /context/nofilesuffix HTTP/1.1\r
-                Host: localhost\r
-                Range: bytes=0-9,20-29,40-49,60-60,70-79\r
-                \r
-                """,
-            HttpStatus.PARTIAL_CONTENT_206,
-            (response) ->
-            {
-                String body = response.getContent();
+                "No mimetype resource - multiple ranges (x5) with empty range request",
+                """
+                    GET /context/nofilesuffix HTTP/1.1\r
+                    Host: localhost\r
+                    Range: bytes=0-9,20-29,40-49,60-60,70-79\r
+                    \r
+                    """,
+                HttpStatus.PARTIAL_CONTENT_206,
+                (response) ->
+                {
+                    String body = response.getContent();
 
-                assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
-                assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
+                    assertThat(response, containsHeaderValue("Content-Type", "multipart/byteranges"));
+                    assertThat(response, containsHeaderValue("Content-Length", "" + body.length()));
 
-                HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
-                String boundary = getContentTypeBoundary(contentType);
+                    HttpField contentType = response.getField(HttpHeader.CONTENT_TYPE);
+                    String boundary = getContentTypeBoundary(contentType);
 
-                assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
+                    assertThat("Boundary expected: " + contentType.getValue(), boundary, notNullValue());
 
-                assertThat(body, containsString("Content-Range: bytes 0-9/80"));
-                assertThat(body, containsString("Content-Range: bytes 20-29/80"));
-                assertThat(body, containsString("Content-Range: bytes 40-49/80"));
-                assertThat(body, containsString("Content-Range: bytes 60-60/80")); // empty range
-                assertThat(body, containsString("Content-Range: bytes 70-79/80"));
+                    assertThat(body, containsString("Content-Range: bytes 0-9/80"));
+                    assertThat(body, containsString("Content-Range: bytes 20-29/80"));
+                    assertThat(body, containsString("Content-Range: bytes 40-49/80"));
+                    assertThat(body, containsString("Content-Range: bytes 60-60/80")); // empty range
+                    assertThat(body, containsString("Content-Range: bytes 70-79/80"));
 
-                assertThat(response.getContent(), startsWith("--" + boundary));
-                assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
-            }
+                    assertThat(response.getContent(), startsWith("--" + boundary));
+                    assertThat(response.getContent(), endsWith(boundary + "--\r\n"));
+                }
         );
 
         return scenarios.stream();
@@ -630,14 +633,14 @@ public class ResourceHandlerTest
         Scenarios scenarios = new Scenarios();
 
         scenarios.addScenario(
-            "GET /context/ - (no match)",
-            """
-                GET /context/ HTTP/1.1\r
-                Host: local\r
-                Connection: close\r
-                \r
-                """,
-            HttpStatus.FORBIDDEN_403
+                "GET /context/ - (no match)",
+                """
+                    GET /context/ HTTP/1.1\r
+                    Host: local\r
+                    Connection: close\r
+                    \r
+                    """,
+                HttpStatus.FORBIDDEN_403
         );
 
         addBasicWelcomeScenarios(scenarios);
@@ -698,7 +701,7 @@ public class ResourceHandlerTest
         getLocalConnectorConfig().setOutputBufferSize(2048);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -716,7 +719,7 @@ public class ResourceHandlerTest
         getLocalConnectorConfig().setOutputBufferSize(16 * 1024);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -734,7 +737,7 @@ public class ResourceHandlerTest
         getLocalConnectorConfig().setOutputBufferSize(8);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -750,7 +753,7 @@ public class ResourceHandlerTest
     {
         setupBigFiles(docRoot);
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/bigger.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1169,7 +1172,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/directory/ HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1194,7 +1197,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1224,7 +1227,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1241,7 +1244,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/simple.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1267,7 +1270,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1284,7 +1287,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/simple.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1310,7 +1313,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1327,7 +1330,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/simple.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1349,7 +1352,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/does-not-exist HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1369,7 +1372,7 @@ public class ResourceHandlerTest
         setupBigFiles(docRoot);
 
         long expectedSize = Files.size(docRoot.resolve("big.txt")) +
-            Files.size(docRoot.resolve("big.txt.gz"));
+                Files.size(docRoot.resolve("big.txt.gz"));
 
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
         CachingHttpContentFactory contentFactory = (CachingHttpContentFactory)_rootResourceHandler.getHttpContentFactory();
@@ -1377,7 +1380,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response1 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1394,7 +1397,7 @@ public class ResourceHandlerTest
             }
 
             HttpTester.Response response2 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1420,7 +1423,7 @@ public class ResourceHandlerTest
     {
         setupBigFiles(docRoot);
         long expectedSize = Files.size(docRoot.resolve("big.txt")) +
-            Files.size(docRoot.resolve("big.txt.gz"));
+                Files.size(docRoot.resolve("big.txt.gz"));
 
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
         _rootResourceHandler.setEtags(true);
@@ -1429,7 +1432,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response1 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1450,7 +1453,7 @@ public class ResourceHandlerTest
             }
 
             HttpTester.Response response2 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1467,7 +1470,7 @@ public class ResourceHandlerTest
             assertThat(response2.getContent(), endsWith("   400\tThis is a big file\n"));
 
             HttpTester.Response response3 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1478,7 +1481,7 @@ public class ResourceHandlerTest
             assertThat(response3.getStatus(), is(HttpStatus.NOT_MODIFIED_304));
 
             HttpTester.Response response4 = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/big.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1509,7 +1512,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/temp.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1534,7 +1537,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/temp.txt HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1560,7 +1563,7 @@ public class ResourceHandlerTest
         for (int i = 0; i < 10; i++)
         {
             HttpTester.Response response = HttpTester.parseResponse(
-                _local.getResponse("""
+                    _local.getResponse("""
                     GET /context/directory/ HTTP/1.1\r
                     Host: local\r
                     Connection: close\r
@@ -1582,7 +1585,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setEtags(true);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1601,7 +1604,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setEtags(true);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 HEAD /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1640,9 +1643,9 @@ public class ResourceHandlerTest
         Files.writeString(docRoot.resolve("data0.txt.bz2"), "fake bzip2", UTF_8);
 
         _rootResourceHandler.setPrecompressedFormats(
-            new CompressedContentFormat("bzip2", ".bz2"),
-            new CompressedContentFormat("gzip", ".gz"),
-            new CompressedContentFormat("br", ".br")
+                new CompressedContentFormat("bzip2", ".bz2"),
+                new CompressedContentFormat("gzip", ".gz"),
+                new CompressedContentFormat("br", ".br")
         );
 
         String rawResponse;
@@ -1736,25 +1739,25 @@ public class ResourceHandlerTest
     public static Stream<Arguments> directoryRedirectSource()
     {
         return Stream.of(
-            Arguments.of("""
+                Arguments.of("""
                 GET /context/directory HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
                 """, "/context/directory/"),
-            Arguments.of("""
+                Arguments.of("""
                 GET /context/directory;JSESSIONID=12345678 HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
                 """, "/context/directory/;JSESSIONID=12345678"),
-            Arguments.of("""
+                Arguments.of("""
                 GET /context/directory?name=value HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
                 \r
                 """, "/context/directory/?name=value"),
-            Arguments.of("""
+                Arguments.of("""
                 GET /context/directory;JSESSIONID=12345678?name=value HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1780,7 +1783,7 @@ public class ResourceHandlerTest
         copySimpleTestResource(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1795,7 +1798,7 @@ public class ResourceHandlerTest
         assertThat(content, containsString("/context/directory/"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/jetty-dir.css HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1811,12 +1814,12 @@ public class ResourceHandlerTest
         copySimpleTestResource(docRoot);
         _rootResourceHandler.stop();
         _rootResourceHandler.setBaseResource(ResourceFactory.combine(
-            ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer0")),
-            _rootResourceHandler.getBaseResource()));
+                ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer0")),
+                _rootResourceHandler.getBaseResource()));
         _rootResourceHandler.start();
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/other/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1830,7 +1833,7 @@ public class ResourceHandlerTest
         assertThat(content, containsString("/context/other/data.txt"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/other/jetty-dir.css HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1840,7 +1843,7 @@ public class ResourceHandlerTest
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/double/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1854,7 +1857,7 @@ public class ResourceHandlerTest
         assertThat(content, containsString("/context/double/zero.txt"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/double/jetty-dir.css HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1870,13 +1873,13 @@ public class ResourceHandlerTest
         copySimpleTestResource(docRoot);
         _rootResourceHandler.stop();
         _rootResourceHandler.setBaseResource(ResourceFactory.combine(
-            ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer0")),
-            ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer1")),
-            _rootResourceHandler.getBaseResource()));
+                ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer0")),
+                ResourceFactory.root().newResource(MavenPaths.findTestResourceDir("layer1")),
+                _rootResourceHandler.getBaseResource()));
         _rootResourceHandler.start();
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1893,7 +1896,7 @@ public class ResourceHandlerTest
         assertThat(content, containsString("/context/double/"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/double/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1908,7 +1911,7 @@ public class ResourceHandlerTest
         assertThat(content, containsString("/context/double/one.txt"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/double/jetty-dir.css HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1926,7 +1929,7 @@ public class ResourceHandlerTest
         Files.writeString(testFile, "some content\n");
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/test-etag-file.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1947,7 +1950,7 @@ public class ResourceHandlerTest
         while (Files.getLastModifiedTime(testFile).equals(before));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/test-etag-file.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1965,7 +1968,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setEtags(true);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -1977,7 +1980,7 @@ public class ResourceHandlerTest
         String etag = response.get(ETAG);
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2265,7 +2268,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setGzipEquivalentFileExtensions(List.of(CompressedContentFormat.GZIP.getExtension()));
 
         HttpTester.Response response1 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt.gz HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2275,7 +2278,7 @@ public class ResourceHandlerTest
         assertThat(response1.get(CONTENT_ENCODING), is("gzip"));
 
         HttpTester.Response response2 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2291,7 +2294,7 @@ public class ResourceHandlerTest
         setupSimpleText(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2306,8 +2309,8 @@ public class ResourceHandlerTest
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "Hello World",
-        "Now is the time for all good men to come to the aid of the party"
+            "Hello World",
+            "Now is the time for all good men to come to the aid of the party"
     })
     public void testIfETag(String content) throws Exception
     {
@@ -2412,8 +2415,8 @@ public class ResourceHandlerTest
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "Hello World",
-        "Now is the time for all good men to come to the aid of the party"
+            "Hello World",
+            "Now is the time for all good men to come to the aid of the party"
     })
     public void testIfModified(String content) throws Exception
     {
@@ -2508,7 +2511,7 @@ public class ResourceHandlerTest
         setupSimpleText(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2520,7 +2523,7 @@ public class ResourceHandlerTest
         String lastModified = response.get(LAST_MODIFIED);
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2532,7 +2535,7 @@ public class ResourceHandlerTest
         assertThat(response.getContent(), is(""));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2553,7 +2556,7 @@ public class ResourceHandlerTest
         Files.writeString(testFile, "some content\n");
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/test-unmodified-since-file.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2597,7 +2600,7 @@ public class ResourceHandlerTest
         setupSimpleText(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2609,7 +2612,7 @@ public class ResourceHandlerTest
         String lastModified = response.get(LAST_MODIFIED);
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2627,7 +2630,7 @@ public class ResourceHandlerTest
         copySimpleTestResource(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2645,7 +2648,7 @@ public class ResourceHandlerTest
     public void testJettyDirRedirect() throws Exception
     {
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2885,7 +2888,7 @@ public class ResourceHandlerTest
     public void testNonExistentFile() throws Exception
     {
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/no-such-file.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2902,7 +2905,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2921,7 +2924,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2941,7 +2944,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2960,7 +2963,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP);
 
         HttpTester.Response response1 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2975,7 +2978,7 @@ public class ResourceHandlerTest
         assertThat(response1.getContentBytes(), is(bigGzBytes));
 
         HttpTester.Response response2 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -2995,7 +2998,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(new CompressedContentFormat("zip", ".zip"), CompressedContentFormat.GZIP);
 
         HttpTester.Response response1 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3008,7 +3011,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP, new CompressedContentFormat("zip", ".zip"));
 
         HttpTester.Response response2 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3028,7 +3031,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(CompressedContentFormat.GZIP, new CompressedContentFormat("zip", ".zip"));
 
         HttpTester.Response response1 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3041,7 +3044,7 @@ public class ResourceHandlerTest
         _rootResourceHandler.setPrecompressedFormats(new CompressedContentFormat("zip", ".zip"), CompressedContentFormat.GZIP);
 
         HttpTester.Response response2 = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/big.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3061,9 +3064,9 @@ public class ResourceHandlerTest
         Files.writeString(docRoot.resolve("data0.txt.bz2"), "fake bzip2", UTF_8);
 
         _rootResourceHandler.setPrecompressedFormats(
-            new CompressedContentFormat("bzip2", ".bz2"),
-            new CompressedContentFormat("gzip", ".gz"),
-            new CompressedContentFormat("br", ".br")
+                new CompressedContentFormat("bzip2", ".bz2"),
+                new CompressedContentFormat("gzip", ".gz"),
+                new CompressedContentFormat("br", ".br")
         );
 
         String rawResponse;
@@ -3181,7 +3184,7 @@ public class ResourceHandlerTest
         setupSimpleText(docRoot);
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/simple.txt/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3211,7 +3214,7 @@ public class ResourceHandlerTest
         }
 
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/biggest.txt HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3315,7 +3318,7 @@ public class ResourceHandlerTest
     {
         copySimpleTestResource(docRoot);
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/directory/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3357,7 +3360,7 @@ public class ResourceHandlerTest
     {
         setupQuestionMarkDir(docRoot);
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/dir? HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3366,7 +3369,7 @@ public class ResourceHandlerTest
         assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/dir%3F HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3376,7 +3379,7 @@ public class ResourceHandlerTest
         assertThat(response.getField(LOCATION).getValue(), endsWith("/context/dir%3F/"));
 
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/dir%3F/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3387,7 +3390,7 @@ public class ResourceHandlerTest
 
         _rootResourceHandler.setWelcomeMode(ResourceService.WelcomeMode.REDIRECT);
         response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/dir%3F/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3591,7 +3594,7 @@ public class ResourceHandlerTest
         copySimpleTestResource(docRoot);
         _rootResourceHandler.setWelcomeMode(ResourceService.WelcomeMode.REDIRECT);
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("""
+                _local.getResponse("""
                 GET /context/directory/ HTTP/1.1\r
                 Host: local\r
                 Connection: close\r
@@ -3842,8 +3845,8 @@ public class ResourceHandlerTest
         try (Stream<Path> walk = Files.walk(simpleSrc, 4))
         {
             List<Path> testSources = walk
-                .filter(Files::isRegularFile)
-                .map(simpleSrc::relativize).toList();
+                    .filter(Files::isRegularFile)
+                    .map(simpleSrc::relativize).toList();
             for (Path testSourceRelative : testSources)
             {
                 Path src = simpleSrc.resolve(testSourceRelative);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -64,6 +64,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.Sha1Sum;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
@@ -75,6 +76,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,6 +99,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@ExtendWith(WorkDirExtension.class) 
 public class GzipHandlerTest
 {
     protected static final int DEFAULT_OUTPUT_BUFFER_SIZE = new HttpConfiguration().getOutputBufferSize();
@@ -124,7 +127,6 @@ public class GzipHandlerTest
     private static final String CONTENT_ETAG = String.format("W/\"%x\"", CONTENT.hashCode());
     private static final String CONTENT_ETAG_GZIP = String.format("W/\"%x" + CompressedContentFormat.GZIP.getEtagSuffix() + "\"", CONTENT.hashCode());
 
-    public WorkDir _workDir;
     private Server _server;
     private ServerConnector _httpConnector;
     private LocalConnector _connector;
@@ -599,12 +601,13 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testExcludePaths() throws Exception
+    public void testExcludePaths(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         _gzipHandler.addIncludedMimeTypes("text/plain");
         _gzipHandler.setExcludedPaths("*.txt");
 
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -691,11 +694,11 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testExcludedMimeTypesUpperCase() throws Exception
+    public void testExcludedMimeTypesUpperCase(WorkDir workDir) throws Exception
     {
         _gzipHandler.addExcludedMimeTypes("text/PLAIN");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -991,12 +994,12 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testIncludedExcludePaths() throws Exception
+    public void testIncludedExcludePaths(WorkDir workDir) throws Exception
     {
         _gzipHandler.setExcludedPaths("/ctx/bad.txt");
         _gzipHandler.setIncludedPaths("*.txt");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1064,11 +1067,11 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testIncludedMimeTypes() throws Exception
+    public void testIncludedMimeTypes(WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1121,11 +1124,11 @@ public class GzipHandlerTest
      * </p>
      */
     @Test
-    public void testIncludedMimeTypesPrecompressedByWrappedHandler() throws Exception
+    public void testIncludedMimeTypesPrecompressedByWrappedHandler(WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("image/svg+xml");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1281,11 +1284,11 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testRequestAcceptEncodingWithQuality() throws Exception
+    public void testRequestAcceptEncodingWithQuality(WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1337,11 +1340,11 @@ public class GzipHandlerTest
      * See: <a href="http://bugs.eclipse.org/388072">Bugzilla #388072</a>
      */
     @Test
-    public void testRequestAcceptEncodingWithZeroQuality() throws Exception
+    public void testRequestAcceptEncodingWithZeroQuality(WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1391,11 +1394,11 @@ public class GzipHandlerTest
      */
     @ParameterizedTest
     @MethodSource("compressibleSizesSource")
-    public void testRequestIfModifiedSinceInFutureGzipCompressedResponse(int fileSize) throws Exception
+    public void testRequestIfModifiedSinceInFutureGzipCompressedResponse(int fileSize, WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1441,11 +1444,11 @@ public class GzipHandlerTest
      */
     @ParameterizedTest
     @MethodSource("compressibleSizesSource")
-    public void testRequestIfModifiedSinceInPastGzipCompressedResponse(int fileSize) throws Exception
+    public void testRequestIfModifiedSinceInPastGzipCompressedResponse(int fileSize, WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1522,11 +1525,11 @@ public class GzipHandlerTest
     }
 
     @Test
-    public void testResponseCustomMimeTypeSVG() throws Exception
+    public void testResponseCustomMimeTypeSVG(WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("image/svg+xml");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);
@@ -1601,11 +1604,11 @@ public class GzipHandlerTest
 
     @ParameterizedTest
     @MethodSource("compressibleSizesSource")
-    public void testSimpleCompressedResponse(int fileSize) throws Exception
+    public void testSimpleCompressedResponse(int fileSize, WorkDir workDir) throws Exception
     {
         _gzipHandler.addIncludedMimeTypes("text/plain");
-
-        Path contextDir = _workDir.getEmptyPathDir().resolve("context");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path contextDir = tmpPath.resolve("context");
         FS.ensureDirExists(contextDir);
 
         _contextHandler.setBaseResourceAsPath(contextDir);

--- a/jetty-core/jetty-slf4j-impl/pom.xml
+++ b/jetty-core/jetty-slf4j-impl/pom.xml
@@ -28,6 +28,8 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- we need this as some tests assert Logging content which is done in a static way -->
+          <reuseForks>false</reuseForks>
           <argLine>
             @{argLine} ${jetty.surefire.argLine} --add-reads org.eclipse.jetty.logging=java.management
           </argLine>

--- a/jetty-core/jetty-slf4j-impl/src/test/java/org/eclipse/jetty/logging/JMXTest.java
+++ b/jetty-core/jetty-slf4j-impl/src/test/java/org/eclipse/jetty/logging/JMXTest.java
@@ -25,6 +25,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated("Because the test is making assertions on Logger which is static and may have data from other tests")
 public class JMXTest
 {
     @Test

--- a/jetty-core/jetty-start/pom.xml
+++ b/jetty-core/jetty-start/pom.xml
@@ -9,6 +9,7 @@
   <name>Core :: Start</name>
   <description>The start utility</description>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.start</bundle-symbolic-name>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.start.*</spotbugs.onlyAnalyze>
   </properties>

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/FSTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/FSTest.java
@@ -22,12 +22,15 @@ import java.util.List;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class FSTest
 {
     @Test
@@ -54,8 +57,8 @@ public class FSTest
     @Test
     public void testExtractEscaperZip(WorkDir workDir) throws IOException
     {
-        Path archive = MavenPaths.findTestResourceFile("bad-libs/escaper.zip");
         Path dest = workDir.getEmptyPathDir();
+        Path archive = MavenPaths.findTestResourceFile("bad-libs/escaper.zip");
         Path bad = Path.of("/tmp/evil.txt");
         Files.deleteIfExists(bad);
         assertThrows(IOException.class, () -> FS.extractZip(archive, dest));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -133,7 +132,7 @@ public class MainTest
         }
 
         // Test a System Property that comes from JVM
-        List<String> warnings = output.stream().filter((line) -> line.startsWith("WARN")).collect(Collectors.toList());
+        List<String> warnings = output.stream().filter((line) -> line.startsWith("WARN")).toList();
         // warnings.forEach(System.out::println);
         Iterator<String> warningIter = warnings.iterator();
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
@@ -38,14 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class ModuleGraphWriterTest
 {
-    public WorkDir testdir;
 
     @Test
-    public void testGenerateNothingEnabled() throws IOException
+    public void testGenerateNothingEnabled(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -75,7 +74,7 @@ public class ModuleGraphWriterTest
         {
             if (execDotCmd("dot", "-V"))
             {
-                Path outputPng = testdir.getPath().resolve("output.png");
+                Path outputPng = baseDir.resolve("output.png");
                 assertTrue(execDotCmd("dot", "-Tpng", "-o" + outputPng, dotFile.toString()));
 
                 assertThat("PNG File does not exist", FS.exists(outputPng));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
@@ -35,14 +35,13 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class ModuleTest
 {
-    public WorkDir testdir;
 
     @Test
-    public void testLoadMain() throws IOException
+    public void testLoadMain(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
@@ -41,14 +41,12 @@ public class ModulesTest
 {
     private static final String TEST_SOURCE = "<test>";
 
-    public WorkDir testdir;
-
     @Test
-    public void testLoadAllModules() throws IOException
+    public void testLoadAllModules(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -140,11 +138,11 @@ public class ModulesTest
     }
 
     @Test
-    public void testResolveServerHttp() throws IOException
+    public void testResolveServerHttp(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -203,11 +201,11 @@ public class ModulesTest
     }
 
     @Test
-    public void testResolveNotRequiredModuleNotFound() throws IOException
+    public void testResolveNotRequiredModuleNotFound(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=cannot-find-me"};
 
         // Configuration
@@ -252,11 +250,11 @@ public class ModulesTest
     }
 
     @Test
-    public void testResolveNotRequiredModuleFound() throws IOException
+    public void testResolveNotRequiredModuleFound(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=dive"};
 
         // Configuration
@@ -303,11 +301,11 @@ public class ModulesTest
     }
 
     @Test
-    public void testResolveNotRequiredModuleFoundDynamic() throws IOException
+    public void testResolveNotRequiredModuleFoundDynamic(WorkDir workDir) throws IOException
     {
+        Path baseDir = workDir.getEmptyPathDir();
         // Test Env
         Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
-        Path baseDir = testdir.getEmptyPathDir();
         String[] cmdLine = new String[]{"bar.type=dynamic"};
 
         // Configuration

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PathFinderTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PathFinderTest.java
@@ -31,14 +31,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirExtension.class)
 public class PathFinderTest
 {
-    public WorkDir testdir;
-
     @Test
-    public void testFindInis() throws IOException
+    public void testFindInis(WorkDir workDir) throws IOException
     {
+        Path basePath = workDir.getPath();
         File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
         Path homePath = homeDir.toPath().toAbsolutePath();
-        Path basePath = testdir.getEmptyPathDir();
 
         PathFinder finder = new PathFinder();
         finder.setFileMatcher("glob:**/*.ini");
@@ -60,11 +58,11 @@ public class PathFinderTest
     }
 
     @Test
-    public void testFindMods() throws IOException
+    public void testFindMods(WorkDir workDir) throws IOException
     {
+        Path basePath = workDir.getEmptyPathDir();
         File homeDir = MavenTestingUtils.getTestResourceDir("dist-home");
         Path homePath = homeDir.toPath().toAbsolutePath();
-        Path basePath = testdir.getEmptyPathDir();
 
         List<String> expected = new ArrayList<>();
         File modulesDir = new File(homeDir, "modules");

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
@@ -27,16 +27,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(WorkDirExtension.class)
 public class PropertyPassingTest
 {
     private static class ConsoleCapture implements Runnable
@@ -89,8 +85,6 @@ public class PropertyPassingTest
             return this;
         }
     }
-
-    public WorkDir testingdir;
 
     @Test
     public void testAsJvmArg() throws IOException, InterruptedException

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/StartMatchers.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/StartMatchers.java
@@ -24,7 +24,7 @@ public final class StartMatchers
 {
     public static Matcher<Path> pathExists()
     {
-        return new BaseMatcher<Path>()
+        return new BaseMatcher<>()
         {
             @Override
             public boolean matches(Object item)
@@ -49,7 +49,7 @@ public final class StartMatchers
 
     public static Matcher<Path> notPathExists()
     {
-        return new BaseMatcher<Path>()
+        return new BaseMatcher<>()
         {
             @Override
             public boolean matches(Object item)
@@ -74,7 +74,7 @@ public final class StartMatchers
 
     public static Matcher<Path> fileExists()
     {
-        return new BaseMatcher<Path>()
+        return new BaseMatcher<>()
         {
             @Override
             public boolean matches(Object item)

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
@@ -36,10 +36,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(WorkDirExtension.class)
+@ExtendWith(WorkDirExtension.class) 
 public class ConfigSourcesTest
 {
-    public WorkDir testdir;
 
     private void assertIdOrder(ConfigSources sources, String... expectedOrder)
     {
@@ -78,15 +77,16 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testOrderBasicConfig() throws IOException
+    public void testOrderBasicConfig(WorkDir workDir) throws IOException
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1");
@@ -102,20 +102,21 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testOrderWith1ExtraConfig() throws IOException
+    public void testOrderWith1ExtraConfig(WorkDir workDir) throws IOException
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         common = common.toRealPath();
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -132,20 +133,21 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testCommandLine1ExtraFromSimpleProp() throws Exception
+    public void testCommandLine1ExtraFromSimpleProp(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini", "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1");
@@ -174,15 +176,16 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testCommandLine1ExtraFromPropPrefix() throws Exception
+    public void testCommandLine1ExtraFromPropPrefix(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create opt
-        Path opt = testdir.getPathFile("opt");
+        Path opt = testdir.resolve("opt");
         FS.ensureEmpty(opt);
 
         // Create common
@@ -191,7 +194,7 @@ public class ConfigSourcesTest
         TestEnv.makeFile(common, "start.ini", "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1");
@@ -221,15 +224,16 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testCommandLine1ExtraFromCompoundProp() throws Exception
+    public void testCommandLine1ExtraFromCompoundProp(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create opt
-        Path opt = testdir.getPathFile("opt");
+        Path opt = testdir.resolve("opt");
         FS.ensureEmpty(opt);
 
         // Create common
@@ -238,7 +242,7 @@ public class ConfigSourcesTest
         TestEnv.makeFile(common, "start.ini", "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1");
@@ -271,20 +275,21 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommon() throws Exception
+    public void testRefCommon(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini", "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -306,24 +311,25 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommonAndCorp() throws Exception
+    public void testRefCommonAndCorp(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini", "jetty.http.port=8080");
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -349,28 +355,29 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommonRefCorp() throws Exception
+    public void testRefCommonRefCorp(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
         TestEnv.makeFile(corp, "start.ini",
             "jetty.http.port=9090");
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "--include-jetty-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -395,21 +402,22 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommonRefCorpFromSimpleProps() throws Exception
+    public void testRefCommonRefCorpFromSimpleProps(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
         TestEnv.makeFile(corp, "start.ini",
             "jetty.http.port=9090");
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "my.corp=" + corp,
@@ -417,7 +425,7 @@ public class ConfigSourcesTest
             "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -444,35 +452,36 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommonRefCorpCmdLineRef() throws Exception
+    public void testRefCommonRefCorpCmdLineRef(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create devops
-        Path devops = testdir.getPathFile("devops");
+        Path devops = testdir.resolve("devops");
         FS.ensureEmpty(devops);
         TestEnv.makeFile(devops, "start.ini",
             "--modules=logging",
             "jetty.http.port=2222");
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
         TestEnv.makeFile(corp, "start.ini",
             "jetty.http.port=9090");
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "--include-jetty-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -502,28 +511,29 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testRefCommonRefCorpCmdLineProp() throws Exception
+    public void testRefCommonRefCorpCmdLineProp(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
         TestEnv.makeFile(corp, "start.ini",
             "jetty.http.port=9090");
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "--include-jetty-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
@@ -551,19 +561,20 @@ public class ConfigSourcesTest
     }
 
     @Test
-    public void testBadDoubleRef() throws Exception
+    public void testBadDoubleRef(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Create home
-        Path home = testdir.getPathFile("home");
+        Path home = testdir.resolve("home");
         FS.ensureEmpty(home);
         TestEnv.copyTestDir("dist-home", home);
 
         // Create common
-        Path common = testdir.getPathFile("common");
+        Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
 
         // Create corp
-        Path corp = testdir.getPathFile("corp");
+        Path corp = testdir.resolve("corp");
         FS.ensureEmpty(corp);
         TestEnv.makeFile(corp, "start.ini",
             // standard property
@@ -579,7 +590,7 @@ public class ConfigSourcesTest
             "--include-jetty-dir=" + corp);
 
         // Create base
-        Path base = testdir.getPathFile("base");
+        Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -42,15 +42,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(WorkDirExtension.class)
 public class MavenLocalRepoFileInitializerTest
 {
-    public WorkDir testdir;
+    public WorkDir workDir;
+    public Path testdir;
 
     private BaseHome baseHome;
 
     @BeforeEach
     public void setupBaseHome() throws IOException
     {
-        Path homeDir = testdir.getEmptyPathDir().resolve("home");
-        Path baseDir = testdir.getEmptyPathDir().resolve("base");
+        testdir = workDir.getEmptyPathDir();
+        Path homeDir = testdir.resolve("home");
+        Path baseDir = testdir.resolve("base");
 
         FS.ensureDirExists(homeDir);
         FS.ensureDirExists(baseDir);
@@ -192,7 +194,7 @@ public class MavenLocalRepoFileInitializerTest
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
                    is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.4.31.v20200723/jetty-http-9.4.31.v20200723-tests.jar"));
 
-        Path destination = testdir.getEmptyPathDir().resolve("jetty-http-9.4.31.v20200723-tests.jar");
+        Path destination = testdir.resolve("jetty-http-9.4.31.v20200723-tests.jar");
         Files.deleteIfExists(destination);
         repo.download(coords.toCentralURI(), destination);
         assertThat(Files.exists(destination), is(true));
@@ -204,7 +206,7 @@ public class MavenLocalRepoFileInitializerTest
     public void testDownloadSnapshotRepo()
         throws Exception
     {
-        Path snapshotLocalRepoDir = testdir.getPath().resolve("snapshot-repo");
+        Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
         FS.ensureEmpty(snapshotLocalRepoDir);
 
         MavenLocalRepoFileInitializer repo =
@@ -233,7 +235,7 @@ public class MavenLocalRepoFileInitializerTest
     public void testDownloadSnapshotRepoWithExtractDeep()
         throws Exception
     {
-        Path snapshotLocalRepoDir = testdir.getPath().resolve("snapshot-repo");
+        Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
         FS.ensureEmpty(snapshotLocalRepoDir);
 
         MavenLocalRepoFileInitializer repo =
@@ -251,7 +253,7 @@ public class MavenLocalRepoFileInitializerTest
     public void testDownloadSnapshotRepoWithExtractDefault()
         throws Exception
     {
-        Path snapshotLocalRepoDir = testdir.getPath().resolve("snapshot-repo");
+        Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
         FS.ensureEmpty(snapshotLocalRepoDir);
 
         MavenLocalRepoFileInitializer repo =

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
@@ -40,14 +40,18 @@ import org.eclipse.jetty.start.StartEnvironment;
 import org.eclipse.jetty.start.StartLog;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public abstract class AbstractUseCase
 {
     public WorkDir workDir;
+    public Path testdir;
 
     protected Path homeDir;
     protected Path baseDir;
@@ -62,8 +66,7 @@ public abstract class AbstractUseCase
     @BeforeEach
     public void setupTest() throws IOException
     {
-        Path testdir = workDir.getEmptyPathDir();
-
+        testdir = workDir.getEmptyPathDir();
         // Create empty base directory for testcase to use
         baseDir = testdir.resolve("test-base");
         FS.ensureDirExists(baseDir);

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
@@ -184,9 +184,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/logging-a.xml"
-        );
+        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-a.xml");
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -221,9 +219,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/logging-b.xml"
-        );
+        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-b.xml");
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -374,7 +370,7 @@ public class BasicTest extends AbstractUseCase
     @Test
     public void testHomeWithSpaces() throws Exception
     {
-        homeDir = workDir.getPath().resolve("jetty home with spaces");
+        homeDir = testdir.resolve("jetty home with spaces");
         FS.ensureDirExists(homeDir);
 
         setupDistHome();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -60,6 +60,7 @@ import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -488,6 +489,7 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("flaky")
     public void testDownloadWithCloseBeforeContent(Transport transport) throws Exception
     {
         byte[] data = new byte[128 * 1024];
@@ -533,6 +535,7 @@ public class HttpClientStreamTest extends AbstractTest
     }
 
     @ParameterizedTest
+    @Tag("flaky")
     @MethodSource("transports")
     public void testDownloadWithCloseMiddleOfContent(Transport transport) throws Exception
     {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TrailersTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TrailersTest.java
@@ -92,7 +92,7 @@ public class TrailersTest extends AbstractTest
             requestTrailers.put(trailerName, trailerValue);
         }
 
-        var response = listener.get(5, TimeUnit.SECONDS);
+        var response = listener.get(10, TimeUnit.SECONDS);
 
         // Read slowly.
         try (InputStream input = listener.getInputStream())

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FileIDTest.java
@@ -82,7 +82,7 @@ public class FileIDTest
     @MethodSource("basenameCases")
     public void testGetBasename(String input, String expected) throws IOException
     {
-        Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path outputJar = workDir.getPath().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 
@@ -181,7 +181,7 @@ public class FileIDTest
     @MethodSource("hasNamedPathSegmentCasesTrue")
     public void testHasNamedPathSegmentsTrueZipFs(String input, String dirname) throws IOException
     {
-        Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path outputJar = workDir.getPath().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 
@@ -211,7 +211,7 @@ public class FileIDTest
     @MethodSource("hasNamedPathSegmentFalseZipFsCases")
     public void testHasNamedPathSegmentFalseZipFs(String input, String dirname) throws IOException
     {
-        Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path outputJar = workDir.getPath().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 
@@ -422,7 +422,7 @@ public class FileIDTest
     })
     public void testIsMetaInfVersions(String input) throws IOException
     {
-        Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path outputJar = workDir.getPath().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 
@@ -514,7 +514,7 @@ public class FileIDTest
     })
     public void testNotMetaInfVersions(String input) throws IOException
     {
-        Path outputJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path outputJar = workDir.getPath().resolve("test.jar");
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/MultiReleaseJarFileTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/MultiReleaseJarFileTest.java
@@ -44,8 +44,6 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class MultiReleaseJarFileTest
 {
-    public WorkDir workDir;
-
     private void createExampleJar(Path outputJar) throws IOException
     {
         Map<String, String> env = new HashMap<>();
@@ -93,9 +91,9 @@ public class MultiReleaseJarFileTest
     }
 
     @Test
-    public void testStreamAllFiles() throws Exception
+    public void testStreamAllFiles(WorkDir workDir) throws Exception
     {
-        Path exampleJar = workDir.getEmptyPathDir().resolve("multirelease.jar");
+        Path exampleJar = workDir.getPath().resolve("multirelease.jar");
         createExampleJar(exampleJar);
 
         try (MultiReleaseJarFile jarFile = new MultiReleaseJarFile(exampleJar))
@@ -128,7 +126,7 @@ public class MultiReleaseJarFileTest
     }
 
     @Test
-    public void testClassLoaderWithMultiReleaseBehaviors() throws Exception
+    public void testClassLoaderWithMultiReleaseBehaviors(WorkDir workDir) throws Exception
     {
         Path exampleJar = workDir.getEmptyPathDir().resolve("multirelease.jar");
         createExampleJar(exampleJar);
@@ -153,7 +151,7 @@ public class MultiReleaseJarFileTest
     }
 
     @Test
-    public void testStreamAllFilesForEachEntries() throws IOException
+    public void testStreamAllFilesForEachEntries(WorkDir workDir) throws IOException
     {
         List<String> entries = new ArrayList<>();
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -41,7 +41,8 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class RolloverFileOutputStreamTest
 {
-    public WorkDir testingDir;
+
+    public WorkDir workDir;
 
     private static ZoneId toZoneId(String timezoneId)
     {
@@ -184,8 +185,7 @@ public class RolloverFileOutputStreamTest
     @Test
     public void testFileHandling() throws Exception
     {
-        Path testPath = testingDir.getEmptyPathDir();
-
+        Path testPath = workDir.getEmptyPathDir();
         ZoneId zone = toZoneId("Australia/Sydney");
         ZonedDateTime now = toDateTime("2016.04.10-08:30:12.3 AM AEDT", zone);
 
@@ -287,8 +287,7 @@ public class RolloverFileOutputStreamTest
     @Test
     public void testRollover() throws Exception
     {
-        Path testPath = testingDir.getEmptyPathDir();
-
+        Path testPath = workDir.getEmptyPathDir();
         ZoneId zone = toZoneId("Australia/Sydney");
         ZonedDateTime now = toDateTime("2016.04.10-11:59:55.0 PM AEDT", zone);
 
@@ -327,8 +326,7 @@ public class RolloverFileOutputStreamTest
     @Test
     public void testRolloverBackup() throws Exception
     {
-        Path testPath = testingDir.getEmptyPathDir();
-
+        Path testPath = workDir.getEmptyPathDir();
         ZoneId zone = toZoneId("Australia/Sydney");
         ZonedDateTime now = toDateTime("2016.04.10-11:59:55.0 PM AEDT", zone);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
@@ -51,7 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ScannerTest
 {
     public WorkDir workDir;
-    private Path _directory;
+
+    public Path _directory;
     private Scanner _scanner;
     private final BlockingQueue<Event> _queue = new LinkedBlockingQueue<>();
     private final BlockingQueue<Set<String>> _bulk = new LinkedBlockingQueue<>();

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -55,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class URIUtilTest
 {
+
     public WorkDir workDir;
 
     public static Stream<Arguments> encodePathSource()
@@ -674,9 +675,10 @@ public class URIUtilTest
     }
 
     @Test
-    public void testCorrectBadFileURIActualFile(WorkDir workDir) throws Exception
+    public void testCorrectBadFileURIActualFile() throws Exception
     {
-        Path testfile = workDir.getEmptyPathDir().resolve("testCorrectBadFileURIActualFile.txt");
+        Path testDir = workDir.getEmptyPathDir();
+        Path testfile = testDir.resolve("testCorrectBadFileURIActualFile.txt");
         FS.touch(testfile);
 
         URI expectedUri = testfile.toUri(); // correct URI with `://`
@@ -796,7 +798,7 @@ public class URIUtilTest
     @MethodSource("resourceUriLastSegmentSource")
     public void testFileUriGetUriLastPathSegment(String basePath, String expectedName) throws IOException
     {
-        Path root = workDir.getPath();
+        Path root = workDir.getEmptyPathDir();
         Path base = root.resolve(basePath);
         if (basePath.endsWith("/"))
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
@@ -54,8 +54,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class CombinedResourceTest
 {
-    private final ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable();
+
     public WorkDir workDir;
+
+    private final ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable();
 
     @BeforeEach
     public void beforeEach()
@@ -145,6 +147,7 @@ public class CombinedResourceTest
     @Test
     public void testCopyTo() throws Exception
     {
+        Path destDir = workDir.getEmptyPathDir();
         Path one = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/one");
         Path two = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/two");
         Path three = MavenTestingUtils.getTestResourcePathDir("org/eclipse/jetty/util/resource/three");
@@ -154,7 +157,6 @@ public class CombinedResourceTest
                 resourceFactory.newResource(two),
                 resourceFactory.newResource(three)
         );
-        Path destDir = workDir.getEmptyPathDir();
         rc.copyTo(destDir);
 
         Resource r = resourceFactory.newResource(destDir);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -72,7 +72,6 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
 @ExtendWith(WorkDirExtension.class)
 public class FileSystemResourceTest
 {
-    public WorkDir workDir;
 
     @BeforeEach
     public void beforeEach()
@@ -209,9 +208,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testNewResourceWithSpace() throws Exception
+    public void testNewResourceWithSpace(WorkDir workDir) throws Exception
     {
-        Path dir = workDir.getPath().normalize().toRealPath();
+        Path dir = workDir.getEmptyPathDir().normalize().toRealPath();
 
         Path baseDir = dir.resolve("base with spaces");
         FS.ensureDirExists(baseDir);
@@ -232,10 +231,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolvePathClass()
+    public void testResolvePathClass(WorkDir workDir)
     {
         Path dir = workDir.getEmptyPathDir();
-
         Path subdir = dir.resolve("sub");
         FS.ensureDirExists(subdir);
 
@@ -248,7 +246,7 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveRootPath() throws Exception
+    public void testResolveRootPath(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Path subdir = dir.resolve("sub");
@@ -274,10 +272,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testAccessUniCodeFile() throws Exception
+    public void testAccessUniCodeFile(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-
         String readableRootDir = findAnyDirectoryOffRoot(dir.getFileSystem());
         assumeTrue(readableRootDir != null, "Readable Root Dir found");
 
@@ -352,7 +349,7 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testIsContainedIn() throws Exception
+    public void testIsContainedIn(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -365,7 +362,7 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testIsDirectory() throws Exception
+    public void testIsDirectory(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -384,10 +381,10 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testLastModified() throws Exception
+    public void testLastModified(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Path file = workDir.getPathFile("foo");
+        Path file = dir.resolve("foo");
         Files.createFile(file);
 
         Instant expected = Files.getLastModifiedTime(file).toInstant();
@@ -398,7 +395,7 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testLength() throws Exception
+    public void testLength(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -414,7 +411,7 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testDelete() throws Exception
+    public void testDelete(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -432,11 +429,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testName() throws Exception
+    public void testName(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         String expected = dir.toAbsolutePath().toString();
 
         Resource base = ResourceFactory.root().newResource(dir);
@@ -444,11 +439,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testFileName() throws Exception
+    public void testFileName(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         String expected = dir.getFileName().toString();
 
         Resource base = ResourceFactory.root().newResource(dir);
@@ -456,11 +449,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testInputStream() throws Exception
+    public void testInputStream(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path file = dir.resolve("foo");
         String content = "Foo is here";
         touchFile(file, content);
@@ -477,11 +468,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testReadableByteChannel() throws Exception
+    public void testReadableByteChannel(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path file = dir.resolve("foo");
         String content = "Foo is here";
 
@@ -504,11 +493,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testGetURI() throws Exception
+    public void testGetURI(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path file = dir.resolve("foo");
         Files.createFile(file);
 
@@ -520,11 +507,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testList() throws Exception
+    public void testList(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Files.createFile(dir.resolve("foo"));
         Files.createFile(dir.resolve("bar"));
         Files.createDirectories(dir.resolve("tick"));
@@ -545,10 +530,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testSymlink() throws Exception
+    public void testSymlink(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-
         Path foo = dir.resolve("foo");
         Path bar = dir.resolve("bar");
 
@@ -585,11 +569,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testNonExistentSymlink() throws Exception
+    public void testNonExistentSymlink(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path foo = dir.resolve("foo"); // does not exist
         Path bar = dir.resolve("bar"); // to become a link to "foo"
 
@@ -616,10 +598,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testCaseInsensitiveAlias() throws Exception
+    public void testCaseInsensitiveAlias(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
         Path path = dir.resolve("file");
         Files.createFile(path);
 
@@ -653,11 +634,9 @@ public class FileSystemResourceTest
      */
     @Test
     @EnabledOnOs(WINDOWS)
-    public void testCase8dot3Alias() throws Exception
+    public void testCase8dot3Alias(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("TextFile.Long.txt");
         Files.createFile(path);
 
@@ -690,11 +669,9 @@ public class FileSystemResourceTest
      */
     @Test
     @EnabledOnOs(WINDOWS)
-    public void testNTFSFileStreamAlias() throws Exception
+    public void testNTFSFileStreamAlias(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("testfile");
         Files.createFile(path);
 
@@ -732,11 +709,9 @@ public class FileSystemResourceTest
      */
     @Test
     @EnabledOnOs(WINDOWS)
-    public void testNTFSFileDataStreamAlias() throws Exception
+    public void testNTFSFileDataStreamAlias(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("testfile");
         Files.createFile(path);
 
@@ -776,11 +751,9 @@ public class FileSystemResourceTest
      */
     @Test
     @EnabledOnOs(WINDOWS)
-    public void testNTFSFileEncodedDataStreamAlias() throws Exception
+    public void testNTFSFileEncodedDataStreamAlias(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("testfile");
         Files.createFile(path);
 
@@ -810,10 +783,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testSemicolon() throws Exception
+    public void testSemicolon(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-
         try
         {
             // attempt to create file
@@ -831,11 +803,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testSingleQuote() throws Exception
+    public void testSingleQuote(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -857,11 +827,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testSingleBackTick() throws Exception
+    public void testSingleBackTick(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -883,11 +851,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testBrackets() throws Exception
+    public void testBrackets(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -909,11 +875,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testBraces() throws Exception
+    public void testBraces(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -936,11 +900,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testCaret() throws Exception
+    public void testCaret(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -962,11 +924,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testPipe() throws Exception
+    public void testPipe(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         try
         {
             // attempt to create file
@@ -993,7 +953,7 @@ public class FileSystemResourceTest
      * @throws Exception failed test
      */
     @Test
-    public void testExistNormal() throws Exception
+    public void testExistNormal(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -1001,13 +961,13 @@ public class FileSystemResourceTest
         Path path = dir.resolve("a.jsp");
         Files.createFile(path);
 
-        URI ref = workDir.getPath().toUri().resolve("a.jsp");
+        URI ref = dir.toUri().resolve("a.jsp");
         Resource fileres = ResourceFactory.root().newResource(ref);
         assertThat("Resource: " + fileres, fileres.exists(), is(true));
     }
 
     @Test
-    public void testSingleQuoteInFileName() throws Exception
+    public void testSingleQuoteInFileName(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
         Files.createDirectories(dir);
@@ -1062,18 +1022,16 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testExistBadURINull() throws Exception
+    public void testExistBadURINull(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("a.jsp");
         Files.createFile(path);
 
         try
         {
             // request with null at end
-            URI uri = workDir.getPath().toUri().resolve("a.jsp%00");
+            URI uri = dir.toUri().resolve("a.jsp%00");
             assertThat("Null URI", uri, notNullValue());
 
             Resource r = ResourceFactory.root().newResource(uri);
@@ -1088,18 +1046,16 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testExistBadURINullX() throws Exception
+    public void testExistBadURINullX(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path path = dir.resolve("a.jsp");
         Files.createFile(path);
 
         try
         {
             // request with null and x at end
-            URI uri = workDir.getPath().toUri().resolve("a.jsp%00x");
+            URI uri = dir.toUri().resolve("a.jsp%00x");
             assertThat("NullX URI", uri, notNullValue());
 
             Resource r = ResourceFactory.root().newResource(uri);
@@ -1114,11 +1070,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveWindowsSlash() throws Exception
+    public void testResolveWindowsSlash(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path basePath = dir.resolve("base");
         FS.ensureDirExists(basePath);
         Path dirPath = basePath.resolve("aa");
@@ -1156,11 +1110,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveWindowsExtensionLess() throws Exception
+    public void testResolveWindowsExtensionLess(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path basePath = dir.resolve("base");
         FS.ensureDirExists(basePath);
         Path dirPath = basePath.resolve("aa");
@@ -1197,11 +1149,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveInitialSlash() throws Exception
+    public void testResolveInitialSlash(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path basePath = dir.resolve("base");
         FS.ensureDirExists(basePath);
         Path filePath = basePath.resolve("foo.txt");
@@ -1227,11 +1177,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveInitialDoubleSlash() throws Exception
+    public void testResolveInitialDoubleSlash(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path basePath = dir.resolve("base");
         FS.ensureDirExists(basePath);
         Path filePath = basePath.resolve("foo.txt");
@@ -1257,11 +1205,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testResolveDoubleSlash() throws Exception
+    public void testResolveDoubleSlash(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path basePath = dir.resolve("base");
         FS.ensureDirExists(basePath);
         Path dirPath = basePath.resolve("aa");
@@ -1289,11 +1235,9 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testEncoding() throws Exception
+    public void testEncoding(WorkDir workDir) throws Exception
     {
         Path dir = workDir.getEmptyPathDir();
-        Files.createDirectories(dir);
-
         Path specials = dir.resolve("a file with,spe#ials");
         Files.createFile(specials);
 
@@ -1306,11 +1250,10 @@ public class FileSystemResourceTest
     }
 
     @Test
-    public void testUtf8Dir() throws Exception
+    public void testUtf8Dir(WorkDir workDir) throws Exception
     {
-        Path dir = workDir.getEmptyPathDir();
         Path utf8Dir;
-
+        Path dir = workDir.getEmptyPathDir();
         try
         {
             utf8Dir = dir.resolve("bãm");

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -46,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class MountedPathResourceTest
 {
-    public WorkDir workDir;
 
     @BeforeEach
     public void beforeEach()
@@ -61,7 +60,7 @@ public class MountedPathResourceTest
     }
 
     @Test
-    public void testJarFile()
+    public void testJarFile(WorkDir workDir)
         throws Exception
     {
         Path testZip = MavenTestingUtils.getTestResourcePathFile("TestData/test.zip");
@@ -78,7 +77,7 @@ public class MountedPathResourceTest
             assertTrue(Resources.isReadableFile(file));
             assertThat(file.getFileName(), is("numbers"));
 
-            Path extract = workDir.getPathFile("extract");
+            Path extract = workDir.getEmptyPathDir().resolve("extract");
             FS.ensureEmpty(extract);
 
             r.copyTo(extract);
@@ -94,7 +93,7 @@ public class MountedPathResourceTest
             entries = r.list().stream().map(Resource::getFileName).toList();
             assertThat(entries, containsInAnyOrder("alphabet", "numbers"));
 
-            Path extract2 = workDir.getPathFile("extract2");
+            Path extract2 = workDir.getEmptyPathDir().resolve("extract2");
             FS.ensureEmpty(extract2);
 
             r.copyTo(extract2);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -29,11 +29,13 @@ import java.util.Map;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class PathResourceTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(PathResourceTest.class);
@@ -143,7 +146,8 @@ public class PathResourceTest
     @Test
     public void testJarFileIsAliasFile(WorkDir workDir) throws IOException
     {
-        Path testJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testJar = tmpPath.resolve("test.jar");
 
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
@@ -186,8 +190,9 @@ public class PathResourceTest
     @Test
     public void testJarFileIsAliasDirectory(WorkDir workDir) throws IOException
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         boolean supportsUtf8Dir = false;
-        Path testJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path testJar = tmpPath.resolve("test.jar");
 
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
@@ -268,7 +273,8 @@ public class PathResourceTest
     @Test
     public void testNullCharEndingFilename(WorkDir workDir) throws Exception
     {
-        Path testJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testJar = tmpPath.resolve("test.jar");
 
         Map<String, String> env = new HashMap<>();
         env.put("create", "true");
@@ -344,7 +350,8 @@ public class PathResourceTest
     @Test
     public void testSymlink(WorkDir workDir) throws Exception
     {
-        Path testJar = workDir.getEmptyPathDir().resolve("test.jar");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testJar = tmpPath.resolve("test.jar");
         Path foo = null;
         Path bar = null;
 
@@ -453,7 +460,6 @@ public class PathResourceTest
     public void testResolveNavigation(WorkDir workDir) throws Exception
     {
         Path docroot = workDir.getEmptyPathDir();
-
         Path dir = docroot.resolve("dir");
         Files.createDirectory(dir);
 
@@ -480,7 +486,6 @@ public class PathResourceTest
     public void testUnicodeResolve(WorkDir workDir) throws Exception
     {
         Path docroot = workDir.getEmptyPathDir();
-
         Path dir = docroot.resolve("dir");
         Files.createDirectory(dir);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceAliasTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceAliasTest.java
@@ -42,8 +42,6 @@ public class ResourceAliasTest
 
     private final ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable();
 
-    public WorkDir workDir;
-
     @BeforeEach
     public void beforeEach()
     {
@@ -58,10 +56,9 @@ public class ResourceAliasTest
     }
 
     @Test
-    public void testAliasNavigation() throws IOException
+    public void testAliasNavigation(WorkDir workDir) throws IOException
     {
         Path docroot = workDir.getEmptyPathDir();
-
         Path dir = docroot.resolve("dir");
         Files.createDirectory(dir);
 
@@ -86,10 +83,9 @@ public class ResourceAliasTest
     }
 
     @Test
-    public void testPercentPaths() throws IOException
+    public void testPercentPaths(WorkDir workDir) throws IOException
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path foo = baseDir.resolve("%foo");
         Files.createDirectories(foo);
 
@@ -123,10 +119,9 @@ public class ResourceAliasTest
     }
 
     @Test
-    public void testNullCharEndingFilename() throws Exception
+    public void testNullCharEndingFilename(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path file = baseDir.resolve("test.txt");
         FS.touch(file);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -256,8 +256,6 @@ public class ResourceTest
         return cases.stream();
     }
 
-    public WorkDir workDir;
-
     @ParameterizedTest
     @MethodSource("scenarios")
     public void testResourceExists(Scenario data)
@@ -342,6 +340,7 @@ public class ResourceTest
     public void testResourceExtraSlashStripping(WorkDir workDir) throws IOException
     {
         Path docRoot = workDir.getEmptyPathDir();
+
         Files.createDirectories(docRoot.resolve("d/e/f"));
 
         Resource ra = resourceFactory.newResource(docRoot);
@@ -368,7 +367,7 @@ public class ResourceTest
     @Test
     public void testClimbAboveBase(WorkDir workDir)
     {
-        Path testdir = workDir.getEmptyPathDir().resolve("foo/bar");
+        Path testdir = workDir.getEmptyPathDir();
         FS.ensureDirExists(testdir);
         Resource resource = resourceFactory.newResource(testdir);
         assertThrows(IllegalArgumentException.class, () -> resource.resolve(".."));

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
@@ -11,6 +11,7 @@
   <name>Core :: Websocket :: Tests</name>
 
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.core.tests</bundle-symbolic-name>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -43,6 +43,7 @@ import org.eclipse.jetty.logging.StdErrAppender;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
@@ -57,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -82,6 +84,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class XmlConfigurationTest
 {
     private static final String STRING_ARRAY_XML = "<Array type=\"String\"><Item type=\"String\">String1</Item><Item type=\"String\">String2</Item></Array>";

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationConfiguration.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationConfiguration.java
@@ -28,22 +28,22 @@ import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestAnnotationConfiguration
 {
     public static class TestableAnnotationConfiguration extends AnnotationConfiguration
@@ -57,7 +57,6 @@ public class TestAnnotationConfiguration
         }
     }
 
-    public WorkDir workDir;
     public Path web25;
     public Path web31false;
     public Path web31true;
@@ -65,7 +64,7 @@ public class TestAnnotationConfiguration
     public Path testSciJar;
     public Path testContainerSciJar;
     public Path testWebInfClassesJar;
-    public Path unpacked;
+    public WorkDir workDir;
     public URLClassLoader containerLoader;
     public URLClassLoader webAppLoader;
     public List<Resource> classes;
@@ -75,7 +74,6 @@ public class TestAnnotationConfiguration
     @BeforeEach
     public void setup() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         web25 = MavenTestingUtils.getTestResourcePathFile("web25.xml");
         web31false = MavenTestingUtils.getTestResourcePathFile("web31false.xml");
         web31true = MavenTestingUtils.getTestResourcePathFile("web31true.xml");
@@ -87,9 +85,8 @@ public class TestAnnotationConfiguration
 
         testContainerSciJar = jarDir.resolve("test-sci-for-container-path.jar");
         testWebInfClassesJar = jarDir.resolve("test-sci-for-webinf.jar");
-
+        Path unpacked = workDir.getEmptyPathDir();
         // unpack some classes to pretend that are in WEB-INF/classes
-        unpacked = workDir.getEmptyPathDir();
         FS.cleanDirectory(unpacked);
         JAR.unpack(testWebInfClassesJar.toFile(), unpacked.toFile());
         webInfClasses = ResourceFactory.root().newResource(unpacked);
@@ -106,12 +103,6 @@ public class TestAnnotationConfiguration
             testSciJar.toUri().toURL(), targetClasses.getURI().toURL(), webInfClasses.getURI().toURL()
         },
             containerLoader);
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationDecorator.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationDecorator.java
@@ -23,11 +23,13 @@ import org.eclipse.jetty.ee10.webapp.MetaData;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.webapp.WebDescriptor;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlParser;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,9 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestAnnotationDecorator
 {
-    public WorkDir workDir;
 
     public class TestWebDescriptor extends WebDescriptor
     {
@@ -81,17 +83,14 @@ public class TestAnnotationDecorator
     }
 
     @Test
-    public void testAnnotationDecorator() throws Exception
+    public void testAnnotationDecorator(WorkDir workDir) throws Exception
     {
         Path docroot = workDir.getEmptyPathDir();
         Path dummyDescriptor = docroot.resolve("dummy.xml");
         Files.createFile(dummyDescriptor);
         Resource dummyResource = ResourceFactory.root().newResource(dummyDescriptor);
 
-        assertThrows(NullPointerException.class, () ->
-        {
-            new AnnotationDecorator(null);
-        });
+        assertThrows(NullPointerException.class, () -> new AnnotationDecorator(null));
 
         WebAppContext context = new WebAppContext();
         AnnotationDecorator decorator = new AnnotationDecorator(context);

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestAnnotationParser.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -99,12 +98,10 @@ public class TestAnnotationParser
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testSampleAnnotation() throws Exception
+    public void testSampleAnnotation(WorkDir workDir) throws Exception
     {
-        Path root = testdir.getEmptyPathDir();
+        Path root = workDir.getEmptyPathDir();
         copyClass(ClassA.class, root);
 
         AnnotationParser parser = new AnnotationParser();
@@ -149,9 +146,9 @@ public class TestAnnotationParser
     }
 
     @Test
-    public void testMultiAnnotation() throws Exception
+    public void testMultiAnnotation(WorkDir workDir) throws Exception
     {
-        Path root = testdir.getEmptyPathDir();
+        Path root = workDir.getEmptyPathDir();
         copyClass(ClassB.class, root);
         AnnotationParser parser = new AnnotationParser();
 
@@ -254,14 +251,15 @@ public class TestAnnotationParser
     }
 
     @Test
-    public void testBasedirExclusion() throws Exception
+    public void testBasedirExclusion(WorkDir workDir) throws Exception
     {
+        Path testdir = workDir.getEmptyPathDir();
         // Build up basedir, which itself has a path segment that violates java package and classnaming.
         // The basedir should have no effect on annotation scanning.
         // Intentionally using a base directory name that starts with a "."
         // This mimics what you see in jenkins, hudson, hadoop, solr, camel, and selenium for their 
         // installed and/or managed webapps
-        Path basedir = testdir.getPathFile(".base/workspace/classes");
+        Path basedir = testdir.resolve(".base/workspace/classes");
         FS.ensureEmpty(basedir);
 
         // Copy in class that is known to have annotations.
@@ -288,8 +286,8 @@ public class TestAnnotationParser
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            Resource testJar = resourceFactory.newResource(MavenTestingUtils.getTargetFile("test-classes/tinytest.jar").toPath());
-            Resource testJar2 = resourceFactory.newResource(MavenTestingUtils.getTargetFile("test-classes/tinytest_copy.jar").toPath());
+            Resource testJar = resourceFactory.newResource(MavenTestingUtils.getTargetPath("test-classes/tinytest.jar"));
+            Resource testJar2 = resourceFactory.newResource(MavenTestingUtils.getTargetPath("test-classes/tinytest_copy.jar"));
             AnnotationParser parser = new AnnotationParser();
             DuplicateClassScanHandler handler = new DuplicateClassScanHandler();
             Set<AnnotationParser.Handler> handlers = Collections.singleton(handler);

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestRunAsAnnotation.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestRunAsAnnotation.java
@@ -20,18 +20,21 @@ import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.webapp.WebDescriptor;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestRunAsAnnotation
 {
-    public WorkDir workDir;
 
     @Test
-    public void testRunAsAnnotation() throws Exception
+    public void testRunAsAnnotation(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         WebAppContext wac = new WebAppContext();
         
         //pre-add a servlet but not by descriptor
@@ -47,7 +50,7 @@ public class TestRunAsAnnotation
         holder2.setHeldClass(ServletC.class);
         holder2.setInitOrder(1);
         wac.getServletHandler().addServletWithMapping(holder2, "/foo2/*");
-        Path fakeXml = workDir.getEmptyPathDir().resolve("fake.xml");
+        Path fakeXml = tmpPath.resolve("fake.xml");
         Files.createFile(fakeXml);
         wac.getMetaData().setOrigin(holder2.getName() + ".servlet.run-as", new WebDescriptor(wac.getResourceFactory().newResource(fakeXml)));
         

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestServletAnnotations.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestServletAnnotations.java
@@ -53,8 +53,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ExtendWith(WorkDirExtension.class)
 public class TestServletAnnotations
 {
-    public WorkDir workDir;
-
     public class TestWebServletAnnotationHandler extends WebServletAnnotationHandler
     {
         List<DiscoveredAnnotation> _list = null;
@@ -74,7 +72,7 @@ public class TestServletAnnotations
     }
 
     @Test
-    public void testServletAnnotation() throws Exception
+    public void testServletAnnotation(WorkDir workDir) throws Exception
     {
         Path root = workDir.getEmptyPathDir();
         copyClass(org.eclipse.jetty.ee10.annotations.ServletC.class, root);

--- a/jetty-ee10/jetty-ee10-apache-jsp/src/test/java/org/eclipse/jetty/ee10/jsp/TestJettyJspServlet.java
+++ b/jetty-ee10/jetty-ee10-apache-jsp/src/test/java/org/eclipse/jetty/ee10/jsp/TestJettyJspServlet.java
@@ -73,7 +73,7 @@ public class TestJettyJspServlet
         _server.setHandler(context);
         context.setClassLoader(new URLClassLoader(new URL[0], Thread.currentThread().getContextClassLoader()));
         ServletHolder jspHolder = context.addServlet(JettyJspServlet.class, "/*");
-        jspHolder.setInitParameter("scratchdir", workdir.getPath().toString());
+        jspHolder.setInitParameter("scratchdir", workdir.getEmptyPathDir().toString());
         context.setBaseResourceAsPath(baseDir);
         context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
         ServletHolder dfltHolder = new ServletHolder();

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FastFileServerTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FastFileServerTest.java
@@ -40,22 +40,21 @@ public class FastFileServerTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
+
+    private WorkDir workDir;
     private Server server;
 
     @BeforeEach
     public void startServer() throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
-        Path textFile = baseDir.resolve("simple.txt");
+        Path textFile = workDir.getEmptyPathDir().resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {
             writer.write(TEXT_CONTENT);
         }
 
         //TODO fix me
-        // server = FastFileServer.createServer(0, baseDir.toFile());
+        //server = FastFileServer.createServer(0, baseDir.toFile());
         server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FileServerTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FileServerTest.java
@@ -40,14 +40,13 @@ public class FileServerTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
+    public Path baseDir;
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
+        baseDir = workDir.getEmptyPathDir();
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FileServerXmlTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/FileServerXmlTest.java
@@ -39,14 +39,13 @@ public class FileServerXmlTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
+
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/JarServerTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/JarServerTest.java
@@ -52,7 +52,6 @@ public class JarServerTest extends AbstractEmbeddedTest
     public void stopServer() throws Exception
     {
         server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextJmxStatsTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextJmxStatsTest.java
@@ -25,11 +25,9 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.AssertionFailedError;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +37,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ExtendWith(WorkDirExtension.class)
 public class OneServletContextJmxStatsTest extends AbstractEmbeddedTest
 {
     private Server server;

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextTest.java
@@ -40,14 +40,15 @@ import static org.hamcrest.Matchers.is;
 public class OneServletContextTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "The secret of getting ahead is getting started. - Mark Twain";
+
     public WorkDir workDir;
+    public Path baseDir;
     private Server server;
 
     @BeforeEach
     public void startServer() throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
+        baseDir = workDir.getEmptyPathDir();
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextWithSessionTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/OneServletContextWithSessionTest.java
@@ -41,14 +41,15 @@ import static org.hamcrest.Matchers.is;
 public class OneServletContextWithSessionTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "Do the right thing. It will gratify some people and astonish the rest. - Mark Twain";
-    public WorkDir workDir;
     private Server server;
+
+    public WorkDir workDir;
+    private Path baseDir;
 
     @BeforeEach
     public void startServer() throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
+        baseDir = workDir.getEmptyPathDir();
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/test/java/org/eclipse/jetty/ee10/jstl/JspIncludeTest.java
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/test/java/org/eclipse/jetty/ee10/jstl/JspIncludeTest.java
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.webapp.Configurations;
@@ -32,14 +33,17 @@ import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(WorkDirExtension.class)
 public class JspIncludeTest
 {
     private static Server server;
@@ -48,6 +52,7 @@ public class JspIncludeTest
     @BeforeAll
     public static void startServer(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         // Setup Server
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
@@ -55,7 +60,7 @@ public class JspIncludeTest
         server.addConnector(connector);
         
         //Base dir for test
-        File testDir = workDir.getEmptyPathDir().toFile();
+        File testDir = tmpPath.toFile();
         File testLibDir = new File(testDir, "WEB-INF/lib");
         FS.ensureDirExists(testLibDir);
                 

--- a/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
@@ -11,6 +11,7 @@
   <name>EE10 :: Jetty Maven Plugin</name>
   <description>Jetty EE10 maven plugins</description>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.maven.plugin</bundle-symbolic-name>
     <jetty.stopKey>FREEBEER</jetty.stopKey>
     <jetty.jvmArgs></jetty.jvmArgs>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestForkedChild.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestForkedChild.java
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,11 +32,14 @@ import java.util.Random;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,11 +48,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Test the JettyForkedChild class, which
  * is the main that is executed by jetty:run/start in mode FORKED.
  */
+@ExtendWith(WorkDirExtension.class)
 public class TestForkedChild
 {
     File testDir;
     File baseDir;
-    File tmpDir;
+    Path tmpDir;
     File tokenFile;
     File webappPropsFile;
     int stopPort;
@@ -79,7 +84,7 @@ public class TestForkedChild
 
                 MavenWebAppContext webapp = new MavenWebAppContext();
                 webapp.setContextPath("/foo");
-                webapp.setTempDirectory(tmpDir);
+                webapp.setTempDirectory(tmpDir.toFile());
                 webapp.setBaseResourceAsPath(baseDir.toPath());
                 WebAppPropertyConverter.toProperties(webapp, webappPropsFile, null);
                 child = new JettyForkedChild(cmd.toArray(new String[0]));
@@ -94,13 +99,13 @@ public class TestForkedChild
     }
     
     @BeforeEach
-    public void setUp()
+    public void setUp(WorkDir workDir)
     {
+        tmpDir = workDir.getEmptyPathDir();
         baseDir = MavenTestingUtils.getTestResourceDir("root");
         testDir = MavenTestingUtils.getTargetTestingDir("forkedChild");
         FS.ensureEmpty(testDir);
-        tmpDir = new File(testDir, "tmp");
-        webappPropsFile = new File(testDir, "webapp.props");
+        webappPropsFile = new File(tmpDir.toFile(), "webapp.props");
 
         String stopPortString = System.getProperty("stop.port");
         assertNotNull(stopPortString, "stop.port System property");
@@ -111,7 +116,7 @@ public class TestForkedChild
 
         Random random = new Random();
         token = Long.toString(random.nextLong() ^ System.currentTimeMillis(), 36).toUpperCase(Locale.ENGLISH);
-        tokenFile = testDir.toPath().resolve(token + ".txt").toFile();
+        tokenFile = tmpDir.resolve(token + ".txt").toFile();
     }
     
     @AfterEach

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestJettyEmbedder.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestJettyEmbedder.java
@@ -34,10 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class TestJettyEmbedder
 {
-    public WorkDir workDir;
-
     @Test
-    public void testJettyEmbedderFromDefaults() throws Exception
+    public void testJettyEmbedderFromDefaults(WorkDir workDir) throws Exception
     {
         Path basePath = workDir.getEmptyPathDir();
         MavenWebAppContext webApp = new MavenWebAppContext();
@@ -74,11 +72,11 @@ public class TestJettyEmbedder
     }
 
     @Test
-    public void testJettyEmbedder()
+    public void testJettyEmbedder(WorkDir workDir)
         throws Exception
     {
+        Path basePath = workDir.getPath();
         MavenWebAppContext webApp = new MavenWebAppContext();
-        Path basePath = workDir.getEmptyPathDir();
         webApp.setBaseResourceAsPath(basePath);
         Server server = new Server();
         Map<String, String> jettyProperties = new HashMap<>();

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestQuickStartGenerator.java
@@ -19,8 +19,10 @@ import java.nio.file.Path;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -30,15 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  *
  */
+@ExtendWith(WorkDirExtension.class)
 public class TestQuickStartGenerator
 {
-    public WorkDir workDir;
-
     @Test
-    public void testGenerator() throws Exception
+    public void testGenerator(WorkDir workDir) throws Exception
     {
         Path tmpDir = workDir.getEmptyPathDir();
-
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/shouldbeoverridden");
         Path rootDir = MavenTestingUtils.getTargetPath("test-classes/root");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestSelectiveJarResource.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestSelectiveJarResource.java
@@ -32,13 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class TestSelectiveJarResource
 {
-    public WorkDir workDir;
 
     @Test
-    public void testIncludesNoExcludes() throws Exception
+    public void testIncludesNoExcludes(WorkDir workDir) throws Exception
     {
-        Path unpackDir = workDir.getEmptyPathDir();
-
+        Path unpackDir = workDir.getPath();
         Path testJar = MavenTestingUtils.getTestResourcePathFile("selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -61,10 +59,9 @@ public class TestSelectiveJarResource
     }
 
     @Test
-    public void testExcludesNoIncludes() throws Exception
+    public void testExcludesNoIncludes(WorkDir workDir) throws Exception
     {
-        Path unpackDir = workDir.getEmptyPathDir();
-
+        Path unpackDir = workDir.getPath();
         Path testJar = MavenTestingUtils.getTestResourcePathFile("selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -87,10 +84,9 @@ public class TestSelectiveJarResource
     }
     
     @Test
-    public void testIncludesExcludes() throws Exception
+    public void testIncludesExcludes(WorkDir workDir) throws Exception
     {
-        Path unpackDir = workDir.getEmptyPathDir();
-
+        Path unpackDir = workDir.getPath();
         Path testJar = MavenTestingUtils.getTestResourcePathFile("selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/annotation/LifeCycleCallbackCollectionTest.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/annotation/LifeCycleCallbackCollectionTest.java
@@ -22,14 +22,17 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(WorkDirExtension.class)
 public class LifeCycleCallbackCollectionTest
 {
     public static class TestServlet extends HttpServlet
@@ -174,9 +177,7 @@ public class LifeCycleCallbackCollectionTest
     @Test
     public void testServletPostConstructPreDestroy(WorkDir workDir) throws Exception
     {
-        // Start with an empty dir
         Path testDir = workDir.getEmptyPathDir();
-
         Server server = new Server();
         WebAppContext context = new WebAppContext();
         Path predestroyTestDir = testDir.resolve("predestroy-test");

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/jndi/TestNamingEntries.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/jndi/TestNamingEntries.java
@@ -31,6 +31,7 @@ import javax.naming.spi.ObjectFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Isolated("jndi entries")
 public class TestNamingEntries
 {
     public class ScopeA

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/jndi/TestNamingEntryUtil.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/jndi/TestNamingEntryUtil.java
@@ -21,6 +21,7 @@ import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Isolated("jndi entries")
 public class TestNamingEntryUtil
 {
     public class MyNamingEntry extends NamingEntry

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/PlusDescriptorProcessorTest.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.util.IntrospectionUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -51,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * PlusDescriptorProcessorTest
  */
+@Isolated("jndi entries")
 public class PlusDescriptorProcessorTest
 {
     protected static final Class<?>[] STRING_ARG = new Class[]{String.class};

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -94,8 +94,6 @@ public class AsyncMiddleManServletTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncMiddleManServletTest.class);
     private static final String PROXIED_HEADER = "X-Proxied";
-
-    public WorkDir workDir;
     private HttpClient client;
     private Server proxy;
     private ServerConnector proxyConnector;
@@ -984,11 +982,9 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    public void testAfterContentTransformerOverflowingToDisk() throws Exception
+    public void testAfterContentTransformerOverflowingToDisk(WorkDir workDir) throws Exception
     {
-        // Make sure the temporary directory we use exists and it's empty.
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         String key0 = "id";
         long value0 = 1;
         String key1 = "channel";
@@ -1107,10 +1103,9 @@ public class AsyncMiddleManServletTest
 
     @Test
     @Disabled("idle timeouts do not work yet")
-    public void testAfterContentTransformerClosingFilesOnClientRequestException() throws Exception
+    public void testAfterContentTransformerClosingFilesOnClientRequestException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         startServer(new HttpServlet()
         {
             @Override
@@ -1172,10 +1167,9 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    public void testAfterContentTransformerClosingFilesOnServerResponseException() throws Exception
+    public void testAfterContentTransformerClosingFilesOnServerResponseException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         CountDownLatch serviceLatch = new CountDownLatch(1);
         startServer(new HttpServlet()
         {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
@@ -757,7 +757,7 @@ public class AsyncServletTest
             socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();
             String response = IO.toString(socket.getInputStream());
-            assertTrue(_latch.await(1, TimeUnit.SECONDS));
+            assertTrue(_latch.await(5, TimeUnit.SECONDS));
             return response;
         }
         catch (Exception e)

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CustomRequestLogTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CustomRequestLogTest.java
@@ -35,21 +35,25 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Credential;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(WorkDirExtension.class)
 public class CustomRequestLogTest
 {
     private final BlockingQueue<String> _logs = new BlockingArrayQueue<>();
-    public WorkDir workDir;
+
     private Server _server;
     private LocalConnector _connector;
     private Path _baseDir;
@@ -64,7 +68,6 @@ public class CustomRequestLogTest
         RequestLog requestLog = new CustomRequestLog(writer, formatString);
         _server.setRequestLog(requestLog);
 
-        _baseDir = workDir.getEmptyPathDir();
         Files.createDirectory(_baseDir.resolve("servlet"));
         Files.createFile(_baseDir.resolve("servlet/info"));
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
@@ -105,6 +108,12 @@ public class CustomRequestLogTest
         LifeCycle.stop(_server);
     }
 
+    @BeforeEach
+    public void setup(WorkDir workDir)
+    {
+        _baseDir = workDir.getEmptyPathDir();
+    }
+
     @Test
     public void testLogFilename() throws Exception
     {
@@ -112,7 +121,7 @@ public class CustomRequestLogTest
 
         _connector.getResponse("GET /context/servlet/info HTTP/1.0\n\n");
         String log = _logs.poll(5, TimeUnit.SECONDS);
-        String expected = workDir.getPath().resolve("servlet/info").toString();
+        String expected = _baseDir.resolve("servlet/info").toString();
         assertThat(log, is("Filename: " + expected));
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletRangesTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletRangesTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.LocalConnector;
@@ -39,7 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DefaultServletRangesTest
 {
     public static final String DATA = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWZYZ!@#$%^&*()_+/.,[]";
-    public WorkDir testdir;
+
+    public WorkDir workDir;
+    public Path testdir;
 
     private Server server;
     private LocalConnector connector;
@@ -47,6 +50,7 @@ public class DefaultServletRangesTest
     @BeforeEach
     public void init() throws Exception
     {
+        testdir = workDir.getEmptyPathDir();
         server = new Server();
 
         connector = new LocalConnector(server);
@@ -59,8 +63,7 @@ public class DefaultServletRangesTest
         server.setHandler(context);
         server.addConnector(connector);
 
-        testdir.ensureEmpty();
-        File resBase = testdir.getPathFile("docroot").toFile();
+        File resBase = testdir.resolve("docroot").toFile();
         FS.ensureDirExists(resBase);
         File data = new File(resBase, "data.txt");
         createFile(data, DATA);

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -825,7 +825,7 @@ public class DefaultServletTest
         assumeMkDirSupported(docRoot, "dir;");
 
         /* create some content outside of the docroot */
-        Path sekret = workDir.getPath().resolve("sekret");
+        Path sekret = docRoot.resolve("sekret");
         FS.ensureDirExists(sekret);
         Path pass = sekret.resolve("pass");
         Files.writeString(pass, "Sssh, you shouldn't be seeing this", UTF_8);
@@ -951,7 +951,7 @@ public class DefaultServletTest
         Path inde = dir.resolve("index.htm");
         Path index = dir.resolve("index.html");
 
-        Path altRoot = workDir.getPath().resolve("altroot");
+        Path altRoot = docRoot.resolve("altroot");
         Path altDir = altRoot.resolve("dir");
         FS.ensureDirExists(altDir);
         Path altInde = altDir.resolve("index.htm");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -267,7 +267,7 @@ public class MultiPartServletTest
         String responseContent = null;
         try
         {
-            Response response = listener.get(30, TimeUnit.SECONDS);
+            Response response = listener.get(60, TimeUnit.SECONDS);
             assertThat(response.getStatus(), equalTo(HttpStatus.BAD_REQUEST_400));
             responseContent = IO.toString(listener.getInputStream());
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/SessionHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/SessionHandlerTest.java
@@ -73,8 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class SessionHandlerTest
 {
-    public WorkDir workDir;
-    
+
     public static class SessionConsumer implements Consumer<ManagedSession>
     {
         private ManagedSession _session;
@@ -104,7 +103,7 @@ public class SessionHandlerTest
      * Test that a session listener can access classes only visible to the context it is in.
      */
     @Test
-    public void testSessionListenerWithClassloader() throws Exception
+    public void testSessionListenerWithClassloader(WorkDir workDir) throws Exception
     {
         Path foodir = workDir.getEmptyPathDir();
         Path fooClass = foodir.resolve("Foo.class");
@@ -347,6 +346,7 @@ public class SessionHandlerTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
 
             String sessionCookie = response.getHeaders().get("Set-Cookie");
+
             assertTrue(sessionCookie != null);
             assertThat(sessionCookie, containsString("Path=/"));
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/HashLoginServiceTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/HashLoginServiceTest.java
@@ -16,15 +16,11 @@ package org.eclipse.jetty.ee10.servlet.security;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -36,17 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class HashLoginServiceTest
 {
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
 
     @Test
     public void testAutoCreatedUserStore() throws Exception

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AbstractDoSFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AbstractDoSFilterTest.java
@@ -35,7 +35,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.FileSessionDataStore;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
@@ -56,7 +55,7 @@ public abstract class AbstractDoSFilterTest
     private ServerConnector _connector;
     protected long _requestMaxTime = 200;
 
-    public void startServer(WorkDir workDir, Class<? extends Filter> filter) throws Exception
+    public void startServer(Path workDir, Class<? extends Filter> filter) throws Exception
     {
         _server = new Server();
         _connector = new ServerConnector(_server);
@@ -66,7 +65,7 @@ public abstract class AbstractDoSFilterTest
         DefaultSessionCache sessionCache = new DefaultSessionCache(context.getSessionHandler());
         FileSessionDataStore fileStore = new FileSessionDataStore();
 
-        Path p = workDir.getPathFile("sessions");
+        Path p = workDir.resolve("sessions");
         FS.ensureEmpty(p);
         fileStore.setStoreDir(p.toFile());
         sessionCache.setSessionDataStore(fileStore);

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AbstractGzipTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AbstractGzipTest.java
@@ -32,24 +32,20 @@ import java.util.zip.InflaterInputStream;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.TypeUtil;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+@ExtendWith(WorkDirExtension.class)
 public abstract class AbstractGzipTest
 {
     protected static final int DEFAULT_OUTPUT_BUFFER_SIZE = new HttpConfiguration().getOutputBufferSize();
 
-    protected Path workDir;
-
-    public AbstractGzipTest()
-    {
-        workDir = MavenTestingUtils.getTargetTestingPath(this.getClass().getName());
-        FS.ensureEmpty(workDir);
-    }
+    protected WorkDir workDir;
 
     protected FilterInputStream newContentEncodingFilterInputStream(String contentEncoding, InputStream inputStream) throws IOException
     {

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/CloseableDoSFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/CloseableDoSFilterTest.java
@@ -26,6 +26,6 @@ public class CloseableDoSFilterTest extends AbstractDoSFilterTest
     @BeforeEach
     public void setUp() throws Exception
     {
-        startServer(workDir, CloseableDoSFilter.class);
+        startServer(workDir.getEmptyPathDir(), CloseableDoSFilter.class);
     }
 }

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipContentLengthTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipContentLengthTest.java
@@ -163,7 +163,7 @@ public class GzipContentLengthTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipDefaultServletDeferredContentTypeTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipDefaultServletDeferredContentTypeTest.java
@@ -69,7 +69,7 @@ public class GzipDefaultServletDeferredContentTypeTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipHandlerNoReCompressTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/GzipHandlerNoReCompressTest.java
@@ -92,7 +92,7 @@ public class GzipHandlerNoReCompressTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/DeploymentErrorTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/DeploymentErrorTest.java
@@ -81,12 +81,12 @@ public class DeploymentErrorTest
         ServerConnector connector = new ServerConnector(server);
         connector.setPort(0);
         server.addConnector(connector);
-         
+
         ResourceFactory resourceFactory = ResourceFactory.of(server);
 
         // Empty contexts collections
         contexts = new ContextHandlerCollection();
-        
+
         //Environment
         Environment ee10 = Environment.ensure("ee10");
         ee10.setAttribute("contextHandlerClass", "org.eclipse.jetty.ee10.webapp.WebAppContext");
@@ -108,7 +108,7 @@ public class DeploymentErrorTest
         System.setProperty("test.docroots", docroots.toAbsolutePath().toString());
         ContextProvider appProvider = new ContextProvider();
         appProvider.setEnvironmentName("ee10");
-        
+
         appProvider.setScanInterval(1);
         appProvider.setMonitoredDirResource(resourceFactory.newResource(docroots));
         deploymentManager.addAppProvider(appProvider);
@@ -120,11 +120,11 @@ public class DeploymentErrorTest
 
         // Setup Configurations
         Configurations.setServerDefault(server)
-            .add("org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration",
-                "org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration",
-                "org.eclipse.jetty.ee10.annotations.AnnotationConfiguration",
-                TrackedConfiguration.class.getName()
-            );
+                .add("org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration",
+                        "org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration",
+                        "org.eclipse.jetty.ee10.annotations.AnnotationConfiguration",
+                        TrackedConfiguration.class.getName()
+                );
 
         server.start();
         return docroots;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/KeyStoreScannerTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/KeyStoreScannerTest.java
@@ -58,16 +58,9 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @ExtendWith(WorkDirExtension.class)
 public class KeyStoreScannerTest
 {
-    public WorkDir testdir;
     private Server server;
     private Path keystoreDir;
     private KeyStoreScanner keyStoreScanner;
-
-    @BeforeEach
-    public void before()
-    {
-        keystoreDir = testdir.getEmptyPathDir();
-    }
 
     @FunctionalInterface
     public interface Configuration
@@ -110,6 +103,12 @@ public class KeyStoreScannerTest
         server.addBean(keyStoreScanner);
 
         server.start();
+    }
+
+    @BeforeEach
+    public void setup(WorkDir workDir)
+    {
+        keystoreDir = workDir.getEmptyPathDir();
     }
 
     @AfterEach

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
@@ -37,11 +37,8 @@ import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.Callback;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -94,7 +91,7 @@ public abstract class RFC2616BaseTest
      * STRICT RFC TESTS
      */
     private static final boolean STRICT = false;
-    private static XmlBasedJettyServer server;
+
     private HttpTesting http;
 
     class TestFile
@@ -120,31 +117,24 @@ public abstract class RFC2616BaseTest
         }
     }
 
-    public static void setUpServer(XmlBasedJettyServer testableserver, Class<?> testclazz) throws Exception
+    public static XmlBasedJettyServer setUpServer(XmlBasedJettyServer testableserver, Class<?> testclazz, Path tmpPath) throws Exception
     {
-        Path testWorkDir = MavenTestingUtils.getTargetTestingPath(testclazz.getName());
-        FS.ensureDirExists(testWorkDir);
-
-        System.setProperty("java.io.tmpdir", testWorkDir.toString());
-
-        server = testableserver;
+        XmlBasedJettyServer server = testableserver;
         server.load();
+        server.getServer().setTempDirectory(tmpPath.toFile());
         server.start();
+        return server;
     }
 
     @BeforeEach
     public void setUp() throws Exception
     {
-        http = new HttpTesting(getHttpClientSocket(), server.getServerPort());
-    }
-
-    @AfterAll
-    public static void tearDownServer() throws Exception
-    {
-        server.stop();
+        http = new HttpTesting(getHttpClientSocket(), getServer().getServerPort());
     }
 
     public abstract HttpSocket getHttpClientSocket() throws Exception;
+
+    public abstract XmlBasedJettyServer getServer();
 
     /**
      * Test Date/Time format Specs.
@@ -1098,7 +1088,7 @@ public abstract class RFC2616BaseTest
 
         specId = "10.3 Redirection HTTP/1.0 - basic";
         assertThat(specId, response.getStatus(), is(HttpStatus.FOUND_302));
-        assertEquals(server.getScheme() + "://myhost:1234/tests/", response.get("Location"), specId);
+        assertEquals(getServer().getScheme() + "://myhost:1234/tests/", response.get("Location"), specId);
     }
 
     /**
@@ -1127,12 +1117,12 @@ public abstract class RFC2616BaseTest
         HttpTester.Response response = responses.get(0);
         String specId = "10.3 Redirection HTTP/1.1 - basic (response 1)";
         assertThat(specId, response.getStatus(), is(HttpStatus.FOUND_302));
-        assertEquals(server.getScheme() + "://localhost:" + server.getServerPort() + "/tests/", response.get("Location"), specId);
+        assertEquals(getServer().getScheme() + "://localhost:" + getServer().getServerPort() + "/tests/", response.get("Location"), specId);
 
         response = responses.get(1);
         specId = "10.3 Redirection HTTP/1.1 - basic (response 2)";
         assertThat(specId, response.getStatus(), is(HttpStatus.FOUND_302));
-        assertEquals(server.getScheme() + "://localhost:" + server.getServerPort() + "/tests/", response.get("Location"), specId);
+        assertEquals(getServer().getScheme() + "://localhost:" + getServer().getServerPort() + "/tests/", response.get("Location"), specId);
         assertEquals("close", response.get("Connection"), specId);
     }
 
@@ -1156,7 +1146,7 @@ public abstract class RFC2616BaseTest
 
         String specId = "10.3 Redirection HTTP/1.0 w/content";
         assertThat(specId, response.getStatus(), is(HttpStatus.FOUND_302));
-        assertEquals(server.getScheme() + "://localhost:" + server.getServerPort() + "/tests/R1.txt", response.get("Location"), specId);
+        assertEquals(getServer().getScheme() + "://localhost:" + getServer().getServerPort() + "/tests/R1.txt", response.get("Location"), specId);
     }
 
     /**
@@ -1179,7 +1169,7 @@ public abstract class RFC2616BaseTest
 
         String specId = "10.3 Redirection HTTP/1.1 w/content";
         assertThat(specId + " [status]", response.getStatus(), is(HttpStatus.FOUND_302));
-        assertThat(specId + " [location]", response.get("Location"), is(server.getScheme() + "://localhost:" + server.getServerPort() + "/tests/R2.txt"));
+        assertThat(specId + " [location]", response.get("Location"), is(getServer().getScheme() + "://localhost:" + getServer().getServerPort() + "/tests/R2.txt"));
         assertThat(specId + " [connection]", response.get("Connection"), is("close"));
     }
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616NIOHttpTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616NIOHttpTest.java
@@ -13,19 +13,28 @@
 
 package org.eclipse.jetty.ee10.test.rfcs;
 
+import java.nio.file.Path;
+
 import org.eclipse.jetty.ee10.test.support.XmlBasedJettyServer;
 import org.eclipse.jetty.ee10.test.support.rawhttp.HttpSocket;
 import org.eclipse.jetty.ee10.test.support.rawhttp.HttpSocketImpl;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Perform the RFC2616 tests against a server running with the Jetty NIO Connector and listening on standard HTTP.
  */
+@ExtendWith(WorkDirExtension.class)
 public class RFC2616NIOHttpTest extends RFC2616BaseTest
 {
+    private static XmlBasedJettyServer xmlBasedJettyServer;
+
     @BeforeAll
-    public static void setupServer() throws Exception
+    public static void setupServer(WorkDir workDir) throws Exception
     {
         XmlBasedJettyServer server = new XmlBasedJettyServer();
         server.setScheme(HttpScheme.HTTP.asString());
@@ -33,12 +42,24 @@ public class RFC2616NIOHttpTest extends RFC2616BaseTest
         server.addXmlConfiguration("RFC2616_Redirects.xml");
         server.addXmlConfiguration("RFC2616_Filters.xml");
         server.addXmlConfiguration("NIOHttp.xml");
-        setUpServer(server, RFC2616NIOHttpTest.class);
+        xmlBasedJettyServer = setUpServer(server, RFC2616NIOHttpTest.class, workDir.getEmptyPathDir());
     }
 
     @Override
     public HttpSocket getHttpClientSocket()
     {
         return new HttpSocketImpl();
+    }
+
+    @AfterAll
+    public static void tearDownServer() throws Exception
+    {
+        xmlBasedJettyServer.stop();
+    }
+
+    @Override
+    public XmlBasedJettyServer getServer()
+    {
+        return xmlBasedJettyServer;
     }
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616NIOHttpsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616NIOHttpsTest.java
@@ -13,20 +13,31 @@
 
 package org.eclipse.jetty.ee10.test.rfcs;
 
+import java.nio.file.Path;
+
 import org.eclipse.jetty.ee10.test.support.XmlBasedJettyServer;
 import org.eclipse.jetty.ee10.test.support.rawhttp.HttpSocket;
 import org.eclipse.jetty.ee10.test.support.rawhttp.HttpsSocketImpl;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Perform the RFC2616 tests against a server running with the Jetty NIO Connector and listening on HTTPS (HTTP over SSL).
  */
+@ExtendWith(WorkDirExtension.class)
 public class RFC2616NIOHttpsTest extends RFC2616BaseTest
 {
+
+    private static XmlBasedJettyServer xmlBasedJettyServer;
+
     @BeforeAll
-    public static void setupServer() throws Exception
+    public static void setupServer(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         XmlBasedJettyServer server = new XmlBasedJettyServer();
         server.setScheme(HttpScheme.HTTPS.asString());
         server.addXmlConfiguration("RFC2616Base.xml");
@@ -34,12 +45,24 @@ public class RFC2616NIOHttpsTest extends RFC2616BaseTest
         server.addXmlConfiguration("RFC2616_Filters.xml");
         server.addXmlConfiguration("ssl.xml");
         server.addXmlConfiguration("NIOHttps.xml");
-        setUpServer(server, RFC2616NIOHttpsTest.class);
+        xmlBasedJettyServer = setUpServer(server, RFC2616NIOHttpsTest.class, tmpPath);
     }
 
     @Override
     public HttpSocket getHttpClientSocket() throws Exception
     {
         return new HttpsSocketImpl();
+    }
+
+    @AfterAll
+    public static void tearDownServer() throws Exception
+    {
+        xmlBasedJettyServer.stop();
+    }
+
+    @Override
+    public XmlBasedJettyServer getServer()
+    {
+        return xmlBasedJettyServer;
     }
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
@@ -158,7 +158,7 @@ public class XmlBasedJettyServer
         assertEquals(1, serverCount, "Server load count");
 
         this._server = foundServer;
-        this._server.setStopTimeout(2000);
+        this._server.setStopTimeout(10000);
     }
 
     public String getScheme()

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee10-test-loginservice</artifactId>
   <name>EE10 :: Tests :: Login Service</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.loginservice</bundle-symbolic-name>
   </properties>
   <dependencies>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DatabaseLoginServiceTestServer.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/src/test/java/org/eclipse/jetty/ee10/loginservice/DatabaseLoginServiceTestServer.java
@@ -84,8 +84,6 @@ public class DatabaseLoginServiceTestServer
         MARIA_DB = (MariaDBContainer)MARIA_DB.withInitScript("createdb.sql");
         MARIA_DB = (MariaDBContainer)MARIA_DB.withLogConsumer(new Slf4jLogConsumer(MARIADB_LOG));
         MARIA_DB.start();
-        String containerIpAddress =  MARIA_DB.getContainerIpAddress();
-        int mariadbPort = MARIA_DB.getMappedPort(3306);
         MARIA_DB_URL = MARIA_DB.getJdbcUrl();
         MARIA_DB_FULL_URL = MARIA_DB_URL + "?user=" + MARIA_DB_USER + "&password=" + MARIA_DB_PASSWORD;
         MARIA_DB_DRIVER_CLASS = MARIA_DB.getDriverClassName();

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
@@ -58,5 +58,10 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.session;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.ServletException;
@@ -24,6 +25,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -82,7 +84,8 @@ public class AsyncTest
             
             //session should now be evicted from the cache after request exited
             String id = SessionTestSupport.extractSessionId(sessionCookie);
-            assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
+            Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                    .until(() -> !contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertTrue(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
         }
         finally

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/src/test/java/org/eclipse/jetty/ee10/session/file/ClusteredOrphanedSessionTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/src/test/java/org/eclipse/jetty/ee10/session/file/ClusteredOrphanedSessionTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.session.file;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import org.eclipse.jetty.ee10.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.session.FileSessionDataStoreFactory;
@@ -40,7 +39,7 @@ public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessi
     @BeforeEach
     public void before() throws Exception
     {
-        _storeDir = Objects.requireNonNull(workDir.getEmptyPathDir());
+        _storeDir = workDir.getEmptyPathDir();
         assertTrue(Files.exists(_storeDir), "Path must exist: " + _storeDir);
         assertTrue(Files.isDirectory(_storeDir), "Path must be a directory: " + _storeDir);
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
@@ -10,7 +10,7 @@
   <name>EE10 :: Tests :: Sessions :: Hazelcast</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.sessions.hazelcast</bundle-symbolic-name>
-    <skipTests>true</skipTests> <!-- disabled, see Issue #8877 -->
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
   </properties>
   <build>
     <plugins>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/ClientOrphanedSessionClientTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/ClientOrphanedSessionClientTest.java
@@ -11,15 +11,15 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee9.session.hazelcast.client;
+package org.eclipse.jetty.ee10.session.hazelcast.client;
 
-import org.eclipse.jetty.ee9.session.AbstractClusteredOrphanedSessionTest;
-import org.eclipse.jetty.ee9.session.hazelcast.HazelcastTestHelper;
+import org.eclipse.jetty.ee10.session.AbstractClusteredOrphanedSessionTest;
+import org.eclipse.jetty.ee10.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientOrphanedSessionTest
+public class ClientOrphanedSessionClientTest
     extends AbstractClusteredOrphanedSessionTest
 {
     HazelcastTestHelper _testHelper;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/ClientSessionScavengingClientTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/ClientSessionScavengingClientTest.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.jetty.ee10.session.hazelcast.client;
 
-import org.eclipse.jetty.ee10.session.AbstractClusteredOrphanedSessionTest;
+import org.eclipse.jetty.ee10.session.AbstractClusteredSessionScavengingTest;
 import org.eclipse.jetty.ee10.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientOrphanedSessionTest
-    extends AbstractClusteredOrphanedSessionTest
+public class ClientSessionScavengingClientTest
+    extends AbstractClusteredSessionScavengingTest
 {
     HazelcastTestHelper _testHelper;
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/HazelcastSessionDataStoreClientTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee10/session/hazelcast/client/HazelcastSessionDataStoreClientTest.java
@@ -11,10 +11,10 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee9.session.hazelcast.client;
+package org.eclipse.jetty.ee10.session.hazelcast.client;
 
-import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee9.session.hazelcast.HazelcastTestHelper;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.hazelcast.session.HazelcastSessionDataStore;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.session.AbstractSessionDataStoreFactory;
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * HazelcastSessionDataStoreTest
  */
-public class HazelcastSessionDataStoreTest extends AbstractSessionDataStoreTest
+public class HazelcastSessionDataStoreClientTest extends AbstractSessionDataStoreTest
 {
-    public HazelcastSessionDataStoreTest() throws Exception
+    public HazelcastSessionDataStoreClientTest() throws Exception
     {
         super();
     }
@@ -115,11 +115,11 @@ public class HazelcastSessionDataStoreTest extends AbstractSessionDataStoreTest
         // create the SessionDataStore
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/test");
-        context.getSessionHandler().getSessionManager().setSessionIdManager(idMgr);
+        context.getSessionHandler().setSessionIdManager(idMgr);
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         ((AbstractSessionDataStoreFactory)factory).setGracePeriodSec(GRACE_PERIOD_SEC);
-        SessionDataStore store = factory.getSessionDataStore(context.getSessionHandler().getSessionManager());
-        SessionContext sessionContext = new SessionContext(context.getSessionHandler().getSessionManager());
+        SessionDataStore store = factory.getSessionDataStore(context.getSessionHandler());
+        SessionContext sessionContext = new SessionContext(context.getSessionHandler());
         store.initialize(sessionContext);
 
         // persist a session

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee10-test-sessions-infinispan</artifactId>
   <name>EE10 :: Tests :: Sessions :: Infinispan</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.infinispan</bundle-symbolic-name>
     <!-- if changing this version please update default in RemoteInfinispanTestSupport you will get thanks from Eclipse IDE users -->
     <infinispan.docker.image.version>11.0.9.Final</infinispan.docker.image.version>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee10/session/infinispan/InfinispanTestSupport.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee10/session/infinispan/InfinispanTestSupport.java
@@ -13,9 +13,7 @@
 
 package org.eclipse.jetty.ee10.session.infinispan;
 
-import java.io.File;
 import java.lang.annotation.ElementType;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -23,7 +21,6 @@ import org.eclipse.jetty.session.SessionData;
 import org.eclipse.jetty.session.infinispan.InfinispanSerializationContextInitializer;
 import org.eclipse.jetty.session.infinispan.InfinispanSessionData;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.util.IO;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.cfg.SearchMapping;
 import org.infinispan.Cache;
@@ -47,7 +44,7 @@ public class InfinispanTestSupport
     public Cache _cache;
 
     public ConfigurationBuilder _builder;
-    private File _tmpdir;
+    private Path _tmpdir;
     private boolean _useFileStore;
     private boolean _serializeSessionData;
     private String _name;
@@ -76,7 +73,7 @@ public class InfinispanTestSupport
     public InfinispanTestSupport(String cacheName)
     {
         if (cacheName == null)
-            cacheName = DEFAULT_CACHE_NAME + System.currentTimeMillis();
+            cacheName = DEFAULT_CACHE_NAME + System.nanoTime();
 
         _name = cacheName;
         _builder = new ConfigurationBuilder();
@@ -100,6 +97,7 @@ public class InfinispanTestSupport
     public void setup(Path root) throws Exception
     {
         Path indexesDir = root.resolve("indexes");
+        this._tmpdir = root.resolve("tmp");
         FS.ensureDirExists(indexesDir);
 
         SearchMapping mapping = new SearchMapping();
@@ -109,11 +107,13 @@ public class InfinispanTestSupport
         properties.put("hibernate.search.default.indexBase", indexesDir.toString());
         properties.put("hibernate.cache.infinispan.entity.eviction.strategy", "NONE");
 
+        if (_manager.cacheExists(_name))
+        {
+            _manager.administration().removeCache(_name);
+        }
+
         if (_useFileStore)
         {
-            Path tmpDir = Files.createTempDirectory("infinispan");
-            _tmpdir = tmpDir.toFile();
-
             ConfigurationChildBuilder b = _builder
                 .indexing()
                 .addIndexedEntity(SessionData.class)
@@ -123,14 +123,13 @@ public class InfinispanTestSupport
                 .persistence()
                 .addSingleFileStore()
                 .segmented(false)
-                .location(_tmpdir.getAbsolutePath());
+                .location(_tmpdir.toFile().getAbsolutePath());
             if (_serializeSessionData)
             {
                 b = b.memory().storage(StorageType.HEAP)
                     .encoding()
                     .mediaType("application/x-protostream");
             }
-                
             _manager.defineConfiguration(_name, b.build());
         }
         else
@@ -155,13 +154,6 @@ public class InfinispanTestSupport
     {
         _cache.clear();
         _manager.administration().removeCache(_name);
-        if (_useFileStore)
-        {
-            if (_tmpdir != null)
-            {
-                IO.delete(_tmpdir);
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee10/session/infinispan/remote/RemoteInfinispanTestSupport.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee10/session/infinispan/remote/RemoteInfinispanTestSupport.java
@@ -58,7 +58,7 @@ public class RemoteInfinispanTestSupport
     private static final String IMAGE_NAME = System.getProperty("infinispan.docker.image.name", "infinispan/server") +
             ":" + System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
 
-    private static final GenericContainer INFINISPAN = new GenericContainer(IMAGE_NAME)
+    private final GenericContainer infinispan = new GenericContainer(IMAGE_NAME)
             .withEnv("USER", "theuser")
             .withEnv("PASS", "foobar")
             .withEnv("MGMT_USER", "admin")
@@ -68,7 +68,6 @@ public class RemoteInfinispanTestSupport
             .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
             .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
             .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
-
     private static final String INFINISPAN_VERSION = System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
 
     public RemoteInfinispanTestSupport()
@@ -79,22 +78,22 @@ public class RemoteInfinispanTestSupport
     public RemoteInfinispanTestSupport(String cacheName)
     {
         if (cacheName == null)
-            cacheName = DEFAULT_CACHE_NAME + System.currentTimeMillis();
+            cacheName = DEFAULT_CACHE_NAME + System.nanoTime();
 
         _name = cacheName;
 
-        if (!INFINISPAN.isRunning())
+        if (!infinispan.isRunning())
         {
             try
             {
                 long start = System.currentTimeMillis();
 
-                INFINISPAN.start();
-                System.setProperty("hotrod.host", INFINISPAN.getContainerIpAddress());
+                infinispan.start();
+                System.setProperty("hotrod.host", infinispan.getContainerIpAddress());
 
                 LOG.info("Infinispan container started for {}:{} - {}ms",
-                        INFINISPAN.getContainerIpAddress(),
-                        INFINISPAN.getMappedPort(11222),
+                        infinispan.getContainerIpAddress(),
+                        infinispan.getMappedPort(11222),
                         System.currentTimeMillis() - start);
             }
             catch (Exception e)
@@ -114,8 +113,8 @@ public class RemoteInfinispanTestSupport
 
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().withProperties(properties)
                     .addServer()
-                    .host(INFINISPAN.getContainerIpAddress())
-                    .port(INFINISPAN.getMappedPort(11222))
+                    .host(infinispan.getContainerIpAddress())
+                    .port(infinispan.getMappedPort(11222))
                     // we just want to limit connectivity to list of host:port we knows at start
                     // as infinispan create new host:port dynamically but due to how docker expose host/port we cannot do that
                     .clientIntelligence(ClientIntelligence.BASIC)
@@ -180,7 +179,7 @@ public class RemoteInfinispanTestSupport
 
     public void shutdown() throws Exception
     {
-        INFINISPAN.stop();
+        infinispan.stop();
     }
 
     public void createSession(InfinispanSessionData data)

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee10-test-sessions-jdbc</artifactId>
   <name>EE10 :: Tests :: Sessions :: JDBC</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.jdbc</bundle-symbolic-name>
   </properties>
   <build>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee10/session/jdbc/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee10/session/jdbc/ReloadedSessionMissingClassTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.ContentResponse;
@@ -47,20 +48,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * ReloadedSessionMissingClassTest
  */
 //TODO
-@ExtendWith(WorkDirExtension.class)
 @Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(WorkDirExtension.class)
 public class ReloadedSessionMissingClassTest
 {
-    public WorkDir testdir;
-
     @Test
-    public void testSessionReloadWithMissingClass() throws Exception
+    public void testSessionReloadWithMissingClass(WorkDir workDir) throws Exception
     {
+        Path unpackedWarDir = workDir.getEmptyPathDir();
         String contextPath = "/foo";
 
-        File unpackedWarDir = testdir.getEmptyPathDir().toFile();
-
-        File webInfDir = new File(unpackedWarDir, "WEB-INF");
+        File webInfDir = new File(unpackedWarDir.toFile(), "WEB-INF");
         webInfDir.mkdir();
 
         File webXml = new File(webInfDir, "web.xml");
@@ -95,7 +93,7 @@ public class ReloadedSessionMissingClassTest
 
         SessionTestSupport server1 = new SessionTestSupport(0, SessionTestSupport.DEFAULT_MAX_INACTIVE, SessionTestSupport.DEFAULT_SCAVENGE_SEC, cacheFactory, storeFactory);
 
-        WebAppContext webApp = server1.addWebAppContext(unpackedWarDir.getCanonicalPath(), contextPath);
+        WebAppContext webApp = server1.addWebAppContext(unpackedWarDir.toFile().getCanonicalPath(), contextPath);
         webApp.getSessionHandler().getSessionCache().setRemoveUnloadableSessions(true);
         webApp.setClassLoader(loaderWithFoo);
         webApp.addServlet("Bar", "/bar");

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee10-test-sessions-mongodb</artifactId>
   <name>EE10 :: Tests :: Sessions :: Mongo</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.mongo</bundle-symbolic-name>
     <embedmongo.host>localhost</embedmongo.host>
   </properties>

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/ConfigurationsTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/ConfigurationsTest.java
@@ -13,32 +13,30 @@
 
 package org.eclipse.jetty.ee10.webapp;
 
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.jetty.ee10.webapp.Configurations.getKnown;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+@Isolated("Access static field of Configurations")
 public class ConfigurationsTest
 {
     @AfterEach
     public void tearDown()
     {
         Configurations.cleanKnown();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @BeforeEach
     public void setup()
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         Configurations.cleanKnown();
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
@@ -78,18 +78,6 @@ public class MetaInfConfigurationTest
         }
     }
 
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
     @Test
     public void testScanTypes() throws Exception
     {

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/OrderingTest.java
@@ -20,12 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -37,9 +36,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * OrderingTest
  */
+@ExtendWith(WorkDirExtension.class)
 public class OrderingTest
 {
-    WorkDir workDir;
+
+    public WorkDir workDir;
 
     private Resource newTestableDirResource(String name) throws IOException
     {
@@ -55,20 +56,6 @@ public class OrderingTest
         if (!Files.exists(file))
             Files.createFile(file);
         return ResourceFactory.root().newResource(file);
-    }
-
-    @BeforeEach
-    public void beforeEach()
-    {
-        // ensure work dir exists, and is empty
-        workDir.getEmptyPathDir();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
@@ -22,17 +22,21 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(WorkDirExtension.class)
 public class StandardDescriptorProcessorTest
 {
     //TODO add tests for other methods
@@ -41,7 +45,6 @@ public class StandardDescriptorProcessorTest
     @BeforeEach
     public void beforeEach() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         _server = new Server();
         _server.start();
     }
@@ -50,16 +53,15 @@ public class StandardDescriptorProcessorTest
     public void afterEach() throws Exception
     {
         _server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test
     public void testVisitSessionConfig(WorkDir workDir) throws Exception
     {
+        Path docroot = workDir.getEmptyPathDir();
         File webXml = MavenTestingUtils.getTestResourceFile("web-session-config.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
-        Path docroot = workDir.getEmptyPathDir();
         wac.setBaseResourceAsPath(docroot);
         wac.setDescriptor(webXml.toURI().toURL().toString());
         wac.start();
@@ -92,14 +94,14 @@ public class StandardDescriptorProcessorTest
         assertEquals(10, wac.getSessionHandler().getMaxCookieAge());
         
         //secure
-        assertEquals(false, wac.getSessionHandler().getSessionCookieConfig().isSecure());
+        assertFalse(wac.getSessionHandler().getSessionCookieConfig().isSecure());
         assertEquals("false", wac.getSessionHandler().getSessionCookieConfig().getAttribute("Secure"));
-        assertEquals(false, wac.getSessionHandler().isSecureCookies());
+        assertFalse(wac.getSessionHandler().isSecureCookies());
         
         //httponly
-        assertEquals(false, wac.getSessionHandler().getSessionCookieConfig().isHttpOnly());
+        assertFalse(wac.getSessionHandler().getSessionCookieConfig().isHttpOnly());
         assertEquals("false", wac.getSessionHandler().getSessionCookieConfig().getAttribute("HttpOnly"));
-        assertEquals(false, wac.getSessionHandler().isHttpOnly());
+        assertFalse(wac.getSessionHandler().isHttpOnly());
 
         //SessionCookieConfig javadoc states that all setters must be also represented as attributes
         Map<String, String> attributes = wac.getSessionHandler().getSessionCookieConfig().getAttributes();

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TestMetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TestMetaData.java
@@ -23,24 +23,24 @@ import org.acme.webapp.TestAnnotation;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.eclipse.jetty.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestMetaData
 {
     Path fragFile;
@@ -62,10 +62,9 @@ public class TestMetaData
     @BeforeEach
     public void setUp(WorkDir workDir) throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        Path testDir = workDir.getEmptyPathDir();
         resourceFactory = ResourceFactory.closeable();
 
-        Path testDir = workDir.getEmptyPathDir();
         Path jarsDir = testDir.resolve("jars");
         FS.ensureDirExists(jarsDir);
 
@@ -112,7 +111,6 @@ public class TestMetaData
     public void tearDown()
     {
         IO.close(resourceFactory);
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test
@@ -131,10 +129,7 @@ public class TestMetaData
         wac.getMetaData().addWebInfResource(fragResource);
         wac.getMetaData().addWebInfResource(nonFragResource);
         wac.getMetaData().addFragmentDescriptor(fragResource, new FragmentDescriptor(webfragxml));
-        assertThrows(NullPointerException.class, () ->
-        {
-            wac.getMetaData().addFragmentDescriptor(nonFragResource, null);
-        });
+        assertThrows(NullPointerException.class, () -> wac.getMetaData().addFragmentDescriptor(nonFragResource, null));
 
         assertNotNull(wac.getMetaData().getFragmentDescriptorForJar(fragResource));
         assertNull(wac.getMetaData().getFragmentDescriptorForJar(nonFragResource));

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoaderTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoaderTest.java
@@ -57,7 +57,6 @@ public class WebAppClassLoaderTest
     @BeforeEach
     public void init() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         _server = new Server();
 
         _testWebappDir = MavenTestingUtils.getProjectDirPath("src/test/webapp");
@@ -81,7 +80,6 @@ public class WebAppClassLoaderTest
     {
         IO.close(_loader);
         LifeCycle.stop(_server);
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     public void assertCanLoadClass(String clazz) throws ClassNotFoundException

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -77,11 +78,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated()
 @ExtendWith(WorkDirExtension.class)
 public class WebAppContextTest
 {
     public static final Logger LOG = LoggerFactory.getLogger(WebAppContextTest.class);
-    public WorkDir workDir;
     private final List<Object> lifeCycles = new ArrayList<>();
 
     @BeforeEach
@@ -272,9 +273,9 @@ public class WebAppContextTest
     }
 
     @Test
-    public void testAlias() throws Exception
+    public void testAlias(WorkDir workDir) throws Exception
     {
-        Path tempDir = workDir.getEmptyPathDir().resolve("dir");
+        Path tempDir = workDir.getEmptyPathDir();
         FS.ensureEmpty(tempDir);
 
         Path webinf = tempDir.resolve("WEB-INF");

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletTest.java
@@ -39,19 +39,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(WorkDirExtension.class)
 public class WebAppDefaultServletTest
 {
-    public WorkDir workDir;
     private Server server;
     private LocalConnector connector;
 
     @BeforeEach
-    public void prepareServer() throws Exception
+    public void prepareServer(WorkDir workDir) throws Exception
     {
+        Path directoryPath = workDir.getEmptyPathDir();
         server = new Server();
         connector = new LocalConnector(server);
         connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         server.addConnector(connector);
 
-        Path directoryPath = workDir.getEmptyPathDir();
         Path welcomeResource = directoryPath.resolve("index.html");
         try (OutputStream output = Files.newOutputStream(welcomeResource))
         {

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebDescriptorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebDescriptorTest.java
@@ -27,13 +27,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirExtension.class)
 public class WebDescriptorTest
 {
-    public WorkDir workDir;
 
     /**
      * Test to ensure that the XMLParser XML entity mapping is functioning properly.
      */
     @Test
-    public void testXmlWithXsd() throws Exception
+    public void testXmlWithXsd(WorkDir workDir) throws Exception
     {
         Path xml = workDir.getEmptyPathDir().resolve("test.xml");
         Files.writeString(xml, """

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebInfConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebInfConfigurationTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class WebInfConfigurationTest
 {
-    public WorkDir workDir;
 
     public static Stream<Arguments> fileBaseResourceNames()
     {
@@ -60,9 +59,9 @@ public class WebInfConfigurationTest
 
     @ParameterizedTest
     @MethodSource("fileBaseResourceNames")
-    public void testPathGetResourceBaseName(String basePath, String expectedName) throws IOException
+    public void testPathGetResourceBaseName(String basePath, String expectedName, WorkDir workDir) throws IOException
     {
-        Path root = workDir.getPath();
+        Path root = workDir.getEmptyPathDir();
         Path base = root.resolve(basePath);
         if (basePath.endsWith("/"))
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/AltFilterTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/AltFilterTest.java
@@ -40,12 +40,11 @@ import static org.hamcrest.Matchers.notNullValue;
 @ExtendWith(WorkDirExtension.class)
 public class AltFilterTest
 {
-    public WorkDir testdir;
 
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("alt-filter-web.xml");
         // the endpoint (extends jakarta.websocket.Endpoint)

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/EndpointViaConfigTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/EndpointViaConfigTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee10.websocket.jakarta.tests.server;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -45,12 +46,10 @@ public class EndpointViaConfigTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(EndpointViaConfigTest.class);
 
-    public WorkDir testdir;
-
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         // the endpoint (extends jakarta.websocket.Endpoint)
         app.copyClass(BasicEchoEndpoint.class);

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/LargeAnnotatedTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/LargeAnnotatedTest.java
@@ -52,12 +52,10 @@ public class LargeAnnotatedTest
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.createWebInf();
         app.copyClass(LargeEchoConfiguredSocket.class);

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/LargeContainerTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/LargeContainerTest.java
@@ -41,13 +41,11 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class LargeContainerTest
 {
-    public WorkDir testdir;
-
     @SuppressWarnings("Duplicates")
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("large-echo-config-web.xml");
         app.copyClass(LargeEchoDefaultSocket.class);

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/OnMessageReturnTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/OnMessageReturnTest.java
@@ -76,12 +76,10 @@ public class OnMessageReturnTest
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testEchoReturn() throws Exception
+    public void testEchoReturn(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("empty-web.xml");
         app.copyClass(EchoReturnEndpoint.class);

--- a/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
@@ -10,6 +10,7 @@
   <name>EE8 :: Jetty Maven Plugin</name>
   <description>Jetty maven plugins</description>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.maven.plugin</bundle-symbolic-name>
     <jetty.stopKey>FREEBEER</jetty.stopKey>
     <jetty.jvmArgs></jetty.jvmArgs>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
@@ -11,6 +11,7 @@
   <name>EE8 :: Websocket :: Javax Common</name>
 
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <ee9.module>jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common</ee9.module>
     <bundle-symbolic-name>${project.groupId}.javax.common</bundle-symbolic-name>
   </properties>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
@@ -11,6 +11,7 @@
   <name>EE8 :: Websocket :: Javax Tests</name>
 
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <ee9.module>jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests</ee9.module>
     <bundle-symbolic-name>${project.groupId}.javax.tests</bundle-symbolic-name>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationConfiguration.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationConfiguration.java
@@ -28,22 +28,22 @@ import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestAnnotationConfiguration
 {
     public static class TestableAnnotationConfiguration extends AnnotationConfiguration
@@ -57,7 +57,6 @@ public class TestAnnotationConfiguration
         }
     }
 
-    public WorkDir workDir;
     public Path web25;
     public Path web31false;
     public Path web31true;
@@ -73,9 +72,9 @@ public class TestAnnotationConfiguration
     public Resource webInfClasses;
 
     @BeforeEach
-    public void setup() throws Exception
+    public void setup(WorkDir workDir) throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        unpacked = workDir.getEmptyPathDir();
         web25 = MavenTestingUtils.getTargetPath().resolve("test-classes/web25.xml");
         web31false = MavenTestingUtils.getTargetPath().resolve("test-classes/web31false.xml");
         web31true = MavenTestingUtils.getTargetPath().resolve("test-classes/web31true.xml");
@@ -93,7 +92,6 @@ public class TestAnnotationConfiguration
         testWebInfClassesJar = jarDir.resolve("test-sci-for-webinf.jar");
 
         // unpack some classes to pretend that are in WEB-INF/classes
-        unpacked = workDir.getEmptyPathDir();
         FS.cleanDirectory(unpacked);
         JAR.unpack(testWebInfClassesJar.toFile(), unpacked.toFile());
         webInfClasses = ResourceFactory.root().newResource(unpacked);
@@ -110,12 +108,6 @@ public class TestAnnotationConfiguration
             testSciJar.toUri().toURL(), targetClasses.getURI().toURL(), webInfClasses.getURI().toURL()
         },
             containerLoader);
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationDecorator.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationDecorator.java
@@ -23,11 +23,13 @@ import org.eclipse.jetty.ee9.webapp.MetaData;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.ee9.webapp.WebDescriptor;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlParser;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,9 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestAnnotationDecorator
 {
-    public WorkDir workDir;
 
     public class TestWebDescriptor extends WebDescriptor
     {
@@ -81,17 +83,14 @@ public class TestAnnotationDecorator
     }
 
     @Test
-    public void testAnnotationDecorator() throws Exception
+    public void testAnnotationDecorator(WorkDir workDir) throws Exception
     {
         Path docroot = workDir.getEmptyPathDir();
         Path dummyDescriptor = docroot.resolve("dummy.xml");
         Files.createFile(dummyDescriptor);
         Resource dummyResource = ResourceFactory.root().newResource(dummyDescriptor);
 
-        assertThrows(NullPointerException.class, () ->
-        {
-            new AnnotationDecorator(null);
-        });
+        assertThrows(NullPointerException.class, () -> new AnnotationDecorator(null));
 
         WebAppContext context = new WebAppContext();
         AnnotationDecorator decorator = new AnnotationDecorator(context);

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestAnnotationParser.java
@@ -98,12 +98,10 @@ public class TestAnnotationParser
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testSampleAnnotation() throws Exception
+    public void testSampleAnnotation(WorkDir workDir) throws Exception
     {
-        Path root = testdir.getEmptyPathDir();
+        Path root = workDir.getEmptyPathDir();
         copyClass(ClassA.class, root);
 
         AnnotationParser parser = new AnnotationParser();
@@ -148,9 +146,9 @@ public class TestAnnotationParser
     }
 
     @Test
-    public void testMultiAnnotation() throws Exception
+    public void testMultiAnnotation(WorkDir workDir) throws Exception
     {
-        Path root = testdir.getEmptyPathDir();
+        Path root = workDir.getEmptyPathDir();
         copyClass(ClassB.class, root);
         AnnotationParser parser = new AnnotationParser();
 
@@ -253,14 +251,14 @@ public class TestAnnotationParser
     }
 
     @Test
-    public void testBasedirExclusion() throws Exception
+    public void testBasedirExclusion(WorkDir workDir) throws Exception
     {
         // Build up basedir, which itself has a path segment that violates java package and classnaming.
         // The basedir should have no effect on annotation scanning.
         // Intentionally using a base directory name that starts with a "."
         // This mimics what you see in jenkins, hudson, hadoop, solr, camel, and selenium for their 
         // installed and/or managed webapps
-        Path basedir = testdir.getPathFile(".base/workspace/classes");
+        Path basedir = workDir.getPath().resolve(".base/workspace/classes");
         FS.ensureEmpty(basedir);
 
         // Copy in class that is known to have annotations.

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestRunAsAnnotation.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestRunAsAnnotation.java
@@ -20,17 +20,19 @@ import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.ee9.webapp.WebDescriptor;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestRunAsAnnotation
 {
-    public WorkDir workDir;
 
     @Test
-    public void testRunAsAnnotation() throws Exception
+    public void testRunAsAnnotation(WorkDir workDir)  throws Exception
     {
         WebAppContext wac = new WebAppContext();
         
@@ -47,7 +49,8 @@ public class TestRunAsAnnotation
         holder2.setHeldClass(ServletC.class);
         holder2.setInitOrder(1);
         wac.getServletHandler().addServletWithMapping(holder2, "/foo2/*");
-        Path fakeXml = workDir.getEmptyPathDir().resolve("fake.xml");
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path fakeXml = tmpPath.resolve("fake.xml");
         Files.createFile(fakeXml);
         wac.getMetaData().setOrigin(holder2.getName() + ".servlet.run-as", new WebDescriptor(wac.getResourceFactory().newResource(fakeXml)));
         

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestServletAnnotations.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestServletAnnotations.java
@@ -53,8 +53,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ExtendWith(WorkDirExtension.class)
 public class TestServletAnnotations
 {
-    public WorkDir workDir;
-
     public class TestWebServletAnnotationHandler extends WebServletAnnotationHandler
     {
         List<DiscoveredAnnotation> _list = null;
@@ -74,7 +72,7 @@ public class TestServletAnnotations
     }
 
     @Test
-    public void testServletAnnotation() throws Exception
+    public void testServletAnnotation(WorkDir workDir) throws Exception
     {
         Path root = workDir.getEmptyPathDir();
         copyClass(org.eclipse.jetty.ee9.annotations.ServletC.class, root);

--- a/jetty-ee9/jetty-ee9-apache-jsp/src/test/java/org/eclipse/jetty/ee9/jsp/TestJettyJspServlet.java
+++ b/jetty-ee9/jetty-ee9-apache-jsp/src/test/java/org/eclipse/jetty/ee9/jsp/TestJettyJspServlet.java
@@ -71,7 +71,7 @@ public class TestJettyJspServlet
         ServletContextHandler context = new ServletContextHandler(_server, "/context", true, false);
         context.setClassLoader(new URLClassLoader(new URL[0], Thread.currentThread().getContextClassLoader()));
         ServletHolder jspHolder = context.addServlet(JettyJspServlet.class, "/*");
-        jspHolder.setInitParameter("scratchdir", workdir.getPath().toString());
+        jspHolder.setInitParameter("scratchdir", workdir.getEmptyPathDir().toString());
         context.setResourceBase(baseDir.getAbsolutePath());
         context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
         ServletHolder dfltHolder = new ServletHolder();

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FastFileServerTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FastFileServerTest.java
@@ -35,21 +35,20 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(WorkDirExtension.class)
 // FIXME
 @Disabled
+@ExtendWith(WorkDirExtension.class)
 public class FastFileServerTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
+
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FileServerTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FileServerTest.java
@@ -40,14 +40,12 @@ public class FileServerTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FileServerXmlTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/FileServerXmlTest.java
@@ -39,14 +39,12 @@ public class FileServerXmlTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "I am an old man and I have known a great " +
         "many troubles, but most of them never happened. - Mark Twain";
-    public WorkDir workDir;
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
-
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/JarServerTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/JarServerTest.java
@@ -55,7 +55,6 @@ public class JarServerTest extends AbstractEmbeddedTest
     public void stopServer() throws Exception
     {
         server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextJmxStatsTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextJmxStatsTest.java
@@ -25,11 +25,9 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.AssertionFailedError;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +37,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ExtendWith(WorkDirExtension.class)
 public class OneServletContextJmxStatsTest extends AbstractEmbeddedTest
 {
     private Server server;

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextTest.java
@@ -40,14 +40,13 @@ import static org.hamcrest.Matchers.is;
 public class OneServletContextTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "The secret of getting ahead is getting started. - Mark Twain";
-    public WorkDir workDir;
+    public Path baseDir;
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
+        baseDir = workDir.getEmptyPathDir();
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextWithSessionTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/OneServletContextWithSessionTest.java
@@ -41,14 +41,13 @@ import static org.hamcrest.Matchers.is;
 public class OneServletContextWithSessionTest extends AbstractEmbeddedTest
 {
     private static final String TEXT_CONTENT = "Do the right thing. It will gratify some people and astonish the rest. - Mark Twain";
-    public WorkDir workDir;
+    private Path baseDir;
     private Server server;
 
     @BeforeEach
-    public void startServer() throws Exception
+    public void startServer(WorkDir workDir) throws Exception
     {
-        Path baseDir = workDir.getEmptyPathDir();
-
+        baseDir = workDir.getEmptyPathDir();
         Path textFile = baseDir.resolve("simple.txt");
         try (BufferedWriter writer = Files.newBufferedWriter(textFile, UTF_8))
         {

--- a/jetty-ee9/jetty-ee9-glassfish-jstl/src/test/java/org/eclipse/jetty/ee9/jstl/JspIncludeTest.java
+++ b/jetty-ee9/jetty-ee9-glassfish-jstl/src/test/java/org/eclipse/jetty/ee9/jstl/JspIncludeTest.java
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Path;
 
 import org.eclipse.jetty.ee9.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee9.webapp.Configurations;
@@ -32,14 +33,17 @@ import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.JAR;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(WorkDirExtension.class)
 public class JspIncludeTest
 {
     private static Server server;
@@ -48,6 +52,7 @@ public class JspIncludeTest
     @BeforeAll
     public static void startServer(WorkDir workDir) throws Exception
     {
+        Path tmpPath = workDir.getEmptyPathDir();
         // Setup Server
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
@@ -55,7 +60,7 @@ public class JspIncludeTest
         server.addConnector(connector);
         
         //Base dir for test
-        File testDir = workDir.getEmptyPathDir().toFile();
+        File testDir = tmpPath.toFile();
         File testLibDir = new File(testDir, "WEB-INF/lib");
         FS.ensureDirExists(testLibDir);
                 

--- a/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
@@ -10,6 +10,7 @@
   <name>EE9 :: Jetty Maven Plugin</name>
   <description>Jetty maven plugins</description>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.maven.plugin</bundle-symbolic-name>
     <jetty.stopKey>FREEBEER</jetty.stopKey>
     <jetty.jvmArgs></jetty.jvmArgs>

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestJettyEmbedder.java
@@ -37,10 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class TestJettyEmbedder
 {
-    public WorkDir workDir;
 
     @Test
-    public void testJettyEmbedderFromDefaults() throws Exception
+    public void testJettyEmbedderFromDefaults(WorkDir workDir) throws Exception
     {
         Path baseResource = workDir.getEmptyPathDir();
         MavenWebAppContext webApp = new MavenWebAppContext();
@@ -77,11 +76,11 @@ public class TestJettyEmbedder
     }
 
     @Test
-    public void testJettyEmbedder()
+    public void testJettyEmbedder(WorkDir workDir)
         throws Exception
     {
-        MavenWebAppContext webApp = new MavenWebAppContext();
         Path baseResource = workDir.getEmptyPathDir();
+        MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setBaseResource(webApp.getResourceFactory().newResource(baseResource));
         Server server = new Server();
         Map<String, String> jettyProperties = new HashMap<>();

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestQuickStartGenerator.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestQuickStartGenerator.java
@@ -19,8 +19,10 @@ import java.nio.file.Path;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -30,15 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  *
  */
+@ExtendWith(WorkDirExtension.class)
 public class TestQuickStartGenerator
 {
-    public WorkDir workDir;
-
     @Test
-    public void testGenerator() throws Exception
+    public void testGenerator(WorkDir workDir) throws Exception
     {
         Path tmpDir = workDir.getEmptyPathDir();
-
         MavenWebAppContext webApp = new MavenWebAppContext();
         webApp.setContextPath("/shouldbeoverridden");
         Path rootDir = MavenTestingUtils.getTargetPath().resolve("test-classes/root");

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestSelectiveJarResource.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/test/java/org/eclipse/jetty/ee9/maven/plugin/TestSelectiveJarResource.java
@@ -32,13 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class TestSelectiveJarResource
 {
-    public WorkDir workDir;
 
     @Test
-    public void testIncludesNoExcludes() throws Exception
+    public void testIncludesNoExcludes(WorkDir workDir) throws Exception
     {
         Path unpackDir = workDir.getEmptyPathDir();
-
         Path testJar = MavenTestingUtils.getTargetPath("test-classes/selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -61,10 +59,9 @@ public class TestSelectiveJarResource
     }
 
     @Test
-    public void testExcludesNoIncludes() throws Exception
+    public void testExcludesNoIncludes(WorkDir workDir) throws Exception
     {
         Path unpackDir = workDir.getEmptyPathDir();
-
         Path testJar = MavenTestingUtils.getTargetPath("test-classes/selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -87,10 +84,9 @@ public class TestSelectiveJarResource
     }
     
     @Test
-    public void testIncludesExcludes() throws Exception
+    public void testIncludesExcludes(WorkDir workDir) throws Exception
     {
         Path unpackDir = workDir.getEmptyPathDir();
-
         Path testJar = MavenTestingUtils.getTargetPath("test-classes/selective-jar-test.jar");
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -118,7 +118,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class RequestTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(RequestTest.class);
-    public WorkDir workDir;
     private Server _server;
     private ContextHandler _context;
     private LocalConnector _connector;
@@ -245,14 +244,10 @@ public class RequestTest
     public void testParameterExtractionKeepOrderingIntact() throws Exception
     {
         AtomicReference<Map<String, String[]>> reference = new AtomicReference<>();
-        _handler._checker = new RequestTester()
+        _handler._checker = (request, response) ->
         {
-            @Override
-            public boolean check(HttpServletRequest request, HttpServletResponse response)
-            {
-                reference.set(request.getParameterMap());
-                return true;
-            }
+            reference.set(request.getParameterMap());
+            return true;
         };
 
         String request = "POST /?first=1&second=2&third=3&fourth=4 HTTP/1.1\r\n" +
@@ -272,14 +267,10 @@ public class RequestTest
     public void testParameterExtractionOrderingWithMerge() throws Exception
     {
         AtomicReference<Map<String, String[]>> reference = new AtomicReference<>();
-        _handler._checker = new RequestTester()
+        _handler._checker = (request, response) ->
         {
-            @Override
-            public boolean check(HttpServletRequest request, HttpServletResponse response)
-            {
-                reference.set(request.getParameterMap());
-                return true;
-            }
+            reference.set(request.getParameterMap());
+            return true;
         };
 
         String request = "POST /?a=1&b=2&c=3&a=4 HTTP/1.1\r\n" +
@@ -461,11 +452,10 @@ public class RequestTest
     }
 
     @Test
-    public void testMultiPart() throws Exception
+    public void testMultiPart(WorkDir workDir) throws Exception
     {
         Path testTmpDir = workDir.getEmptyPathDir();
-
-        // We should have two tmp files after parsing the multipart form.
+        // We should have two tmp files after parsing the multipart form. bb
         RequestTester tester = (request, response) ->
         {
             try (Stream<Path> s = Files.list(testTmpDir))
@@ -518,10 +508,10 @@ public class RequestTest
     }
 
     @Test
-    public void testBadMultiPart() throws Exception
+    public void testBadMultiPart(WorkDir workDir) throws Exception
     {
-        //a bad multipart where one of the fields has no name
         Path testTmpDir = workDir.getEmptyPathDir();
+        //a bad multipart where one of the fields has no name
 
         _server.stop();
         _context.setContextPath("/foo");

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/annotation/LifeCycleCallbackCollectionTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/annotation/LifeCycleCallbackCollectionTest.java
@@ -22,14 +22,17 @@ import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(WorkDirExtension.class)
 public class LifeCycleCallbackCollectionTest
 {
     public static class TestServlet extends HttpServlet
@@ -174,12 +177,9 @@ public class LifeCycleCallbackCollectionTest
     @Test
     public void testServletPostConstructPreDestroy(WorkDir workDir) throws Exception
     {
-        // Start with an empty dir
-        Path testDir = workDir.getEmptyPathDir();
-
         Server server = new Server();
         WebAppContext context = new WebAppContext();
-        Path predestroyTestDir = testDir.resolve("predestroy-test");
+        Path predestroyTestDir = workDir.getPath().resolve("predestroy-test");
         FS.ensureDirExists(predestroyTestDir);
         context.setBaseResourceAsPath(predestroyTestDir);
         context.setContextPath("/");

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/jndi/TestNamingEntries.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/jndi/TestNamingEntries.java
@@ -31,6 +31,7 @@ import javax.naming.spi.ObjectFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Isolated("jndi entries")
 public class TestNamingEntries
 {
     public class ScopeA

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/jndi/TestNamingEntryUtil.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/jndi/TestNamingEntryUtil.java
@@ -21,6 +21,7 @@ import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Isolated("jndi entries")
 public class TestNamingEntryUtil
 {
     public class MyNamingEntry extends NamingEntry

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.util.IntrospectionUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -51,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * PlusDescriptorProcessorTest
  */
+@Isolated("jndi entries")
 public class PlusDescriptorProcessorTest
 {
     protected static final Class<?>[] STRING_ARG = new Class[]{String.class};

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -95,7 +95,6 @@ public class AsyncMiddleManServletTest
     private static final Logger LOG = LoggerFactory.getLogger(AsyncMiddleManServletTest.class);
     private static final String PROXIED_HEADER = "X-Proxied";
 
-    public WorkDir workDir;
     private HttpClient client;
     private Server proxy;
     private ServerConnector proxyConnector;
@@ -984,11 +983,9 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    public void testAfterContentTransformerOverflowingToDisk() throws Exception
+    public void testAfterContentTransformerOverflowingToDisk(WorkDir workDir) throws Exception
     {
-        // Make sure the temporary directory we use exists and it's empty.
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         String key0 = "id";
         long value0 = 1;
         String key1 = "channel";
@@ -1107,10 +1104,9 @@ public class AsyncMiddleManServletTest
 
     @Test
     @Disabled("idle timeouts do not work yet")
-    public void testAfterContentTransformerClosingFilesOnClientRequestException() throws Exception
+    public void testAfterContentTransformerClosingFilesOnClientRequestException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         startServer(new HttpServlet()
         {
             @Override
@@ -1172,10 +1168,9 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    public void testAfterContentTransformerClosingFilesOnServerResponseException() throws Exception
+    public void testAfterContentTransformerClosingFilesOnServerResponseException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();
-
         CountDownLatch serviceLatch = new CountDownLatch(1);
         startServer(new HttpServlet()
         {

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/HashLoginServiceTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/HashLoginServiceTest.java
@@ -16,15 +16,11 @@ package org.eclipse.jetty.ee9.security;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -36,17 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class HashLoginServiceTest
 {
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
 
     @Test
     public void testAutoCreatedUserStore() throws Exception

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/PropertyUserStoreTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/PropertyUserStoreTest.java
@@ -110,24 +110,17 @@ public class PropertyUserStoreTest
         }
     }
 
-    public WorkDir testdir;
+    public Path testdir;
 
     @BeforeEach
-    public void beforeEach()
+    public void beforeEach(WorkDir workDir)
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        testdir = workDir.getEmptyPathDir();
     }
 
     private Path initUsersText() throws Exception
     {
-        Path dir = testdir.getPath();
-        Path users = dir.resolve("users.txt");
+        Path users = testdir.resolve("users.txt");
         Files.deleteIfExists(users);
 
         writeUser(users);
@@ -137,10 +130,9 @@ public class PropertyUserStoreTest
     private URI initUsersPackedFileText()
         throws Exception
     {
-        Path dir = testdir.getPath();
-        Path users = dir.resolve("users.txt");
+        Path users = testdir.resolve("users.txt");
         writeUser(users);
-        Path usersJar = dir.resolve("users.jar");
+        Path usersJar = testdir.resolve("users.jar");
         String entryPath = "mountain_goat/pale_ale.txt";
         try (InputStream fileInputStream = Files.newInputStream(users))
         {
@@ -194,8 +186,6 @@ public class PropertyUserStoreTest
     @Test
     public void testPropertyUserStoreLoad() throws Exception
     {
-        testdir.ensureEmpty();
-
         final UserCount userCount = new UserCount();
         final Path usersFile = initUsersText();
 
@@ -228,8 +218,6 @@ public class PropertyUserStoreTest
     @Test
     public void testPropertyUserStoreLoadFromJarFile() throws Exception
     {
-        testdir.ensureEmpty();
-
         final UserCount userCount = new UserCount();
         final URI usersFile = initUsersPackedFileText();
 
@@ -257,8 +245,6 @@ public class PropertyUserStoreTest
     @Test
     public void testPropertyUserStoreLoadUpdateUser() throws Exception
     {
-        testdir.ensureEmpty();
-
         final UserCount userCount = new UserCount();
         final Path usersFile = initUsersText();
         final AtomicInteger loadCount = new AtomicInteger(0);
@@ -288,10 +274,10 @@ public class PropertyUserStoreTest
         userCount.assertThatUsers(hasItem("skip"));
 
         if (OS.LINUX.isCurrentOs())
-            Files.createFile(testdir.getPath().toRealPath().resolve("unrelated.txt"),
+            Files.createFile(testdir.toRealPath().resolve("unrelated.txt"),
                 PosixFilePermissions.asFileAttribute(EnumSet.noneOf(PosixFilePermission.class)));
         else
-            Files.createFile(testdir.getPath().toRealPath().resolve("unrelated.txt"));
+            Files.createFile(testdir.toRealPath().resolve("unrelated.txt"));
 
         Scanner scanner = store.getBean(Scanner.class);
         CountDownLatch latch = new CountDownLatch(2);
@@ -307,8 +293,6 @@ public class PropertyUserStoreTest
     @Test
     public void testPropertyUserStoreLoadRemoveUser() throws Exception
     {
-        testdir.ensureEmpty();
-
         final UserCount userCount = new UserCount();
         // initial user file (3) users
         final Path usersFile = initUsersText();

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AsyncServletTest
 {
@@ -660,7 +661,7 @@ public class AsyncServletTest
             socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();
             String response = IO.toString(socket.getInputStream());
-            __latch.await(1, TimeUnit.SECONDS);
+            assertTrue(__latch.await(5, TimeUnit.SECONDS));
             return response;
         }
         catch (Exception e)

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CustomRequestLogTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CustomRequestLogTest.java
@@ -35,23 +35,28 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Credential;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@ExtendWith(WorkDirExtension.class)
 public class CustomRequestLogTest
 {
     private final BlockingQueue<String> _logs = new BlockingArrayQueue<>();
-    public WorkDir workDir;
+
     private Server _server;
     private LocalConnector _connector;
+
     private Path _baseDir;
 
     private void start(String formatString, HttpServlet servlet) throws Exception
@@ -64,7 +69,6 @@ public class CustomRequestLogTest
         RequestLog requestLog = new CustomRequestLog(writer, formatString);
         _server.setRequestLog(requestLog);
 
-        _baseDir = workDir.getEmptyPathDir();
         Files.createDirectory(_baseDir.resolve("servlet"));
         Files.createFile(_baseDir.resolve("servlet/info"));
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
@@ -99,6 +103,12 @@ public class CustomRequestLogTest
         _server.start();
     }
 
+    @BeforeEach
+    public void setup(WorkDir workDir)
+    {
+        this._baseDir = workDir.getEmptyPathDir();
+    }
+
     @AfterEach
     public void after()
     {
@@ -112,7 +122,7 @@ public class CustomRequestLogTest
 
         _connector.getResponse("GET /context/servlet/info HTTP/1.0\n\n");
         String log = _logs.poll(5, TimeUnit.SECONDS);
-        String expected = workDir.getPath().resolve("servlet/info").toString();
+        String expected = _baseDir.resolve("servlet/info").toString();
         assertThat(log, is("Filename: " + expected));
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletRangesTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletRangesTest.java
@@ -39,30 +39,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DefaultServletRangesTest
 {
     public static final String DATA = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWZYZ!@#$%^&*()_+/.,[]";
-    public WorkDir testdir;
 
     private Server server;
     private LocalConnector connector;
-    private ServletContextHandler context;
 
     @BeforeEach
-    public void init() throws Exception
+    public void init(WorkDir workDir) throws Exception
     {
         server = new Server();
 
         connector = new LocalConnector(server);
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
 
-        context = new ServletContextHandler();
+        ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/context");
         context.setWelcomeFiles(new String[]{"index.html", "index.jsp", "index.htm"});
 
         server.setHandler(context);
         server.addConnector(connector);
 
-        testdir.ensureEmpty();
-        File resBase = testdir.getPathFile("docroot").toFile();
-        FS.ensureDirExists(resBase);
+        File resBase = workDir.getEmptyPathDir().toFile();
+        FS.ensureDirExists(resBase.toPath());
         File data = new File(resBase, "data.txt");
         createFile(data, DATA);
         String resBasePath = resBase.getAbsolutePath();

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
@@ -88,7 +88,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @ExtendWith(WorkDirExtension.class)
 public class DefaultServletTest
 {
-    public WorkDir workDir;
 
     public Path docRoot;
 
@@ -100,7 +99,7 @@ public class DefaultServletTest
     private ServletContextHandler context;
 
     @BeforeEach
-    public void init() throws Exception
+    public void init(WorkDir workDir) throws Exception
     {
         assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         docRoot = workDir.getEmptyPathDir().resolve("docroot");
@@ -571,7 +570,7 @@ public class DefaultServletTest
     @ParameterizedTest
     @MethodSource("contextBreakoutScenarios")
     @Disabled // TODO
-    public void testListingContextBreakout(Scenario scenario) throws Exception
+    public void testListingContextBreakout(Scenario scenario, WorkDir workDir) throws Exception
     {
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
@@ -693,7 +692,7 @@ public class DefaultServletTest
     }
 
     @Test
-    public void testWelcomeMultipleBasesBase() throws Exception
+    public void testWelcomeMultipleBasesBase(WorkDir workDir) throws Exception
     {
         Path dir = docRoot.resolve("dir");
         FS.ensureDirExists(dir);
@@ -811,9 +810,9 @@ public class DefaultServletTest
     }
 
     @Test
-    public void testIncludedWelcomeDifferentBase() throws Exception
+    public void testIncludedWelcomeDifferentBase(WorkDir workDir) throws Exception
     {
-        Path altRoot = workDir.getPath().resolve("altroot");
+        Path altRoot = workDir.getEmptyPathDir().resolve("altroot");
         FS.ensureDirExists(altRoot);
         Path altIndex = altRoot.resolve("index.html");
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerIsHandledTest.java
@@ -25,25 +25,24 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 /**
  * Tests of behavior of GzipHandler when Request.isHandled() or Response.isCommitted() is true
  */
+@ExtendWith(WorkDirExtension.class)
 public class GzipHandlerIsHandledTest
 {
-    public WorkDir workDir;
 
     private Server server;
     private HttpClient client;
@@ -63,27 +62,20 @@ public class GzipHandlerIsHandledTest
         client.start();
     }
 
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
     @AfterEach
     public void tearDown()
     {
         LifeCycle.stop(client);
         LifeCycle.stop(server);
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test
-    public void testRequest() throws Exception
+    public void testRequest(WorkDir workDir) throws Exception
     {
         Handler.Sequence handlers = new Handler.Sequence();
 
         ResourceHandler resourceHandler = new ResourceHandler();
-        resourceHandler.setBaseResource(ResourceFactory.root().newResource(workDir.getPath()));
+        resourceHandler.setBaseResource(ResourceFactory.root().newResource(workDir.getEmptyPathDir()));
         resourceHandler.setDirAllowed(true);
         resourceHandler.setHandler(new EventHandler(events, "ResourceHandler"));
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
@@ -286,7 +286,7 @@ public class MultiPartServletTest
         String responseContent = null;
         try
         {
-            Response response = listener.get(30, TimeUnit.SECONDS);
+            Response response = listener.get(60, TimeUnit.SECONDS);
             assertThat(response.getStatus(), equalTo(HttpStatus.BAD_REQUEST_400));
             responseContent = IO.toString(listener.getInputStream());
         }

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AbstractDoSFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AbstractDoSFilterTest.java
@@ -35,7 +35,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.FileSessionDataStore;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
@@ -56,7 +55,7 @@ public abstract class AbstractDoSFilterTest
     private ServerConnector _connector;
     protected long _requestMaxTime = 200;
 
-    public void startServer(WorkDir workDir, Class<? extends Filter> filter) throws Exception
+    public void startServer(Path workDir, Class<? extends Filter> filter) throws Exception
     {
         _server = new Server();
         _connector = new ServerConnector(_server);
@@ -66,7 +65,7 @@ public abstract class AbstractDoSFilterTest
         DefaultSessionCache sessionCache = new DefaultSessionCache(context.getSessionHandler().getSessionManager());
         FileSessionDataStore fileStore = new FileSessionDataStore();
 
-        Path p = workDir.getPathFile("sessions");
+        Path p = workDir.resolve("sessions");
         FS.ensureEmpty(p);
         fileStore.setStoreDir(p.toFile());
         sessionCache.setSessionDataStore(fileStore);

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AbstractGzipTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AbstractGzipTest.java
@@ -32,24 +32,20 @@ import java.util.zip.InflaterInputStream;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.TypeUtil;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+@ExtendWith(WorkDirExtension.class)
 public abstract class AbstractGzipTest
 {
     protected static final int DEFAULT_OUTPUT_BUFFER_SIZE = new HttpConfiguration().getOutputBufferSize();
 
-    protected Path workDir;
-
-    public AbstractGzipTest()
-    {
-        workDir = MavenTestingUtils.getTargetTestingPath(this.getClass().getName());
-        FS.ensureEmpty(workDir);
-    }
+    protected WorkDir workDir;
 
     protected FilterInputStream newContentEncodingFilterInputStream(String contentEncoding, InputStream inputStream) throws IOException
     {

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/CloseableDoSFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/CloseableDoSFilterTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.ee9.servlets;
 
+import java.nio.file.Path;
+
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,12 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirExtension.class)
 public class CloseableDoSFilterTest extends AbstractDoSFilterTest
 {
-    public WorkDir workDir;
-
     @BeforeEach
-    public void setUp() throws Exception
+    public void setUp(WorkDir workDir) throws Exception
     {
-        startServer(workDir, CloseableDoSFilter.class);
+        startServer(workDir.getEmptyPathDir(), CloseableDoSFilter.class);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/DoSFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/DoSFilterTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee9.servlets;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
 
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class DoSFilterTest extends AbstractDoSFilterTest
 {
-    public WorkDir workDir;
+    private Path tmpPath;
 
     private static class RemoteAddressRequest extends org.eclipse.jetty.ee9.nested.Request
     {
@@ -101,9 +102,10 @@ public class DoSFilterTest extends AbstractDoSFilterTest
     }
 
     @BeforeEach
-    public void setUp() throws Exception
+    public void setUp(WorkDir workDir) throws Exception
     {
-        startServer(workDir, DoSFilter.class);
+        tmpPath = workDir.getEmptyPathDir();
+        startServer(tmpPath, DoSFilter.class);
     }
 
     // TODO Remove mock request. Use a real one

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipContentLengthTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipContentLengthTest.java
@@ -154,7 +154,7 @@ public class GzipContentLengthTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletDeferredContentTypeTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletDeferredContentTypeTest.java
@@ -68,7 +68,7 @@ public class GzipDefaultServletDeferredContentTypeTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
@@ -79,7 +79,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -161,7 +161,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -224,7 +224,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -281,7 +281,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -341,7 +341,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -400,7 +400,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -466,7 +466,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -522,7 +522,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -578,7 +578,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -635,7 +635,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -692,7 +692,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -750,7 +750,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -808,7 +808,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -887,7 +887,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();
@@ -943,7 +943,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipHandlerNoReCompressTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipHandlerNoReCompressTest.java
@@ -91,7 +91,7 @@ public class GzipHandlerNoReCompressTest extends AbstractGzipTest
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 
-        Path contextDir = workDir.resolve("context");
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
         FS.ensureDirExists(contextDir);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler();

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/DefaultHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/DefaultHandlerTest.java
@@ -55,7 +55,6 @@ public class DefaultHandlerTest
         server.setScheme(HttpScheme.HTTP.asString());
         server.addXmlConfiguration("DefaultHandler.xml");
         server.addXmlConfiguration("NIOHttp.xml");
-
         server.load();
         server.start();
     }
@@ -69,6 +68,7 @@ public class DefaultHandlerTest
     @AfterAll
     public static void tearDownServer() throws Exception
     {
+        server.getServer().setStopTimeout(20000);
         server.stop();
     }
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/KeyStoreScannerTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/KeyStoreScannerTest.java
@@ -59,16 +59,9 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @ExtendWith(WorkDirExtension.class)
 public class KeyStoreScannerTest
 {
-    public WorkDir testdir;
     private Server server;
     private Path keystoreDir;
     private KeyStoreScanner keyStoreScanner;
-
-    @BeforeEach
-    public void before()
-    {
-        keystoreDir = testdir.getEmptyPathDir();
-    }
 
     @FunctionalInterface
     public interface Configuration
@@ -106,6 +99,12 @@ public class KeyStoreScannerTest
         server.addBean(keyStoreScanner);
 
         server.start();
+    }
+
+    @BeforeEach
+    public void setup(WorkDir workDir)
+    {
+        keystoreDir = workDir.getEmptyPathDir();
     }
 
     @AfterEach

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616NIOHttpTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616NIOHttpTest.java
@@ -17,15 +17,23 @@ import org.eclipse.jetty.ee9.test.support.XmlBasedJettyServer;
 import org.eclipse.jetty.ee9.test.support.rawhttp.HttpSocket;
 import org.eclipse.jetty.ee9.test.support.rawhttp.HttpSocketImpl;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Perform the RFC2616 tests against a server running with the Jetty NIO Connector and listening on standard HTTP.
  */
+@ExtendWith(WorkDirExtension.class)
 public class RFC2616NIOHttpTest extends RFC2616BaseTest
 {
+
+    private static XmlBasedJettyServer xmlBasedJettyServer;
+
     @BeforeAll
-    public static void setupServer() throws Exception
+    public static void setupServer(WorkDir workDir) throws Exception
     {
         XmlBasedJettyServer server = new XmlBasedJettyServer();
         server.setScheme(HttpScheme.HTTP.asString());
@@ -33,12 +41,24 @@ public class RFC2616NIOHttpTest extends RFC2616BaseTest
         server.addXmlConfiguration("RFC2616_Redirects.xml");
         server.addXmlConfiguration("RFC2616_Filters.xml");
         server.addXmlConfiguration("NIOHttp.xml");
-        setUpServer(server, RFC2616NIOHttpTest.class);
+        xmlBasedJettyServer = setUpServer(server, RFC2616NIOHttpsTest.class, workDir.getEmptyPathDir());
     }
 
     @Override
     public HttpSocket getHttpClientSocket()
     {
         return new HttpSocketImpl();
+    }
+
+    @AfterAll
+    public static void tearDownServer() throws Exception
+    {
+        xmlBasedJettyServer.stop();
+    }
+
+    @Override
+    public XmlBasedJettyServer getServer()
+    {
+        return xmlBasedJettyServer;
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616NIOHttpsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616NIOHttpsTest.java
@@ -13,19 +13,31 @@
 
 package org.eclipse.jetty.ee9.test.rfcs;
 
+import java.nio.file.Path;
+
 import org.eclipse.jetty.ee9.test.support.XmlBasedJettyServer;
 import org.eclipse.jetty.ee9.test.support.rawhttp.HttpSocket;
 import org.eclipse.jetty.ee9.test.support.rawhttp.HttpsSocketImpl;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Perform the RFC2616 tests against a server running with the Jetty NIO Connector and listening on HTTPS (HTTP over SSL).
  */
+@ExtendWith(WorkDirExtension.class)
 public class RFC2616NIOHttpsTest extends RFC2616BaseTest
 {
+
+    private static XmlBasedJettyServer xmlBasedJettyServer;
+
     @BeforeAll
-    public static void setupServer() throws Exception
+    public static void setupServer(WorkDir workDir) throws Exception
     {
         XmlBasedJettyServer server = new XmlBasedJettyServer();
         server.setScheme(HttpScheme.HTTPS.asString());
@@ -34,12 +46,24 @@ public class RFC2616NIOHttpsTest extends RFC2616BaseTest
         server.addXmlConfiguration("RFC2616_Filters.xml");
         server.addXmlConfiguration("ssl.xml");
         server.addXmlConfiguration("NIOHttps.xml");
-        setUpServer(server, RFC2616NIOHttpsTest.class);
+        xmlBasedJettyServer = setUpServer(server, RFC2616NIOHttpsTest.class, workDir.getEmptyPathDir());
     }
 
     @Override
     public HttpSocket getHttpClientSocket() throws Exception
     {
         return new HttpsSocketImpl();
+    }
+
+    @AfterAll
+    public static void tearDownServer() throws Exception
+    {
+        xmlBasedJettyServer.stop();
+    }
+
+    @Override
+    public XmlBasedJettyServer getServer()
+    {
+        return xmlBasedJettyServer;
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee9-test-loginservice</artifactId>
   <name>EE9 :: Tests :: Login Service</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.loginservice</bundle-symbolic-name>
   </properties>
   <dependencies>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
@@ -58,5 +58,10 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/DuplicateCookieTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/DuplicateCookieTest.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
@@ -416,7 +417,7 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
 
             //check that all valid sessions have their request counts decremented correctly after the request, back to 0
-            assertEquals(0, s1234.getRequests());
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> s1234.getRequests() == 0);
         }
         finally
         {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/DuplicateCookieTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/DuplicateCookieTest.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.session.SessionDataStoreFactory;
 import org.eclipse.jetty.session.SessionManager;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -417,7 +418,7 @@ public class DuplicateCookieTest
             assertEquals(HttpServletResponse.SC_OK, response.getStatus());
 
             //check that all valid sessions have their request counts decremented correctly after the request, back to 0
-            Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> s1234.getRequests() == 0);
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).until(s1234::getRequests, Matchers.is(0L));
         }
         finally
         {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/src/test/java/org/eclipse/jetty/ee9/session/file/ClusteredOrphanedSessionTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/src/test/java/org/eclipse/jetty/ee9/session/file/ClusteredOrphanedSessionTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee9.session.file;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import org.eclipse.jetty.ee9.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.session.FileSessionDataStoreFactory;
@@ -34,13 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessionTest
 {
-    public WorkDir workDir;
     public Path _storeDir;
 
     @BeforeEach
-    public void before() throws Exception
+    public void before(WorkDir workDir) throws Exception
     {
-        _storeDir = Objects.requireNonNull(workDir.getEmptyPathDir());
+        _storeDir = workDir.getEmptyPathDir();
         assertTrue(Files.exists(_storeDir), "Path must exist: " + _storeDir);
         assertTrue(Files.isDirectory(_storeDir), "Path must be a directory: " + _storeDir);
     }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee9-test-sessions-hazelcast</artifactId>
   <name>EE9 :: Tests :: Sessions :: Hazelcast</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.hazelcast</bundle-symbolic-name>
   </properties>
   <build>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/ClientOrphanedSessionClientTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/ClientOrphanedSessionClientTest.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.jetty.ee9.session.hazelcast.client;
 
-import org.eclipse.jetty.ee9.session.AbstractClusteredSessionScavengingTest;
+import org.eclipse.jetty.ee9.session.AbstractClusteredOrphanedSessionTest;
 import org.eclipse.jetty.ee9.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientSessionScavengingTest
-    extends AbstractClusteredSessionScavengingTest
+public class ClientOrphanedSessionClientTest
+    extends AbstractClusteredOrphanedSessionTest
 {
     HazelcastTestHelper _testHelper;
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/ClientSessionScavengingClientTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/ClientSessionScavengingClientTest.java
@@ -11,15 +11,15 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee10.session.hazelcast.client;
+package org.eclipse.jetty.ee9.session.hazelcast.client;
 
-import org.eclipse.jetty.ee10.session.AbstractClusteredSessionScavengingTest;
-import org.eclipse.jetty.ee10.session.hazelcast.HazelcastTestHelper;
+import org.eclipse.jetty.ee9.session.AbstractClusteredSessionScavengingTest;
+import org.eclipse.jetty.ee9.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ClientSessionScavengingTest
+public class ClientSessionScavengingClientTest
     extends AbstractClusteredSessionScavengingTest
 {
     HazelcastTestHelper _testHelper;

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/HazelcastSessionDataStoreClientTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/src/test/java/org/eclipse/jetty/ee9/session/hazelcast/client/HazelcastSessionDataStoreClientTest.java
@@ -11,10 +11,10 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee10.session.hazelcast.client;
+package org.eclipse.jetty.ee9.session.hazelcast.client;
 
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.session.hazelcast.HazelcastTestHelper;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.session.hazelcast.HazelcastTestHelper;
 import org.eclipse.jetty.hazelcast.session.HazelcastSessionDataStore;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.session.AbstractSessionDataStoreFactory;
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * HazelcastSessionDataStoreTest
  */
-public class HazelcastSessionDataStoreTest extends AbstractSessionDataStoreTest
+public class HazelcastSessionDataStoreClientTest extends AbstractSessionDataStoreTest
 {
-    public HazelcastSessionDataStoreTest() throws Exception
+    public HazelcastSessionDataStoreClientTest() throws Exception
     {
         super();
     }
@@ -115,11 +115,11 @@ public class HazelcastSessionDataStoreTest extends AbstractSessionDataStoreTest
         // create the SessionDataStore
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/test");
-        context.getSessionHandler().setSessionIdManager(idMgr);
+        context.getSessionHandler().getSessionManager().setSessionIdManager(idMgr);
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         ((AbstractSessionDataStoreFactory)factory).setGracePeriodSec(GRACE_PERIOD_SEC);
-        SessionDataStore store = factory.getSessionDataStore(context.getSessionHandler());
-        SessionContext sessionContext = new SessionContext(context.getSessionHandler());
+        SessionDataStore store = factory.getSessionDataStore(context.getSessionHandler().getSessionManager());
+        SessionContext sessionContext = new SessionContext(context.getSessionHandler().getSessionManager());
         store.initialize(sessionContext);
 
         // persist a session

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>jetty-ee9-test-sessions-infinispan</artifactId>
   <name>EE9 :: Tests :: Sessions :: Infinispan</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.infinispan</bundle-symbolic-name>
     <!-- if changing this version please update default in RemoteInfinispanTestSupport you will get thanks from Eclipse IDE users -->
     <infinispan.docker.image.version>11.0.9.Final</infinispan.docker.image.version>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/ClusteredOrphanedSessionTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/ClusteredOrphanedSessionTest.java
@@ -29,11 +29,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class ClusteredOrphanedSessionTest extends AbstractClusteredOrphanedSessionTest
 {
 
-    public WorkDir workDir;
     public InfinispanTestSupport testSupport;
 
     @BeforeEach
-    public void setup() throws Exception
+    public void setup(WorkDir workDir) throws Exception
     {
         testSupport = new InfinispanTestSupport();
         testSupport.setup(workDir.getEmptyPathDir());

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteInfinispanTestSupport.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteInfinispanTestSupport.java
@@ -53,12 +53,12 @@ public class RemoteInfinispanTestSupport
     private final String _name;
     public RemoteCacheManager _manager;
     private static final Logger INFINISPAN_LOG =
-            LoggerFactory.getLogger("org.eclipse.jetty.session.remote.infinispanLogs");
+            LoggerFactory.getLogger("org.eclipse.jetty.server.session.remote.infinispanLogs");
 
     private static final String IMAGE_NAME = System.getProperty("infinispan.docker.image.name", "infinispan/server") +
             ":" + System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
 
-    private static final GenericContainer INFINISPAN = new GenericContainer(IMAGE_NAME)
+    private final GenericContainer infinispan = new GenericContainer(IMAGE_NAME)
             .withEnv("USER", "theuser")
             .withEnv("PASS", "foobar")
             .withEnv("MGMT_USER", "admin")
@@ -68,7 +68,6 @@ public class RemoteInfinispanTestSupport
             .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
             .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
             .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
-
     private static final String INFINISPAN_VERSION = System.getProperty("infinispan.docker.image.version", "11.0.9.Final");
 
     public RemoteInfinispanTestSupport()
@@ -79,22 +78,22 @@ public class RemoteInfinispanTestSupport
     public RemoteInfinispanTestSupport(String cacheName)
     {
         if (cacheName == null)
-            cacheName = DEFAULT_CACHE_NAME + System.currentTimeMillis();
+            cacheName = DEFAULT_CACHE_NAME + System.nanoTime();
 
         _name = cacheName;
 
-        if (!INFINISPAN.isRunning())
+        if (!infinispan.isRunning())
         {
             try
             {
                 long start = System.currentTimeMillis();
 
-                INFINISPAN.start();
-                System.setProperty("hotrod.host", INFINISPAN.getContainerIpAddress());
+                infinispan.start();
+                System.setProperty("hotrod.host", infinispan.getContainerIpAddress());
 
                 LOG.info("Infinispan container started for {}:{} - {}ms",
-                        INFINISPAN.getContainerIpAddress(),
-                        INFINISPAN.getMappedPort(11222),
+                        infinispan.getContainerIpAddress(),
+                        infinispan.getMappedPort(11222),
                         System.currentTimeMillis() - start);
             }
             catch (Exception e)
@@ -114,8 +113,8 @@ public class RemoteInfinispanTestSupport
 
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().withProperties(properties)
                     .addServer()
-                    .host(INFINISPAN.getContainerIpAddress())
-                    .port(INFINISPAN.getMappedPort(11222))
+                    .host(infinispan.getContainerIpAddress())
+                    .port(infinispan.getMappedPort(11222))
                     // we just want to limit connectivity to list of host:port we knows at start
                     // as infinispan create new host:port dynamically but due to how docker expose host/port we cannot do that
                     .clientIntelligence(ClientIntelligence.BASIC)
@@ -162,12 +161,12 @@ public class RemoteInfinispanTestSupport
 
     public void setup() throws Exception
     {
-        String xml = String.format("<infinispan>"  + 
-            "<cache-container>" + "<distributed-cache name=\"%s\" mode=\"SYNC\">" +
-            "<encoding media-type=\"application/x-protostream\"/>" +
-            "</distributed-cache>" +
-            "</cache-container>" +
-            "</infinispan>", _name);
+        String xml = String.format("<infinispan>"  +
+                "<cache-container>" + "<distributed-cache name=\"%s\" mode=\"SYNC\">" +
+                "<encoding media-type=\"application/x-protostream\"/>" +
+                "</distributed-cache>" +
+                "</cache-container>" +
+                "</infinispan>", _name);
 
         XMLStringConfiguration xmlConfig = new XMLStringConfiguration(xml);
         _cache = _manager.administration().getOrCreateCache(_name, xmlConfig);
@@ -180,11 +179,11 @@ public class RemoteInfinispanTestSupport
 
     public void shutdown() throws Exception
     {
-        INFINISPAN.stop();
+        infinispan.stop();
     }
 
     public void createSession(InfinispanSessionData data)
-        throws Exception
+            throws Exception
     {
         data.serializeAttributes();
         _cache.put(data.getContextPath() + "_" + data.getVhost() + "_" + data.getId(), data);
@@ -196,13 +195,13 @@ public class RemoteInfinispanTestSupport
     }
 
     public boolean checkSessionExists(InfinispanSessionData data)
-        throws Exception
+            throws Exception
     {
         return (_cache.get(data.getContextPath() + "_" + data.getVhost() + "_" + data.getId()) != null);
     }
 
     public boolean checkSessionPersisted(SessionData data)
-        throws Exception
+            throws Exception
     {
         Object obj = _cache.get(data.getContextPath() + "_" + data.getVhost() + "_" + data.getId());
         if (obj == null)

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee9-test-sessions-jdbc</artifactId>
   <name>EE9 :: Tests :: Sessions :: JDBC</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.jdbc</bundle-symbolic-name>
   </properties>
   <build>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee9/session/jdbc/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee9/session/jdbc/ReloadedSessionMissingClassTest.java
@@ -46,18 +46,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * ReloadedSessionMissingClassTest
  */
-@ExtendWith(WorkDirExtension.class)
 @Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(WorkDirExtension.class)
 public class ReloadedSessionMissingClassTest
 {
-    public WorkDir testdir;
 
     @Test
-    public void testSessionReloadWithMissingClass() throws Exception
+    public void testSessionReloadWithMissingClass(WorkDir workDir) throws Exception
     {
         String contextPath = "/foo";
 
-        File unpackedWarDir = testdir.getEmptyPathDir().toFile();
+        File unpackedWarDir = workDir.getEmptyPathDir().toFile();
 
         File webInfDir = new File(unpackedWarDir, "WEB-INF");
         webInfDir.mkdir();

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
@@ -9,6 +9,7 @@
   <artifactId>jetty-ee9-test-sessions-mongodb</artifactId>
   <name>EE9 :: Tests :: Sessions :: Mongo</name>
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.sessions.mongo</bundle-symbolic-name>
     <embedmongo.host>localhost</embedmongo.host>
   </properties>

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/ConfigurationsTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/ConfigurationsTest.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.jetty.ee9.webapp.Configurations.getKnown;
@@ -26,19 +27,18 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+@Isolated("Access static field of Configurations")
 public class ConfigurationsTest
 {
     @AfterEach
     public void tearDown()
     {
         Configurations.cleanKnown();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @BeforeEach
     public void setup()
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         Configurations.cleanKnown();
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/ForcedServletTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/ForcedServletTest.java
@@ -56,7 +56,6 @@ public class ForcedServletTest
     @BeforeEach
     public void setup() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         server = new Server();
         connector = new LocalConnector(server);
         server.addConnector(connector);
@@ -84,12 +83,6 @@ public class ForcedServletTest
         server.start();
     }
 
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-    
     private void copyClass(Class<?> clazz, Path destClasses) throws IOException
     {
         String classRelativeFilename = clazz.getName().replace('.', '/') + ".class";

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
@@ -78,18 +78,6 @@ public class MetaInfConfigurationTest
         }
     }
 
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
     @Test
     public void testScanTypes() throws Exception
     {

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
@@ -20,12 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
-import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -37,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * OrderingTest
  */
+@ExtendWith(WorkDirExtension.class)
 public class OrderingTest
 {
     WorkDir workDir;
@@ -55,20 +55,6 @@ public class OrderingTest
         if (!Files.exists(file))
             Files.createFile(file);
         return ResourceFactory.root().newResource(file);
-    }
-
-    @BeforeEach
-    public void beforeEach()
-    {
-        // ensure work dir exists, and is empty
-        workDir.getEmptyPathDir();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
@@ -19,15 +19,18 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(WorkDirExtension.class)
 public class StandardDescriptorProcessorTest
 {
     //TODO add tests for other methods
@@ -36,7 +39,6 @@ public class StandardDescriptorProcessorTest
     @BeforeEach
     public void beforeEach() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         _server = new Server();
         _server.start();
     }
@@ -45,16 +47,15 @@ public class StandardDescriptorProcessorTest
     public void afterEach() throws Exception
     {
         _server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test
     public void testVisitSessionConfig(WorkDir workDir) throws Exception
     {
+        Path docroot = workDir.getEmptyPathDir();
         Path webXml = MavenPaths.findTestResourceFile("web-session-config.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
-        Path docroot = workDir.getEmptyPathDir();
         wac.setBaseResourceAsPath(docroot);
         wac.setDescriptor(webXml.toUri().toURL().toString());
         wac.start();

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
@@ -19,14 +19,11 @@ import java.nio.file.Path;
 
 import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.PathMatchers;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.FileSystemPool;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,44 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(WorkDirExtension.class)
 public class TempDirTest
 {
-    public WorkDir workDir;
-    private Server server;
-    private WebAppContext webapp;
-
-    private Path jettyBase;
-
-    @BeforeEach
-    public void before()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-        jettyBase = workDir.getEmptyPathDir().resolve("base");
-        FS.ensureEmpty(jettyBase);
-        System.setProperty("jetty.base", jettyBase.toString());
-    }
-
-    public void setupServer()
-    {
-        server = new Server();
-        ServerConnector connector = new ServerConnector(server);
-        server.addConnector(connector);
-
-        File testWebAppDir = MavenTestingUtils.getTargetPath("test-classes/webapp").toFile();
-        webapp = new WebAppContext();
-        webapp.setContextPath("/");
-        webapp.setWar(testWebAppDir.getAbsolutePath());
-        server.setHandler(webapp);
-    }
-
-    @AfterEach
-    public void stopServer() throws Exception
-    {
-        if (server != null)
-            server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void tearDown()
+    public static void tearDown()
     {
         assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
@@ -89,10 +49,11 @@ public class TempDirTest
      */
     @ParameterizedTest
     @ValueSource(strings = {"File", "String", "Path"})
-    public void attributeWithValidDirectory(String type) throws Exception
+    public void attributeWithValidDirectory(String type, WorkDir workDir) throws Exception
     {
+        Path jettyBase = workDir.getEmptyPathDir();
         WebAppContext webAppContext = new WebAppContext();
-        Path tmpDir = workDir.getPath().resolve("temp");
+        Path tmpDir = jettyBase.resolve("temp");
         FS.ensureDirExists(tmpDir);
         switch (type)
         {
@@ -114,12 +75,13 @@ public class TempDirTest
      */
     @ParameterizedTest
     @ValueSource(strings = {"File", "String", "Path"})
-    public void attributeWithNonExistentDirectory(String type) throws Exception
+    public void attributeWithNonExistentDirectory(String type, WorkDir workDir) throws Exception
     {
+        Path jettyBase = workDir.getEmptyPathDir();
         Server server = new Server();
         WebAppContext webAppContext = new WebAppContext();
         server.setHandler(webAppContext);
-        Path tmpDir = workDir.getPath().resolve("foo_did_not_exist");
+        Path tmpDir = jettyBase.resolve("foo_did_not_exist");
         assertFalse(Files.exists(tmpDir));
 
         switch (type)
@@ -141,12 +103,13 @@ public class TempDirTest
      * Test Server.setTempDirectory as valid directory
      */
     @Test
-    public void serverTempDirAttributeWithValidDirectory() throws Exception
+    public void serverTempDirAttributeWithValidDirectory(WorkDir workDir) throws Exception
     {
+        Path jettyBase = workDir.getEmptyPathDir();
         WebAppContext webAppContext = new WebAppContext();
         Server server = new Server();
         webAppContext.setServer(server);
-        Path tmpDir = workDir.getPath().resolve("temp_test");
+        Path tmpDir = jettyBase.resolve("temp_test");
         FS.ensureDirExists(tmpDir);
         server.setTempDirectory(tmpDir.toFile());
 
@@ -163,15 +126,17 @@ public class TempDirTest
      * so webappContent#tempDirectory is created under <code>java.io.tmpdir</code>
      */
     @Test
-    public void jettyBaseWorkExists() throws Exception
+    public void jettyBaseWorkExists(WorkDir workDirExt) throws Exception
     {
+        Path jettyBase = workDirExt.getEmptyPathDir();
         Path workDir = jettyBase.resolve("work");
         FS.ensureDirExists(workDir);
         WebInfConfiguration webInfConfiguration = new WebInfConfiguration();
         Server server = new Server();
+        server.setTempDirectory(workDir.toFile());
         WebAppContext webAppContext = new WebAppContext();
         server.setHandler(webAppContext);
         webInfConfiguration.resolveTempDirectory(webAppContext);
-        assertThat(webAppContext.getTempDirectory().getParent(), is(workDir.toString()));
+        assertThat(webAppContext.getTempDirectory().getParentFile().toPath(), PathMatchers.isSame(workDir));
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TestMetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TestMetaData.java
@@ -23,24 +23,25 @@ import org.acme.webapp.TestAnnotation;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class TestMetaData
 {
     Path fragFile;
@@ -62,10 +63,9 @@ public class TestMetaData
     @BeforeEach
     public void setUp(WorkDir workDir) throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        Path testDir = workDir.getEmptyPathDir();
         resourceFactory = ResourceFactory.closeable();
 
-        Path testDir = workDir.getEmptyPathDir();
         Path jarsDir = testDir.resolve("jars");
         FS.ensureDirExists(jarsDir);
 
@@ -112,7 +112,6 @@ public class TestMetaData
     public void tearDown()
     {
         IO.close(resourceFactory);
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test
@@ -132,9 +131,7 @@ public class TestMetaData
         wac.getMetaData().addWebInfResource(nonFragResource);
         wac.getMetaData().addFragmentDescriptor(fragResource, new FragmentDescriptor(webfragxml));
         assertThrows(NullPointerException.class, () ->
-        {
-            wac.getMetaData().addFragmentDescriptor(nonFragResource, null);
-        });
+                wac.getMetaData().addFragmentDescriptor(nonFragResource, null));
 
         assertNotNull(wac.getMetaData().getFragmentDescriptorForJar(fragResource));
         assertNull(wac.getMetaData().getFragmentDescriptorForJar(nonFragResource));

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoaderTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoaderTest.java
@@ -57,7 +57,6 @@ public class WebAppClassLoaderTest
     @BeforeEach
     public void init() throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
         _server = new Server();
 
         _testWebappDir = MavenTestingUtils.getTargetPath("test-classes/webapp");
@@ -81,7 +80,6 @@ public class WebAppClassLoaderTest
     {
         IO.close(_loader);
         LifeCycle.stop(_server);
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     public void assertCanLoadClass(String clazz) throws ClassNotFoundException

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -48,7 +48,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -58,6 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,17 +75,17 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated
 @ExtendWith(WorkDirExtension.class)
 public class WebAppContextTest
 {
     public static final Logger LOG = LoggerFactory.getLogger(WebAppContextTest.class);
-    public WorkDir workDir;
     private final List<Object> lifeCycles = new ArrayList<>();
 
     @BeforeEach
     public void beforeEach()
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        //assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @AfterEach
@@ -94,7 +93,7 @@ public class WebAppContextTest
     {
         lifeCycles.forEach(LifeCycle::stop);
         Configurations.cleanKnown();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        //assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     private Server newServer()
@@ -272,9 +271,9 @@ public class WebAppContextTest
     }
 
     @Test
-    public void testAlias() throws Exception
+    public void testAlias(WorkDir workDir) throws Exception
     {
-        Path tempDir = workDir.getEmptyPathDir().resolve("dir");
+        Path tempDir = workDir.getEmptyPathDir();
         FS.ensureEmpty(tempDir);
 
         Path webinf = tempDir.resolve("WEB-INF");

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppDefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppDefaultServletTest.java
@@ -24,7 +24,6 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
-import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,26 +33,24 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(WorkDirExtension.class)
 public class WebAppDefaultServletTest
 {
-    public WorkDir workDir;
+    public Path directoryPath;
     private Server server;
     private LocalConnector connector;
 
     @BeforeEach
-    public void prepareServer() throws Exception
+    public void prepareServer(WorkDir workDir) throws Exception
     {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+        directoryPath = workDir.getEmptyPathDir();
         server = new Server();
         connector = new LocalConnector(server);
         connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         server.addConnector(connector);
 
-        Path directoryPath = workDir.getEmptyPathDir();
         Path welcomeResource = directoryPath.resolve("index.html");
         Files.writeString(welcomeResource, "<h1>welcome page</h1>", StandardCharsets.UTF_8);
 
@@ -89,7 +86,6 @@ public class WebAppDefaultServletTest
     {
         if (server != null)
             server.stop();
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     public static Stream<Arguments> argumentsStream()

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebDescriptorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebDescriptorTest.java
@@ -31,13 +31,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirExtension.class)
 public class WebDescriptorTest
 {
-    public WorkDir workDir;
 
     /**
      * Test to ensure that the XMLParser XML entity mapping is functioning properly.
      */
     @Test
-    public void testXmlWithXsd() throws Exception
+    public void testXmlWithXsd(WorkDir workDir) throws Exception
     {
         // TODO: need to address ee8 issues with missing jsp-configType from the <xsd:include schemaLocation="jsp_2_3.xsd"/> that seems to be a missing resource
         // org.xml.sax.SAXParseException; systemId: jar:file:///path/to/jetty-servlet-api-4.0.6.jar!/javax/servlet/resources/web-common_4_0.xsd; lineNumber: 142; columnNumber: 50;

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebInfConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebInfConfigurationTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class WebInfConfigurationTest
 {
-    public WorkDir workDir;
 
     public static Stream<Arguments> fileBaseResourceNames()
     {
@@ -60,9 +59,9 @@ public class WebInfConfigurationTest
 
     @ParameterizedTest
     @MethodSource("fileBaseResourceNames")
-    public void testPathGetResourceBaseName(String basePath, String expectedName) throws IOException
+    public void testPathGetResourceBaseName(String basePath, String expectedName, WorkDir workDir) throws IOException
     {
-        Path root = workDir.getPath();
+        Path root = workDir.getEmptyPathDir();
         Path base = root.resolve(basePath);
         if (basePath.endsWith("/"))
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
@@ -11,6 +11,7 @@
   <name>EE9 :: Websocket :: Jakarta Common</name>
 
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.jakarta.common</bundle-symbolic-name>
   </properties>
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
@@ -11,6 +11,7 @@
   <name>EE9 :: Websocket :: Jakarta Tests</name>
 
   <properties>
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <bundle-symbolic-name>${project.groupId}.jakarta.tests</bundle-symbolic-name>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/AltFilterTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/AltFilterTest.java
@@ -40,12 +40,11 @@ import static org.hamcrest.Matchers.notNullValue;
 @ExtendWith(WorkDirExtension.class)
 public class AltFilterTest
 {
-    public WorkDir testdir;
 
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("alt-filter-web.xml");
         // the endpoint (extends jakarta.websocket.Endpoint)

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/EndpointViaConfigTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/EndpointViaConfigTest.java
@@ -45,12 +45,10 @@ public class EndpointViaConfigTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(EndpointViaConfigTest.class);
 
-    public WorkDir testdir;
-
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         // the endpoint (extends jakarta.websocket.Endpoint)
         app.copyClass(BasicEchoEndpoint.class);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/LargeAnnotatedTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/LargeAnnotatedTest.java
@@ -52,12 +52,10 @@ public class LargeAnnotatedTest
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.createWebInf();
         app.copyClass(LargeEchoConfiguredSocket.class);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/LargeContainerTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/LargeContainerTest.java
@@ -41,13 +41,11 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(WorkDirExtension.class)
 public class LargeContainerTest
 {
-    public WorkDir testdir;
-
     @SuppressWarnings("Duplicates")
     @Test
-    public void testEcho() throws Exception
+    public void testEcho(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("large-echo-config-web.xml");
         app.copyClass(LargeEchoDefaultSocket.class);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/OnMessageReturnTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/OnMessageReturnTest.java
@@ -76,12 +76,10 @@ public class OnMessageReturnTest
         }
     }
 
-    public WorkDir testdir;
-
     @Test
-    public void testEchoReturn() throws Exception
+    public void testEchoReturn(WorkDir workDir) throws Exception
     {
-        WSServer wsb = new WSServer(testdir.getPath());
+        WSServer wsb = new WSServer(workDir.getEmptyPathDir());
         WSServer.WebApp app = wsb.createWebApp("app");
         app.copyWebInf("empty-web.xml");
         app.copyClass(EchoReturnEndpoint.class);

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
+    <!-- execute top-level classes in parallel but methods in same thread -->
+    <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+    <junit.jupiter.execution.parallel.mode.default>same_thread</junit.jupiter.execution.parallel.mode.default>
+    <junit.jupiter.execution.parallel.mode.classes.default>concurrent</junit.jupiter.execution.parallel.mode.classes.default>
+    <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+    <junit.jupiter.execution.parallel.config.fixed.parallelism>3</junit.jupiter.execution.parallel.config.fixed.parallelism>
+    <junit.jupiter.extensions.autodetection.enabled>false</junit.jupiter.extensions.autodetection.enabled>
+
     <!-- dependency versions -->
     <alpn.agent.version>2.0.10</alpn.agent.version>
     <ant.version>1.10.13</ant.version>
@@ -86,7 +94,8 @@
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
     <jetty-quiche-native.version>0.16.0</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
-    <jetty.test.version>6.0</jetty.test.version>
+<!--    <jetty.test.version>6.0</jetty.test.version>-->
+    <jetty.test.version>6.0-SNAPSHOT</jetty.test.version>
     <jetty.xhtml.schemas-version>1.1</jetty.xhtml.schemas-version>
     <jmh.version>1.36</jmh.version>
     <jna.version>5.13.0</jna.version>
@@ -184,7 +193,7 @@
     <invoker.mergeUserSettings>false</invoker.mergeUserSettings>
     <it.debug>false</it.debug>
     <localRepoPath>${project.build.directory}/local-repo</localRepoPath>
-    <jetty.surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -showversion -Xmx4g -Xms2g -Xlog:gc:stderr:time,level,tags</jetty.surefire.argLine>
+    <jetty.surefire.argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.region=US -Djava.io.tmpdir=${project.build.directory} -showversion -Xmx6g -Xms4g -Xlog:gc:stderr:time,level,tags</jetty.surefire.argLine>
     <jetty.testtracker.log>true</jetty.testtracker.log>
     <jetty.unixdomain.dir>/tmp</jetty.unixdomain.dir>
     <!-- if changing this version please update default in MongoTestHelper you will get thanks from Eclipse IDE users -->
@@ -210,6 +219,18 @@
     <url>https://github.com/eclipse/jetty.project</url>
   </scm>
 
+  <repositories>
+    <repository>
+      <id>jetty.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>jetty.snapshots</id>
@@ -755,15 +776,23 @@
             <!-- order can be different depending on os jvm so let's force it -->
             <runOrder>alphabetical</runOrder>
             <systemPropertyVariables>
-              <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <jetty.unixdomain.dir>${jetty.unixdomain.dir}</jetty.unixdomain.dir>
-              <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
               <jetty.testtracker.log>${jetty.testtracker.log}</jetty.testtracker.log>
             </systemPropertyVariables>
             <!-- The LC_ALL env variable must have some UTF variant otherwise creating and/or reading files with non-ascii names doesn't work -->
             <environmentVariables>
               <LC_ALL>en_US.UTF-8</LC_ALL>
             </environmentVariables>
+            <properties>
+              <configurationParameters>
+                junit.jupiter.execution.parallel.enabled=${junit.jupiter.execution.parallel.enabled}
+                junit.jupiter.execution.parallel.mode.default=${junit.jupiter.execution.parallel.mode.default}
+                junit.jupiter.execution.parallel.mode.classes.default=${junit.jupiter.execution.parallel.mode.classes.default}
+                junit.jupiter.execution.parallel.config.strategy=${junit.jupiter.execution.parallel.config.strategy}
+                junit.jupiter.execution.parallel.config.fixed.parallelism=${junit.jupiter.execution.parallel.config.fixed.parallelism}
+                junit.jupiter.extensions.autodetection.enabled=${junit.jupiter.extensions.autodetection.enabled}
+              </configurationParameters>
+            </properties>
           </configuration>
           <dependencies>
             <dependency>
@@ -2005,6 +2034,7 @@
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
         <maven.repo.uri></maven.repo.uri>
+        <home.start.timeout>90</home.start.timeout>
       </properties>
       <modules>
       <!-- FIXME: Do we want to keep this?

--- a/pom.xml
+++ b/pom.xml
@@ -2034,7 +2034,7 @@
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
         <maven.repo.uri></maven.repo.uri>
-        <home.start.timeout>90</home.start.timeout>
+        <home.start.timeout>120</home.start.timeout>
       </properties>
       <modules>
       <!-- FIXME: Do we want to keep this?

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <junit.jupiter.execution.parallel.mode.default>same_thread</junit.jupiter.execution.parallel.mode.default>
     <junit.jupiter.execution.parallel.mode.classes.default>concurrent</junit.jupiter.execution.parallel.mode.classes.default>
     <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
-    <junit.jupiter.execution.parallel.config.fixed.parallelism>3</junit.jupiter.execution.parallel.config.fixed.parallelism>
+    <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <junit.jupiter.extensions.autodetection.enabled>false</junit.jupiter.extensions.autodetection.enabled>
 
     <!-- dependency versions -->

--- a/tests/jetty-home-tester/src/main/java/org/eclipse/jetty/tests/hometester/JettyHomeTester.java
+++ b/tests/jetty-home-tester/src/main/java/org/eclipse/jetty/tests/hometester/JettyHomeTester.java
@@ -24,6 +24,7 @@ import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -38,7 +39,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -295,7 +295,7 @@ public class JettyHomeTester
         return "java";
     }
 
-    public static void unzip(Path archive, Path outputDir) throws IOException
+    public static synchronized void unzip(Path archive, Path outputDir) throws IOException
     {
         if (!Files.exists(outputDir))
             throw new FileNotFoundException("Directory does not exist: " + outputDir);
@@ -318,7 +318,7 @@ public class JettyHomeTester
                 // ensure proper unpack order (eg: directories before files)
                 List<Path> sorted = entriesStream
                     .sorted()
-                    .collect(Collectors.toList());
+                    .toList();
 
                 for (Path path : sorted)
                 {
@@ -337,6 +337,10 @@ public class JettyHomeTester
                     }
                 }
             }
+        }
+        catch (FileAlreadyExistsException e)
+        {
+            LOGGER.warn("ignore FileAlreadyExistsException: archiveURI {}, outputDir {}", archiveURI, outputDir);
         }
     }
 

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -12,7 +12,6 @@
 
   <properties>
     <distribution.debug.port>-1</distribution.debug.port>
-    <home.start.timeout>10</home.start.timeout>
     <environmentsToTest>ee8,ee9,ee10</environmentsToTest>
     <sessionLogLevel>INFO</sessionLogLevel>
   </properties>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -11,6 +11,8 @@
   <packaging>jar</packaging>
 
   <properties>
+<!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
+    <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
   </properties>
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
@@ -24,14 +24,18 @@ import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith({WorkDirExtension.class})
 public class AbstractJettyHomeTest
 {
     protected HttpClient client;
 
-    public static final int START_TIMEOUT = Integer.getInteger("home.start.timeout", 20);
+    public static final int START_TIMEOUT = Integer.getInteger("home.start.timeout", 30);
 
     public static String toEnvironment(String module, String environment)
     {
@@ -63,11 +67,11 @@ public class AbstractJettyHomeTest
         client.start();
     }
 
-    public static Path newTestJettyBaseDirectory() throws IOException
+    public WorkDir workDir;
+
+    public Path newTestJettyBaseDirectory() throws IOException
     {
-        Path bases = MavenTestingUtils.getTargetTestingPath("bases");
-        FS.ensureDirExists(bases);
-        return Files.createTempDirectory(bases, "jetty_base_");
+        return workDir.getEmptyPathDir();
     }
 
     @AfterEach

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
@@ -108,7 +108,7 @@ public class BadAppTests extends AbstractJettyHomeTest
             int port = distribution.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/badapp/");
@@ -148,7 +148,7 @@ public class BadAppTests extends AbstractJettyHomeTest
             int port = distribution.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port, "jetty.server.dumpAfterStart=true"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 //ContentResponse response = client.GET("http://localhost:" + port + "/badapp/bad/x");
@@ -194,7 +194,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
                 assertFalse(run2.getLogs().stream().anyMatch(s -> s.contains("LinkageError")));
 
                 startHttpClient();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
@@ -183,7 +183,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(args1))
         {
-            assertTrue(run1.awaitFor(5, TimeUnit.SECONDS));
+            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());
 
             File badWebApp = distribution.resolveArtifact("org.eclipse.jetty." + env + ":" + "jetty-" + env + "-test-bad-websocket-webapp:war:" + jettyVersion);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/CDITests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/CDITests.java
@@ -119,7 +119,7 @@ public class CDITests extends AbstractJettyHomeTest
             int port = distribution.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/demo/greetings");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-//@Isolated("TODO investigate more why this cannot run in parallel?")
 @ExtendWith(WorkDirExtension.class)
 public class DemoModulesTests extends AbstractJettyHomeTest
 {

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -24,9 +24,12 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.FormRequestContent;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Fields;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,9 +40,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+//@Isolated("TODO investigate more why this cannot run in parallel?")
+@ExtendWith(WorkDirExtension.class)
 public class DemoModulesTests extends AbstractJettyHomeTest
 {
     private static Stream<Arguments> provideEnvironmentsToTest()
@@ -154,8 +160,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
                 .build();
 
         int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
                 "--add-modules=http," + toEnvironment("demos", env)
@@ -170,9 +174,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             String[] argsStart = 
             {
-                    "jetty.http.port=" + httpPort,
-                    "jetty.httpConfig.port=" + httpsPort,
-                    "jetty.ssl.port=" + httpsPort
+                    "jetty.http.port=" + httpPort
             };
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -334,7 +336,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", 20, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.util.Fields;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,10 +63,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             .jettyBase(jettyBase)
             .mavenLocalRepository(System.getProperty("mavenRepoPath"))
             .build();
-
-        int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
             "--add-modules=http," + toEnvironment("demos", env)
@@ -111,8 +105,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             .build();
 
         int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
             "--add-modules=http," + toEnvironment("demos", env)
@@ -126,9 +118,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
-                "jetty.ssl.port=" + httpsPort
+                "jetty.http.port=" + httpPort
             };
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -206,8 +196,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
                 .build();
 
         int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
                 "--add-modules=http," + toEnvironment("demos", env)
@@ -221,9 +209,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                    "jetty.http.port=" + httpPort,
-                    "jetty.httpConfig.port=" + httpsPort,
-                    "jetty.ssl.port=" + httpsPort
+                    "jetty.http.port=" + httpPort
             };
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -257,8 +243,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             .build();
 
         int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
             "--add-modules=http," + toEnvironment("demos", env)
@@ -272,9 +256,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
-                "jetty.ssl.port=" + httpsPort
+                "jetty.http.port=" + httpPort
             };
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -316,8 +298,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             .build();
 
         int httpPort = distribution.freePort();
-        int httpsPort = distribution.freePort();
-        assertThat("httpPort != httpsPort", httpPort, is(not(httpsPort)));
 
         String[] argsConfig = {
             "--add-modules=http," + toEnvironment("demos", env)
@@ -329,9 +309,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
-                "jetty.ssl.port=" + httpsPort
+                "jetty.http.port=" + httpPort
             };
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -386,13 +364,10 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             int httpPort = distribution.freePort();
-            int httpsPort = distribution.freePort();
             String[] argsStart = {
                 "--jpms",
                 "--debug",
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
-                "jetty.ssl.port=" + httpsPort
+                "jetty.http.port=" + httpPort
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
@@ -430,11 +405,8 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             int httpPort = distribution.freePort();
-            int httpsPort = distribution.freePort();
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
-                "jetty.ssl.port=" + httpsPort
+                "jetty.http.port=" + httpPort
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -410,7 +410,8 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
+                        String.join("", runStart.getLogs()));
 
                 String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1137,7 +1137,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start("--dry-run"))
             {
-                run2.awaitFor(5, TimeUnit.SECONDS);
+                run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
                 Queue<String> logs = run2.getLogs();
                 assertThat(logs.size(), equalTo(1));
                 assertThat(logs.poll(), not(containsString("${jetty.home.uri}")));
@@ -1159,7 +1159,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         String[] args1 = {"--add-module=server,http,deploy,requestlog"};
         try (JettyHomeTester.Run run1 = distribution.start(args1))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());
 
             // Setup custom format string with spaces
@@ -1317,7 +1317,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=threadpool-virtual-preview,http"))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());
 
             int httpPort = distribution.freePort();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -813,13 +813,14 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start("--add-modules=ssl-patch"))
             {
-                assertTrue(run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), run2.getLogs().stream().toList().toString());
+                assertTrue(run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), String.join("", run2.getLogs()));
                 assertEquals(0, run2.getExitValue());
 
                 int port = distribution.freePort();
                 try (JettyHomeTester.Run run3 = distribution.start("jetty.http.port=" + port))
                 {
-                    assertTrue(run3.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                    assertTrue(run3.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
+                            String.join("", run3.getLogs()));
 
                     // Check for the protocol order: fcgi must be after ssl and before http.
                     assertTrue(run3.getLogs().stream()

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -813,7 +813,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start("--add-modules=ssl-patch"))
             {
-                assertTrue(run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), run2.getLogs().stream().toList().toString());
                 assertEquals(0, run2.getExitValue());
 
                 int port = distribution.freePort();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -817,7 +817,8 @@ public class DistributionTests extends AbstractJettyHomeTest
                 assertEquals(0, run2.getExitValue());
 
                 int port = distribution.freePort();
-                try (JettyHomeTester.Run run3 = distribution.start("jetty.http.port=" + port))
+                int sslPort = distribution.freePort();
+                try (JettyHomeTester.Run run3 = distribution.start("jetty.http.port=" + port, "jetty.ssl.port=" + sslPort))
                 {
                     assertTrue(run3.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
                             String.join("", run3.getLogs()));

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DynamicListenerTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DynamicListenerTests.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.jetty.tests.distribution;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -32,18 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DynamicListenerTests extends AbstractJettyHomeTest
 {
-    private Path jettyBase;
-
-    @BeforeEach
-    public void setUp() throws IOException
-    {
-        jettyBase = newTestJettyBaseDirectory();
-    }
 
     @ParameterizedTest
     @ValueSource(strings = {"ee8", "ee9", "ee10"})
     public void testSimpleWebAppWithJSP(String env) throws Exception
     {
+        Path jettyBase = newTestJettyBaseDirectory();
         String jettyVersion = System.getProperty("jettyVersion");
         JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
             .jettyBase(jettyBase)
@@ -65,7 +58,7 @@ public class DynamicListenerTests extends AbstractJettyHomeTest
         int port = distribution.freePort();
         try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
         {
-            assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+            assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
             startHttpClient();
             ContentResponse response = client.GET("http://localhost:" + port + "/" + env + "-test/testservlet/foo");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/GzipModuleTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/GzipModuleTests.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -68,7 +69,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", 20, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/demo/index.html");
@@ -112,7 +113,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", 20, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/demo/jetty.webp");
@@ -158,7 +159,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", 20, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/demo/jetty.icon");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/LoggingOptionsTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/LoggingOptionsTests.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -131,7 +132,8 @@ public class LoggingOptionsTests extends AbstractJettyHomeTest
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("validLoggingModules")
-    public void testLoggingConfiguration(String env, String loggingModules, List<String> expectedClasspathEntries, List<String> expectedEnabledModules) throws Exception
+    public void testLoggingConfiguration(String env, String loggingModules, List<String> expectedClasspathEntries,
+                                         List<String> expectedEnabledModules) throws Exception
     {
         Path jettyBase = newTestJettyBaseDirectory();
         String jettyVersion = System.getProperty("jettyVersion");
@@ -156,8 +158,7 @@ public class LoggingOptionsTests extends AbstractJettyHomeTest
                 assertTrue(listConfigRun.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
                 assertEquals(0, listConfigRun.getExitValue());
 
-                List<String> rawConfigLogs = new ArrayList<>();
-                rawConfigLogs.addAll(listConfigRun.getLogs());
+                List<String> rawConfigLogs = new ArrayList<>(listConfigRun.getLogs());
 
                 for (String expectedEnabledModule : expectedEnabledModules)
                 {
@@ -176,7 +177,7 @@ public class LoggingOptionsTests extends AbstractJettyHomeTest
             int port = distribution.freePort();
             try (JettyHomeTester.Run requestRun = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(requestRun.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(requestRun.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
@@ -69,7 +69,7 @@ public class ModulesTest
         try (LogDisabler ignored = new LogDisabler(JettyHomeTester.class);
             JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Issuer was not configured", 5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Issuer was not configured", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
             assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
         }
@@ -95,7 +95,7 @@ public class ModulesTest
         // Verify that Jetty starts.
         try (JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", 5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
             assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
         }
@@ -120,7 +120,7 @@ public class ModulesTest
         // Verify that Jetty starts.
         try (JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", 5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
             assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
         }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.jetty.tests.distribution.AbstractJettyHomeTest.START_TIMEOUT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -61,7 +62,7 @@ public class ModulesTest
         // Add module.
         try (JettyHomeTester.Run run = distribution.start("--add-modules=" + module))
         {
-            run.awaitFor(5, TimeUnit.SECONDS);
+            run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
             assertThat(run.getExitValue(), is(0));
         }
 
@@ -69,9 +70,9 @@ public class ModulesTest
         try (LogDisabler ignored = new LogDisabler(JettyHomeTester.class);
             JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Issuer was not configured", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Issuer was not configured", START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
-            assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), is(true));
         }
     }
 
@@ -88,16 +89,16 @@ public class ModulesTest
         // Add module.
         try (JettyHomeTester.Run run = distribution.start("--add-modules=" + module))
         {
-            run.awaitFor(5, TimeUnit.SECONDS);
+            run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
             assertThat(run.getExitValue(), is(0));
         }
 
         // Verify that Jetty starts.
         try (JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
-            assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), is(true));
         }
     }
 
@@ -113,16 +114,16 @@ public class ModulesTest
         // Add module.
         try (JettyHomeTester.Run run = distribution.start("--add-modules=statistics"))
         {
-            run.awaitFor(5, TimeUnit.SECONDS);
+            run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
             assertThat(run.getExitValue(), is(0));
         }
 
         // Verify that Jetty starts.
         try (JettyHomeTester.Run run = distribution.start())
         {
-            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", AbstractJettyHomeTest.START_TIMEOUT, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
-            assertThat(run.awaitFor(5, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), is(true));
         }
     }
 }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/OsgiAppTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/OsgiAppTests.java
@@ -59,7 +59,7 @@ public class OsgiAppTests extends AbstractJettyHomeTest
             int port = distribution.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/info");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/StatsTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/StatsTests.java
@@ -76,7 +76,7 @@ public class StatsTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
 
                 startHttpClient();
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
@@ -178,7 +178,7 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
 
                 try (JettyHomeTester.Run run2 = distribution.start(argsStart))
                 {
-                    assertTrue(run2.awaitConsoleLogsFor("Started @", 60, TimeUnit.SECONDS));
+                    assertTrue(run2.awaitConsoleLogsFor("Started @", START_TIMEOUT, TimeUnit.SECONDS));
 
                     startHttpClient();
                     ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=CREATE");
@@ -194,7 +194,7 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
 
                 try (JettyHomeTester.Run run2 = distribution.start(argsStart))
                 {
-                    assertTrue(run2.awaitConsoleLogsFor("Started @", 15, TimeUnit.SECONDS));
+                    assertTrue(run2.awaitConsoleLogsFor("Started @", START_TIMEOUT, TimeUnit.SECONDS));
 
                     ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=READ");
                     assertEquals(HttpStatus.OK_200, response.getStatus());

--- a/tests/test-distribution/test-ee10-distribution/src/test/java/org/eclipse/jetty/ee10/tests/distribution/OpenIdTests.java
+++ b/tests/test-distribution/test-ee10-distribution/src/test/java/org/eclipse/jetty/ee10/tests/distribution/OpenIdTests.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.distribution.AbstractJettyHomeTest;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -74,7 +75,7 @@ public class OpenIdTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
                 startHttpClient(false);
                 String uri = "http://localhost:" + port + "/test";
                 openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));

--- a/tests/test-distribution/test-ee9-distribution/src/test/java/org/eclipse/jetty/ee9/tests/distribution/OpenIdTests.java
+++ b/tests/test-distribution/test-ee9-distribution/src/test/java/org/eclipse/jetty/ee9/tests/distribution/OpenIdTests.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.tests.distribution.AbstractJettyHomeTest;
 import org.eclipse.jetty.tests.hometester.JettyHomeTester;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;


### PR DESCRIPTION
build time with those changes
<img width="630" alt="Screenshot 2023-04-11 at 5 19 58 pm" src="https://user-images.githubusercontent.com/19728/231085582-6deb56a1-043f-4cb4-85fd-3c2b23f43ef5.png">

build time without 
<img width="654" alt="Screenshot 2023-04-11 at 5 20 47 pm" src="https://user-images.githubusercontent.com/19728/231085856-34ec9356-2e42-4358-8dd4-069b57b241b8.png">


