### PR TITLE
Issue #9682 - fix RetainableByteBuffer release bug in WebSocket

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketConnection.java
@@ -220,6 +220,15 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         if (!coreSession.isClosed())
             coreSession.onEof();
         flusher.onClose(cause);
+
+        try (AutoLock l = lock.lock())
+        {
+            if (networkBuffer != null)
+            {
+                networkBuffer.clear();
+                releaseNetworkBuffer();
+            }
+        }
         super.onClose(cause);
     }
 

--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -467,6 +467,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
                     needDemand = true;
                     frame = delayedFrame;
                     callback = delayedCallback;
+                    delayedFrame = null;
+                    delayedCallback = null;
                     state = SuspendState.DEMANDING;
                     break;
 

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
@@ -202,7 +202,7 @@ public class SuspendResumeTest
     }
 
     @Test
-    public void timeoutWhileSuspended() throws Exception
+    public void testTimeoutWhileSuspended() throws Exception
     {
         URI uri = new URI("ws://localhost:" + connector.getLocalPort() + "/suspend");
         EventSocket clientSocket = new EventSocket();

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/SuspendResumeTest.java
@@ -15,16 +15,21 @@ package org.eclipse.jetty.websocket.tests;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.io.ArrayRetainableByteBufferPool;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.websocket.api.BatchMode;
 import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.SuspendToken;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.api.exceptions.WebSocketTimeoutException;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
@@ -34,7 +39,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,14 +72,15 @@ public class SuspendResumeTest
         }
     }
 
-    private Server server = new Server();
-    private WebSocketClient client = new WebSocketClient();
-    private SuspendSocket serverSocket = new SuspendSocket();
+    private Server server;
+    private WebSocketClient client;
+    private SuspendSocket serverSocket;
     private ServerConnector connector;
 
     @BeforeEach
     public void start() throws Exception
     {
+        server = new Server();
         connector = new ServerConnector(server);
         server.addConnector(connector);
 
@@ -79,10 +88,12 @@ public class SuspendResumeTest
         contextHandler.setContextPath("/");
         server.setHandler(contextHandler);
         contextHandler.addServlet(new ServletHolder(new UpgradeServlet()), "/suspend");
+        serverSocket = new SuspendSocket();
 
         JettyWebSocketServletContainerInitializer.configure(contextHandler, null);
 
         server.start();
+        client = new WebSocketClient();
         client.start();
     }
 
@@ -188,5 +199,50 @@ public class SuspendResumeTest
 
         // suspend after closed throws ISE
         assertThrows(IllegalStateException.class, () -> clientSocket.session.suspend());
+    }
+
+    @Test
+    public void timeoutWhileSuspended() throws Exception
+    {
+        URI uri = new URI("ws://localhost:" + connector.getLocalPort() + "/suspend");
+        EventSocket clientSocket = new EventSocket();
+        Future<Session> connect = client.connect(clientSocket, uri);
+        connect.get(5, TimeUnit.SECONDS);
+        assertTrue(serverSocket.openLatch.await(5, TimeUnit.SECONDS));
+
+        // Set short idleTimeout on server.
+        int idleTimeout = 1000;
+        serverSocket.session.setIdleTimeout(Duration.ofMillis(idleTimeout));
+
+        // Suspend on the server.
+        clientSocket.session.getRemote().sendString("suspend");
+        assertThat(serverSocket.textMessages.poll(5, TimeUnit.SECONDS), is("suspend"));
+
+        // Send two messages, with batching on, so they are read into same network buffer on the server.
+        // First frame is read and delayed inside the JettyWebSocketFrameHandler suspendState, second frame remains in the network buffer.
+        clientSocket.session.getRemote().setBatchMode(BatchMode.ON);
+        clientSocket.session.getRemote().sendString("no demand");
+        clientSocket.session.getRemote().sendString("this should sit in network buffer");
+        clientSocket.session.getRemote().flush();
+        assertNotNull(serverSocket.suspendToken);
+
+        // Make sure both sides are closed.
+        assertTrue(serverSocket.closeLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));
+
+        // We received no additional messages.
+        assertNull(serverSocket.textMessages.poll());
+        assertNull(serverSocket.binaryMessages.poll());
+
+        // Check the idleTimeout occurred.
+        assertThat(serverSocket.error, instanceOf(WebSocketTimeoutException.class));
+        assertNull(clientSocket.error);
+        assertThat(clientSocket.closeCode, equalTo(StatusCode.SHUTDOWN));
+        assertThat(clientSocket.closeReason, equalTo("Connection Idle Timeout"));
+
+        // We should have no used buffers in the pool.
+        ArrayRetainableByteBufferPool pool = (ArrayRetainableByteBufferPool)connector.getByteBufferPool().asRetainableByteBufferPool();
+        assertThat(pool.getHeapByteBufferCount(), equalTo(pool.getAvailableHeapByteBufferCount()));
+        assertThat(pool.getDirectByteBufferCount(), equalTo(pool.getAvailableDirectByteBufferCount()));
     }
 }


### PR DESCRIPTION
## Issue #9682

I suspect this is the cause for issue #9682, but not enough information to confirm.

The test `SuspendResumeTest.timeoutWhileSuspended()` reproduces a the leak where the buffer from the RetainableByteBufferPool is not released after the websocket connection is closed.

This could happen in two cases.
1. The application does not demand another frame and there is still data in the network buffer, then an idleTimeout happens and the connection is closed and the network buffer still contains data and is never released from WebSocketConnection.
2. The application suspends with the Jetty WebSocket API, the frame+callback are stored away until resume is called, then the idleTimeout fires and the connection is closed, the delayed callback is never completed so the network buffer is never released.