### PR TITLE
Add constructors accepting the handler to wrap to all core handler wrappers

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/extras/default-handler.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/extras/default-handler.adoc
@@ -31,17 +31,17 @@ There is also an link:#error-handler[Error Handler] that services errors related
 
 _____
 [NOTE]
-The `DefaultHandler` will also handle serving out the `flav.ico` file should a request make it through all of the other handlers without being resolved.
+The `DefaultHandler` will also handle serving out the `favicon.ico` file should a request make it through all of the other handlers without being resolved.
 _____
 
 [source, java, subs="{sub-order}"]
 ----
     Server server = new Server(8080);
-    HandlerList handlers = new HandlerList();
     ResourceHandler resourceHandler = new ResourceHandler();
-    resourceHandler.setBaseResource(Resource.newResource("."));
-    handlers.setHandlers(new Handler[]
-    { resourceHandler, new DefaultHandler() });
+    resourceHandler.setBaseResource(ResourceFactory.of(resourceHandler).newResource("."));
+    Handler.Sequence handlers = new Handler.Sequence(
+        resourceHandler, new DefaultHandler()
+    );
     server.setHandler(handlers);
     server.start();
 ----

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
@@ -46,7 +46,7 @@ The Jetty Server Libraries provides a number of out-of-the-box __Handler__s that
 ====== ContextHandler
 
 `ContextHandler` is a `Handler` that represents a _context_ for a web application.
-It is a `HandlerWrapper` that performs some action before and after delegating to the nested `Handler`.
+It is a `Handler.Wrapper` that performs some action before and after delegating to the nested `Handler`.
 // TODO: expand on what the ContextHandler does, e.g. ServletContext.
 
 The simplest use of `ContextHandler` is the following:
@@ -140,7 +140,7 @@ See also xref:pg-server-http-handler-use-util-default-handler[how to use] `Defau
 
 `GzipHandler` provides supports for automatic decompression of compressed request content and automatic compression of response content.
 
-`GzipHandler` is a `HandlerWrapper` that inspects the request and, if the request matches the `GzipHandler` configuration, just installs the required components to eventually perform decompression of the request content or compression of the response content.
+`GzipHandler` is a `Handler.Wrapper` that inspects the request and, if the request matches the `GzipHandler` configuration, just installs the required components to eventually perform decompression of the request content or compression of the response content.
 The decompression/compression is not performed until the web application reads request content or writes response content.
 
 `GzipHandler` can be configured at the server level in this way:
@@ -291,7 +291,7 @@ include::../../{doc_code}/org/eclipse/jetty/docs/programming/server/http/HTTPSer
 * Sends a HTTP `404` response for any other request
 * The HTTP `404` response content nicely shows a HTML table with all the contexts deployed on the `Server` instance
 
-`DefaultHandler` is best used as the last `Handler` of a `HandlerList`, for example:
+`DefaultHandler` is best used directly set on the server, for example:
 
 [source,java,indent=0]
 ----
@@ -310,7 +310,7 @@ Server
   └── DefaultHandler
 ----
 
-In the example above, `ContextHandlerCollection` will try to match a request to one of the contexts; if the match fails, `HandlerList` will call the next `Handler` which is `DefaultHandler` that will return a HTTP `404` with an HTML page showing the existing contexts deployed on the `Server`.
+In the example above, `ContextHandlerCollection` will try to match a request to one of the contexts; if the match fails, `Server` will call the `DefaultHandler` that will return a HTTP `404` with an HTML page showing the existing contexts deployed on the `Server`.
 
 NOTE: `DefaultHandler` just sends a nicer HTTP `404` response in case of wrong requests from clients.
 Jetty will send an HTTP `404` response anyway if `DefaultHandler` is not used.

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -43,15 +43,15 @@ public class RewriteHandler extends Handler.Wrapper
 
     public RewriteHandler()
     {
-        this(new RuleContainer(), null);
+        this(null, new RuleContainer());
     }
 
     public RewriteHandler(RuleContainer rules)
     {
-        this(rules, null);
+        this(null, rules);
     }
 
-    public RewriteHandler(RuleContainer rules, Handler handler)
+    public RewriteHandler(Handler handler, RuleContainer rules)
     {
         super(handler);
         _rules = rules;

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -43,11 +43,17 @@ public class RewriteHandler extends Handler.Wrapper
 
     public RewriteHandler()
     {
-        this(new RuleContainer());
+        this(new RuleContainer(), null);
     }
 
     public RewriteHandler(RuleContainer rules)
     {
+        this(rules, null);
+    }
+
+    public RewriteHandler(RuleContainer rules, Handler handler)
+    {
+        super(handler);
         _rules = rules;
         addBean(_rules);
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -51,6 +51,11 @@ public class RewriteHandler extends Handler.Wrapper
         this(null, rules);
     }
 
+    public RewriteHandler(Handler handler)
+    {
+        this(handler, new RuleContainer());
+    }
+
     public RewriteHandler(Handler handler, RuleContainer rules)
     {
         super(handler);

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -651,6 +651,7 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
 
         public PathMapped()
         {
+            this(null);
         }
 
         public PathMapped(Handler handler)

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -87,6 +87,12 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
 
     protected SecurityHandler()
     {
+        this(null);
+    }
+
+    protected SecurityHandler(Handler handler)
+    {
+        super(handler);
         addBean(new DumpableCollection("knownAuthenticatorFactories", __knownAuthenticatorFactories));
     }
 
@@ -645,6 +651,11 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
 
         public PathMapped()
         {
+        }
+
+        public PathMapped(Handler handler)
+        {
+            super(handler);
         }
 
         public Constraint put(String pathSpec, Constraint constraint)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -65,6 +65,12 @@ public class BufferedResponseHandler extends Handler.Wrapper
 
     public BufferedResponseHandler()
     {
+        this(null);
+    }
+
+    public BufferedResponseHandler(Handler handler)
+    {
+        super(handler);
         _methods.include(HttpMethod.GET.asString());
         for (String type : MimeTypes.DEFAULTS.getMimeMap().values())
         {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
@@ -77,7 +77,7 @@ public class ConnectHandler extends Handler.Wrapper
 
     public ConnectHandler(Handler handler)
     {
-        setHandler(handler);
+        super(handler);
     }
 
     public Executor getExecutor()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -159,11 +159,22 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
     public ContextHandler()
     {
-        this(null);
+        this(null, null);
+    }
+
+    public ContextHandler(Handler handler)
+    {
+        this(null, handler);
     }
 
     public ContextHandler(String contextPath)
     {
+        this(contextPath, null);
+    }
+
+    public ContextHandler(String contextPath, Handler handler)
+    {
+        super(handler);
         _context = newContext();
         if (contextPath != null)
             setContextPath(contextPath);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -164,15 +164,15 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
     public ContextHandler(Handler handler)
     {
-        this(null, handler);
+        this(handler, null);
     }
 
     public ContextHandler(String contextPath)
     {
-        this(contextPath, null);
+        this(null, contextPath);
     }
 
-    public ContextHandler(String contextPath, Handler handler)
+    public ContextHandler(Handler handler, String contextPath)
     {
         super(handler);
         _context = newContext();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
@@ -41,6 +41,15 @@ public class DebugHandler extends Handler.Wrapper implements Connection.Listener
     private OutputStream _out;
     private PrintStream _print;
 
+    public DebugHandler()
+    {
+    }
+
+    public DebugHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     @Override
     public boolean handle(Request request, Response response, Callback callback) throws Exception
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DebugHandler.java
@@ -43,6 +43,7 @@ public class DebugHandler extends Handler.Wrapper implements Connection.Listener
 
     public DebugHandler()
     {
+        this(null);
     }
 
     public DebugHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
@@ -40,6 +40,7 @@ public class DelayedHandler extends Handler.Wrapper
 {
     public DelayedHandler()
     {
+        this(null);
     }
 
     public DelayedHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DelayedHandler.java
@@ -38,6 +38,15 @@ import org.eclipse.jetty.util.StringUtil;
 
 public class DelayedHandler extends Handler.Wrapper
 {
+    public DelayedHandler()
+    {
+    }
+
+    public DelayedHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     @Override
     public boolean handle(Request request, Response response, Callback callback) throws Exception
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
@@ -55,6 +55,7 @@ public abstract class EventsHandler extends Handler.Wrapper
     
     public EventsHandler()
     {
+        this(null);
     }
 
     public EventsHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -39,6 +39,12 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
 
     public GracefulHandler()
     {
+        this(null);
+    }
+
+    public GracefulHandler(Handler handler)
+    {
+        super(handler);
         _shutdown = new Shutdown(this)
         {
             @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
@@ -36,6 +36,15 @@ public class IdleTimeoutHandler extends Handler.Wrapper
     private long _idleTimeoutMs = 1000;
     private boolean _applyToAsync = false;
 
+    public IdleTimeoutHandler()
+    {
+    }
+
+    public IdleTimeoutHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     public boolean isApplyToAsync()
     {
         return _applyToAsync;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/IdleTimeoutHandler.java
@@ -38,6 +38,7 @@ public class IdleTimeoutHandler extends Handler.Wrapper
 
     public IdleTimeoutHandler()
     {
+        this(null);
     }
 
     public IdleTimeoutHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -47,6 +47,15 @@ public class InetAccessHandler extends Handler.Wrapper
 
     private final IncludeExcludeSet<PatternTuple, AccessTuple> _set = new IncludeExcludeSet<>(InetAccessSet.class);
 
+    public InetAccessHandler()
+    {
+    }
+
+    public InetAccessHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     /**
      * Clears all the includes, excludes, included connector names and excluded
      * connector names.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/InetAccessHandler.java
@@ -49,6 +49,7 @@ public class InetAccessHandler extends Handler.Wrapper
 
     public InetAccessHandler()
     {
+        this(null);
     }
 
     public InetAccessHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -63,6 +63,15 @@ public class ResourceHandler extends Handler.Wrapper
     private MimeTypes _mimeTypes;
     private List<String> _welcomes = List.of("index.html");
 
+    public ResourceHandler()
+    {
+    }
+
+    public ResourceHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     protected ResourceService newResourceService()
     {
         return new HandlerResourceService();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -65,6 +65,7 @@ public class ResourceHandler extends Handler.Wrapper
 
     public ResourceHandler()
     {
+        this(null);
     }
 
     public ResourceHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -47,17 +47,27 @@ public class SecuredRedirectHandler extends Handler.Wrapper
      */
     public SecuredRedirectHandler()
     {
-        this(HttpStatus.MOVED_TEMPORARILY_302);
+        this(null, HttpStatus.MOVED_TEMPORARILY_302);
+    }
+
+    /**
+     * Uses moved temporarily code (302) as the redirect code.
+     */
+    public SecuredRedirectHandler(Handler handler)
+    {
+        this(handler, HttpStatus.MOVED_TEMPORARILY_302);
     }
 
     /**
      * Use supplied code as the redirect code.
      *
+     * @param handler the handler to wrap
      * @param code the redirect code to use in the response
      * @throws IllegalArgumentException if parameter is an invalid redirect code
      */
-    public SecuredRedirectHandler(final int code)
+    public SecuredRedirectHandler(Handler handler, final int code)
     {
+        super(handler);
         if (!HttpStatus.isRedirection(code))
             throw new IllegalArgumentException("Not a 3xx redirect code");
         _redirectCode = code;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -51,6 +51,17 @@ public class SecuredRedirectHandler extends Handler.Wrapper
     }
 
     /**
+     * Use supplied code as the redirect code.
+     *
+     * @param code the redirect code to use in the response
+     * @throws IllegalArgumentException if parameter is an invalid redirect code
+     */
+    public SecuredRedirectHandler(int code)
+    {
+        this(null, code);
+    }
+
+    /**
      * Uses moved temporarily code (302) as the redirect code.
      */
     public SecuredRedirectHandler(Handler handler)
@@ -65,7 +76,7 @@ public class SecuredRedirectHandler extends Handler.Wrapper
      * @param code the redirect code to use in the response
      * @throws IllegalArgumentException if parameter is an invalid redirect code
      */
-    public SecuredRedirectHandler(Handler handler, final int code)
+    public SecuredRedirectHandler(Handler handler, int code)
     {
         super(handler);
         if (!HttpStatus.isRedirection(code))

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
@@ -91,7 +91,7 @@ public class ShutdownHandler extends Handler.Wrapper
      */
     public ShutdownHandler(String shutdownToken)
     {
-        this(null, shutdownToken, false, null);
+        this(null, null, shutdownToken, false);
     }
 
     /**
@@ -102,18 +102,18 @@ public class ShutdownHandler extends Handler.Wrapper
      */
     public ShutdownHandler(String shutdownToken, boolean exitJVM)
     {
-        this(null, shutdownToken, exitJVM, null);
+        this(null, null, shutdownToken, exitJVM);
     }
 
     /**
      * Creates a Handler that lets the server be shut down remotely (but only from localhost).
      *
+     * @param handler the handler to wrap
      * @param shutdownPath the path to respond to shutdown requests against (default is "{@code /shutdown}")
      * @param shutdownToken a secret password to avoid unauthorized shutdown attempts
      * @param exitJVM If true, when the shutdown is executed, the handler class System.exit()
-     * @param handler the handler to wrap
      */
-    public ShutdownHandler(String shutdownPath, String shutdownToken, boolean exitJVM, Handler handler)
+    public ShutdownHandler(Handler handler, String shutdownPath, String shutdownToken, boolean exitJVM)
     {
         super(handler);
         this._shutdownPath = StringUtil.isBlank(shutdownPath) ? "/shutdown" : shutdownPath;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java
@@ -91,7 +91,7 @@ public class ShutdownHandler extends Handler.Wrapper
      */
     public ShutdownHandler(String shutdownToken)
     {
-        this(null, shutdownToken, false);
+        this(null, shutdownToken, false, null);
     }
 
     /**
@@ -102,7 +102,7 @@ public class ShutdownHandler extends Handler.Wrapper
      */
     public ShutdownHandler(String shutdownToken, boolean exitJVM)
     {
-        this(null, shutdownToken, exitJVM);
+        this(null, shutdownToken, exitJVM, null);
     }
 
     /**
@@ -111,9 +111,11 @@ public class ShutdownHandler extends Handler.Wrapper
      * @param shutdownPath the path to respond to shutdown requests against (default is "{@code /shutdown}")
      * @param shutdownToken a secret password to avoid unauthorized shutdown attempts
      * @param exitJVM If true, when the shutdown is executed, the handler class System.exit()
+     * @param handler the handler to wrap
      */
-    public ShutdownHandler(String shutdownPath, String shutdownToken, boolean exitJVM)
+    public ShutdownHandler(String shutdownPath, String shutdownToken, boolean exitJVM, Handler handler)
     {
+        super(handler);
         this._shutdownPath = StringUtil.isBlank(shutdownPath) ? "/shutdown" : shutdownPath;
         this._shutdownToken = shutdownToken;
         this._exitJvm = exitJVM;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -241,17 +241,17 @@ public class StatisticsHandler extends EventsHandler
          */
         public MinimumDataRateHandler(long minimumReadRate, long minimumWriteRate)
         {
-            _minimumReadRate = minimumReadRate;
-            _minimumWriteRate = minimumWriteRate;
+            this(null, minimumReadRate, minimumWriteRate);
         }
 
         /**
          * Creates a {@code MinimumDataRateHandler} with the specified read and write rates.
+         *
+         * @param handler the handler to wrap.
          * @param minimumReadRate the minimum number of bytes to be read per second, or 0 for not checking the read rate.
          * @param minimumWriteRate the minimum number of bytes to be written per second, or 0 for not checking the write rate.
-         * @param handler the handler to wrap.
          */
-        public MinimumDataRateHandler(long minimumReadRate, long minimumWriteRate, Handler handler)
+        public MinimumDataRateHandler(Handler handler, long minimumReadRate, long minimumWriteRate)
         {
             super(handler);
             _minimumReadRate = minimumReadRate;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
@@ -80,17 +80,22 @@ public class ThreadLimitHandler extends Handler.Wrapper
 
     public ThreadLimitHandler()
     {
-        this(null, true);
+        this(null, true, null);
     }
 
     public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader)
     {
-        this(forwardedHeader, HttpHeader.FORWARDED.is(forwardedHeader));
+        this(forwardedHeader, HttpHeader.FORWARDED.is(forwardedHeader), null);
     }
 
     public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader, @Name("rfc7239") boolean rfc7239)
     {
-        super();
+        this(forwardedHeader, rfc7239, null);
+    }
+
+    public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader, @Name("rfc7239") boolean rfc7239, @Name("handler") Handler handler)
+    {
+        super(handler);
         _rfc7239 = rfc7239;
         _forwardedHeader = forwardedHeader;
         _enabled = true;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
@@ -80,20 +80,20 @@ public class ThreadLimitHandler extends Handler.Wrapper
 
     public ThreadLimitHandler()
     {
-        this(null, true, null);
+        this(null, null, true);
     }
 
     public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader)
     {
-        this(forwardedHeader, HttpHeader.FORWARDED.is(forwardedHeader), null);
+        this(null, forwardedHeader, HttpHeader.FORWARDED.is(forwardedHeader));
     }
 
     public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader, @Name("rfc7239") boolean rfc7239)
     {
-        this(forwardedHeader, rfc7239, null);
+        this(null, forwardedHeader, rfc7239);
     }
 
-    public ThreadLimitHandler(@Name("forwardedHeader") String forwardedHeader, @Name("rfc7239") boolean rfc7239, @Name("handler") Handler handler)
+    public ThreadLimitHandler(@Name("handler") Handler handler, @Name("forwardedHeader") String forwardedHeader, @Name("rfc7239") boolean rfc7239)
     {
         super(handler);
         _rfc7239 = rfc7239;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -73,6 +73,7 @@ public class TryPathsHandler extends Handler.Wrapper
 
     public TryPathsHandler()
     {
+        this(null);
     }
 
     public TryPathsHandler(Handler handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/TryPathsHandler.java
@@ -71,6 +71,15 @@ public class TryPathsHandler extends Handler.Wrapper
     private String originalQueryAttribute;
     private List<String> paths;
 
+    public TryPathsHandler()
+    {
+    }
+
+    public TryPathsHandler(Handler handler)
+    {
+        super(handler);
+    }
+
     /**
      * @return the attribute name of the original request path
      */

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -63,6 +63,16 @@ public class GzipHandler extends Handler.Wrapper implements GzipFactory
      */
     public GzipHandler()
     {
+        this(null);
+    }
+
+    /**
+     * Instantiates a new GzipHandler.
+     * @param handler the handler to wrap
+     */
+    public GzipHandler(Handler handler)
+    {
+        super(handler);
         _methods.include(HttpMethod.GET.asString());
         _methods.include(HttpMethod.POST.asString());
         for (String type : MimeTypes.DEFAULTS.getMimeMap().values())

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -158,7 +158,7 @@ public class StatisticsHandlerTest
         AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         int expectedContentLength = 1000;
-        StatisticsHandler.MinimumDataRateHandler mdrh = new StatisticsHandler.MinimumDataRateHandler(0, 1000, new Handler.Abstract.NonBlocking()
+        StatisticsHandler.MinimumDataRateHandler mdrh = new StatisticsHandler.MinimumDataRateHandler(new Handler.Abstract.NonBlocking()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -217,7 +217,7 @@ public class StatisticsHandlerTest
                     response.write(true, ByteBuffer.allocate(1), finalCallback);
                 }
             }
-        });
+        }, 0, 1000);
 
         _latchHandler.setHandler(mdrh);
         _server.start();


### PR DESCRIPTION
Add constructors that accept the wrapped handler to all core `Handler.Wrapper` subclasses

This allows the chaining of hander wrappers in a more elegant way; this is how we currently do it:

```java
GzipHandler handler = new GzipHandler();
handler.setHandler(new EchoHandler());
server.setHandler(handler);
```

and this is what this change allows us to write:

```java
server.setHandler(new GzipHandler(new EchoHandler()));
```
