### PR TITLE
Fix replacement logic for `Configuration` lists

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
@@ -232,6 +232,7 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
     public Configurations(List<Configuration> configurations)
     {
         _configurations = new ArrayList<>();
+        //ensure replacements are processed
         if (configurations != null)
             configurations.forEach(this::add);
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
@@ -231,7 +231,9 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
 
     public Configurations(List<Configuration> configurations)
     {
-        _configurations = new ArrayList<>(configurations == null ? Collections.emptyList() : configurations);
+        _configurations = new ArrayList<>();
+        if (configurations != null)
+            configurations.forEach(this::add);
     }
 
     public Configurations(Configuration... configurations)

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/ConfigurationsTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/ConfigurationsTest.java
@@ -136,6 +136,44 @@ public class ConfigurationsTest
     }
 
     @Test
+    public void testReplacementWithInstances()
+    {
+        //ConfigDick should be replaced by ReplacementDick
+        Configurations configs = new Configurations(
+            new ConfigDick(),
+            new ConfigBar(),
+            new ConfigZ(),
+            new ConfigY(),
+            new ConfigX(),
+            new ConfigTom(),
+            new ReplacementDick(),
+            new ConfigHarry(),
+            new ConfigAdditionalHarry(),
+            new ConfigFoo()
+        );
+
+        configs.sort();
+
+        assertThat(configs.stream().map(c -> c.getClass().getName()).collect(toList()),
+            contains(
+                ConfigFoo.class.getName(),
+                ConfigBar.class.getName(),
+                ConfigX.class.getName(),
+                ConfigY.class.getName(),
+                ConfigZ.class.getName(),
+                ConfigTom.class.getName(),
+                ReplacementDick.class.getName(),
+                ConfigHarry.class.getName(),
+                ConfigAdditionalHarry.class.getName()
+            ));
+
+         assertThat(configs.stream().map(c -> c.getClass().getName()).collect(toList()),
+            not(contains(
+                ConfigDick.class.getName()
+            )));
+    }
+    
+    @Test
     public void testReplacement()
     {
         Configurations.setKnown(


### PR DESCRIPTION
jetty-12 ee10

When a list of `Configuration` classes was passed to the `Configurations(List<Configuration>)` constructor, it was not processing the list for replacements.