### PR TITLE
Fixes #9795 - jetty-slf4j-impl is non-optional on some modules

### DIFF
--- a/demos/demo-jetty-webapp/pom.xml
+++ b/demos/demo-jetty-webapp/pom.xml
@@ -191,5 +191,10 @@
       <artifactId>websocket-javax-server</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/demos/demo-proxy-webapp/pom.xml
+++ b/demos/demo-proxy-webapp/pom.xml
@@ -26,6 +26,10 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
     </dependency>

--- a/demos/demo-proxy-webapp/pom.xml
+++ b/demos/demo-proxy-webapp/pom.xml
@@ -26,15 +26,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
     </dependency>

--- a/jetty-http3/http3-common/pom.xml
+++ b/jetty-http3/http3-common/pom.xml
@@ -35,11 +35,6 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/jetty-http3/http3-common/pom.xml
+++ b/jetty-http3/http3-common/pom.xml
@@ -35,6 +35,11 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jetty-infinispan/infinispan-embedded-query/pom.xml
+++ b/jetty-infinispan/infinispan-embedded-query/pom.xml
@@ -94,5 +94,10 @@
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tests/test-jmx/jmx-webapp/pom.xml
+++ b/tests/test-jmx/jmx-webapp/pom.xml
@@ -27,11 +27,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
   <build>
     <finalName>jmx-webapp</finalName>

--- a/tests/test-jpms/pom.xml
+++ b/tests/test-jpms/pom.xml
@@ -17,6 +17,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -94,6 +94,10 @@
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tests/test-webapps/test-openid-webapp/pom.xml
+++ b/tests/test-webapps/test-openid-webapp/pom.xml
@@ -14,15 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
@@ -14,6 +14,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
@@ -14,15 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-client-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-webapp/pom.xml
@@ -14,6 +14,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-client-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-webapp/pom.xml
@@ -14,15 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-webapp/pom.xml
@@ -18,6 +18,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-javax-websocket-api</artifactId>
       <scope>provided</scope>

--- a/tests/test-webapps/test-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-webapp/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-javax-websocket-api</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
Cleanup `<dependency>` declarations of `jetty-slf4j-impl` across the jetty-10.0.x build.