### PR TITLE
H3: Fix racy read from stream-less channel

### DIFF
--- a/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3SessionClient.java
+++ b/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3SessionClient.java
@@ -106,6 +106,7 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             return promise;
 
         stream.setListener(listener);
+        notifyNewStream(listener, stream);
 
         stream.writeFrame(frame)
             .whenComplete((r, x) ->
@@ -125,6 +126,21 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             });
 
         return promise;
+    }
+
+    private void notifyNewStream(Stream.Client.Listener listener, HTTP3StreamClient stream)
+    {
+        if (listener != null)
+        {
+            try
+            {
+                listener.onNewStream(stream);
+            }
+            catch (Throwable x)
+            {
+                LOG.info("Failure while notifying listener {}", listener, x);
+            }
+        }
     }
 
     @Override

--- a/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3SessionClient.java
+++ b/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3SessionClient.java
@@ -106,7 +106,7 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             return promise;
 
         stream.setListener(listener);
-        notifyNewStream(listener, stream);
+        stream.onOpen();
 
         stream.writeFrame(frame)
             .whenComplete((r, x) ->
@@ -126,21 +126,6 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
             });
 
         return promise;
-    }
-
-    private void notifyNewStream(Stream.Client.Listener listener, HTTP3StreamClient stream)
-    {
-        if (listener != null)
-        {
-            try
-            {
-                listener.onNewStream(stream);
-            }
-            catch (Throwable x)
-            {
-                LOG.info("Failure while notifying listener {}", listener, x);
-            }
-        }
     }
 
     @Override

--- a/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
+++ b/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
@@ -42,6 +42,11 @@ public class HTTP3StreamClient extends HTTP3Stream implements  Stream.Client
         return listener;
     }
 
+    public void onOpen()
+    {
+        notifyNewStream();
+    }
+
     public void setListener(Stream.Client.Listener listener)
     {
         this.listener = listener;
@@ -62,6 +67,20 @@ public class HTTP3StreamClient extends HTTP3Stream implements  Stream.Client
             notIdle();
             notifyResponse(frame);
             updateClose(frame.isLast(), false);
+        }
+    }
+
+    private void notifyNewStream()
+    {
+        Stream.Client.Listener listener = getListener();
+        try
+        {
+            if (listener != null)
+               listener.onNewStream(this);
+        }
+        catch (Throwable x)
+        {
+            LOG.info("Failure while notifying listener {}", listener, x);
         }
     }
 

--- a/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
+++ b/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
@@ -76,7 +76,7 @@ public class HTTP3StreamClient extends HTTP3Stream implements  Stream.Client
         try
         {
             if (listener != null)
-               listener.onNewStream(this);
+                listener.onNewStream(this);
         }
         catch (Throwable x)
         {

--- a/jetty-http3/http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-http3/http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -139,6 +139,16 @@ public interface Stream
         public interface Listener
         {
             /**
+             * <p>Callback method invoked when a stream is created locally by
+             * {@link Session.Client#newRequest(HeadersFrame, Listener)}.</p>
+             *
+             * @param stream the newly created stream
+             */
+            public default void onNewStream(Stream.Client stream)
+            {
+            }
+
+            /**
              * <p>Callback method invoked when a response is received.</p>
              * <p>To read response content, applications should call
              * {@link Stream#demand()} and override

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpReceiverOverHTTP3.java
@@ -59,9 +59,24 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
             return;
 
         if (notifySuccess)
+        {
             responseSuccess(exchange);
+        }
         else
-            getHttpChannel().getStream().demand();
+        {
+            Stream stream = getHttpChannel().getStream();
+            if (LOG.isDebugEnabled())
+                LOG.debug("Demanding from {} in {}", stream, this);
+            if (stream == null)
+                return;
+            stream.demand();
+        }
+    }
+
+    @Override
+    public void onNewStream(Stream.Client stream)
+    {
+        getHttpChannel().setStream(stream);
     }
 
     @Override

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpSenderOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpSenderOverHTTP3.java
@@ -138,7 +138,6 @@ public class HttpSenderOverHTTP3 extends HttpSender
 
     private Stream onNewStream(Stream stream, HttpRequest request)
     {
-        getHttpChannel().setStream(stream);
         long idleTimeout = request.getIdleTimeout();
         if (idleTimeout > 0)
             ((HTTP3Stream)stream).setIdleTimeout(idleTimeout);

--- a/tests/test-http-client-transport/src/test/resources/jetty-logging.properties
+++ b/tests/test-http-client-transport/src/test/resources/jetty-logging.properties
@@ -7,6 +7,7 @@ org.eclipse.jetty.jmx.LEVEL=INFO
 org.eclipse.jetty.http2.hpack.LEVEL=INFO
 #org.eclipse.jetty.http2.client.LEVEL=DEBUG
 #org.eclipse.jetty.http3.LEVEL=DEBUG
+#org.eclipse.jetty.http3.client.LEVEL=DEBUG
 org.eclipse.jetty.http3.qpack.LEVEL=INFO
 #org.eclipse.jetty.quic.LEVEL=DEBUG
 org.eclipse.jetty.quic.quiche.LEVEL=INFO


### PR DESCRIPTION
There is a race condition in the client when it is setting the stream, which happens _after_ a new request is created and its headers are sent onto the network. If the network and the server happen to be fast enough, the response could arrive at the client before the channel's stream has been set, making `HttpReceiverOverHTTP3` see a `null` stream.

The solution is to set the stream field before any data is sent onto the network, like HTTP/2 is doing.

Fixes https://github.com/eclipse/jetty.project/issues/9655 once merged to 12.