### PR TITLE
Simplified and fixed TryPathsHandler.

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
@@ -291,25 +291,25 @@ public class FastCGIProxyHandler extends ProxyHandler.Reverse
         String scheme = clientToProxyRequest.getHttpURI().getScheme();
         proxyToServerRequest.attribute(SCHEME_ATTRIBUTE, scheme);
 
-        // Has the original URI been rewritten?
-        String originalURI = null;
+        // If the request URI been rewritten, use the original request URI.
+        String originalPath = null;
         String originalQuery = null;
         String originalPathAttribute = getOriginalPathAttribute();
         if (originalPathAttribute != null)
-            originalURI = (String)clientToProxyRequest.getAttribute(originalPathAttribute);
-        if (originalURI != null)
+            originalPath = (String)clientToProxyRequest.getAttribute(originalPathAttribute);
+        if (originalPath != null)
         {
             String originalQueryAttribute = getOriginalQueryAttribute();
             if (originalQueryAttribute != null)
             {
                 originalQuery = (String)clientToProxyRequest.getAttribute(originalQueryAttribute);
                 if (originalQuery != null)
-                    originalURI += "?" + originalQuery;
+                    originalPath += "?" + originalQuery;
             }
         }
 
-        if (originalURI != null)
-            proxyToServerRequest.attribute(REQUEST_URI_ATTRIBUTE, originalURI);
+        if (originalPath != null)
+            proxyToServerRequest.attribute(REQUEST_URI_ATTRIBUTE, originalPath);
         if (originalQuery != null)
             proxyToServerRequest.attribute(REQUEST_QUERY_ATTRIBUTE, originalQuery);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -87,11 +87,15 @@ public class PathMappingsHandler extends Handler.AbstractContainer
         if (matchedResource == null)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("No match on pathInContext of {}", pathInContext);
+                LOG.debug("No mappings matched {}", pathInContext);
             return false;
         }
+        Handler handler = matchedResource.getResource();
         if (LOG.isDebugEnabled())
-            LOG.debug("Matched pathInContext of {} to {} -> {}", pathInContext, matchedResource.getPathSpec(), matchedResource.getResource());
-        return matchedResource.getResource().handle(request, response, callback);
+            LOG.debug("Matched {} to {} -> {}", pathInContext, matchedResource.getPathSpec(), handler);
+        boolean handled = handler.handle(request, response, callback);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Handled {} {} by {}", handled, pathInContext, handler);
+        return handled;
     }
 }


### PR DESCRIPTION
Improved logging and variable naming in related classes.

Previously, a 404 received from a child handler would have resulted in an infinite loop trying to write the 404 response. However, `TryPathsHandler` should just delegate to other handlers.

Replaced the `IteratingCallback` loop with a simple `for` loop over the paths to try, returning if the path was handled by a child `Handler`.