### PR TITLE
Fix #9685 & #9648 test isCommitted in sendError

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -227,7 +227,12 @@ public class ServletApiResponse implements HttpServletResponse
                     }
                 }
             }
-            default -> _response.getState().sendError(sc, msg);
+            default ->
+            {
+                if (isCommitted())
+                    throw new IllegalStateException("Committed");
+                _response.getState().sendError(sc, msg);
+            }
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -351,6 +351,8 @@ public class ServletContextResponse extends ContextResponse
 
     public void resetContent()
     {
+        if (isCommitted())
+            throw new IllegalStateException("Committed");
         _httpOutput.resetBuffer();
         _outputType = OutputType.NONE;
         _contentLength = -1;
@@ -368,25 +370,16 @@ public class ServletContextResponse extends ContextResponse
 
             switch (field.getHeader())
             {
-                case CONTENT_TYPE:
-                case CONTENT_LENGTH:
-                case CONTENT_ENCODING:
-                case CONTENT_LANGUAGE:
-                case CONTENT_RANGE:
-                case CONTENT_MD5:
-                case CONTENT_LOCATION:
-                case TRANSFER_ENCODING:
-                case CACHE_CONTROL:
-                case LAST_MODIFIED:
-                case EXPIRES:
-                case VARY:
-                    i.remove();
-                    continue;
-                case ETAG:
+                case CONTENT_TYPE, CONTENT_LENGTH, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_RANGE, CONTENT_MD5,
+                    CONTENT_LOCATION, TRANSFER_ENCODING, CACHE_CONTROL, LAST_MODIFIED, EXPIRES, VARY -> i.remove();
+                case ETAG ->
+                {
                     if (getStatus() != HttpStatus.NOT_MODIFIED_304)
                         i.remove();
-                    continue;
-                default:
+                }
+                default ->
+                {
+                }
             }
         }
     }


### PR DESCRIPTION
Merging #9685 to 12 broke the build as it turned out that the error handling was depending on the attempt to remove the Date header to detect if the response was already committed during a sendError.   This fix makes the test for committed explicit, it also fixes which exception is passed to abort.