### PR TITLE
Fixes delivery of events to `Response.CompleteListener`s.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
@@ -81,7 +81,7 @@ public abstract class HttpConnection implements IConnection, Attachable
 
         httpRequest.sent();
         if (listener != null)
-            responseListeners.addCompleteListener(listener);
+            responseListeners.addCompleteListener(listener, true);
 
         HttpExchange exchange = new HttpExchange(getHttpDestination(), httpRequest);
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -549,7 +549,7 @@ public class HttpRequest implements Request
     @Override
     public Request onComplete(Response.CompleteListener listener)
     {
-        responseListeners.addCompleteListener(listener);
+        responseListeners.addCompleteListener(listener, false);
         return this;
     }
 
@@ -674,7 +674,7 @@ public class HttpRequest implements Request
     void sendAsync(HttpDestination destination, Response.CompleteListener listener)
     {
         if (listener != null)
-            responseListeners.addCompleteListener(listener);
+            responseListeners.addCompleteListener(listener, true);
         destination.send(this);
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/ResponseListeners.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/ResponseListeners.java
@@ -308,12 +308,7 @@ public class ResponseListeners
         }
     }
 
-    public boolean addCompleteListener(Response.CompleteListener listener)
-    {
-        return addCompleteListener(listener, true);
-    }
-
-    private boolean addCompleteListener(Response.CompleteListener listener, boolean includeOtherEvents)
+    public boolean addCompleteListener(Response.CompleteListener listener, boolean includeOtherEvents)
     {
         if (listener == null)
             return false;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1013,7 +1013,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         start(scenario, new EmptyServerHandler());
 
         AtomicInteger counter = new AtomicInteger();
-        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(2);
         Response.Listener listener = new Response.Listener()
         {
             @Override
@@ -1079,12 +1079,13 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .onResponseContentAsync(listener)
             .onResponseSuccess(listener)
             .onResponseFailure(listener)
+            .onComplete(listener)
             .send(listener);
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
-        int expectedEventsTriggeredByOnResponseXXXListeners = 3;
-        int expectedEventsTriggeredByCompletionListener = 4;
-        int expected = expectedEventsTriggeredByOnResponseXXXListeners + expectedEventsTriggeredByCompletionListener;
+        int expectedEventsTriggeredByResponseListeners = 4;
+        int expectedEventsTriggeredBySendListener = 4;
+        int expected = expectedEventsTriggeredByResponseListeners + expectedEventsTriggeredBySendListener;
         assertEquals(expected, counter.get());
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -186,7 +186,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
             if (listener != null)
             {
                 HttpChannelOverHTTP2 pushChannel = getHttpChannel().getHttpConnection().acquireHttpChannel();
-                pushRequest.getResponseListeners().addCompleteListener(listener);
+                pushRequest.getResponseListeners().addCompleteListener(listener, true);
                 HttpExchange pushExchange = new HttpExchange(getHttpDestination(), pushRequest);
                 pushChannel.associate(pushExchange);
                 pushChannel.setStream(stream);


### PR DESCRIPTION
In case of `request.onComplete(Response.CompleteListener l)`, only the complete event should be delivered to `l`, not all the events (in case `l` implements other listener interfaces).

Only `Response.CompleteListener` passed to `request.send(Response.CompleteListener)` should receive all events.