### PR TITLE
Update to bundle-plugin-5.1.9

### DIFF
--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -102,8 +102,6 @@
           <configuration>
             <!-- jetty-runner is not an OSGi component -->
             <skip>true</skip>
-            <!-- there is no way to skip MANIFEST creation by the plugin so just configure dummy location -->
-            <manifestLocation>${project.build.directory}/NON_USED_MANIFEST</manifestLocation>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <license.maven.plugin.version>4.1</license.maven.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>
-    <maven.bundle.plugin.version>5.1.8</maven.bundle.plugin.version>
+    <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
     <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
     <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
     <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -57,6 +57,24 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultEntries/>
+              </manifest>
+              <manifestEntries>
+                <Comment>Jetty Jmh Support Classes</Comment>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencies>


### PR DESCRIPTION
The dependabot automatic update to bundle-plugin 5.1.9 needed a more complex fix, this is that fix.