### PR TITLE
H3: Fix racy read from stream-less channel

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
@@ -139,7 +139,6 @@ public class HttpSenderOverHTTP3 extends HttpSender
 
     private Stream onNewStream(Stream stream, HttpRequest request)
     {
-        getHttpChannel().setStream(stream);
         long idleTimeout = request.getIdleTimeout();
         if (idleTimeout > 0)
             ((HTTP3Stream)stream).setIdleTimeout(idleTimeout);

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
@@ -106,6 +106,7 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             return promise;
 
         stream.setListener(listener);
+        notifyNewStream(listener, stream);
 
         stream.writeFrame(frame)
             .whenComplete((r, x) ->
@@ -125,6 +126,21 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             });
 
         return promise;
+    }
+
+    private void notifyNewStream(Stream.Client.Listener listener, HTTP3StreamClient stream)
+    {
+        if (listener != null)
+        {
+            try
+            {
+                listener.onNewStream(stream);
+            }
+            catch (Throwable x)
+            {
+                LOG.info("Failure while notifying listener {}", listener, x);
+            }
+        }
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -141,6 +141,16 @@ public interface Stream
         public interface Listener
         {
             /**
+             * <p>Callback method invoked when a stream is created locally by
+             * {@link Session.Client#newRequest(HeadersFrame, Listener)}.</p>
+             *
+             * @param stream the newly created stream
+             */
+            public default void onNewStream(Stream.Client stream)
+            {
+            }
+
+            /**
              * <p>Callback method invoked when a response is received.</p>
              * <p>To read response content, applications should call
              * {@link Stream#demand()} and override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/resources/jetty-logging.properties
@@ -7,6 +7,7 @@ org.eclipse.jetty.jmx.LEVEL=INFO
 org.eclipse.jetty.http2.hpack.LEVEL=INFO
 #org.eclipse.jetty.http2.client.LEVEL=DEBUG
 #org.eclipse.jetty.http3.LEVEL=DEBUG
+#org.eclipse.jetty.http3.client.LEVEL=DEBUG
 org.eclipse.jetty.http3.qpack.LEVEL=INFO
 #org.eclipse.jetty.quic.LEVEL=DEBUG
 org.eclipse.jetty.quic.quiche.LEVEL=INFO


### PR DESCRIPTION
`HttpReceiverOverHTTP3.read()` fails when it is called while `HttpChannelOverHTTP3.getStream()` returns null.

This is caused by a race condition in the client when it is setting the stream, which happens _after_ a new request is created and its headers were sent on the network. If the network and the server happen to be fast enough, the response could arrive at the client before the channel's stream has been set, making `HttpReceiverOverHTTP3.read()` see a `null` stream.

The solution is to set the stream field before any data is sent onto the network, like HTTP/2 is going.

Fixes https://github.com/eclipse/jetty.project/issues/9655


