### PR TITLE
Fix spotbugs packages

### DIFF
--- a/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
@@ -9,7 +9,7 @@
   <name>Core :: ALPN :: Client</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.alpn.client</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.alpn.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.alpn.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>

--- a/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
@@ -9,7 +9,7 @@
   <name>Core :: ALPN :: Server</name>
   <properties>
     <bundle-symbolic-name>${project.groupId}.alpn.server</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.alpn.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.alpn.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>

--- a/jetty-core/jetty-client/pom.xml
+++ b/jetty-core/jetty-client/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.client</bundle-symbolic-name>
     <jetty.test.policy.loc>target/test-policy</jetty.test.policy.loc>
-    <spotbugs.onlyAnalyze>org.eclipse.client.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.client.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-core/jetty-deploy/pom.xml
+++ b/jetty-core/jetty-deploy/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.deploy</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.deploy.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.deploy.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee10/jetty-ee10-annotations/pom.xml
+++ b/jetty-ee10/jetty-ee10-annotations/pom.xml
@@ -11,7 +11,7 @@
   <description>Annotation support for deploying servlets in jetty.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.annotations</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.annotations.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee10.annotations.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee10/jetty-ee10-jaspi/pom.xml
+++ b/jetty-ee10/jetty-ee10-jaspi/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.security.jaspi</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.jaspi.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee10.security.jaspi.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee10/jetty-ee10-plus/pom.xml
+++ b/jetty-ee10/jetty-ee10-plus/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.plus</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.plus.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee10.plus.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee10/jetty-ee10-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlet/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.servlet</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee10.servlet.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-annotations/pom.xml
+++ b/jetty-ee8/jetty-ee8-annotations/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <ee9.module>jetty-ee9-annotations</ee9.module>
     <bundle-symbolic-name>${project.groupId}.annotations</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.annotations.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.annotations.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-nested/pom.xml
+++ b/jetty-ee8/jetty-ee8-nested/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <ee9.module>jetty-ee9-nested</ee9.module>
     <bundle-symbolic-name>${project.groupId}.server</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.server.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.server.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-openid/pom.xml
+++ b/jetty-ee8/jetty-ee8-openid/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <ee9.module>jetty-ee9-openid</ee9.module>
     <bundle-symbolic-name>${project.groupId}.openid</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.openid.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.security.openid.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-plus/pom.xml
+++ b/jetty-ee8/jetty-ee8-plus/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <ee9.module>jetty-ee9-plus</ee9.module>
     <bundle-symbolic-name>${project.groupId}.plus</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.plus.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.plus.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-security/pom.xml
+++ b/jetty-ee8/jetty-ee8-security/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <ee9.module>jetty-ee9-security</ee9.module>
     <bundle-symbolic-name>${project.groupId}.security</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.security.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee8/jetty-ee8-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlet/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <ee9.module>jetty-ee9-servlet</ee9.module>
     <bundle-symbolic-name>${project.groupId}.servlet</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee8.servlet.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-annotations/pom.xml
+++ b/jetty-ee9/jetty-ee9-annotations/pom.xml
@@ -11,7 +11,7 @@
   <description>Annotation support for deploying servlets in jetty.</description>
   <properties>
     <bundle-symbolic-name>${project.groupId}.annotations</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.annotations.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.annotations.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-jaspi/pom.xml
+++ b/jetty-ee9/jetty-ee9-jaspi/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.security.jaspi</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.jaspi.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.security.jaspi.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-nested/pom.xml
+++ b/jetty-ee9/jetty-ee9-nested/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.server</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.server.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.nested.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-openid/pom.xml
+++ b/jetty-ee9/jetty-ee9-openid/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.openid</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.openid.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.security.openid.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-plus/pom.xml
+++ b/jetty-ee9/jetty-ee9-plus/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.plus</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.plus.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.plus.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-proxy/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.proxy</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.proxy.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.proxy.*</spotbugs.onlyAnalyze>
   </properties>
   <build>
     <plugins>

--- a/jetty-ee9/jetty-ee9-security/pom.xml
+++ b/jetty-ee9/jetty-ee9-security/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.security</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.security.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.security.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/jetty-ee9/jetty-ee9-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlet/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.servlet</bundle-symbolic-name>
-    <spotbugs.onlyAnalyze>org.eclipse.jetty.*</spotbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.ee9.servlet.*</spotbugs.onlyAnalyze>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2100,17 +2100,6 @@
       </build>
     </profile>
     <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <!-- disable plugins known not to work with JDK 17 (yet) -->
-        <spotbugs.skip>true</spotbugs.skip>
-        <jacoco.skip>true</jacoco.skip>
-      </properties>
-    </profile>
-    <profile>
       <id>update-version</id>
       <build>
         <plugins>


### PR DESCRIPTION
Spotbugs was disabled for JDK 17+ some time ago in 04acdb72f041a15267bb79c36d8fc4d517beaadb. After investigating, if the new Spotbugs releases allow to re-enable the check in the project, I've seen that some packages in the `<spotbugs.onlyAnalyze>` tags are wrong. Those tags were introduced at the [migration from findbugs](https://github.com/eclipse/jetty.project/pull/5735). I've corrected the packages and made adjustments according to the package splitting of the different EE versions.