### PR TITLE
Don't use `ResourceFactory.root()` in `AttributeNormalizer`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resources.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resources.java
@@ -31,6 +31,17 @@ public final class Resources
     }
 
     /**
+     * True if the resource has been created by {@link ResourceFactory#combine(java.util.List) combining} other resources.
+     *
+     * @param resource the resource to test
+     * @return true if resource is a combination of other resources
+     */
+    public static boolean isCombined(Resource resource)
+    {
+        return resource instanceof CombinedResource;
+    }
+
+    /**
      * True if the resource is missing.
      *
      * @param resource the resource to test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AttributeNormalizerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AttributeNormalizerTest.java
@@ -88,15 +88,6 @@ public class AttributeNormalizerTest
         war = asTargetPath(title, "app%2Fnasty/base/webapps/FOO");
         data.add(Arguments.of(new Scenario(arch, title, jettyHome, jettyBase, resourceFactory.newResource(war))));
 
-        // ------
-        title = "ResourceCollection Setup";
-        jettyHome = asTargetPath(title, "jetty-collection");
-        jettyBase = asTargetPath(title, "jetty-collection/demo.base");
-        Path warA = asTargetPath(title, "jetty-collection/demo.base/webapps/WarA");
-        Path warB = asTargetPath(title, "jetty-collection/demo.base/webapps/WarB");
-        data.add(Arguments.of(new Scenario(arch, title, jettyHome, jettyBase,
-            ResourceFactory.combine(resourceFactory.newResource(warA), resourceFactory.newResource(warB)))));
-
         return data.stream();
     }
 


### PR DESCRIPTION
Since `AttributeNormalizer` cannot guarantee that it will only ever work with `file:` resources, it cannot use `ResourceFactory.root()` as that `ResourceFactory` never unmounts.

Since the generated URI is changed to a `Resource` to check for existence, there is no need to keep the `ResourceFactory` around.

Closes #9680.