### PR TITLE
Issue #9906 Empty path info

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -313,23 +313,6 @@ public class ServletContextHandler extends ContextHandler
             new DumpableCollection("initparams " + this, getInitParams().entrySet()));
     }
 
-    /**
-     * @return the allowNullPathInfo true if /context is not redirected to /context/
-     */
-    @ManagedAttribute("Checks if the /context is not redirected to /context/")
-    public boolean getAllowNullPathInfo()
-    {
-        return _allowNullPathInfo;
-    }
-
-    /**
-     * @param allowNullPathInfo true if /context is not redirected to /context/
-     */
-    public void setAllowNullPathInfo(boolean allowNullPathInfo)
-    {
-        _allowNullPathInfo = allowNullPathInfo;
-    }
-
     public boolean isUsingSecurityManager()
     {
         return _usingSecurityManager;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -468,7 +468,7 @@ public class ServletHandler extends Handler.Wrapper
      */
     public MatchedResource<MappedServlet> getMatchedServlet(String target)
     {
-        if (target.startsWith("/"))
+        if (target.startsWith("/") || target.length() == 0)
         {
             if (_servletPathMap == null)
                 return null;

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
@@ -2461,6 +2461,6 @@ public class ServletContextHandlerTest
 
         String rawResponse = _connector.getResponse(rawRequest);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-        assertThat(response.getContent(), containsString("OK"));
+        assertThat(response.getContent(), containsString("OK2"));
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
@@ -2432,4 +2432,35 @@ public class ServletContextHandlerTest
         String setCookieValue = response.get(HttpHeader.SET_COOKIE);
         assertThat(setCookieValue, containsString("example=bogus; SameSite=Strict"));
     }
+
+    @Test
+    public void testEmptyPathInfo() throws Exception
+    {
+        ServletContextHandler context = new ServletContextHandler(null, "/c1", ServletContextHandler.NO_SESSIONS);
+        context.setAllowNullPathInContext(true);
+        context.addServlet(new ServletHolder("default-servlet", new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+            {
+                resp.setContentType("text/plain");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write("OK2\n");
+                resp.getWriter().close();
+            }
+        }), "/");
+
+        _server.setHandler(context);
+        _server.start();
+        String rawRequest = """
+            GET /c1 HTTP/1.1\r
+            Host: localhost\r
+            Connection: close\r
+            \r
+            """;
+
+        String rawResponse = _connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getContent(), containsString("OK"));
+    }
 }

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHandler.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHandler.java
@@ -546,7 +546,7 @@ public class ServletHandler extends ScopedHandler
      */
     public MatchedResource<MappedServlet> getMatchedServlet(String target)
     {
-        if (target.startsWith("/"))
+        if (target.startsWith("/") || target.length() == 0)
         {
             if (_servletPathMap == null)
                 return null;

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
@@ -2272,4 +2272,35 @@ public class ServletContextHandlerTest
         assertThat(response, containsString("200 OK"));
         assertThat(response, containsString("/three"));
     }
+
+    @Test
+    public void testEmptyPathInfo() throws Exception
+    {
+        ServletContextHandler context = new ServletContextHandler(null, "/c1", ServletContextHandler.NO_SESSIONS);
+        context.setAllowNullPathInfo(true);
+        context.addServlet(new ServletHolder("default-servlet", new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+            {
+                resp.setContentType("text/plain");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write("OK2\n");
+                resp.getWriter().close();
+            }
+        }), "/");
+
+        _server.setHandler(context);
+        _server.start();
+        String rawRequest = """
+            GET /c1 HTTP/1.1\r
+            Host: localhost\r
+            Connection: close\r
+            \r
+            """;
+
+        String rawResponse = _connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getContent(), containsString("OK"));
+    }
 }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
@@ -2301,6 +2301,6 @@ public class ServletContextHandlerTest
 
         String rawResponse = _connector.getResponse(rawRequest);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-        assertThat(response.getContent(), containsString("OK"));
+        assertThat(response.getContent(), containsString("OK2"));
     }
 }


### PR DESCRIPTION
Closes #9906 

When using `ContextHandler.setAllowNullPathInfo(true)` a URL like `/ctx` is not redirected to `/ctx/`. In older versions of jetty, the resulting path in context of `""` is forced to be `/` and is thus sent on to whatever servlet matches that (usually the default servlet). In jetty-12 we do not fake the path to be `/` and we were returning a `404`.  

This PR allows the path in context of `""` to match the _same_ servlet as does a path in context of `/`. 

However, unlike previous versions of jetty, we do _not_ force the path in context to be `/`, the path in context will continue to be `""`.  To do the forcing would impose extra processing on the critical path of handling a request that isn't justified by this edge-case. If skipping the redirect of `/ctx` to `/ctx/` is desired _and_ the application wants the path in context to be `/`, then the `RewriteHandler` can be used to rewrite `/ctx` to `/ctx/` before the request hits the `ServletContextHandler`.