### PR TITLE
Fix invalid warning

### DIFF
--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -320,7 +320,7 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
         for (String d : deprecated)
         {
             value = super.getInitParameter(d);
-            if (value != name)
+            if (value != null)
             {
                 LOG.warn("Deprecated {} used instead of {}", d, name);
                 return value;


### PR DESCRIPTION
There was a typo in EE9 `DefaultServlet.getInitParameter(String name, String... deprecated)` that made it always emit a warning.

Closes #9639