### PR TITLE
Fix flaky DistributionTests.testIniSectionPropertyOverriddenByCommandLine

### DIFF
--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -11,8 +11,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <!-- DistributionTests tests cannot run in parallel as they bind ports hardcoded in the distribution's config files -->
-    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+<!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
   </properties>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -11,7 +11,8 @@
   <packaging>jar</packaging>
 
   <properties>
-<!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
+    <!-- DistributionTests tests cannot run in parallel as they bind ports hardcoded in the distribution's config files -->
+    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
   </properties>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -968,10 +968,10 @@ public class DistributionTests extends AbstractJettyHomeTest
             "\n" +
             "[ini]\n" +
             "" + pathProperty + "=modbased\n";
-        String moduleName = "ssl-ini";
-        Files.writeString(jettyBaseModules.resolve(moduleName + ".mod"), module, StandardOpenOption.CREATE);
+        Files.writeString(jettyBaseModules.resolve("ssl-ini.mod"), module, StandardOpenOption.CREATE);
 
-        try (JettyHomeTester.Run run1 = distribution.start("--add-module=https,test-keystore,ssl-ini"))
+        int port = distribution.freePort();
+        try (JettyHomeTester.Run run1 = distribution.start("--add-module=https,test-keystore,ssl-ini", "jetty.ssl.port=" + port))
         {
             assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());


### PR DESCRIPTION
`DistributionTests` tests bind ports that are hardcoded in the distribution's config files, so they cannot run in parallel otherwise they risk failing to bind the ports.

This is why they've been flaky recently.