### PR TITLE
Fix Quoting of arguments from Jetty `start.jar --dry-run`

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -499,7 +499,8 @@ case "$ACTION" in
           disown \$!
           echo \$! > \"$JETTY_PID\""
       else
-        echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
+        # echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
+        echo ${RUN_ARGS[*]} | xargs ${JAVA} & # TODO: don't check in this version only used for cli debugging
         disown $!
         echo $! > "$JETTY_PID"
       fi

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
@@ -211,7 +211,7 @@ public class CommandLineBuilder
             char c = input.charAt(i);
 
             // Characters that require quoting
-            if (NEEDS_QUOTING[c])
+            if (c > NEEDS_QUOTING.length || NEEDS_QUOTING[c])
             {
                 return true;
             }

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/CommandLineBuilder.java
@@ -188,7 +188,7 @@ public class CommandLineBuilder
     /**
      * A version of {@link #toString()} where every arg is evaluated for potential {@code '} (strong quote) wrapping.
      *
-     * @return the toString but each arg that has spaces is surrounded by {@code '} (string quote)
+     * @return the toString but each arg that needs quoting is surrounded by {@code '} (strong quotes)
      */
     public String toQuotedString()
     {

--- a/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -819,7 +819,7 @@ public class StartArgs
             {
                 for (Prop p : properties)
                 {
-                    cmd.addRawArg(CommandLineBuilder.quote(p.key) + "=" + CommandLineBuilder.quote(properties.expand(p.value)));
+                    cmd.addRawArg(p.key + "=" + properties.expand(p.value));
                 }
             }
             else if (properties.size() > 0)

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -60,12 +60,13 @@ Report Commands:
 
   --dry-run
                    Prints the command line that start.jar generates,
-                   then exits.
+                   in a format usable by the unix sh command, then exits.
                    This may be used to generate command lines into scripts:
                      $ java -jar start.jar --dry-run > jetty.sh
 
   --dry-run=<part>(,<part>)*
-                   Prints specific parts of the command line. The parts are:
+                   Prints specific parts of the command line in a format usable by
+                   the unix sh command. The parts are:
                      o  "java" - the JVM to run
                      o  "opts" - the JVM options (e.g. -D, -X and -XX flags)
                      o  "path" - the JVM class-path and/or the JPMS module-path

--- a/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
@@ -36,6 +36,8 @@ public class CommandLineBuilderTest
             Arguments.of("Foo Bar", "'Foo Bar'"),
             Arguments.of("An 'internal' quoting", "'An '\\''internal'\\'' quoting'"),
             Arguments.of("requestlog.format=%u cost for $USER", "'requestlog.format=%u cost for $USER'"),
+            // Unicode escaping (we escape all unicode, as shell use of unicode is undefined)
+            Arguments.of("monetary.symbol=€", "'monetary.symbol=€'"),
             // Raw system property, as defined in start.d/exec.ini
             Arguments.of("-Dxxx.key=more values", "'-Dxxx.key=more values'")
         );
@@ -90,6 +92,6 @@ public class CommandLineBuilderTest
         CommandLineBuilder cmd = new CommandLineBuilder("java");
         cmd.addEqualsArg("-Djetty.home", "/opt/jetty");
         cmd.addEqualsArg("monetary.symbol", "€");
-        assertThat(cmd.toQuotedString(), is("java -Djetty.home=/opt/jetty monetary.symbol=€"));
+        assertThat(cmd.toQuotedString(), is("java -Djetty.home=/opt/jetty 'monetary.symbol=€'"));
     }
 }

--- a/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
@@ -13,13 +13,43 @@
 
 package org.eclipse.jetty.start;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class CommandLineBuilderTest
 {
+    public static Stream<Arguments> shellQuoteIfNeededSource()
+    {
+        return Stream.of(
+            // The following consists of raw arguments from the start mechanism
+            // compared to the output if quoted for shell usage (--dry-run)
+            Arguments.of("", "''"),
+            Arguments.of("Foo", "Foo"),
+            Arguments.of("Foo,Bar", "'Foo,Bar'"),
+            Arguments.of("Foo Bar", "'Foo Bar'"),
+            Arguments.of("An 'internal' quoting", "'An '\\''internal'\\'' quoting'"),
+            Arguments.of("requestlog.format=%u cost for $USER", "'requestlog.format=%u cost for $USER'"),
+            // Raw system property, as defined in start.d/exec.ini
+            Arguments.of("-Dxxx.key=more values", "'-Dxxx.key=more values'")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shellQuoteIfNeededSource")
+    public void testNeedsShellQuoting(String input, String expected)
+    {
+        StringBuilder result = new StringBuilder();
+        CommandLineBuilder.shellQuoteIfNeeded(result, input);
+        assertThat(result.toString(), is(expected));
+    }
+
     @Test
     public void testSimpleCommandline()
     {


### PR DESCRIPTION
This addresses the concerns brought up by Issue #10055 with a minimal fix.
