### PR TITLE
Jetty 12 : Re-enable more `jetty-core` tests

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BadURITest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BadURITest.java
@@ -43,7 +43,6 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -69,7 +68,6 @@ public class BadURITest
     }
 
     @Test
-    @Disabled("TODO: need to fix ErrorHandler")
     public void testBadURI() throws Exception
     {
         CountDownLatch handlerLatch = new CountDownLatch(1);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2CServerTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2CServerTest.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -94,9 +93,7 @@ public class HTTP2CServerTest extends AbstractServerTest
         }
     }
 
-    // TODO: this test fails on IO.toString(), for some reason the second request does not close the connection.
     @Test
-    @Disabled
     public void testHTTP11Simple() throws Exception
     {
         try (Socket client = new Socket("localhost", connector.getLocalPort()))

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -78,7 +78,6 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -736,7 +735,6 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         });
     }
 
-    @Disabled
     @Test
     @Tag("external")
     public void testExternalServer() throws Exception
@@ -750,9 +748,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         clientConnector.setExecutor(executor);
         httpClient.start();
 
-//        ContentResponse response = httpClient.GET("https://http2.akamai.com/");
         ContentResponse response = httpClient.GET("https://webtide.com/");
-
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
         httpClient.stop();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -81,7 +81,6 @@ import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
@@ -334,13 +333,7 @@ public class StreamResetTest extends AbstractTest
         assertTrue(dataLatch.await(5, TimeUnit.SECONDS));
     }
 
-    // TODO: This test writes after a failure and highlights some problem in the implementation
-    //  of the handling of errors. For example, the request._error field is set by the failure,
-    //  but checked during the succeed of the callback (so cannot turn a failure into a success)
-    //  and also highlights that the implementation should be more precise at severing the link
-    //  between channel and request, possibly where the request only has one field, the channel.
     @Test
-    @Disabled
     public void testAsyncWriteAfterStreamReceivingReset() throws Exception
     {
         CountDownLatch commitLatch = new CountDownLatch(1);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HalfCloseTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HalfCloseTest.java
@@ -24,12 +24,10 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled // TODO
 public class HalfCloseTest
 {
     @Test


### PR DESCRIPTION
Another pass at the `@Disabled` tests in `jetty-core` in Jetty 12