### PR TITLE
Fix Path to URL conversion for windows users

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
@@ -88,7 +88,7 @@ public class UrlResourceFactoryTest
     {
         Path path = MavenTestingUtils.getTestResourcePath("example.jar");
         int fileSize = (int)Files.size(path);
-        URL fileUrl = new URL("file:" + path.toUri().toASCIIString());
+        URL fileUrl = path.toUri().toURL();
         URLResourceFactory urlResourceFactory = new URLResourceFactory();
         Resource resource = urlResourceFactory.newResource(fileUrl);
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
@@ -88,7 +88,7 @@ public class UrlResourceFactoryTest
     {
         Path path = MavenTestingUtils.getTestResourcePath("example.jar");
         int fileSize = (int)Files.size(path);
-        URL fileUrl = new URL("file:" + path.toAbsolutePath());
+        URL fileUrl = new URL("file:" + path.toUri().toASCIIString());
         URLResourceFactory urlResourceFactory = new URLResourceFactory();
         Resource resource = urlResourceFactory.newResource(fileUrl);
 
@@ -106,7 +106,7 @@ public class UrlResourceFactoryTest
     public void testJarFileUrl() throws Exception
     {
         Path path = MavenTestingUtils.getTestResourcePath("example.jar");
-        URL jarFileUrl = new URL("jar:file:" + path.toAbsolutePath() + "!/WEB-INF/web.xml");
+        URL jarFileUrl = new URL("jar:" + path.toUri().toASCIIString() + "!/WEB-INF/web.xml");
         int fileSize = (int)fileSize(jarFileUrl);
         URLResourceFactory urlResourceFactory = new URLResourceFactory();
         Resource resource = urlResourceFactory.newResource(jarFileUrl);


### PR DESCRIPTION
Fixing UrlResourceFactoryTest to convert from Path to URL properly for users building on Windows.