### PR TITLE
Issue #9925 Also use current context for alternate getServletContextHandler method

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -157,6 +157,9 @@ public class ServletContextHandler extends ContextHandler
     {
         if (servletContext instanceof ServletContextApi servletContextApi)
             return servletContextApi.getContext().getServletContextHandler();
+        ServletContextHandler sch = getCurrentServletContextHandler();
+        if (sch != null)
+            return sch;
         throw new IllegalStateException("No Jetty ServletContextHandler, " + purpose + " unavailable");
     }
 


### PR DESCRIPTION
Apply same fix as #9933 for #9925 to `ServletContextHandler.getServletContextHandler(ServletContext, String purpose)` method.