### PR TITLE
Fix #9476 IteratingCallback multiple onCompleteFailure calls

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -400,6 +400,7 @@ public abstract class IteratingCallback implements Callback
                     break;
                 case PENDING:
                 {
+                    _state = State.FAILED;
                     failure = true;
                     break;
                 }

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.util;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -321,5 +322,45 @@ public class IteratingCallbackTest
             completed.await(10, TimeUnit.SECONDS);
             return isSucceeded();
         }
+    }
+
+    @Test
+    public void testMultipleFailures() throws Exception
+    {
+        AtomicInteger process = new AtomicInteger();
+        AtomicInteger failure = new AtomicInteger();
+        IteratingCallback icb = new IteratingCallback()
+        {
+            @Override
+            protected Action process() throws Throwable
+            {
+                process.incrementAndGet();
+                return Action.SCHEDULED;
+            }
+
+            @Override
+            protected void onCompleteFailure(Throwable cause)
+            {
+                super.onCompleteFailure(cause);
+                failure.incrementAndGet();
+            }
+        };
+
+        icb.iterate();
+        assertEquals(1, process.get());
+        assertEquals(0, failure.get());
+
+        icb.failed(new Throwable("test1"));
+
+        assertEquals(1, process.get());
+        assertEquals(1, failure.get());
+
+        icb.succeeded();
+        assertEquals(1, process.get());
+        assertEquals(1, failure.get());
+
+        icb.failed(new Throwable("test2"));
+        assertEquals(1, process.get());
+        assertEquals(1, failure.get());
     }
 }


### PR DESCRIPTION
Cherry-picked  from 9.4.x for #9476 
Change state to FAILED from PENDING state