### PR TITLE
review and cleanup of HTTP/3 QPACK Integer and String encoding

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/compression/NBitIntegerEncoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/compression/NBitIntegerEncoder.java
@@ -43,7 +43,7 @@ public class NBitIntegerEncoder
         int lz = Long.numberOfLeadingZeros(value);
         int log = 64 - lz;
 
-        // The return value is 1 for the prefix + the number of 7-bit groups used to encode the value.
+        // The return value is 1 for the prefix + the number of 7-bit groups necessary to encode the value.
         return 1 + (log + 6) / 7;
     }
 
@@ -74,7 +74,8 @@ public class NBitIntegerEncoder
             long length = value - bits;
             while (true)
             {
-                if ((length & ~0x7F) == 0)
+                // The value of ~0x7F is different to 0x80 because of all the 1s from the MSB.
+                if ((length & ~0x7FL) == 0)
                 {
                     buffer.put((byte)length);
                     return;

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/compression/NBitStringEncoder.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/compression/NBitStringEncoder.java
@@ -1,0 +1,77 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http.compression;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.http.HttpTokens;
+
+public class NBitStringEncoder
+{
+    private NBitStringEncoder()
+    {
+    }
+
+    public static int octetsNeeded(int prefix, String value, boolean huffman)
+    {
+        if (prefix <= 0 || prefix > 8)
+            throw new IllegalArgumentException();
+
+        int contentPrefix = (prefix == 1) ? 8 : prefix - 1;
+        int encodedValueSize = huffman ? HuffmanEncoder.octetsNeeded(value) : value.length();
+        int encodedLengthSize = NBitIntegerEncoder.octetsNeeded(contentPrefix, encodedValueSize);
+
+        // If prefix was 1, then we count an extra byte needed for the prefix.
+        return encodedLengthSize + encodedValueSize + (prefix == 1 ? 1 : 0);
+    }
+
+    public static void encode(ByteBuffer buffer, int prefix, String value, boolean huffman)
+    {
+        if (prefix <= 0 || prefix > 8)
+            throw new IllegalArgumentException();
+
+        byte huffmanFlag = huffman ? (byte)(0x01 << (prefix - 1)) : (byte)0x00;
+        if (prefix == 8)
+        {
+            buffer.put(huffmanFlag);
+        }
+        else
+        {
+            int p = buffer.position() - 1;
+            buffer.put(p, (byte)(buffer.get(p) | huffmanFlag));
+        }
+
+        // Start encoding size & content in rest of prefix.
+        // If prefix was 1 we set it back to 8 to indicate to start on a new byte.
+        prefix = (prefix == 1) ? 8 : prefix - 1;
+
+        if (huffman)
+        {
+            int encodedValueSize = HuffmanEncoder.octetsNeeded(value);
+            NBitIntegerEncoder.encode(buffer, prefix, encodedValueSize);
+            HuffmanEncoder.encode(buffer, value);
+        }
+        else
+        {
+            int encodedValueSize = value.length();
+            NBitIntegerEncoder.encode(buffer, prefix, encodedValueSize);
+            for (int i = 0; i < encodedValueSize; i++)
+            {
+                char c = value.charAt(i);
+                c = HttpTokens.sanitizeFieldVchar(c);
+                buffer.put((byte)c);
+            }
+        }
+    }
+}

--- a/jetty-http/src/test/java/org/eclipse/jetty/http/NBitIntegerTest.java
+++ b/jetty-http/src/test/java/org/eclipse/jetty/http/NBitIntegerTest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
 import org.eclipse.jetty.http.compression.NBitIntegerEncoder;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.junit.jupiter.api.Test;
 
@@ -31,17 +32,17 @@ public class NBitIntegerTest
     @Test
     public void testOctetsNeeded()
     {
-        assertEquals(0, NBitIntegerEncoder.octetsNeeded(5, 10));
-        assertEquals(2, NBitIntegerEncoder.octetsNeeded(5, 1337));
+        assertEquals(1, NBitIntegerEncoder.octetsNeeded(5, 10));
+        assertEquals(3, NBitIntegerEncoder.octetsNeeded(5, 1337));
         assertEquals(1, NBitIntegerEncoder.octetsNeeded(8, 42));
         assertEquals(3, NBitIntegerEncoder.octetsNeeded(8, 1337));
 
-        assertEquals(0, NBitIntegerEncoder.octetsNeeded(6, 62));
-        assertEquals(1, NBitIntegerEncoder.octetsNeeded(6, 63));
-        assertEquals(1, NBitIntegerEncoder.octetsNeeded(6, 64));
-        assertEquals(2, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x01));
-        assertEquals(3, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x80));
-        assertEquals(4, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x80 * 0x80));
+        assertEquals(1, NBitIntegerEncoder.octetsNeeded(6, 62));
+        assertEquals(2, NBitIntegerEncoder.octetsNeeded(6, 63));
+        assertEquals(2, NBitIntegerEncoder.octetsNeeded(6, 64));
+        assertEquals(3, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x01));
+        assertEquals(4, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x80));
+        assertEquals(5, NBitIntegerEncoder.octetsNeeded(6, 63 + 0x00 + 0x80 * 0x80 * 0x80));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class NBitIntegerTest
         String r = TypeUtil.toHexString(BufferUtil.toArray(buf));
         assertEquals(expected, r);
 
-        assertEquals(expected.length() / 2, (n < 8 ? 1 : 0) + NBitIntegerEncoder.octetsNeeded(n, i));
+        assertEquals(expected.length() / 2, NBitIntegerEncoder.octetsNeeded(n, i));
     }
 
     @Test
@@ -163,8 +164,7 @@ public class NBitIntegerTest
         NBitIntegerEncoder.encode(buf, 5, 1337);
         BufferUtil.flipToFlush(buf, p);
 
-        String r = TypeUtil.toHexString(BufferUtil.toArray(buf));
-
+        String r = StringUtil.toHexString(BufferUtil.toArray(buf));
         assertEquals("881f9a0a", r);
     }
 

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
@@ -463,7 +463,7 @@ public class HpackContext
                 if (huffmanLen < 0)
                     throw new IllegalStateException("bad value");
                 int lenLen = NBitIntegerEncoder.octetsNeeded(7, huffmanLen);
-                _huffmanValue = new byte[1 + lenLen + huffmanLen];
+                _huffmanValue = new byte[lenLen + huffmanLen];
                 ByteBuffer buffer = ByteBuffer.wrap(_huffmanValue);
 
                 // Indicate Huffman

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/DuplicateInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/DuplicateInstruction.java
@@ -37,7 +37,7 @@ public class DuplicateInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(5, _index) + 1;
+        int size = NBitIntegerEncoder.octetsNeeded(5, _index);
         ByteBuffer buffer = lease.acquire(size, false);
         buffer.put((byte)0x00);
         NBitIntegerEncoder.encode(buffer, 5, _index);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/IndexedNameEntryInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/IndexedNameEntryInstruction.java
@@ -14,10 +14,9 @@
 package org.eclipse.jetty.http3.qpack.internal.instruction;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
-import org.eclipse.jetty.http.compression.HuffmanEncoder;
 import org.eclipse.jetty.http.compression.NBitIntegerEncoder;
+import org.eclipse.jetty.http.compression.NBitStringEncoder;
 import org.eclipse.jetty.http3.qpack.Instruction;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
@@ -55,27 +54,14 @@ public class IndexedNameEntryInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(6, _index) + (_huffman ? HuffmanEncoder.octetsNeeded(_value) : _value.length()) + 2;
+        int size = NBitIntegerEncoder.octetsNeeded(6, _index) + NBitStringEncoder.octetsNeeded(8, _value, _huffman);
         ByteBuffer buffer = lease.acquire(size, false);
 
         // First bit indicates the instruction, second bit is whether it is a dynamic table reference or not.
         buffer.put((byte)(0x80 | (_dynamic ? 0x00 : 0x40)));
         NBitIntegerEncoder.encode(buffer, 6, _index);
 
-        // We will not huffman encode the string.
-        if (_huffman)
-        {
-            buffer.put((byte)(0x80));
-            NBitIntegerEncoder.encode(buffer, 7, HuffmanEncoder.octetsNeeded(_value));
-            HuffmanEncoder.encode(buffer, _value);
-        }
-        else
-        {
-            buffer.put((byte)(0x00));
-            NBitIntegerEncoder.encode(buffer, 7, _value.length());
-            buffer.put(_value.getBytes(StandardCharsets.ISO_8859_1));
-        }
-
+        NBitStringEncoder.encode(buffer, 8, _value, _huffman);
         BufferUtil.flipToFlush(buffer, 0);
         lease.append(buffer, true);
     }

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/InsertCountIncrementInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/InsertCountIncrementInstruction.java
@@ -37,7 +37,7 @@ public class InsertCountIncrementInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(6, _increment) + 1;
+        int size = NBitIntegerEncoder.octetsNeeded(6, _increment);
         ByteBuffer buffer = lease.acquire(size, false);
         buffer.put((byte)0x00);
         NBitIntegerEncoder.encode(buffer, 6, _increment);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/LiteralNameEntryInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/LiteralNameEntryInstruction.java
@@ -14,11 +14,9 @@
 package org.eclipse.jetty.http3.qpack.internal.instruction;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.compression.HuffmanEncoder;
-import org.eclipse.jetty.http.compression.NBitIntegerEncoder;
+import org.eclipse.jetty.http.compression.NBitStringEncoder;
 import org.eclipse.jetty.http3.qpack.Instruction;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
@@ -56,35 +54,13 @@ public class LiteralNameEntryInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = (_huffmanName ? HuffmanEncoder.octetsNeeded(_name) : _name.length()) +
-            (_huffmanValue ? HuffmanEncoder.octetsNeeded(_value) : _value.length()) + 2;
+        int size = NBitStringEncoder.octetsNeeded(6, _name, _huffmanName) +
+            NBitStringEncoder.octetsNeeded(8, _value, _huffmanValue);
         ByteBuffer buffer = lease.acquire(size, false);
 
-        if (_huffmanName)
-        {
-            buffer.put((byte)(0x40 | 0x20));
-            NBitIntegerEncoder.encode(buffer, 5, HuffmanEncoder.octetsNeeded(_name));
-            HuffmanEncoder.encode(buffer, _name);
-        }
-        else
-        {
-            buffer.put((byte)(0x40));
-            NBitIntegerEncoder.encode(buffer, 5, _name.length());
-            buffer.put(_name.getBytes(StandardCharsets.ISO_8859_1));
-        }
-
-        if (_huffmanValue)
-        {
-            buffer.put((byte)(0x80));
-            NBitIntegerEncoder.encode(buffer, 7, HuffmanEncoder.octetsNeeded(_value));
-            HuffmanEncoder.encode(buffer, _value);
-        }
-        else
-        {
-            buffer.put((byte)(0x00));
-            NBitIntegerEncoder.encode(buffer, 7, _value.length());
-            buffer.put(_value.getBytes(StandardCharsets.ISO_8859_1));
-        }
+        buffer.put((byte)0x40); // Instruction Pattern.
+        NBitStringEncoder.encode(buffer, 6, _name, _huffmanName);
+        NBitStringEncoder.encode(buffer, 8, _value, _huffmanValue);
 
         BufferUtil.flipToFlush(buffer, 0);
         lease.append(buffer, true);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/SectionAcknowledgmentInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/SectionAcknowledgmentInstruction.java
@@ -37,7 +37,7 @@ public class SectionAcknowledgmentInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(7, _streamId) + 1;
+        int size = NBitIntegerEncoder.octetsNeeded(7, _streamId);
         ByteBuffer buffer = lease.acquire(size, false);
         buffer.put((byte)0x80);
         NBitIntegerEncoder.encode(buffer, 7, _streamId);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/SetCapacityInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/SetCapacityInstruction.java
@@ -37,7 +37,7 @@ public class SetCapacityInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(5, _capacity) + 1;
+        int size = NBitIntegerEncoder.octetsNeeded(5, _capacity);
         ByteBuffer buffer = lease.acquire(size, false);
         buffer.put((byte)0x20);
         NBitIntegerEncoder.encode(buffer, 5, _capacity);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/StreamCancellationInstruction.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/instruction/StreamCancellationInstruction.java
@@ -32,7 +32,7 @@ public class StreamCancellationInstruction implements Instruction
     @Override
     public void encode(ByteBufferPool.Lease lease)
     {
-        int size = NBitIntegerEncoder.octetsNeeded(6, _streamId) + 1;
+        int size = NBitIntegerEncoder.octetsNeeded(6, _streamId);
         ByteBuffer buffer = lease.acquire(size, false);
         buffer.put((byte)0x40);
         NBitIntegerEncoder.encode(buffer, 6, _streamId);

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/table/Entry.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/table/Entry.java
@@ -120,7 +120,7 @@ public class Entry
                 if (huffmanLen < 0)
                     throw new IllegalStateException("bad value");
                 int lenLen = NBitIntegerEncoder.octetsNeeded(7, huffmanLen);
-                _huffmanValue = new byte[1 + lenLen + huffmanLen];
+                _huffmanValue = new byte[lenLen + huffmanLen];
                 ByteBuffer buffer = ByteBuffer.wrap(_huffmanValue);
 
                 // Indicate Huffman


### PR DESCRIPTION
- Cleanup the code in `NBitIntegerEncoder` to reduce duplication.
- Change implementation of `NBitIntegerEncoder.octetsNeeded()` to include an extra byte for prefixes less than 8, this means we can get rid of the `+ 1` everywhere it is used.
- Added a `NBitStringEncoder` utility class to simplify where we encode strings and calculate their required lengths.