### PR TITLE
deprecate PushSessionCacheFilter

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.util.NanoTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 public class PushSessionCacheFilter implements Filter
 {
     private static final String RESPONSE_ATTR = "PushSessionCacheFilter.response";

--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushSessionCacheFilter.java
@@ -37,6 +37,9 @@ import org.eclipse.jetty.util.NanoTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated no replacement for this deprecated http feature
+ */
 @Deprecated
 public class PushSessionCacheFilter implements Filter
 {
@@ -46,6 +49,11 @@ public class PushSessionCacheFilter implements Filter
     private static final Logger LOG = LoggerFactory.getLogger(PushSessionCacheFilter.class);
     private final ConcurrentMap<String, Target> _cache = new ConcurrentHashMap<>();
     private long _associateDelay = 5000L;
+
+    public PushSessionCacheFilter()
+    {
+        LOG.warn(PushSessionCacheFilter.class.getSimpleName() + " is an example class not suitable for production.");
+    }
 
     @Override
     public void init(FilterConfig config) throws ServletException


### PR DESCRIPTION
deprecate PushSessionCacheFilter, will remove in 12 during the merge.

Addresses CVE-2024-6762