### PR TITLE
do not automatically quote system properties containing spaces

### DIFF
--- a/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -441,7 +441,7 @@ public class Main
         {
             CommandLineBuilder cmd = args.getMainArgs(args.getDryRunParts());
             cmd.debug();
-            System.out.println(cmd.toQuotedString());
+            System.out.println(cmd);
         }
 
         if (args.isStopCommand())

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1308,13 +1308,17 @@ public class DistributionTests extends AbstractJettyHomeTest
             assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());
 
-            String[] args2 = {"--dry-run"};
+            String systemProp = "-Dtest=\"foo bar\"";
+            String[] args2 = {systemProp, "--dry-run"};
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
                 run2.awaitFor(5, TimeUnit.SECONDS);
                 Queue<String> logs = run2.getLogs();
                 assertThat(logs.size(), equalTo(1));
-                assertThat(logs.poll(), not(containsString("${jetty.home.uri}")));
+                String log = logs.poll();
+                assertThat(log, not(containsString("${jetty.home.uri}")));
+                assertThat(log, not(containsString("'" + systemProp)));
+                assertThat(log, containsString(systemProp));
             }
         }
     }


### PR DESCRIPTION
See Issue https://github.com/eclipse/jetty.docker/issues/148

Currently this command 
```sh
 java -jar ~/webtide/jetty-10.0.x/jetty-home/target/jetty-home/start.jar -Dprop="\"foo bar\"" --dry-run
```

Quotes the system property like this in the generated command `'-Dprop="foo bar"'`.
This means it is impossible to use spaces in properties. 

Because of this I have removed the use of `CommandLineBuildertoQuotedString()` and use `CommandLineBuilder.toString()` instead. And if you want the args quoted it will have to be done explicitly.