### PR TITLE
Fixed FCGI content parsing.

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -153,7 +153,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     boolean parseAndFill()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("parseAndFill");
+            LOG.debug("parseAndFill {}", networkBuffer);
         if (networkBuffer == null)
             networkBuffer = newNetworkBuffer();
         EndPoint endPoint = getEndPoint();
@@ -455,7 +455,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         public boolean onHeaders(int request)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("onHeaders r={}", request);
+                LOG.debug("onHeaders r={} {}", request, networkBuffer);
             HttpChannelOverFCGI channel = HttpConnectionOverFCGI.this.channel;
             if (channel != null)
             {
@@ -471,7 +471,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         public boolean onContent(int request, FCGI.StreamType stream, ByteBuffer buffer)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("onContent r={},t={},b={}", request, stream, BufferUtil.toDetailString(buffer));
+                LOG.debug("onContent r={},t={},b={} {}", request, stream, BufferUtil.toDetailString(buffer), networkBuffer);
             switch (stream)
             {
                 case STD_OUT ->

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ResponseContentParser.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpParser;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.util.BufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class ResponseContentParser extends StreamContentParser
             while (remaining > 0)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Response {} {}, state {} {}", request, FCGI.StreamType.STD_OUT, state, buffer);
+                    LOG.debug("Response {} {}, state {} {}", request, FCGI.StreamType.STD_OUT, state, BufferUtil.toDetailString(buffer));
 
                 switch (state)
                 {
@@ -131,7 +132,9 @@ public class ResponseContentParser extends StreamContentParser
                     }
                     case RAW_CONTENT:
                     {
-                        if (notifyContent(buffer))
+                        ByteBuffer content = buffer.asReadOnlyBuffer();
+                        buffer.position(buffer.limit());
+                        if (notifyContent(content))
                             return true;
                         remaining = 0;
                         break;

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/StreamContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/StreamContentParser.java
@@ -55,10 +55,7 @@ public class StreamContentParser extends ContentParser
                 case CONTENT:
                 {
                     int length = Math.min(contentLength, buffer.remaining());
-                    int limit = buffer.limit();
-                    buffer.limit(buffer.position() + length);
-                    ByteBuffer slice = buffer.slice();
-                    buffer.limit(limit);
+                    ByteBuffer slice = buffer.slice(buffer.position(), length);
                     // Only parse the content of this FCGI frame.
                     boolean result = onContent(slice);
                     // Not all the content may have been parsed.
@@ -104,7 +101,9 @@ public class StreamContentParser extends ContentParser
     {
         try
         {
-            return listener.onContent(getRequest(), streamType, buffer);
+            ByteBuffer content = buffer.asReadOnlyBuffer();
+            buffer.position(buffer.limit());
+            return listener.onContent(getRequest(), streamType, content);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/StreamContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/StreamContentParser.java
@@ -58,12 +58,16 @@ public class StreamContentParser extends ContentParser
                     int limit = buffer.limit();
                     buffer.limit(buffer.position() + length);
                     ByteBuffer slice = buffer.slice();
-                    buffer.position(buffer.limit());
                     buffer.limit(limit);
-                    contentLength -= length;
+                    // Only parse the content of this FCGI frame.
+                    boolean result = onContent(slice);
+                    // Not all the content may have been parsed.
+                    int consumed = length - slice.remaining();
+                    buffer.position(buffer.position() + consumed);
+                    contentLength -= consumed;
                     if (contentLength <= 0)
                         state = State.EOF;
-                    if (onContent(slice))
+                    if (result)
                         return Result.ASYNC;
                     break;
                 }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -220,7 +220,7 @@ public class HttpStreamOverFCGI implements HttpStream
         ByteBuffer content = byteBuffer != null ? byteBuffer : BufferUtil.EMPTY_BUFFER;
 
         if (LOG.isDebugEnabled())
-            LOG.debug("send {} {} l={}", this, request, last);
+            LOG.debug("send {} l={} {} {}", request, last, BufferUtil.toDetailString(byteBuffer), this);
         boolean head = HttpMethod.HEAD.is(request.getMethod());
         if (response != null)
         {
@@ -362,5 +362,11 @@ public class HttpStreamOverFCGI implements HttpStream
         {
             return Invocable.getInvocationType(_httpChannel);
         }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "%s@%x".formatted(getClass().getSimpleName(), hashCode());
     }
 }


### PR DESCRIPTION
WordPress sends the initial content in the same frame as the response headers. StreamContentParser was receiving the frame, delegating to HttpParser to parse the headers, but the buffer was still containing some content, that was lost. Now the content after the headers is correctly retained.