### PR TITLE
Issue #9973 - Unwrap URI.scheme-specific-parts until we find a path we can resolve against.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 
 import org.eclipse.jetty.util.FileID;
+import org.eclipse.jetty.util.URIUtil;
 
 /**
  * {@link ResourceFactory} for {@link java.net.URL} based resources.
@@ -122,7 +123,7 @@ public class URLResourceFactory implements ResourceFactory
         @Override
         public URI getURI()
         {
-            return uri;
+            return URIUtil.correctFileURI(uri);
         }
 
         @Override
@@ -140,7 +141,7 @@ public class URLResourceFactory implements ResourceFactory
         @Override
         public Resource resolve(String subUriPath)
         {
-            URI newURI = uri.resolve(subUriPath);
+            URI newURI = resolve(uri, subUriPath);
             try
             {
                 return new URLResource(newURI, this.connectTimeout, this.useCaches);
@@ -148,6 +149,20 @@ public class URLResourceFactory implements ResourceFactory
             catch (MalformedURLException e)
             {
                 return null;
+            }
+        }
+
+        // This could probably live in URIUtil, but it's awefully specific to URLResourceFactory.
+        private static URI resolve(URI parent, String path)
+        {
+            if (parent.getPath() == null)
+            {
+                URI resolved = resolve(URI.create(parent.getRawSchemeSpecificPart()), path);
+                return URI.create(parent.getScheme() + ":" + resolved.toASCIIString());
+            }
+            else
+            {
+                return parent.resolve(path);
             }
         }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
@@ -155,14 +155,19 @@ public class URLResourceFactory implements ResourceFactory
         // This could probably live in URIUtil, but it's awefully specific to URLResourceFactory.
         private static URI resolve(URI parent, String path)
         {
-            if (parent.getPath() == null)
+            if (parent.isOpaque() && parent.getPath() == null)
             {
                 URI resolved = resolve(URI.create(parent.getRawSchemeSpecificPart()), path);
                 return URI.create(parent.getScheme() + ":" + resolved.toASCIIString());
             }
-            else
+            else if (parent.getPath() != null)
             {
                 return parent.resolve(path);
+            }
+            else
+            {
+                // Not possible to use URLs that without a path in Jetty.
+                throw new RuntimeException("URL without path not supported by Jetty: " + parent);
             }
         }
 


### PR DESCRIPTION
URLResourceFactory will unwrap opaque URIs (eg: `jar:file:///example.jar!/`) until it finds a URI with a path it can apply the `resolve(String)` against, and the rebuild the URI.

Not very efficient, but it is URI correct behavior.