### PR TITLE
remove snapshot repositories, force module order (may not work with mvnd)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     skipDefaultCheckout()
     durabilityHint('PERFORMANCE_OPTIMIZED')
     buildDiscarder logRotator( numToKeepStr: '60' )
+    disableRestartFromStage()
   }
   stages {
     stage("Parallel Stage") {

--- a/pom.xml
+++ b/pom.xml
@@ -216,31 +216,6 @@
     <url>https://github.com/eclipse/jetty.project</url>
   </scm>
 
-  <repositories>
-    <repository>
-      <id>jetty.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jetty.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <modules>
     <module>build</module>
     <module>jetty-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -220,9 +220,9 @@
     <module>build</module>
     <module>jetty-core</module>
     <module>jetty-integrations</module>
-    <module>jetty-ee8</module>
-    <module>jetty-ee9</module>
     <module>jetty-ee10</module>
+    <module>jetty-ee9</module>
+    <module>jetty-ee8</module>
     <module>jetty-home</module>
     <module>tests</module>
     <!-- <module>jetty-p2</module> -->


### PR DESCRIPTION
- do not use snapshot repositories per default
- add disableRestartFromStage() option
- change module build orders
