### PR TITLE
Jetty 12 context initial ClassLoader

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -172,19 +172,28 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Grace
 
     public ContextHandler(String contextPath)
     {
-        this(null, contextPath);
+        _context = newContext();
+        if (contextPath != null)
+            setContextPath(contextPath);
+
+        if (File.separatorChar == '/')
+            addAliasCheck(new SymlinkAllowedResourceAliasChecker(this));
+
+        // If the current classloader (or the one that loaded this class) is different
+        // from the Server classloader, then use that as the initial classloader for the context.
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null)
+            classLoader = this.getClass().getClassLoader();
+        if (classLoader != Server.class.getClassLoader())
+            _classLoader = classLoader;
     }
 
     @Deprecated
     public ContextHandler(Handler.Container parent, String contextPath)
     {
-        _context = newContext();
-        if (contextPath != null)
-            setContextPath(contextPath);
+        this(contextPath);
         Container.setAsParent(parent, this);
 
-        if (File.separatorChar == '/')
-            addAliasCheck(new SymlinkAllowedResourceAliasChecker(this));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -135,7 +135,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     private Throwable _unavailableException;
 
     private Map<String, String> _resourceAliases;
-    private boolean _ownClassLoader = false;
+    private ClassLoader _initialClassLoader;
     private boolean _configurationDiscovered = true;
     private boolean _allowDuplicateFragmentNames = false;
     private boolean _throwUnavailableOnStartupException = false;
@@ -471,13 +471,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         }
 
         // Configure classloader
-        _ownClassLoader = false;
-        if (getClassLoader() == null)
-        {
-            WebAppClassLoader classLoader = new WebAppClassLoader(this);
-            setClassLoader(classLoader);
-            _ownClassLoader = true;
-        }
+        _initialClassLoader = getClassLoader();
+        if (!(_initialClassLoader instanceof WebAppClassLoader))
+            setClassLoader(new WebAppClassLoader(_initialClassLoader, this));
 
         if (LOG.isDebugEnabled())
         {
@@ -1305,13 +1301,13 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         }
         finally
         {
-            if (_ownClassLoader)
+            if (!(_initialClassLoader instanceof WebAppClassLoader))
             {
                 ClassLoader loader = getClassLoader();
                 if (loader instanceof URLClassLoader)
                     ((URLClassLoader)loader).close();
-                setClassLoader(null);
             }
+            setClassLoader(_initialClassLoader);
 
             _unavailableException = null;
         }


### PR DESCRIPTION
For issues found in #9796, the `ContextHandler` now initialises its classloader to the thread context loader, or the loader that loaded itself (but only if different to the server loader).
WebAppContext modified to use such an initial classloader as it's parent loader.