### PR TITLE
Fix #9476 IteratingCallback multiple onCompleteFailure calls

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -405,6 +405,7 @@ public abstract class IteratingCallback implements Callback
                     break;
                 case PENDING:
                 {
+                    _state = State.FAILED;
                     failure = true;
                     break;
                 }


### PR DESCRIPTION
Fix #9476 by changing state to FAILED from PENDING state