### PR TITLE
Issue #9476 - Fix 9.4.51 NullPointerException

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -85,14 +85,6 @@ public abstract class AbstractConnection implements Connection
 
     protected void failedCallback(final Callback callback, final Throwable x)
     {
-        if (callback == null)
-        {
-            if (LOG.isDebugEnabled())
-            {
-                LOG.warn("Callback null", x);
-            }
-            return;
-        }
         Runnable failCallback = () ->
         {
             try

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -85,6 +85,12 @@ public abstract class AbstractConnection implements Connection
 
     protected void failedCallback(final Callback callback, final Throwable x)
     {
+        if (callback == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.warn("Callback null", x);
+            }
+            return;
+        }
         Runnable failCallback = () ->
         {
             try
@@ -93,7 +99,7 @@ public abstract class AbstractConnection implements Connection
             }
             catch (Exception e)
             {
-                LOG.warn(e);
+                LOG.warn("Failed callback", e);
             }
         };
 
@@ -107,7 +113,7 @@ public abstract class AbstractConnection implements Connection
                 catch (RejectedExecutionException e)
                 {
                     LOG.debug(e);
-                    callback.failed(x);
+                    failCallback.run();
                 }
                 break;
 

--- a/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -85,8 +85,10 @@ public abstract class AbstractConnection implements Connection
 
     protected void failedCallback(final Callback callback, final Throwable x)
     {
-        if (callback == null) {
-            if (LOG.isDebugEnabled()) {
+        if (callback == null)
+        {
+            if (LOG.isDebugEnabled())
+            {
                 LOG.warn("Callback null", x);
             }
             return;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -897,17 +897,27 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
         @Override
         protected void onCompleteSuccess()
         {
-            release().succeeded();
-            if (_shutdownOut)
-                getEndPoint().shutdownOutput();
+            Callback callback = release();
+            try {
+                if (callback != null)
+                    callback.succeeded();
+            } finally {
+                if (_shutdownOut)
+                    getEndPoint().shutdownOutput();
+            }
         }
 
         @Override
         public void onCompleteFailure(final Throwable x)
         {
-            failedCallback(release(), x);
-            if (_shutdownOut)
-                getEndPoint().shutdownOutput();
+            Callback callback = release();
+            try {
+                if (callback != null)
+                    failedCallback(callback, x);
+            } finally {
+                if (_shutdownOut)
+                    getEndPoint().shutdownOutput();
+            }
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -898,10 +898,13 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
         protected void onCompleteSuccess()
         {
             Callback callback = release();
-            try {
+            try
+            {
                 if (callback != null)
                     callback.succeeded();
-            } finally {
+            }
+            finally
+            {
                 if (_shutdownOut)
                     getEndPoint().shutdownOutput();
             }
@@ -911,10 +914,13 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
         public void onCompleteFailure(final Throwable x)
         {
             Callback callback = release();
-            try {
+            try
+            {
                 if (callback != null)
                     failedCallback(callback, x);
-            } finally {
+            }
+            finally
+            {
                 if (_shutdownOut)
                     getEndPoint().shutdownOutput();
             }


### PR DESCRIPTION
#9476 
Added a null check for the Callback parameter in o.e.j.iAbstractConnection.failedCallback(Callback, Throwable) so that the subsequent code-flow is not aborted; while the root cause may be ascertained in case debug logging is enabled.

Further, in the case of a RejectedExecutionException when submitting the failCallback, the Runnable is run instead of directly invoking the Callback, so that exceptions in the Callback do not abort the synchronous code-flow.