### PR TITLE
Use default HttpExchange#setStreams implementation

### DIFF
--- a/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpExchangeDelegate.java
+++ b/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpExchangeDelegate.java
@@ -209,8 +209,11 @@ public class JettyHttpExchangeDelegate extends HttpExchange
     @Override
     public void setStreams(InputStream i, OutputStream o)
     {
-        _is = i;
-        _os = o;
+        assert _is != null;
+        if (i != null)
+            _is = i;
+        if (o != null)
+            _os = o;
     }
 
     @Override


### PR DESCRIPTION
Right now the `JettyHttpExchangeDelegate#setStreams` implementation just sets given parameters to respective steams. However, the default JDK implementation of `HttpExchange#setStreams` calls `ExchangeImpl#setStreams` which in turn only changes the respective streams when given parameters aren't null. To follow this convention the  `JettyHttpExchangeDelegate#setStreams` was rewritten to have the same implementation