### PR TITLE
Simplified URLResource cleaner

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
@@ -324,11 +324,10 @@ public class URLResourceFactory implements ResourceFactory
                 // Called when the URLResource that held the same InputStream has been collected
                 InputStream in = getAndSet(null);
                 if (in != null)
-                {
                     IO.close(in);
-                    if (ON_SWEEP_LISTENER != null)
-                        ON_SWEEP_LISTENER.accept(in);
-                }
+
+                if (ON_SWEEP_LISTENER != null)
+                    ON_SWEEP_LISTENER.accept(in);
             }
         }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
@@ -110,8 +110,6 @@ public class UrlResourceFactoryTest
         Resource webResource = resource.resolve("/web.xml");
         assertTrue(webResource.exists());
 
-        webResource = null;
-
         await().atMost(5, TimeUnit.SECONDS).until(() ->
         {
             System.gc();

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -106,15 +107,45 @@ public class UrlResourceFactoryTest
                 cleanedRefCount.incrementAndGet();
         };
         Resource resource = urlResourceFactory.newResource(jarFileUri.toURL());
-
         Resource webResource = resource.resolve("/web.xml");
         assertTrue(webResource.exists());
+        resource = null;
+        webResource = null;
+        assertThat(resource, nullValue());
+        assertThat(webResource, nullValue());
 
         await().atMost(5, TimeUnit.SECONDS).until(() ->
         {
             System.gc();
             return cleanedRefCount.get() > 0;
         });
+    }
+
+    @Test
+    public void testTakenInputStreamNotClosedOnCleanUp() throws Exception
+    {
+        Path path = MavenTestingUtils.getTestResourcePath("example.jar");
+        URI jarFileUri = URI.create("jar:" + path.toUri().toASCIIString() + "!/WEB-INF/");
+
+        AtomicInteger cleanedRefCount = new AtomicInteger();
+        URLResourceFactory urlResourceFactory = new URLResourceFactory();
+        URLResourceFactory.ON_SWEEP_LISTENER = in -> cleanedRefCount.incrementAndGet();
+        Resource resource = urlResourceFactory.newResource(jarFileUri.toURL());
+        Resource webResource = resource.resolve("/web.xml");
+        assertTrue(webResource.exists());
+        InputStream in = webResource.newInputStream();
+        resource = null;
+        webResource = null;
+        assertThat(resource, nullValue());
+        assertThat(webResource, nullValue());
+        await().atMost(5, TimeUnit.SECONDS).until(() ->
+        {
+            System.gc();
+            return cleanedRefCount.get() > 0;
+        });
+
+        String webXml = IO.toString(in);
+        assertThat(webXml, is("WEB-INF/web.xml"));
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/UrlResourceFactoryTest.java
@@ -100,9 +100,9 @@ public class UrlResourceFactoryTest
 
         AtomicInteger cleanedRefCount = new AtomicInteger();
         URLResourceFactory urlResourceFactory = new URLResourceFactory();
-        URLResourceFactory.ON_SWEEP_LISTENER = ref ->
+        URLResourceFactory.ON_SWEEP_LISTENER = in ->
         {
-            if (ref != null && ref.get() != null)
+            if (in != null)
                 cleanedRefCount.incrementAndGet();
         };
         Resource resource = urlResourceFactory.newResource(jarFileUri.toURL());


### PR DESCRIPTION
The reference to the InputStream does not need to be soft/weak as a hard reference to it does not prevent the URLResource itself from being collected.  Also by making a runnable record, there is one less allocation per input stream creation.