### PR TITLE
Add a module to produce a standard OSGi Repository

### DIFF
--- a/jetty-osgi-repository/pom.xml
+++ b/jetty-osgi-repository/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.jetty</groupId>
+		<artifactId>jetty-project</artifactId>
+		<version>10.0.16-SNAPSHOT</version>
+	</parent>
+	<artifactId>jetty-osgi-repository</artifactId>
+	<name>Jetty OSGi Repository</name>
+	<description>Provides a OSGi Repository for all Jetty</description>
+	<packaging>repository</packaging>
+	<properties>
+		<tycho-version>4.0.1-SNAPSHOT</tycho-version>
+	</properties>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>tycho-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
     <module>jetty-keystore</module>
     <module>jetty-unixdomain-server</module>
     <module>javadoc</module>
+    <module>jetty-osgi-repository</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Jetty currently already provides a P2 Update-Site as maven artifact, but there is also now a [standardized repository format](https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.repository.html) available.

This adds a new module 'jetty-osgi-repository' that generates such a standard repository.

This currently references the tycho snapshot repository but I plan to do a new release soon so it would be great if it already can be reviewed and discussed if it could be an option for jetty.

As with the P2 module this does not really require anything special or maintained, everything is performed by the maven plugin.