### PR TITLE
Fix `QueuedPool`'s performance

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -39,11 +39,15 @@ import org.eclipse.jetty.util.Pool;
  */
 public class QueuedPool<P> implements Pool<P>
 {
+    // All code that uses these three fields is fully thread-safe.
     private final int maxSize;
     private final Queue<Entry<P>> queue = new ConcurrentLinkedQueue<>();
     private final AtomicInteger queueSize = new AtomicInteger();
 
-    // This lock protects the 'terminated' field.
+    // Only the 'terminated' field is protected by the RW lock,
+    // the other fields are totally ignored w.r.t the scope of this lock;
+    // so when the read lock or the write lock is needed solely depends
+    // on what is being done to the 'terminated' field.
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
     private boolean terminated;
 
@@ -132,6 +136,11 @@ public class QueuedPool<P> implements Pool<P>
         rwLock.writeLock().lock();
         try
         {
+            // Once 'terminated' has been set to true, no entry can be
+            // added nor removed from the queue; the setting to true
+            // as well as the copy and the clearing of the queue MUST be
+            // atomic otherwise we may not return the exact list of entries
+            // that remained in the pool when terminate() was called.
             terminated = true;
             Collection<Entry<P>> copy = new ArrayList<>(queue);
             queue.clear();


### PR DESCRIPTION
Manually maintain `QueuedPool`'s size to avoid calling the super-slow `ConcurrentLinkedQueue.size()`. When `QueuedPool` is hammered with a massive concurrent load, the perf difference can be of two orders of magnitude.

Fixes #9881 
