### PR TITLE
Jetty 12.0.x 9760 fix cookie parsing

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2196,9 +2196,12 @@ public class Request implements HttpServletRequest
             try
             {
                 Cookie result = new Cookie(cookie.getName(), cookie.getValue());
-                //RFC2965 defines the cookie header as supporting path and domain but RFC6265 permits only name=value
+
                 if (compliance.allows(CookieCompliance.Violation.ATTRIBUTE_VALUES))
                 {
+                    if (cookie.getVersion() > 0)
+                        result.setVersion(cookie.getVersion());
+
                     String path = cookie.getPath();
                     if (StringUtil.isNotBlank(path))
                         result.setPath(path);
@@ -2206,6 +2209,10 @@ public class Request implements HttpServletRequest
                     String domain = cookie.getDomain();
                     if (StringUtil.isNotBlank(domain))
                         result.setDomain(domain);
+
+                    String comment = cookie.getComment();
+                    if (StringUtil.isNotBlank(comment))
+                        result.setComment(comment);
                 }
                 return result;
             }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2199,15 +2199,20 @@ public class Request implements HttpServletRequest
                 //RFC2965 defines the cookie header as supporting path and domain but RFC6265 permits only name=value
                 if (CookieCompliance.RFC2965.equals(compliance))
                 {
-                    result.setPath(cookie.getPath());
-                    result.setDomain(cookie.getDomain());
+                    String path = cookie.getPath();
+                    if (StringUtil.isNotBlank(path))
+                        result.setPath(path);
+
+                    String domain = cookie.getDomain();
+                    if (StringUtil.isNotBlank(domain))
+                        result.setDomain(domain);
                 }
                 return result;
             }
-            catch (Exception ignore)
+            catch (Exception x)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Bad Cookie", ignore);
+                    LOG.debug("Bad Cookie", x);
             }
             return null;
         }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2197,7 +2197,7 @@ public class Request implements HttpServletRequest
             {
                 Cookie result = new Cookie(cookie.getName(), cookie.getValue());
                 //RFC2965 defines the cookie header as supporting path and domain but RFC6265 permits only name=value
-                if (CookieCompliance.RFC2965.equals(compliance))
+                if (compliance.allows(CookieCompliance.Violation.ATTRIBUTE_VALUES))
                 {
                     String path = cookie.getPath();
                     if (StringUtil.isNotBlank(path))

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1476,6 +1476,36 @@ public class RequestTest
     }
 
     @Test
+    public void testSpecCookies() throws Exception
+    {
+        _server.stop();
+        _connector.getConnectionFactory(HttpConnectionFactory.class).
+            getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965);
+        _server.start();
+
+        final ArrayList<Cookie> cookies = new ArrayList<>();
+
+        _handler._checker = (request, response) ->
+        {
+            Cookie[] ca = request.getCookies();
+            if (ca != null)
+                cookies.addAll(Arrays.asList(ca));
+            response.getOutputStream().println("Cookie monster!");
+            return true;
+        };
+
+        String response = _connector.getResponse(
+            "GET / HTTP/1.1\n" +
+                "Host: whatever\n" +
+                "Cookie: name1=value1\n" +
+                "Connection: close\n" +
+                "\n"
+        );
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertEquals(1, cookies.size());
+    }
+
+    @Test
     public void testCookies() throws Exception
     {
         final ArrayList<Cookie> cookies = new ArrayList<>();

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1479,8 +1479,8 @@ public class RequestTest
     public void testSpecCookies() throws Exception
     {
         _server.stop();
-        _connector.getConnectionFactory(HttpConnectionFactory.class).
-            getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965);
+        _connector.getConnectionFactory(HttpConnectionFactory.class)
+            .getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965);
         _server.start();
 
         final ArrayList<Cookie> cookies = new ArrayList<>();

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1508,11 +1508,11 @@ public class RequestTest
     }
 
     @Test
-    public void testSpecCookiesLegacy() throws Exception
+    public void testSpecCookiesVersion() throws Exception
     {
         _server.stop();
         _connector.getConnectionFactory(HttpConnectionFactory.class)
-            .getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965_LEGACY);
+            .getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965);
         _server.start();
 
         final ArrayList<Cookie> cookies = new ArrayList<>();

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1495,14 +1495,52 @@ public class RequestTest
         };
 
         String response = _connector.getResponse(
-            "GET / HTTP/1.1\n" +
-                "Host: whatever\n" +
-                "Cookie: name1=value1\n" +
-                "Connection: close\n" +
-                "\n"
+            """
+                GET / HTTP/1.1
+                Host: whatever
+                Cookie: name1=value1
+                Connection: close
+
+                """
         );
         assertTrue(response.startsWith("HTTP/1.1 200 OK"));
         assertEquals(1, cookies.size());
+    }
+
+    @Test
+    public void testSpecCookiesLegacy() throws Exception
+    {
+        _server.stop();
+        _connector.getConnectionFactory(HttpConnectionFactory.class)
+            .getHttpConfiguration().setRequestCookieCompliance(CookieCompliance.RFC2965_LEGACY);
+        _server.start();
+
+        final ArrayList<Cookie> cookies = new ArrayList<>();
+
+        _handler._checker = (request, response) ->
+        {
+            Cookie[] ca = request.getCookies();
+            if (ca != null)
+                cookies.addAll(Arrays.asList(ca));
+            response.getOutputStream().println("Cookie monster!");
+            return true;
+        };
+
+        String response = _connector.getResponse(
+            """
+                GET / HTTP/1.1
+                Host: whatever
+                Cookie: $Version="1"; name1="value1"; $Path="/servlet_jsh_cookie_web"; $Domain="localhost"
+                Connection: close
+                
+                """
+        );
+        assertTrue(response.startsWith("HTTP/1.1 200 OK"));
+        assertEquals(1, cookies.size());
+        Cookie cookie = cookies.get(0);
+        assertThat(cookie.getVersion(), is(1));
+        assertThat(cookie.getPath(), is("/servlet_jsh_cookie_web"));
+        assertThat(cookie.getDomain(), is("localhost"));
     }
 
     @Test


### PR DESCRIPTION
Fixes tck errors with cookie parsing detailed in #9760.