### PR TITLE
Fix flaky test testBlockingReadInADifferentThread

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
@@ -125,9 +125,8 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                 case FRAME ->
                 {
                     action.getAndSet(null).run();
-                    // Release the network buffer here (if empty), since the application may
-                    // not be reading more bytes, to avoid to keep around a consumed buffer.
-                    tryReleaseBuffer(false);
+                    // Do not release the buffer here to avoid races with
+                    // user-spawned threads that may call Stream.read().
                 }
             }
         }


### PR DESCRIPTION
Fix a race condition that can happen when one thread demands and another reads.

Fixes #9765