### PR TITLE
Various improvements to CyclicTimeouts.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
@@ -550,7 +550,7 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
     }
 
     /**
-     * <p>Enforces the total timeout for for exchanges that are still in the queue.</p>
+     * <p>Enforces the total timeout for exchanges that are still in the queue.</p>
      * <p>The total timeout for exchanges that are not in the destination queue
      * is enforced in {@link HttpConnection}.</p>
      */
@@ -572,6 +572,8 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
         {
             HttpRequest request = exchange.getRequest();
             request.abort(new TimeoutException("Total timeout " + request.getConversation().getTimeout() + " ms elapsed"));
+            // The implementation of the Iterator returned above does not support
+            // removal, but the HttpExchange will be removed by request.abort().
             return false;
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2385,6 +2385,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         protected boolean onExpired(HTTP2Stream stream)
         {
             stream.onIdleTimeout(new TimeoutException("Idle timeout " + stream.getIdleTimeout() + " ms elapsed"));
+            // The implementation of the Iterator returned above does not support
+            // removal, but the HTTP2Stream will be removed by stream.onIdleTimeout().
             return false;
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -311,10 +311,9 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         notifyIdleTimeout(this, timeout, Promise.from(timedOut ->
         {
             if (timedOut)
-            {
-                // Tell the other peer that we timed out.
                 reset(new ResetFrame(getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
-            }
+            else
+                notIdle();
         }, x -> reset(new ResetFrame(getId(), ErrorCode.INTERNAL_ERROR.code), Callback.NOOP)));
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -46,7 +46,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
     private CloseState closeState = CloseState.NOT_CLOSED;
     private FrameState frameState = FrameState.INITIAL;
     private long idleTimeout;
-    private long expireNanoTime;
+    private long expireNanoTime = Long.MAX_VALUE;
     private Object attachment;
     private boolean dataDemand;
     private boolean dataStalled;
@@ -129,6 +129,8 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
         {
             if (timedOut)
                 endPoint.close(HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), timeout);
+            else
+                notIdle();
             promise.succeeded(timedOut);
         }, promise::failed));
     }

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicConnection.java
@@ -133,6 +133,8 @@ public class ServerQuicConnection extends QuicConnection
         protected boolean onExpired(ServerQuicSession session)
         {
             session.onIdleTimeout();
+            // The implementation of the Iterator returned above does not support
+            // removal, but the session will be removed by session.onIdleTimeout().
             return false;
         }
     }

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
@@ -44,7 +44,7 @@ import org.eclipse.jetty.util.thread.Scheduler;
 public class ServerQuicSession extends QuicSession implements CyclicTimeouts.Expirable
 {
     private final Connector connector;
-    private long expireNanoTime;
+    private long expireNanoTime = Long.MAX_VALUE;
 
     protected ServerQuicSession(Executor executor, Scheduler scheduler, ByteBufferPool bufferPool, QuicheConnection quicheConnection, QuicConnection connection, SocketAddress remoteAddress, Connector connector)
     {
@@ -101,6 +101,15 @@ public class ServerQuicSession extends QuicSession implements CyclicTimeouts.Exp
         super.setIdleTimeout(idleTimeout);
         notIdle();
         getQuicConnection().schedule(this);
+    }
+
+    @Override
+    public boolean onIdleTimeout()
+    {
+        boolean result = super.onIdleTimeout();
+        if (!result)
+            notIdle();
+        return result;
     }
 
     @Override


### PR DESCRIPTION
* Improved reset of the earliest timeout before iteration.
* Removed check for getExpireNanoTime() == -1, since it's a valid value.
* When onExpired(Expirable) returns false, the Expirable should arrange to move its timeout in the future.