### PR TITLE
Issue #9895 - ensure callback is failed after error in PerMessageDeflateExtension

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -464,6 +464,11 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
             chunk.setPayload(payload);
             chunk.setFin(frame.isFin() && complete);
 
+            // If we are complete we return true, then DemandingFlusher.process() will null out the Frame and Callback.
+            // The application may decide to hold onto the buffer and delay completing the callback, so we need to capture
+            // references to these in the payloadCallback and not rely on state of the flusher which may have moved on.
+            // This flusher could be failed while the application already has the payloadCallback, so we need protection against
+            // the flusher failing and the application completing the callback, that's why we use the payload AtomicReference.
             boolean completeCallback = complete;
             AtomicReference<ByteBuffer> payloadRef = _payloadRef;
             Callback payloadCallback = Callback.from(() ->

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -464,16 +464,18 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
             chunk.setPayload(payload);
             chunk.setFin(frame.isFin() && complete);
 
-            boolean succeedCallback = complete;
+            boolean completeCallback = complete;
             AtomicReference<ByteBuffer> payloadRef = _payloadRef;
             Callback payloadCallback = Callback.from(() ->
             {
                 getBufferPool().release(payloadRef.getAndSet(null));
-                if (succeedCallback)
+                if (completeCallback)
                     callback.succeeded();
             }, t ->
             {
                 getBufferPool().release(payloadRef.getAndSet(null));
+                if (completeCallback)
+                    callback.failed(t);
                 failFlusher(t);
             });
 


### PR DESCRIPTION
fixes #9895 