### PR TITLE
Bring back some openid improvements from 10.0.x to 9.4.x

### DIFF
--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -345,10 +345,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("auth revoked {}", authentication);
-                    synchronized (session)
-                    {
-                        session.removeAttribute(SessionAuthentication.__J_AUTHENTICATED);
-                    }
+                    logout(request);
                 }
                 else
                 {

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -380,10 +380,11 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                             }
                         }
                     }
+
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth {}", authentication);
+                    return authentication;
                 }
-                if (LOG.isDebugEnabled())
-                    LOG.debug("auth {}", authentication);
-                return authentication;
             }
 
             // If we can't send challenge.

--- a/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
+++ b/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdCredentials.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.security.openid;
 
 import java.io.Serializable;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -142,10 +143,22 @@ public class OpenIdCredentials implements Serializable
             throw new AuthenticationException("Authorized party claim value should be the client_id");
 
         // Check that the ID token has not expired by checking the exp claim.
-        long expiry = (Long)claims.get("exp");
-        long currentTimeSeconds = (long)(System.currentTimeMillis() / 1000F);
-        if (currentTimeSeconds > expiry)
+        if (isExpired())
             throw new AuthenticationException("ID Token has expired");
+    }
+
+    public boolean isExpired()
+    {
+        return checkExpiry(claims);
+    }
+
+    public static boolean checkExpiry(Map<String, Object> claims)
+    {
+        if (claims == null)
+            return true;
+
+        // Check that the ID token has not expired by checking the exp claim.
+        return Instant.ofEpochSecond((Long)claims.get("exp")).isBefore(Instant.now());
     }
 
     private void validateAudience(OpenIdConfiguration configuration) throws AuthenticationException

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdAuthenticationTest.java
@@ -18,28 +18,41 @@
 
 package org.eclipse.jetty.security.openid;
 
+import java.io.File;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.server.session.FileSessionDataStoreFactory;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 public class OpenIdAuthenticationTest
@@ -52,8 +65,12 @@ public class OpenIdAuthenticationTest
     private ServerConnector connector;
     private HttpClient client;
 
-    @BeforeEach
-    public void setup() throws Exception
+    public void setup(LoginService loginService) throws Exception
+    {
+        setup(loginService, null);
+    }
+
+    public void setup(LoginService loginService, Consumer<OpenIdConfiguration> configure) throws Exception
     {
         openIdProvider = new OpenIdProvider(CLIENT_ID, CLIENT_SECRET);
         openIdProvider.start();
@@ -93,21 +110,28 @@ public class OpenIdAuthenticationTest
 
         // security handler
         ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
-        securityHandler.setRealmName("OpenID Connect Authentication");
+        assertThat(securityHandler.getKnownAuthenticatorFactories().size(), greaterThanOrEqualTo(2));
+
+        securityHandler.setAuthMethod(Constraint.__OPENID_AUTH);
+        securityHandler.setRealmName(openIdProvider.getProvider());
         securityHandler.addConstraintMapping(profileMapping);
         securityHandler.addConstraintMapping(loginMapping);
         securityHandler.addConstraintMapping(adminMapping);
 
         // Authentication using local OIDC Provider
-        OpenIdConfiguration configuration = new OpenIdConfiguration(openIdProvider.getProvider(), CLIENT_ID, CLIENT_SECRET);
-
-        // Configure OpenIdLoginService optionally providing a base LoginService to provide user roles
-        OpenIdLoginService loginService = new OpenIdLoginService(configuration);
-        securityHandler.setLoginService(loginService);
-
-        Authenticator authenticator = new OpenIdAuthenticator(configuration, "/error");
-        securityHandler.setAuthenticator(authenticator);
+        OpenIdConfiguration openIdConfiguration = new OpenIdConfiguration(openIdProvider.getProvider(), CLIENT_ID, CLIENT_SECRET);
+        if (configure != null)
+            configure.accept(openIdConfiguration);
+        securityHandler.setLoginService(new OpenIdLoginService(openIdConfiguration, loginService));
+        server.addBean(openIdConfiguration);
+        securityHandler.setInitParameter(OpenIdAuthenticator.ERROR_PAGE, "/error");
         context.setSecurityHandler(securityHandler);
+
+        File datastoreDir = MavenTestingUtils.getTargetTestingDir("datastore");
+        IO.delete(datastoreDir);
+        FileSessionDataStoreFactory fileSessionDataStoreFactory = new FileSessionDataStoreFactory();
+        fileSessionDataStoreFactory.setStoreDir(datastoreDir);
+        server.addBean(fileSessionDataStoreFactory);
 
         server.start();
         String redirectUri = "http://localhost:" + connector.getLocalPort() + "/j_security_check";
@@ -127,41 +151,127 @@ public class OpenIdAuthenticationTest
     @Test
     public void testLoginLogout() throws Exception
     {
+        setup(null);
+        openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));
+
         String appUriString = "http://localhost:" + connector.getLocalPort();
 
         // Initially not authenticated
         ContentResponse response = client.GET(appUriString + "/");
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        String[] content = response.getContentAsString().split("[\r\n]+");
-        assertThat(content.length, is(1));
-        assertThat(content[0], is("not authenticated"));
+        String content = response.getContentAsString();
+        assertThat(content, containsString("not authenticated"));
 
         // Request to login is success
         response = client.GET(appUriString + "/login");
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        content = response.getContentAsString().split("[\r\n]+");
-        assertThat(content.length, is(1));
-        assertThat(content[0], is("success"));
+        content = response.getContentAsString();
+        assertThat(content, containsString("success"));
 
         // Now authenticated we can get info
         response = client.GET(appUriString + "/");
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        content = response.getContentAsString().split("[\r\n]+");
-        assertThat(content.length, is(3));
-        assertThat(content[0], is("userId: 123456789"));
-        assertThat(content[1], is("name: Alice"));
-        assertThat(content[2], is("email: Alice@example.com"));
+        content = response.getContentAsString();
+        assertThat(content, containsString("userId: 123456789"));
+        assertThat(content, containsString("name: Alice"));
+        assertThat(content, containsString("email: Alice@example.com"));
 
         // Request to admin page gives 403 as we do not have admin role
         response = client.GET(appUriString + "/admin");
         assertThat(response.getStatus(), is(HttpStatus.FORBIDDEN_403));
 
+        // We can restart the server and still be logged in as we have persistent session datastore.
+        server.stop();
+        server.start();
+        appUriString = "http://localhost:" + connector.getLocalPort();
+
+        // After restarting server the authentication is saved as a session authentication.
+        response = client.GET(appUriString + "/");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        content = response.getContentAsString();
+        assertThat(content, containsString("userId: 123456789"));
+        assertThat(content, containsString("name: Alice"));
+        assertThat(content, containsString("email: Alice@example.com"));
+
         // We are no longer authenticated after logging out
         response = client.GET(appUriString + "/logout");
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        content = response.getContentAsString().split("[\r\n]+");
-        assertThat(content.length, is(1));
-        assertThat(content[0], is("not authenticated"));
+        content = response.getContentAsString();
+        assertThat(content, containsString("not authenticated"));
+
+        // Test that the user was logged out successfully on the openid provider.
+        assertThat(openIdProvider.getLoggedInUsers().getMax(), equalTo(1L));
+        assertThat(openIdProvider.getLoggedInUsers().getTotal(), equalTo(1L));
+    }
+
+    @Test
+    public void testNestedLoginService() throws Exception
+    {
+        AtomicBoolean loggedIn = new AtomicBoolean(true);
+        setup(new AbstractLoginService()
+        {
+            @Override
+            protected String[] loadRoleInfo(UserPrincipal user)
+            {
+                return new String[]{"admin"};
+            }
+
+            @Override
+            protected UserPrincipal loadUserInfo(String username)
+            {
+                return new UserPrincipal(username, new Password(""));
+            }
+
+            @Override
+            public boolean validate(UserIdentity user)
+            {
+                if (!loggedIn.get())
+                    return false;
+                return super.validate(user);
+            }
+        });
+
+        openIdProvider.setUser(new OpenIdProvider.User("123456789", "Alice"));
+
+        String appUriString = "http://localhost:" + connector.getLocalPort();
+
+        // Initially not authenticated
+        ContentResponse response = client.GET(appUriString + "/");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        String content = response.getContentAsString();
+        assertThat(content, containsString("not authenticated"));
+
+        // Request to login is success
+        response = client.GET(appUriString + "/login");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        content = response.getContentAsString();
+        assertThat(content, containsString("success"));
+
+        // Now authenticated we can get info
+        response = client.GET(appUriString + "/");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        content = response.getContentAsString();
+        assertThat(content, containsString("userId: 123456789"));
+        assertThat(content, containsString("name: Alice"));
+        assertThat(content, containsString("email: Alice@example.com"));
+
+        // The nested login service has supplied the admin role.
+        response = client.GET(appUriString + "/admin");
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+
+        // This causes any validation of UserIdentity in the LoginService to fail
+        // causing subsequent requests to be redirected to the auth endpoint for login again.
+        loggedIn.set(false);
+        client.setFollowRedirects(false);
+        response = client.GET(appUriString + "/admin");
+        assertThat(response.getStatus(), is(HttpStatus.SEE_OTHER_303));
+        String location = response.getHeaders().get(HttpHeader.LOCATION);
+        assertThat(location, containsString(openIdProvider.getProvider() + "/auth"));
+
+        // Note that we couldn't follow "OpenID Connect RP-Initiated Logout 1.0" because we redirect straight to auth endpoint.
+        assertThat(openIdProvider.getLoggedInUsers().getCurrent(), equalTo(1L));
+        assertThat(openIdProvider.getLoggedInUsers().getMax(), equalTo(1L));
+        assertThat(openIdProvider.getLoggedInUsers().getTotal(), equalTo(1L));
     }
 
     public static class LoginPage extends HttpServlet
@@ -169,16 +279,18 @@ public class OpenIdAuthenticationTest
         @Override
         protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
         {
+            response.setContentType("text/html");
             response.getWriter().println("success");
+            response.getWriter().println("<br><a href=\"/\">Home</a>");
         }
     }
 
     public static class LogoutPage extends HttpServlet
     {
         @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
         {
-            request.getSession().invalidate();
+            request.logout();
             response.sendRedirect("/");
         }
     }
@@ -188,7 +300,7 @@ public class OpenIdAuthenticationTest
         @Override
         protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
         {
-            Map<String, Object> userInfo = (Map)request.getSession().getAttribute(OpenIdAuthenticator.CLAIMS);
+            Map<String, Object> userInfo = (Map<String, Object>)request.getSession().getAttribute(OpenIdAuthenticator.CLAIMS);
             response.getWriter().println(userInfo.get("sub") + ": success");
         }
     }
@@ -198,18 +310,20 @@ public class OpenIdAuthenticationTest
         @Override
         protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
         {
-            response.setContentType("text/plain");
+            response.setContentType("text/html");
             Principal userPrincipal = request.getUserPrincipal();
             if (userPrincipal != null)
             {
-                Map<String, Object> userInfo = (Map)request.getSession().getAttribute(OpenIdAuthenticator.CLAIMS);
-                response.getWriter().println("userId: " + userInfo.get("sub"));
-                response.getWriter().println("name: " + userInfo.get("name"));
-                response.getWriter().println("email: " + userInfo.get("email"));
+                Map<String, Object> userInfo = (Map<String, Object>)request.getSession().getAttribute(OpenIdAuthenticator.CLAIMS);
+                response.getWriter().println("userId: " + userInfo.get("sub") + "<br>");
+                response.getWriter().println("name: " + userInfo.get("name") + "<br>");
+                response.getWriter().println("email: " + userInfo.get("email") + "<br>");
+                response.getWriter().println("<br><a href=\"/logout\">Logout</a>");
             }
             else
             {
                 response.getWriter().println("not authenticated");
+                response.getWriter().println("<br><a href=\"/login\">Login</a>");
             }
         }
     }
@@ -219,8 +333,9 @@ public class OpenIdAuthenticationTest
         @Override
         protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
         {
-            response.setContentType("text/plain");
+            response.setContentType("text/html");
             response.getWriter().println("not authorized");
+            response.getWriter().println("<br><a href=\"/\">Home</a>");
         }
     }
 }

--- a/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
+++ b/jetty-openid/src/test/java/org/eclipse/jetty/security/openid/OpenIdProvider.java
@@ -19,14 +19,16 @@
 package org.eclipse.jetty.security.openid;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -40,23 +42,52 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.statistic.CounterStatistic;
 
 public class OpenIdProvider extends ContainerLifeCycle
 {
+    private static final Logger LOG = Log.getLogger(OpenIdProvider.class);
+
     private static final String CONFIG_PATH = "/.well-known/openid-configuration";
     private static final String AUTH_PATH = "/auth";
     private static final String TOKEN_PATH = "/token";
+    private static final String END_SESSION_PATH = "/end_session";
     private final Map<String, User> issuedAuthCodes = new HashMap<>();
 
     protected final String clientId;
     protected final String clientSecret;
     protected final List<String> redirectUris = new ArrayList<>();
-
+    private final ServerConnector connector;
+    private final Server server;
+    private int port = 0;
     private String provider;
-    private Server server;
-    private ServerConnector connector;
+    private User preAuthedUser;
+    private final CounterStatistic loggedInUsers = new CounterStatistic();
+    private long _idTokenDuration = Duration.ofSeconds(10).toMillis();
+
+    public static void main(String[] args) throws Exception
+    {
+        String clientId = "CLIENT_ID123";
+        String clientSecret = "PASSWORD123";
+        int port = 5771;
+        String redirectUri = "http://localhost:8080/j_security_check";
+
+        OpenIdProvider openIdProvider = new OpenIdProvider(clientId, clientSecret);
+        openIdProvider.addRedirectUri(redirectUri);
+        openIdProvider.setPort(port);
+        openIdProvider.start();
+        try
+        {
+            openIdProvider.join();
+        }
+        finally
+        {
+            openIdProvider.stop();
+        }
+    }
 
     public OpenIdProvider(String clientId, String clientSecret)
     {
@@ -69,25 +100,67 @@ public class OpenIdProvider extends ContainerLifeCycle
 
         ServletContextHandler contextHandler = new ServletContextHandler();
         contextHandler.setContextPath("/");
-        contextHandler.addServlet(new ServletHolder(new OpenIdConfigServlet()), CONFIG_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdAuthEndpoint()), AUTH_PATH);
-        contextHandler.addServlet(new ServletHolder(new OpenIdTokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new ConfigServlet()), CONFIG_PATH);
+        contextHandler.addServlet(new ServletHolder(new AuthEndpoint()), AUTH_PATH);
+        contextHandler.addServlet(new ServletHolder(new TokenEndpoint()), TOKEN_PATH);
+        contextHandler.addServlet(new ServletHolder(new EndSessionEndpoint()), END_SESSION_PATH);
         server.setHandler(contextHandler);
 
         addBean(server);
     }
 
+    public void setIdTokenDuration(long duration)
+    {
+        _idTokenDuration = duration;
+    }
+
+    public long getIdTokenDuration()
+    {
+        return _idTokenDuration;
+    }
+
+    public void join() throws InterruptedException
+    {
+        server.join();
+    }
+
+    public OpenIdConfiguration getOpenIdConfiguration()
+    {
+        String provider = getProvider();
+        String authEndpoint = provider + AUTH_PATH;
+        String tokenEndpoint = provider + TOKEN_PATH;
+        return new OpenIdConfiguration(provider, authEndpoint, tokenEndpoint, clientId, clientSecret, null);
+    }
+
+    public CounterStatistic getLoggedInUsers()
+    {
+        return loggedInUsers;
+    }
+
     @Override
     protected void doStart() throws Exception
     {
+        connector.setPort(port);
         super.doStart();
         provider = "http://localhost:" + connector.getLocalPort();
     }
 
+    public void setPort(int port)
+    {
+        if (isStarted())
+            throw new IllegalStateException();
+        this.port = port;
+    }
+
+    public void setUser(User user)
+    {
+        this.preAuthedUser = user;
+    }
+
     public String getProvider()
     {
-        if (!isStarted())
-            throw new IllegalStateException();
+        if (!isStarted() && port == 0)
+            throw new IllegalStateException("Port of OpenIdProvider not configured");
         return provider;
     }
 
@@ -96,10 +169,10 @@ public class OpenIdProvider extends ContainerLifeCycle
         redirectUris.add(uri);
     }
 
-    public class OpenIdAuthEndpoint extends HttpServlet
+    public class AuthEndpoint extends HttpServlet
     {
         @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
         {
             if (!clientId.equals(req.getParameter("client_id")))
             {
@@ -110,12 +183,13 @@ public class OpenIdProvider extends ContainerLifeCycle
             String redirectUri = req.getParameter("redirect_uri");
             if (!redirectUris.contains(redirectUri))
             {
+                LOG.warn("invalid redirectUri {}", redirectUri);
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, "invalid redirect_uri");
                 return;
             }
 
             String scopeString = req.getParameter("scope");
-            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(StringUtil.csvSplit(scopeString));
+            List<String> scopes = (scopeString == null) ? Collections.emptyList() : Arrays.asList(scopeString.split(" "));
             if (!scopes.contains("openid"))
             {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, "no openid scope");
@@ -135,20 +209,75 @@ public class OpenIdProvider extends ContainerLifeCycle
                 return;
             }
 
+            if (preAuthedUser == null)
+            {
+                PrintWriter writer = resp.getWriter();
+                resp.setContentType("text/html");
+                writer.println("<h2>Login to OpenID Connect Provider</h2>");
+                writer.println("<form action=\"" + AUTH_PATH + "\" method=\"post\">");
+                writer.println("<input type=\"text\" autocomplete=\"off\" placeholder=\"Username\" name=\"username\" required>");
+                writer.println("<input type=\"hidden\" name=\"redirectUri\" value=\"" + redirectUri + "\">");
+                writer.println("<input type=\"hidden\" name=\"state\" value=\"" + state + "\">");
+                writer.println("<input type=\"submit\">");
+                writer.println("</form>");
+            }
+            else
+            {
+                redirectUser(req, preAuthedUser, redirectUri, state);
+            }
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            String redirectUri = req.getParameter("redirectUri");
+            if (!redirectUris.contains(redirectUri))
+            {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "invalid redirect_uri");
+                return;
+            }
+
+            String state = req.getParameter("state");
+            if (state == null)
+            {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "no state param");
+                return;
+            }
+
+            String username = req.getParameter("username");
+            if (username == null)
+            {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "no username");
+                return;
+            }
+
+            User user = new User(username);
+            redirectUser(req, user, redirectUri, state);
+        }
+
+        public void redirectUser(HttpServletRequest request, User user, String redirectUri, String state) throws IOException
+        {
             String authCode = UUID.randomUUID().toString().replace("-", "");
-            User user = new User(123456789, "Alice");
             issuedAuthCodes.put(authCode, user);
 
-            final Request baseRequest = Request.getBaseRequest(req);
-            final Response baseResponse = baseRequest.getResponse();
-            redirectUri += "?code=" + authCode + "&state=" + state;
-            int redirectCode = (baseRequest.getHttpVersion().getVersion() < HttpVersion.HTTP_1_1.getVersion()
-                ? HttpServletResponse.SC_MOVED_TEMPORARILY : HttpServletResponse.SC_SEE_OTHER);
-            baseResponse.sendRedirect(redirectCode, resp.encodeRedirectURL(redirectUri));
+            try
+            {
+                final Request baseRequest = Objects.requireNonNull(Request.getBaseRequest(request));
+                final Response baseResponse = baseRequest.getResponse();
+                redirectUri += "?code=" + authCode + "&state=" + state;
+                int redirectCode = (baseRequest.getHttpVersion().getVersion() < HttpVersion.HTTP_1_1.getVersion()
+                    ? HttpServletResponse.SC_MOVED_TEMPORARILY : HttpServletResponse.SC_SEE_OTHER);
+                baseResponse.sendRedirect(redirectCode, baseResponse.encodeRedirectURL(redirectUri));
+            }
+            catch (Throwable t)
+            {
+                issuedAuthCodes.remove(authCode);
+                throw t;
+            }
         }
     }
 
-    public class OpenIdTokenEndpoint extends HttpServlet
+    private class TokenEndpoint extends HttpServlet
     {
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
@@ -173,45 +302,79 @@ public class OpenIdProvider extends ContainerLifeCycle
             }
 
             String accessToken = "ABCDEFG";
-            long expiry = System.currentTimeMillis() + Duration.ofMinutes(10).toMillis();
+            long accessTokenDuration = Duration.ofMinutes(10).getSeconds();
             String response = "{" +
                 "\"access_token\": \"" + accessToken + "\"," +
-                "\"id_token\": \"" + JwtEncoder.encode(user.getIdToken()) + "\"," +
-                "\"expires_in\": " + expiry + "," +
+                "\"id_token\": \"" + JwtEncoder.encode(user.getIdToken(provider, clientId, _idTokenDuration)) + "\"," +
+                "\"expires_in\": " + accessTokenDuration + "," +
                 "\"token_type\": \"Bearer\"" +
                 "}";
 
+            loggedInUsers.increment();
             resp.setContentType("text/plain");
             resp.getWriter().print(response);
         }
     }
 
-    public class OpenIdConfigServlet extends HttpServlet
+    private class EndSessionEndpoint extends HttpServlet
     {
         @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            doPost(req, resp);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            String idToken = req.getParameter("id_token_hint");
+            if (idToken == null)
+            {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "no id_token_hint");
+                return;
+            }
+
+            String logoutRedirect = req.getParameter("post_logout_redirect_uri");
+            if (logoutRedirect == null)
+            {
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.getWriter().println("logout success on end_session_endpoint");
+                return;
+            }
+
+            loggedInUsers.decrement();
+            resp.setContentType("text/plain");
+            resp.sendRedirect(logoutRedirect);
+        }
+    }
+
+    private class ConfigServlet extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
         {
             String discoveryDocument = "{" +
                 "\"issuer\": \"" + provider + "\"," +
                 "\"authorization_endpoint\": \"" + provider + AUTH_PATH + "\"," +
                 "\"token_endpoint\": \"" + provider + TOKEN_PATH + "\"," +
+                "\"end_session_endpoint\": \"" + provider + END_SESSION_PATH + "\"," +
                 "}";
 
             resp.getWriter().write(discoveryDocument);
         }
     }
 
-    public class User
+    public static class User
     {
-        private long subject;
-        private String name;
+        private final String subject;
+        private final String name;
 
         public User(String name)
         {
-            this(new Random().nextLong(), name);
+            this(UUID.nameUUIDFromBytes(name.getBytes()).toString(), name);
         }
 
-        public User(long subject, String name)
+        public User(String subject, String name)
         {
             this.subject = subject;
             this.name = name;
@@ -222,10 +385,29 @@ public class OpenIdProvider extends ContainerLifeCycle
             return name;
         }
 
-        public String getIdToken()
+        public String getSubject()
         {
-            long expiry = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
-            return JwtEncoder.createIdToken(provider, clientId, Long.toString(subject), name, expiry);
+            return subject;
+        }
+
+        public String getIdToken(String provider, String clientId, long duration)
+        {
+            long expiryTime = Instant.now().plusMillis(duration).getEpochSecond();
+            return JwtEncoder.createIdToken(provider, clientId, subject, name, expiryTime);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof User))
+                return false;
+            return Objects.equals(subject, ((User)obj).subject) && Objects.equals(name, ((User)obj).name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(subject, name);
         }
     }
 }


### PR DESCRIPTION
bring back some openid improvements from recent commits to 10.0.x

Development in OpenID has been progressing on 10+ but not many of the changes have been brought back to 9.4. So this brings back some minimal changes.

This brings back testing for the nested login service and using Instant instead of `System.currentTimeMillis` for time calculations as well as the improved `OpenIdProvider` test class.

see #9528