### PR TITLE
HttpChannel, AdaptiveExecutionStrategy: improve profiler-friendliness

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -494,15 +494,19 @@ public abstract class HttpChannel implements Runnable, HttpOutput.Interceptor
                         if (!_request.hasMetaData())
                             throw new IllegalStateException("state=" + _state);
 
-                        dispatch(DispatcherType.REQUEST, () ->
+                        dispatch(DispatcherType.REQUEST, new Dispatchable()
                         {
-                            for (HttpConfiguration.Customizer customizer : _configuration.getCustomizers())
+                            @Override
+                            public void dispatch() throws IOException, ServletException
                             {
-                                customizer.customize(getConnector(), _configuration, _request);
-                                if (_request.isHandled())
-                                    return;
+                                for (HttpConfiguration.Customizer customizer : _configuration.getCustomizers())
+                                {
+                                    customizer.customize(getConnector(), _configuration, _request);
+                                    if (_request.isHandled())
+                                        return;
+                                }
+                                getServer().handle(HttpChannel.this);
                             }
-                            getServer().handle(HttpChannel.this);
                         });
 
                         break;

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -137,7 +137,14 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     private final Executor _executor;
     private final TryExecutor _tryExecutor;
     private final Executor _virtualExecutor;
-    private final Runnable _runPendingProducer = () -> tryProduce(true);
+    private final Runnable _runPendingProducer = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            tryProduce(true);
+        }
+    };
     private State _state = State.IDLE;
     private boolean _pending;
 


### PR DESCRIPTION
In an application with multiple Jetty instances in one JVM (e.g. integration test), when examining stack frames using the debugger or profiler, most samples that involve user code will have these two frames in their stack.

Unfortunately, with a lambda, the different Jetty instances actually have different class names for different lambdas, which causes stack analysis to falsely think the frames are different.

It's a little uglier, but by replacing these two specific lambdas with anonymous classes with a stable name, the profiler is able to see that the frames are in fact the same and collapse them, improving observability.

Here is an example Java Mission Control flame graph showing before, notice how the flame splits exactly at the `AdaptiveExecutionStrategy$$Lambda$` due to different names:
![image](https://github.com/eclipse/jetty.project/assets/129097/f9664ef4-e269-453a-aa01-ef1738be7334)

and showing after, now our stack traces only split where the handler chains actually differ (GzipHandler vs not) and thus are more understandable:
![image](https://github.com/eclipse/jetty.project/assets/129097/d1854dd1-d499-48c3-b858-8983ab1300c7)

