### PR TITLE
Issue #8556 Allow getSessionTimeout to be called when not starting

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletContextHandler.java
@@ -1423,8 +1423,6 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public int getSessionTimeout()
         {
-            if (!isStarting())
-                throw new IllegalStateException();
             if (!_enabled)
                 throw new UnsupportedOperationException();
 

--- a/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
+++ b/jetty-servlet/src/test/java/org/eclipse/jetty/servlet/ServletContextHandlerTest.java
@@ -767,6 +767,7 @@ public class ServletContextHandlerTest
         Integer timeout = Integer.valueOf(100);
         ServletContextHandler root = new ServletContextHandler(contexts, "/", ServletContextHandler.SESSIONS);
         root.getSessionHandler().setMaxInactiveInterval((int)TimeUnit.MINUTES.toSeconds(startMin));
+        root.addServlet(new ServletHolder(TestSessionTimeoutServlet.class), "/");
         root.addBean(new MySCIStarter(root.getServletContext(), new MySCI(true, timeout.intValue())), true);
         _server.start();
 
@@ -781,6 +782,17 @@ public class ServletContextHandlerTest
         assertTrue((Boolean)root.getServletContext().getAttribute("MyContextListener.getSessionTimeout"));
         //test can't set session timeout from ContextListener that is not from annotation or web.xml
         assertTrue((Boolean)root.getServletContext().getAttribute("MyContextListener.setSessionTimeout"));
+
+        //test accessing timeout from a servlet
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET / HTTP/1.1\r\n");
+        rawRequest.append("Host: local\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertEquals(200, response.getStatus(), "response status");
+        assertEquals("SessionTimeout = " + timeout, response.getContent(), "response content");
     }
 
     @Test
@@ -2063,6 +2075,20 @@ public class ServletContextHandlerTest
         {
             resp.getWriter().write("Added");
             resp.getWriter().close();
+        }
+    }
+
+    public static class TestSessionTimeoutServlet extends HttpServlet
+    {
+        private static final long serialVersionUID = 1L;
+
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException
+        {
+            int t = req.getServletContext().getSessionTimeout();
+            resp.setStatus(HttpServletResponse.SC_OK);
+            PrintWriter writer = resp.getWriter();
+            writer.write("SessionTimeout = " + t);
         }
     }
 


### PR DESCRIPTION
Closes #8556 

`ServletContext.getSessionTimeout()` should be able to be called outside of the startup sequence.