### PR TITLE
Issue #9656 Use ISE for PushBuilderImpl.push not IAE

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/PushBuilderImpl.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/PushBuilderImpl.java
@@ -97,7 +97,7 @@ class PushBuilderImpl implements PushBuilder
     {
         String pushPath = getPath();
         if (pushPath == null || pushPath.isBlank())
-            throw new IllegalArgumentException("invalid push path: " + pushPath);
+            throw new IllegalStateException("invalid push path: " + pushPath);
 
         String query = getQueryString();
         String pushQuery = query;


### PR DESCRIPTION
Closes #9656 


Use `IllegalStateException` not `IllegalArgumentException` for `PushBuilderImpl.push()` as per specification.