### PR TITLE
jetty 12.0.x rename jakarta classes as well

### DIFF
--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.3-SNAPSHOT</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.3-rename-to-javax-SNAPSHOT</modify-sources-plugin.version>
   </properties>
 
   <modules>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.3</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.4-SNAPSHOT</modify-sources-plugin.version>
   </properties>
 
   <modules>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.3-SNAPSHOT</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.3</modify-sources-plugin.version>
   </properties>
 
   <modules>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.2</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.3-SNAPSHOT</modify-sources-plugin.version>
   </properties>
 
   <modules>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.3-rename-to-javax-SNAPSHOT</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.3-SNAPSHOT</modify-sources-plugin.version>
   </properties>
 
   <modules>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -25,7 +25,7 @@
     <sonar.skip>true</sonar.skip>
     <ee9.module></ee9.module>
     <ee9.module.path>${maven.multiModuleProjectDirectory}/jetty-ee9/${ee9.module}</ee9.module.path>
-    <modify-sources-plugin.version>1.0.4-SNAPSHOT</modify-sources-plugin.version>
+    <modify-sources-plugin.version>1.0.4</modify-sources-plugin.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
- use modify source plugin new snapshot which transform Jakarta classes to Javax classes
work done here https://github.com/jetty-project/jetty-modify-sources-maven-plugin/pull/61
still need a release of the maven plugin 