### PR TITLE
Issue #10055 - fix core deploy with --dry-run

### DIFF
--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -693,7 +693,12 @@ public class StartArgs
                 // TODO module path
 
                 for (Prop property : environment.getProperties())
-                    cmd.addArg(property.key + "=" + property.value);
+                {
+                    String value = property.value;
+                    if (isDryRun() && value != null && value.contains("$"))
+                        value = "'" + value + "'";
+                    cmd.addArg(property.key + "=" + value);
+                }
 
                 for (Path xmlFile : environment.getXmlFiles())
                     cmd.addArg(xmlFile.toAbsolutePath().toString());


### PR DESCRIPTION
## Fixes #10055

Use single quotes around property values containing `$` for `--dry-run`.