### PR TITLE
Fixes #9766 - jetty-12 ee9 ServerPush failures.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -625,12 +625,14 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         streamsState.push(frame, new Promise.Wrapper<>(promise)
         {
             @Override
-            public void succeeded(Stream pushedStream)
+            public void succeeded(Stream pushed)
             {
                 // Pushed streams are implicitly remotely closed.
                 // They are closed when sending an end-stream DATA frame.
-                ((HTTP2Stream)pushedStream).updateClose(true, CloseState.Event.RECEIVED);
-                super.succeeded(pushedStream);
+                HTTP2Stream http2Pushed = (HTTP2Stream)pushed;
+                http2Pushed.process(Stream.Data.eof(pushed.getId()));
+                http2Pushed.updateClose(true, CloseState.Event.RECEIVED);
+                super.succeeded(pushed);
             }
         }, listener);
     }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -153,7 +153,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
     public void onStreamTimeout(Stream stream, Throwable failure, Promise<Boolean> promise)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Idle timeout on {}: {}", stream, failure);
+            LOG.debug("Idle timeout on {}", stream, failure);
         HTTP2Channel.Server channel = (HTTP2Channel.Server)((HTTP2Stream)stream).getAttachment();
         if (channel != null)
         {
@@ -202,7 +202,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
                 .map(HTTP2Channel.Server::isIdle)
                 .reduce(true, Boolean::logicalAnd);
         if (LOG.isDebugEnabled())
-            LOG.debug("{} idle timeout on {}: {}", result ? "Processed" : "Ignored", session, failure);
+            LOG.debug("{} idle timeout on {}", result ? "Processed" : "Ignored", session, failure);
         return result;
     }
 
@@ -224,7 +224,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         httpChannel.setHttpStream(httpStream);
         Runnable task = httpStream.onPushRequest(request);
         if (task != null)
-            offerTask(task, false);
+            offerTask(task, true);
     }
 
 /*

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -259,13 +259,22 @@ public interface Response extends Content.Sink
     static void sendRedirect(Request request, Response response, Callback callback, int code, String location, boolean consumeAvailable)
     {
         if (!HttpStatus.isRedirection(code))
-            throw new IllegalArgumentException("Not a 3xx redirect code");
+        {
+            callback.failed(new IllegalArgumentException("Not a 3xx redirect code"));
+            return;
+        }
 
         if (location == null)
-            throw new IllegalArgumentException("No location");
+        {
+            callback.failed(new IllegalArgumentException("No location"));
+            return;
+        }
 
         if (response.isCommitted())
-            throw new IllegalStateException("Committed");
+        {
+            callback.failed(new IllegalStateException("Committed"));
+            return;
+        }
 
         if (consumeAvailable)
         {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -43,7 +43,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.session.SessionManager;
 import org.eclipse.jetty.util.Blocker;
-import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.StringUtil;
 
 /**
@@ -159,9 +158,11 @@ public class ServletApiResponse implements HttpServletResponse
     public void sendRedirect(int code, String location) throws IOException
     {
         resetBuffer();
-        FutureCallback callback = new FutureCallback();
-        Response.sendRedirect(_response.getServletContextRequest(), _response, callback, code, location, false);
-        callback.block();
+        try (Blocker.Callback callback = Blocker.callback())
+        {
+            Response.sendRedirect(_response.getServletContextRequest(), _response, callback, code, location, false);
+            callback.block();
+        }
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
@@ -1,0 +1,155 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.test.client.transport;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.BufferingResponseListener;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PushedResourcesTest extends AbstractTest
+{
+    @ParameterizedTest
+    @MethodSource("transportsWithPushSupport")
+    public void testPushedResources(Transport transport) throws Exception
+    {
+        Random random = new Random();
+        byte[] bytes = new byte[512];
+        random.nextBytes(bytes);
+        byte[] pushBytes1 = new byte[1024];
+        random.nextBytes(pushBytes1);
+        byte[] pushBytes2 = new byte[2048];
+        random.nextBytes(pushBytes2);
+
+        String path1 = "/secondary1";
+        String path2 = "/secondary2";
+        start(transport, new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                String target = request.getRequestURI();
+                if (target.equals(path1))
+                {
+                    response.getOutputStream().write(pushBytes1);
+                }
+                else if (target.equals(path2))
+                {
+                    response.getOutputStream().write(pushBytes2);
+                }
+                else
+                {
+                    request.newPushBuilder()
+                        .path(path1)
+                        .push();
+                    request.newPushBuilder()
+                        .path(path2)
+                        .push();
+                    response.getOutputStream().write(bytes);
+                }
+            }
+        });
+
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        ContentResponse response = client.newRequest(newURI(transport))
+            .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
+            {
+                @Override
+                public void onComplete(Result result)
+                {
+                    assertTrue(result.isSucceeded());
+                    if (pushedRequest.getPath().equals(path1))
+                    {
+                        assertArrayEquals(pushBytes1, getContent());
+                        latch1.countDown();
+                    }
+                    else if (pushedRequest.getPath().equals(path2))
+                    {
+                        assertArrayEquals(pushBytes2, getContent());
+                        latch2.countDown();
+                    }
+                }
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertArrayEquals(bytes, response.getContent());
+        assertTrue(latch1.await(5, TimeUnit.SECONDS));
+        assertTrue(latch2.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("transportsWithPushSupport")
+    public void testPushedResourceRedirect(Transport transport) throws Exception
+    {
+        Random random = new Random();
+        byte[] pushBytes = new byte[512];
+        random.nextBytes(pushBytes);
+
+        String oldPath = "/old";
+        String newPath = "/new";
+        start(transport, new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                String target = request.getRequestURI();
+                System.err.println("SIMON: target = " + target);
+                if (target.equals(oldPath))
+                    response.sendRedirect(newPath);
+                else if (target.equals(newPath))
+                    response.getOutputStream().write(pushBytes);
+                else
+                    request.newPushBuilder().path(oldPath).push();
+            }
+        });
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ;
+        ContentResponse response = client.newRequest(newURI(transport))
+            .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
+            {
+                @Override
+                public void onComplete(Result result)
+                {
+                    assertTrue(result.isSucceeded());
+                    assertEquals(oldPath, pushedRequest.getPath());
+                    assertEquals(newPath, result.getRequest().getPath());
+                    assertArrayEquals(pushBytes, getContent());
+                    latch.countDown();
+                }
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/PushedResourcesTest.java
@@ -1,0 +1,155 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.test.client.transport;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.BufferingResponseListener;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PushedResourcesTest extends AbstractTest
+{
+    @ParameterizedTest
+    @MethodSource("transportsWithPushSupport")
+    public void testPushedResources(Transport transport) throws Exception
+    {
+        Random random = new Random();
+        byte[] bytes = new byte[512];
+        random.nextBytes(bytes);
+        byte[] pushBytes1 = new byte[1024];
+        random.nextBytes(pushBytes1);
+        byte[] pushBytes2 = new byte[2048];
+        random.nextBytes(pushBytes2);
+
+        String path1 = "/secondary1";
+        String path2 = "/secondary2";
+        start(transport, new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                String target = request.getRequestURI();
+                if (target.equals(path1))
+                {
+                    response.getOutputStream().write(pushBytes1);
+                }
+                else if (target.equals(path2))
+                {
+                    response.getOutputStream().write(pushBytes2);
+                }
+                else
+                {
+                    request.newPushBuilder()
+                        .path(path1)
+                        .push();
+                    request.newPushBuilder()
+                        .path(path2)
+                        .push();
+                    response.getOutputStream().write(bytes);
+                }
+            }
+        });
+
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        ContentResponse response = client.newRequest(newURI(transport))
+            .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
+            {
+                @Override
+                public void onComplete(Result result)
+                {
+                    assertTrue(result.isSucceeded());
+                    if (pushedRequest.getPath().equals(path1))
+                    {
+                        assertArrayEquals(pushBytes1, getContent());
+                        latch1.countDown();
+                    }
+                    else if (pushedRequest.getPath().equals(path2))
+                    {
+                        assertArrayEquals(pushBytes2, getContent());
+                        latch2.countDown();
+                    }
+                }
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertArrayEquals(bytes, response.getContent());
+        assertTrue(latch1.await(5, TimeUnit.SECONDS));
+        assertTrue(latch2.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("transportsWithPushSupport")
+    public void testPushedResourceRedirect(Transport transport) throws Exception
+    {
+        Random random = new Random();
+        byte[] pushBytes = new byte[512];
+        random.nextBytes(pushBytes);
+
+        String oldPath = "/old";
+        String newPath = "/new";
+        start(transport, new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                String target = request.getRequestURI();
+                System.err.println("SIMON: target = " + target);
+                if (target.equals(oldPath))
+                    response.sendRedirect(newPath);
+                else if (target.equals(newPath))
+                    response.getOutputStream().write(pushBytes);
+                else
+                    request.newPushBuilder().path(oldPath).push();
+            }
+        });
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ;
+        ContentResponse response = client.newRequest(newURI(transport))
+            .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
+            {
+                @Override
+                public void onComplete(Result result)
+                {
+                    assertTrue(result.isSucceeded());
+                    assertEquals(oldPath, pushedRequest.getPath());
+                    assertEquals(newPath, result.getRequest().getPath());
+                    assertArrayEquals(pushBytes, getContent());
+                    latch.countDown();
+                }
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
* Restored dispatch=true for pushed requests.
* Restored tests that use the Servlet APIs to push.
* Ensured that pushed streams have request content EOF.