### PR TITLE
JMX total number of keys in SelectorManager

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
@@ -140,6 +140,23 @@ public abstract class SelectorManager extends ContainerLifeCycle implements Dump
     }
 
     /**
+     * Get total number of keys from each selector.
+     *
+     * @return total number of selector keys
+     */
+    @ManagedAttribute(value = "Total number of keys in all selectors", readonly = true)
+    public int getTotalKeys()
+    {
+        int keys = 0;
+        for (final ManagedSelector selector : _selectors)
+        {
+            keys += selector.getTotalKeys();
+        }
+        return keys;
+    }
+
+
+    /**
      * @return the number of selectors in use
      */
     @ManagedAttribute("The number of NIO Selectors")
@@ -505,5 +522,11 @@ public abstract class SelectorManager extends ContainerLifeCycle implements Dump
         default void onAccepted(SelectableChannel channel)
         {
         }
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x[keys=%d]", getClass().getSimpleName(), hashCode(), getTotalKeys());
     }
 }


### PR DESCRIPTION
Added a new JMX property in SelectorManager that reports the total number of keys from all ManagedSelectors
How it was tested? 
Run embedded Jetty
```
        final Server server = new Server(9090);
        final MBeanContainer mbeanContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
        server.addBeanToAllConnectors(mbeanContainer);
        server.start();
        server.join();

```
Open VisualVM and check a new JMX property exists 
![image](https://github.com/eclipse/jetty.project/assets/20584185/0c2346b0-35c7-4a61-b227-6f1fe96229fa)
