### PR TITLE
#9984 fix URLResourceFactory isDirectory and newReadableByteChannel

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -109,7 +110,7 @@ public class URLResourceFactory implements ResourceFactory
         @Override
         public boolean isDirectory()
         {
-            return uri.getPath().endsWith("/");
+            return uri.getSchemeSpecificPart().endsWith("/");
         }
 
         @Override
@@ -200,10 +201,9 @@ public class URLResourceFactory implements ResourceFactory
         }
 
         @Override
-        public ReadableByteChannel newReadableByteChannel()
+        public ReadableByteChannel newReadableByteChannel() throws IOException
         {
-            // not really possible with the URL interface
-            return null;
+            return Channels.newChannel(newInputStream());
         }
 
         @Override


### PR DESCRIPTION
Here are a couple of small fixes reported to us by the Spring team here: https://github.com/eclipse/jetty.project/issues/9984

The Jetty code base never goes into those codepaths, but they're nevertheless incorrect.