### PR TITLE
Issue #10066 - Allow customization of `SAXParserFactory` and `SAXParser` in `XmlParser`

### DIFF
--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -66,7 +66,7 @@ public class XmlParser
      */
     public XmlParser()
     {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = newSAXParserFactory();
         boolean validatingDefault = factory.getClass().toString().contains("org.apache.xerces.");
         String validatingProp = System.getProperty("org.eclipse.jetty.xml.XmlParser.Validating", validatingDefault ? "true" : "false");
         boolean validating = Boolean.valueOf(validatingProp).booleanValue();
@@ -83,11 +83,16 @@ public class XmlParser
         return _lock.lock();
     }
 
+    protected SAXParserFactory newSAXParserFactory()
+    {
+        return SAXParserFactory.newInstance();
+    }
+
     public void setValidating(boolean validating)
     {
         try
         {
-            SAXParserFactory factory = SAXParserFactory.newInstance();
+            SAXParserFactory factory = newSAXParserFactory();
             factory.setValidating(validating);
             _parser = factory.newSAXParser();
 
@@ -127,6 +132,11 @@ public class XmlParser
     public boolean isValidating()
     {
         return _parser.isValidating();
+    }
+
+    public SAXParser getParser()
+    {
+        return _parser;
     }
 
     public void redirectEntity(String name, URL entity)

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -134,7 +134,7 @@ public class XmlParser
         return _parser.isValidating();
     }
 
-    public SAXParser getParser()
+    public SAXParser getSAXParser()
     {
         return _parser;
     }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -15,8 +15,17 @@ package org.eclipse.jetty.xml;
 
 import java.net.URL;
 
-import org.junit.jupiter.api.Test;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class XmlParserTest
@@ -37,5 +46,29 @@ public class XmlParserTest
 
         assertTrue(testDocStr.startsWith("<Configure"));
         assertTrue(testDocStr.endsWith("</Configure>"));
+    }
+
+    /**
+     * Customize SAXParserFactory behavior.
+     */
+    @Test
+    public void testNewSAXParserFactory()
+    {
+        XmlParser xmlParser = new XmlParser()
+        {
+            @Override
+            protected SAXParserFactory newSAXParserFactory()
+            {
+                SAXParserFactory saxParserFactory = super.newSAXParserFactory();
+                // Configure at factory level
+                saxParserFactory.setXIncludeAware(false);
+                return saxParserFactory;
+            }
+        };
+
+        SAXParser saxParser = xmlParser.getParser();
+        assertNotNull(saxParser);
+        // look to see it was set at parser level
+        assertFalse(saxParser.isNamespaceAware());
     }
 }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -15,14 +15,10 @@ package org.eclipse.jetty.xml;
 
 import java.net.URL;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.junit.jupiter.api.Test;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.XMLReader;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -66,7 +62,7 @@ public class XmlParserTest
             }
         };
 
-        SAXParser saxParser = xmlParser.getParser();
+        SAXParser saxParser = xmlParser.getSAXParser();
         assertNotNull(saxParser);
         // look to see it was set at parser level
         assertFalse(saxParser.isNamespaceAware());

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -18,6 +18,8 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,7 +49,7 @@ public class XmlParserTest
      * Customize SAXParserFactory behavior.
      */
     @Test
-    public void testNewSAXParserFactory()
+    public void testNewSAXParserFactory() throws SAXException
     {
         XmlParser xmlParser = new XmlParser()
         {
@@ -63,7 +65,9 @@ public class XmlParserTest
 
         SAXParser saxParser = xmlParser.getSAXParser();
         assertNotNull(saxParser);
-        // look to see it was set at parser level
-        assertFalse(saxParser.isNamespaceAware());
+
+        XMLReader xmlReader = saxParser.getXMLReader();
+        // look to see it was set at XMLReader level
+        assertFalse(xmlReader.getFeature("http://apache.org/xml/features/xinclude"));
     }
 }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -24,6 +24,7 @@ import org.xml.sax.XMLReader;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class XmlParserTest
 {
@@ -67,6 +68,8 @@ public class XmlParserTest
         assertNotNull(saxParser);
 
         XMLReader xmlReader = saxParser.getXMLReader();
+        // Only run testcase if Xerces is being used.
+        assumeTrue(xmlReader.getClass().getName().contains("org.apache.xerces."));
         // look to see it was set at XMLReader level
         assertFalse(xmlReader.getFeature("http://apache.org/xml/features/xinclude"));
     }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.xml;
 
 import java.net.URL;
-
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 


### PR DESCRIPTION
* Allow an override of the `newSAXParserFactory()` to customize the factory.
* Add new getter `getParser()` to fetch the active `SAXParser`.