### PR TITLE
Dependency Updates for `jetty-12.0.x` - July 2023

### DIFF
--- a/jetty-core/jetty-util/pom.xml
+++ b/jetty-core/jetty-util/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.2</version>
+      <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -32,7 +32,7 @@
     <jakarta.xml.bind.impl.version>4.0.1</jakarta.xml.bind.impl.version>
     <jakarta.xml.ws.api.version>4.0.0</jakarta.xml.ws.api.version>
     <jakarta.xml.jaxws.impl.version>4.0.0</jakarta.xml.jaxws.impl.version>
-    <jakarta.websocket.api.version>2.1.0</jakarta.websocket.api.version>
+    <jakarta.websocket.api.version>2.1.1</jakarta.websocket.api.version>
 
     <jsp.impl.version>10.1.7</jsp.impl.version>
     <mail.impl.version>2.0.1</mail.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <google.errorprone.version>2.20.0</google.errorprone.version>
     <grpc.version>1.53.0</grpc.version>
     <gson.version>2.10.1</gson.version>
-    <guava.version>32.0.1-jre</guava.version>
+    <guava.version>32.1.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hazelcast.version>5.3.1</hazelcast.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <hazelcast.version>5.3.1</hazelcast.version>
     <infinispan.protostream.version>4.6.2.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
-    <jackson.version>2.14.3</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <jakarta.activation.api.version>2.0.1</jakarta.activation.api.version>
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
     <jakarta.el.api.version>4.0.0</jakarta.el.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <asciidoctorj-diagram.version>2.2.8</asciidoctorj-diagram.version>
-    <asciidoctorj.version>2.5.7</asciidoctorj.version>
+    <asciidoctorj.version>2.5.10</asciidoctorj.version>
     <mina.core.version>2.2.1</mina.core.version>
     <asm.version>9.5</asm.version>
     <awaitility.version>4.2.0</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <jsp.impl.version>10.0.14</jsp.impl.version>
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>
     <log4j2.version>2.20.0</log4j2.version>
-    <logback.version>1.4.7</logback.version>
+    <logback.version>1.4.8</logback.version>
     <mariadb.version>3.1.4</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.deps.version>3.8.7</maven.deps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <disruptor.version>3.4.2</disruptor.version>
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-    <google.errorprone.version>2.18.0</google.errorprone.version>
+    <google.errorprone.version>2.20.0</google.errorprone.version>
     <grpc.version>1.53.0</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>32.0.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <logback.version>1.4.8</logback.version>
     <mariadb.version>3.1.4</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
-    <maven.deps.version>3.8.7</maven.deps.version>
+    <maven.deps.version>3.9.0</maven.deps.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
     <maven.resolver.version>1.9.13</maven.resolver.version>
     <maven.version>3.9.0</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <grpc.version>1.53.0</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>32.1.1-jre</guava.version>
-    <guice.version>5.1.0</guice.version>
+    <guice.version>7.0.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hazelcast.version>5.3.1</hazelcast.version>
     <infinispan.protostream.version>4.6.2.Final</infinispan.protostream.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>4.0.0</plexus-utils.version>
-    <plexus-xml.version>4.0.0</plexus-xml.version>
+    <plexus-xml.version>4.0.2</plexus-xml.version>
     <slf4j.version>2.0.7</slf4j.version>
     <spifly.version>1.3.6</spifly.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <google.errorprone.version>2.20.0</google.errorprone.version>
-    <grpc.version>1.53.0</grpc.version>
+    <grpc.version>1.56.1</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>32.1.1-jre</guava.version>
     <guice.version>7.0.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <bndlib.version>6.4.1</bndlib.version>
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>10.6.0</checkstyle.version>
-    <commons-codec.version>1.15</commons-codec.version>
+    <commons-codec.version>1.16.0</commons-codec.version>
     <commons.compress.version>1.23.0</commons.compress.version>
     <commons.io.version>2.12.0</commons.io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version> <!-- TODO: remove? -->
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
-    <jboss.logging.version>3.5.1.Final</jboss.logging.version>
+    <jboss.logging.version>3.5.3.Final</jboss.logging.version>
     <jboss-logmanager.version>2.3.0.Alpha1</jboss-logmanager.version>
     <jboss-threads.version>3.5.0.Final</jboss-threads.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>


### PR DESCRIPTION
Dependency Updates for Jetty 12.0.0