### PR TITLE
jetty-util: don't override Enumeration methods in QuotedStringTokenizer

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java
@@ -234,19 +234,6 @@ public class QuotedStringTokenizer
         return nextToken();
     }
 
-    @Override
-    public boolean hasMoreElements()
-    {
-        return hasMoreTokens();
-    }
-
-    @Override
-    public Object nextElement()
-        throws NoSuchElementException
-    {
-        return nextToken();
-    }
-
     /**
      * Not implemented.
      */


### PR DESCRIPTION
There is no code difference in base implementation