### PR TITLE
Fix 9.4.51 NullPointerException #9476

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -85,6 +85,12 @@ public abstract class AbstractConnection implements Connection
 
     protected void failedCallback(final Callback callback, final Throwable x)
     {
+        if (callback == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.warn("Callback null", x);
+            }
+            return;
+        }
         Runnable failCallback = () ->
         {
             try
@@ -93,7 +99,7 @@ public abstract class AbstractConnection implements Connection
             }
             catch (Exception e)
             {
-                LOG.warn(e);
+                LOG.warn("Failed callback", e);
             }
         };
 
@@ -107,7 +113,7 @@ public abstract class AbstractConnection implements Connection
                 catch (RejectedExecutionException e)
                 {
                     LOG.debug(e);
-                    callback.failed(x);
+                    failCallback.run();
                 }
                 break;
 


### PR DESCRIPTION
Added a null check for the Callback parameter in o.e.j.iAbstractConnection.failedCallback(Callback, Throwable) so that the subsequent code-flow is not aborted; while the root cause may be ascertained in case debug logging is enabled.

Further, in the case of a RejectedExecutionException when submitting the failCallback, the Runnable is run instead of directly invoking the Callback, so that exceptions in the Callback do not abort the synchronous code-flow.