### PR TITLE
Unable to redirect to error-page that is an HTML

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -620,7 +620,7 @@ public class Dispatcher implements RequestDispatcher
         public String getPathInfo()
         {
             if (_servletPathMapping == null)
-                return super.getPathInfo();
+                return null;
             return _servletPathMapping.getPathInfo();
         }
 
@@ -628,7 +628,7 @@ public class Dispatcher implements RequestDispatcher
         public String getServletPath()
         {
             if (_servletPathMapping == null)
-                return super.getServletPath();
+                return "";
             return _servletPathMapping.getServletPath();
         }
 
@@ -636,7 +636,7 @@ public class Dispatcher implements RequestDispatcher
         public HttpServletMapping getHttpServletMapping()
         {
             if (_servletPathMapping == null)
-                return super.getHttpServletMapping();
+                return null;
             return _servletPathMapping;
         }
 
@@ -644,12 +644,8 @@ public class Dispatcher implements RequestDispatcher
         public String getQueryString()
         {
             if (_uri != null)
-            {
-                String targetQuery = _uri.getQuery();
-                if (!StringUtil.isEmpty(targetQuery))
-                    return targetQuery;
-            }
-            return _httpServletRequest.getQueryString();
+                return _uri.getQuery();
+            return null;
         }
 
         @Override
@@ -661,7 +657,16 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public StringBuffer getRequestURL()
         {
-            return _uri == null ? super.getRequestURL() :  new StringBuffer(HttpURI.build(_uri).query(null).scheme(super.getScheme()).host(super.getServerName()).port(super.getServerPort()).asString());
+            if (_uri != null)
+            {
+                return new StringBuffer(HttpURI.build(_uri)
+                    .query(getQueryString())
+                    .scheme(super.getScheme())
+                    .host(super.getServerName())
+                    .port(super.getServerPort())
+                    .asString());
+            }
+            return super.getRequestURL();
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -639,30 +639,24 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public String getQueryString()
         {
-            if (_uri != null)
-                return _uri.getQuery();
-            return null;
+            return Objects.requireNonNull(_uri).getQuery();
         }
 
         @Override
         public String getRequestURI()
         {
-            return _uri == null ? super.getRequestURI() : _uri.getPath();
+            return Objects.requireNonNull(_uri).getPath();
         }
 
         @Override
         public StringBuffer getRequestURL()
         {
-            if (_uri != null)
-            {
-                return new StringBuffer(HttpURI.build(_uri)
-                    .query(getQueryString())
-                    .scheme(super.getScheme())
-                    .host(super.getServerName())
-                    .port(super.getServerPort())
-                    .asString());
-            }
-            return super.getRequestURL();
+            Objects.requireNonNull(_uri);
+            return new StringBuffer(HttpURI.build(_uri)
+                .scheme(super.getScheme())
+                .host(super.getServerName())
+                .port(super.getServerPort())
+                .asString());
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -600,7 +600,6 @@ public class Dispatcher implements RequestDispatcher
         }
     }
 
-    // TODO
     private class ErrorRequest extends ParameterRequestWrapper
     {
         private final HttpServletRequest _httpServletRequest;
@@ -620,19 +619,30 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public String getPathInfo()
         {
+            if (_servletPathMapping == null)
+                return super.getPathInfo();
             return _servletPathMapping.getPathInfo();
         }
 
         @Override
         public String getServletPath()
         {
+            if (_servletPathMapping == null)
+                return super.getServletPath();
             return _servletPathMapping.getServletPath();
+        }
+
+        @Override
+        public HttpServletMapping getHttpServletMapping()
+        {
+            if (_named != null)
+                return super.getHttpServletMapping();
+            return _servletPathMapping;
         }
 
         @Override
         public String getQueryString()
         {
-            // TODO
             if (_uri != null)
             {
                 String targetQuery = _uri.getQuery();
@@ -645,26 +655,13 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public String getRequestURI()
         {
-            return _uri == null ? null : _uri.getPath();
+            return _uri == null ? super.getRequestURI() : _uri.getPath();
         }
 
         @Override
-        public Object getAttribute(String name)
+        public StringBuffer getRequestURL()
         {
-            switch (name)
-            {
-                // TODO
-                default:
-                    return super.getAttribute(name);
-            }
-        }
-
-        @Override
-        public Enumeration<String> getAttributeNames()
-        {
-            ArrayList<String> names = new ArrayList<>(Collections.list(super.getAttributeNames()));
-            // TODO
-            return Collections.enumeration(names);
+            return _uri == null ? super.getRequestURL() :  new StringBuffer(HttpURI.build(_uri).query(null).scheme(super.getScheme()).host(super.getServerName()).port(super.getServerPort()).asString());
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -91,6 +91,8 @@ public class Dispatcher implements RequestDispatcher
 
     public void error(ServletRequest request, ServletResponse response) throws ServletException, IOException
     {
+        assert _named == null;
+
         HttpServletRequest httpRequest = (request instanceof HttpServletRequest) ? (HttpServletRequest)request : new ServletRequestHttpWrapper(request);
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -635,7 +635,7 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public HttpServletMapping getHttpServletMapping()
         {
-            if (_named != null)
+            if (_servletPathMapping == null)
                 return super.getHttpServletMapping();
             return _servletPathMapping;
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -619,25 +619,19 @@ public class Dispatcher implements RequestDispatcher
         @Override
         public String getPathInfo()
         {
-            if (_servletPathMapping == null)
-                return null;
-            return _servletPathMapping.getPathInfo();
+            return Objects.requireNonNull(_servletPathMapping).getPathInfo();
         }
 
         @Override
         public String getServletPath()
         {
-            if (_servletPathMapping == null)
-                return "";
-            return _servletPathMapping.getServletPath();
+            return Objects.requireNonNull(_servletPathMapping).getServletPath();
         }
 
         @Override
         public HttpServletMapping getHttpServletMapping()
         {
-            if (_servletPathMapping == null)
-                return null;
-            return _servletPathMapping;
+            return Objects.requireNonNull(_servletPathMapping);
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletTest.java
@@ -82,7 +82,7 @@ public class AsyncServletTest
 
     private void historyAdd(String item)
     {
-        // System.err.println(Thread.currentThread()+" history: "+item);
+        // System.err.printf("%s history: %s%n", Thread.currentThread(), item);
         _history.add(item);
     }
 
@@ -203,7 +203,7 @@ public class AsyncServletTest
             assertThat(_history, contains(
                 "REQUEST /ctx/noasync/info?start=1000",
                 "initial",
-                "ERROR /ctx/error/custom?start=1000",
+                "ERROR /ctx/error/custom",
                 "wrapped REQ",
                 "!initial"
             ));
@@ -224,7 +224,7 @@ public class AsyncServletTest
             "initial",
             "start",
             "onTimeout",
-            "ERROR /ctx/error/custom?start=1000",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onComplete"));
@@ -263,7 +263,7 @@ public class AsyncServletTest
             "start",
             "onTimeout",
             "error",
-            "ERROR /ctx/error/custom?start=200&timeout=error",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onComplete"));
@@ -331,7 +331,7 @@ public class AsyncServletTest
             "initial",
             "start",
             "onError",
-            "ERROR /ctx/error/custom?start=1000&throw=1",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onComplete"));
@@ -430,7 +430,7 @@ public class AsyncServletTest
             "onStartAsync",
             "start",
             "onTimeout",
-            "ERROR /ctx/error/custom?start=1000&dispatch=10&start2=10",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onComplete"));
@@ -447,7 +447,7 @@ public class AsyncServletTest
             "initial",
             "start",
             "onTimeout",
-            "ERROR /ctx/error/custom?start=10&start2=1000&dispatch2=10",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onStartAsync",
@@ -470,7 +470,7 @@ public class AsyncServletTest
             "initial",
             "start",
             "onTimeout",
-            "ERROR /ctx/error/custom?start=10&start2=1000&complete2=10",
+            "ERROR /ctx/error/custom",
             "wrapped REQ",
             "!initial",
             "onStartAsync",
@@ -492,13 +492,13 @@ public class AsyncServletTest
             "initial",
             "start",
             "onTimeout",
-            "ERROR /ctx/path/error?start=10&start2=10",
+            "ERROR /ctx/path/error",
             "wrapped REQ",
             "!initial",
             "onStartAsync",
             "start",
             "onTimeout",
-            "ERROR /ctx/path/error?start=10&start2=10",
+            "ERROR /ctx/path/error",
             "wrapped REQ",
             "!initial",
             "onComplete")); // Error Page Loop!

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -772,7 +772,7 @@ public class DispatcherTest
             \r
             """);
         response = HttpTester.parseResponse(rawResponse);
-        assertThat(response.getContent(), containsString("matchValue=DispatchServlet, pattern=/DispatchServlet, servletName=DispatchServlet, mappingMatch=EXACT"));
+        assertThat(response.getContent(), containsString("matchValue=TestServlet, pattern=/TestServlet, servletName=TestServlet, mappingMatch=EXACT"));
     }
 
     public static class WrappingFilter implements Filter

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -29,7 +29,6 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -39,6 +38,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Handler;
@@ -47,11 +47,12 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.StringUtil;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,77 +71,23 @@ public class ErrorPageTest
 
     private Server _server;
     private LocalConnector _connector;
-    private StacklessLogging _stackless;
-    private static CountDownLatch __asyncSendErrorCompleted;
-    private ErrorPageErrorHandler _errorPageErrorHandler;
-    private static AtomicBoolean __destroyed;
-    private ServletContextHandler _context;
 
-    @BeforeEach
-    public void init() throws Exception
+    private void startServer(ServletContextHandler servletContextHandler) throws Exception
     {
         _server = new Server();
         _connector = new LocalConnector(_server);
         _server.addConnector(_connector);
 
-        _context = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
-
-        _server.setHandler(_context);
-
-        _context.setContextPath("/");
-        _context.addFilter(SingleDispatchFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
-        _context.addServlet(DefaultServlet.class, "/");
-        _context.addServlet(FailServlet.class, "/fail/*");
-        _context.addServlet(FailServletDoubleWrap.class, "/fail-double-wrap/*");
-        _context.addServlet(FailClosedServlet.class, "/fail-closed/*");
-        _context.addServlet(ErrorServlet.class, "/error/*");
-        _context.addServlet(AppServlet.class, "/app/*");
-        _context.addServlet(LongerAppServlet.class, "/longer.app/*");
-        _context.addServlet(SyncSendErrorServlet.class, "/sync/*");
-        _context.addServlet(AsyncSendErrorServlet.class, "/async/*");
-        _context.addServlet(NotEnoughServlet.class, "/notenough/*");
-        _context.addServlet(UnavailableServlet.class, "/unavailable/*");
-        _context.addServlet(DeleteServlet.class, "/delete/*");
-        _context.addServlet(ErrorAndStatusServlet.class, "/error-and-status/*");
-        _context.addServlet(ErrorContentTypeCharsetWriterInitializedServlet.class, "/error-mime-charset-writer/*");
-        _context.addServlet(ExceptionServlet.class, "/exception-servlet");
-        _context.addServlet(FailResetBufferAfterCommit.class, "/fail-reset-buffer/*");
-        _context.addServlet(FailSendErrorAfterCommit.class, "/fail-senderror-after-commit/*");
-
-        Handler.Singleton noopHandler = new Handler.Wrapper()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
-            {
-                if (Request.getPathInContext(request).startsWith("/noop"))
-                    return false;
-                return super.handle(request, response, callback);
-            }
-        };
-        _context.insertHandler(noopHandler);
-
-        _errorPageErrorHandler = new ErrorPageErrorHandler();
-        _context.setErrorHandler(_errorPageErrorHandler);
-        _errorPageErrorHandler.addErrorPage(595, "/error/595");
-        _errorPageErrorHandler.addErrorPage(597, "/sync");
-        _errorPageErrorHandler.addErrorPage(599, "/error/599");
-        _errorPageErrorHandler.addErrorPage(400, "/error/400");
-        // error.addErrorPage(500,"/error/500");
-        _errorPageErrorHandler.addErrorPage(IllegalStateException.class.getCanonicalName(), "/error/TestException");
-        _errorPageErrorHandler.addErrorPage(BadMessageException.class, "/error/BadMessageException");
-        _errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
-        _errorPageErrorHandler.addErrorPage(TestServletException.class, "/error");
-
+        // Add regression test for double dispatch
+        servletContextHandler.addFilter(EnsureSingleDispatchFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+        _server.setHandler(servletContextHandler);
         _server.start();
-        _stackless = new StacklessLogging(ServletHandler.class);
-
-        __asyncSendErrorCompleted = new CountDownLatch(1);
     }
 
     @AfterEach
     public void destroy() throws Exception
     {
-        _stackless.close();
+        // _stackless.close();
         _server.stop();
         _server.join();
     }
@@ -148,6 +95,30 @@ public class ErrorPageTest
     @Test
     public void testErrorOverridesMimeTypeAndCharset() throws Exception
     {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet errorContentServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.setContentType("text/html; charset=US-ASCII");
+                PrintWriter writer = response.getWriter();
+                writer.println("Intentionally using sendError(595)");
+                response.sendError(595);
+            }
+        };
+
+        contextHandler.addServlet(errorContentServlet, "/error-mime-charset-writer/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+        errorPageErrorHandler.addErrorPage(595, "/error/595");
+
+        startServer(contextHandler);
+
         StringBuilder rawRequest = new StringBuilder();
         rawRequest.append("GET /error-mime-charset-writer/ HTTP/1.1\r\n");
         rawRequest.append("Host: test\r\n");
@@ -171,657 +142,1278 @@ public class ErrorPageTest
         assertThat(body, containsString("ERROR_CODE: 595"));
         assertThat(body, containsString("ERROR_EXCEPTION: null"));
         assertThat(body, containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(body, containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$ErrorContentTypeCharsetWriterInitializedServlet-"));
+        assertThat(body, containsString("ERROR_SERVLET: " + errorContentServlet.getClass().getName()));
         assertThat(body, containsString("ERROR_REQUEST_URI: /error-mime-charset-writer/"));
     }
 
     @Test
     public void testErrorOverridesStatus() throws Exception
     {
-        String response = _connector.getResponse("GET /error-and-status/anything HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 594 594"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
-        assertThat(response, Matchers.containsString("ERROR_MESSAGE: custom get error"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 594"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$ErrorAndStatusServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /error-and-status/anything"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet errorAndStatusServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(594, "custom get error");
+                response.setStatus(200);
+            }
+        };
+
+        contextHandler.addServlet(errorAndStatusServlet, "/error-and-status/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /error-and-status/anything HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("Accept: */*\r\n");
+        rawRequest.append("Accept-Charset: *\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(594));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
+        assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: custom get error"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 594"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + errorAndStatusServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /error-and-status/anything"));
     }
 
+    /**
+     * A 204 Response cannot contain a Body.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.3">RFC7230: Section 3.3</a>
+     */
     @Test
     public void testHttp204CannotHaveBody() throws Exception
     {
-        String response = _connector.getResponse("GET /fail/code?code=204 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 204 No Content"));
-        assertThat(response, not(Matchers.containsString("DISPATCH: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_PAGE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_CODE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION_TYPE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_SERVLET: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_REQUEST_URI: ")));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(204);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/204");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/204 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("Accept: */*\r\n");
+        rawRequest.append("Accept-Charset: *\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(204));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat("A 204 Response cannot have a body", responseBody.length(), is(0));
     }
 
+    /**
+     * DELETE responses should not have a response body.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.5">RFC7231: Section 4.3.5</a>
+     */
     @Test
     public void testDeleteCannotHaveBody() throws Exception
     {
-        String response = _connector.getResponse("DELETE /delete/anything HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 595 595"));
-        assertThat(response, not(Matchers.containsString("DISPATCH: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_PAGE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_MESSAGE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_CODE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION_TYPE: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_SERVLET: ")));
-        assertThat(response, not(Matchers.containsString("ERROR_REQUEST_URI: ")));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-        assertThat(response, not(containsString("This shouldn't be seen")));
+        HttpServlet deleteServlet = new HttpServlet()
+        {
+            @Override
+            protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.getWriter().append("This shouldn't be seen");
+                response.sendError(595, "custom delete");
+            }
+        };
+
+        contextHandler.addServlet(deleteServlet, "/delete/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+        errorPageErrorHandler.addErrorPage(595, "/error/595");
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("DELETE /delete/anything HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("Accept: */*\r\n");
+        rawRequest.append("Accept-Charset: *\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(595));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat("A response on DELETE cannot have a body", responseBody.length(), is(0));
     }
 
     @Test
     public void testGenerateAcceptableResponseNoAcceptHeader() throws Exception
     {
-        // no global error page here
-        _errorPageErrorHandler.getErrorPages().remove(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE);
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-        String response = _connector.getResponse("GET /fail/code?code=598 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 598 598"));
-        assertThat(response, Matchers.containsString("<title>Error 598"));
-        assertThat(response, Matchers.containsString("<h2>HTTP ERROR 598"));
-        assertThat(response, Matchers.containsString("/fail/code"));
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(598);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/598");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/598 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        // No `Accept` header present
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(598));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("<title>Error 598"));
+        assertThat(responseBody, Matchers.containsString("<h2>HTTP ERROR 598"));
+        assertThat(responseBody, Matchers.containsString("/fail/598"));
     }
 
     @Test
     public void testGenerateAcceptableResponseHtmlAcceptHeader() throws Exception
     {
-        // no global error page here
-        _errorPageErrorHandler.getErrorPages().remove(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE);
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(598);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/598");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/598 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("Accept: application/bytes,text/html\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(598));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
 
         // even when text/html is not the 1st content type, a html error page should still be generated
-        String response = _connector.getResponse("GET /fail/code?code=598 HTTP/1.0\r\n" +
-            "Accept: application/bytes,text/html\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 598 598"));
-        assertThat(response, Matchers.containsString("<title>Error 598"));
-        assertThat(response, Matchers.containsString("<h2>HTTP ERROR 598"));
-        assertThat(response, Matchers.containsString("/fail/code"));
+        assertThat(responseBody, Matchers.containsString("<title>Error 598"));
+        assertThat(responseBody, Matchers.containsString("<h2>HTTP ERROR 598"));
+        assertThat(responseBody, Matchers.containsString("/fail/598"));
     }
 
     @Test
     public void testGenerateAcceptableResponseNoHtmlAcceptHeader() throws Exception
     {
-        // no global error page here
-        _errorPageErrorHandler.getErrorPages().remove(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE);
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-        String response = _connector.getResponse("GET /fail/code?code=598 HTTP/1.0\r\n" +
-            "Accept: application/bytes\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 598 598"));
-        assertThat(response, not(Matchers.containsString("<title>Error 598")));
-        assertThat(response, not(Matchers.containsString("<h2>HTTP ERROR 598")));
-        assertThat(response, not(Matchers.containsString("/fail/code")));
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(598);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/598");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/598 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("Accept: application/bytes\r\n"); // has an accept header, but not one supported by default in Jetty
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(598));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat("No acceptable response capable of being generated, should result in no body", responseBody.length(), is(0));
     }
 
     @Test
     public void testNestedSendErrorDoesNotLoop() throws Exception
     {
-        String response = _connector.getResponse("GET /fail/code?code=597 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 597 597"));
-        assertThat(response, not(Matchers.containsString("time this error page is being accessed")));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet syncSendErrorServlet = new HttpServlet()
+        {
+            public static final AtomicInteger COUNTER = new AtomicInteger();
+
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                int count = COUNTER.incrementAndGet();
+
+                PrintWriter writer = response.getWriter();
+                writer.println("this is the " + count + " time this error page is being accessed");
+                response.sendError(597, "loop #" + count);
+            }
+        };
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(597);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/597");
+        contextHandler.addServlet(syncSendErrorServlet, "/sync/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(597, "/sync/");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/597 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(597));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, not(Matchers.containsString("time this error page is being accessed")));
     }
 
     @Test
     public void testSendErrorClosedResponse() throws Exception
     {
-        String response = _connector.getResponse("GET /fail-closed/ HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-        assertThat(response, Matchers.containsString("DISPATCH: ERROR"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailClosedServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail-closed/"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-        assertThat(response, not(containsString("This shouldn't be seen")));
-        assertThat(response, not(containsString("BadHeader")));
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(599);
+                // The below should result in no operation, as response should be closed.
+
+                try
+                {
+                    response.setStatus(200); // this status code should not be seen
+                    response.getWriter().append("This shouldn't be seen");
+                    response.addIntHeader("BadHeader", 1234);
+                }
+                catch (Throwable ignore)
+                {
+                    LOG.trace("IGNORED", ignore);
+                }
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail-closed/");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(599, "/error/599");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail-closed/ HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(599));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("DISPATCH: ERROR"));
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + failServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /fail-closed/"));
+
+        assertThat(responseBody, not(containsString("This shouldn't be seen")));
+        assertThat(responseBody, not(containsString("BadHeader")));
     }
 
     @Test
     public void testFailResetBufferAfterCommit() throws Exception
     {
-        String response = _connector.getResponse("GET /fail-reset-buffer/foo HTTP/1.0\r\n\r\n");
-        assertThat(response, containsString("Some content"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.getWriter().println("Some content");
+                response.flushBuffer(); //cause a commit
+
+                assertThrows(IllegalStateException.class,
+                    () -> response.resetBuffer(), // this should throw
+                    "Reset after response committed");
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail-reset-buffer/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(599, "/error/599");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail-reset-buffer/foo HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200)); // request should pass successfully
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, containsString("Some content"));
     }
 
     @Test
     public void testCommitSendError() throws Exception
     {
-        String response = _connector.getResponse("GET /fail-senderror-after-commit/ HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("Response committed"));
-        assertThat(response, not(Matchers.containsString("HTTP/1.1 599 599")));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.getWriter().append("Response committed");
+                response.flushBuffer();
+
+                assertThrows(IllegalStateException.class,
+                    () -> response.sendError(599), // this should throw
+                    "Cannot sendError after commit");
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail-senderror-after-commit/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail-senderror-after-commit/ HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200)); // request should pass successfully
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, Matchers.containsString("Response committed"));
     }
 
     @Test
     public void testErrorCode() throws Exception
     {
-        String response = _connector.getResponse("GET /fail/code?code=599 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/code"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(599);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/599");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(599, "/error/599");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/599 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(599));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + failServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /fail/599"));
     }
 
     @Test
     public void testErrorMessage() throws Exception
     {
-        String response = _connector.getResponse("GET /fail/code?code=599&message=FiveNineNine HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-        assertThat(response, Matchers.containsString("ERROR_MESSAGE: FiveNineNine"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/code"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(599, "FiveNineNine");
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/599");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(599, "/error/599");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/599 HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(599));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 599"));
+        assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: FiveNineNine"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + failServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /fail/599"));
     }
 
-    @Test
-    public void testErrorException() throws Exception
+    @ParameterizedTest
+    @CsvSource({
+        "true,/fail/exception",
+        "true,/fail-double-wrap/exception",
+        "false,/fail/exception",
+        "false,/fail-double-wrap/exception",
+    })
+    public void testErrorException(boolean unwrapServletException, String path) throws Exception
     {
-        _errorPageErrorHandler.setUnwrapServletException(false);
-        try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
-        {
-            String response = _connector.getResponse("GET /fail/exception HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /TestException"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: jakarta.servlet.ServletException: java.lang.IllegalStateException: Test Exception"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class jakarta.servlet.ServletException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/exception"));
-            response = _connector.getResponse("GET /fail-double-wrap/exception HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /TestException"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: jakarta.servlet.ServletException: jakarta.servlet.ServletException: java.lang.IllegalStateException: Test Exception"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class jakarta.servlet.ServletException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServletDoubleWrap-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail-double-wrap/exception"));
-        }
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-        _errorPageErrorHandler.setUnwrapServletException(true);
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                throw new ServletException(new IllegalStateException("Test Exception"));
+            }
+        };
+
+        HttpServlet failDoubleWrapServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+            {
+                throw new ServletException(new ServletException(new IllegalStateException("Test Exception")));
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/*");
+        contextHandler.addServlet(failDoubleWrapServlet, "/fail-double-wrap/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(IllegalStateException.class.getCanonicalName(), "/error/TestException");
+        errorPageErrorHandler.setUnwrapServletException(unwrapServletException);
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
         try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
         {
-            String response = _connector.getResponse("GET /fail/exception HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /TestException"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: java.lang.IllegalStateException: Test Exception"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class java.lang.IllegalStateException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/exception"));
-            response = _connector.getResponse("GET /fail-double-wrap/exception HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /TestException"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: java.lang.IllegalStateException: Test Exception"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class java.lang.IllegalStateException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServletDoubleWrap-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail-double-wrap/exception"));
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET ").append(path).append(" HTTP/1.1\r\n");
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(500));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+            String responseBody = response.getContent();
+
+            boolean isDoubleWrapped = path.contains("-double-");
+
+            // common expectations
+            assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /TestException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_CODE: 500"));
+            assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: " + path));
+
+            if (unwrapServletException)
+            {
+                // with unwrap exceptions turned on
+                assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: java.lang.IllegalStateException: Test Exception"));
+                assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class java.lang.IllegalStateException"));
+            }
+            else
+            {
+                // with unwrap exceptions turned off
+                String expectedException = "jakarta.servlet.ServletException: java.lang.IllegalStateException: Test Exception";
+                if (isDoubleWrapped)
+                    expectedException = "jakarta.servlet.ServletException: " + expectedException;
+                assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: " + expectedException));
+                assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class jakarta.servlet.ServletException"));
+            }
+
+            if (isDoubleWrapped)
+            {
+                // double wrapped throwable expectations
+                assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: jakarta.servlet.ServletException: jakarta.servlet.ServletException: java.lang.IllegalStateException: Test Exception"));
+            }
+            else
+            {
+                // single throwable expectations
+                assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: jakarta.servlet.ServletException: java.lang.IllegalStateException: Test Exception"));
+            }
         }
     }
 
     @Test
     public void testGlobalErrorCode() throws Exception
     {
-        String response = _connector.getResponse("GET /fail/global?code=598 HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 598 598"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 598"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/global"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.sendError(598);
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /fail/global HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(598));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 598"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + failServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /fail/global"));
     }
 
     @Test
     public void testGlobalErrorException() throws Exception
     {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet failServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException
+            {
+                int nan = Integer.parseInt("NAN"); // should trigger java.lang.NumberFormatException
+            }
+        };
+
+        contextHandler.addServlet(failServlet, "/fail/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
         try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
         {
-            String response = _connector.getResponse("GET /fail/global?code=NAN HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: java.lang.NumberFormatException: For input string: \"NAN\""));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class java.lang.NumberFormatException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$FailServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /fail/global"));
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET /fail/global HTTP/1.1\r\n");
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(500));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+            String responseBody = response.getContent();
+
+            assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
+            assertThat(responseBody, Matchers.containsString("ERROR_CODE: 500"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: java.lang.NumberFormatException: For input string: \"NAN\""));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class java.lang.NumberFormatException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + failServlet.getClass().getName()));
+            assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /fail/global"));
         }
     }
 
     @Test
     public void testBadMessage() throws Exception
     {
-        try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet appServlet = new HttpServlet()
         {
-            String response = _connector.getResponse("GET /app?baa=%88%A4 HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 400 Bad Request"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
-            assertThat(response, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 400"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Unable to parse URI query"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$AppServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /app"));
-            assertThat(response, Matchers.containsString("getParameterMap()= {}"));
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                request.getRequestDispatcher("/longer.app/").forward(request, response);
+            }
+        };
+
+        HttpServlet longerAppServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                request.getParameterMap(); // should trigger a BadMessageException
+                PrintWriter writer = response.getWriter();
+                writer.println(request.getRequestURI());
+            }
+        };
+
+        contextHandler.addServlet(appServlet, "/app");
+        contextHandler.addServlet(longerAppServlet, "/longer.app/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(BadMessageException.class, "/error/BadMessageException");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
+        {
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET /app?baa=%88%A4 HTTP/1.1\r\n");
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(400));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+            String responseBody = response.getContent();
+            assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_CODE: 400"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Unable to parse URI query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + appServlet.getClass().getName()));
+            assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /app"));
+            assertThat(responseBody, Matchers.containsString("getParameterMap()= {}"));
         }
     }
 
-    @Test
-    public void testAsyncErrorPageDSC() throws Exception
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "DSC", "SDC", "SCD"
+    })
+    public void testAsyncErrorPage(String mode) throws Exception
     {
-        try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
-        {
-            String response = _connector.getResponse("GET /async/info?mode=DSC HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$AsyncSendErrorServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /async/info"));
-            assertTrue(__asyncSendErrorCompleted.await(10, TimeUnit.SECONDS));
-        }
-    }
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
 
-    @Test
-    public void testAsyncErrorPageSDC() throws Exception
-    {
-        try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
-        {
-            String response = _connector.getResponse("GET /async/info?mode=SDC HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$AsyncSendErrorServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /async/info"));
-            assertTrue(__asyncSendErrorCompleted.await(10, TimeUnit.SECONDS));
-        }
-    }
+        final CountDownLatch asyncSendErrorCompleted = new CountDownLatch(1);
 
-    @Test
-    public void testAsyncErrorPageSCD() throws Exception
-    {
+        HttpServlet asyncServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                try
+                {
+                    final CountDownLatch hold = new CountDownLatch(1);
+                    final String mode = request.getParameter("mode");
+                    switch (mode)
+                    {
+                        case "DSC":
+                        case "SDC":
+                        case "SCD":
+                            break;
+                        default:
+                            throw new IllegalStateException(mode);
+                    }
+
+                    final boolean lateComplete = "true".equals(request.getParameter("latecomplete"));
+                    AsyncContext async = request.startAsync();
+                    async.start(() ->
+                    {
+                        try
+                        {
+                            switch (mode)
+                            {
+                                case "SDC":
+                                    response.sendError(599);
+                                    break;
+                                case "SCD":
+                                    response.sendError(599);
+                                    async.complete();
+                                    break;
+                                default:
+                                    break;
+                            }
+
+                            // Complete after original servlet
+                            hold.countDown();
+
+                            // Wait until request async waiting
+                            while (ServletContextRequest.getServletContextRequest(request).getServletRequestState().getState() == ServletRequestState.State.HANDLING)
+                            {
+                                try
+                                {
+                                    Thread.sleep(10);
+                                }
+                                catch (InterruptedException e)
+                                {
+                                    e.printStackTrace();
+                                }
+                            }
+                            try
+                            {
+                                switch (mode)
+                                {
+                                    case "DSC":
+                                        response.sendError(599);
+                                        async.complete();
+                                        break;
+                                    case "SDC":
+                                        async.complete();
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+                            catch (IllegalStateException e)
+                            {
+                                LOG.trace("IGNORED", e);
+                            }
+                            finally
+                            {
+                                asyncSendErrorCompleted.countDown();
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            LOG.warn("Unable to send error", e);
+                        }
+                    });
+                    hold.await();
+                }
+                catch (InterruptedException e)
+                {
+                    throw new ServletException(e);
+                }
+            }
+        };
+
+        contextHandler.addServlet(asyncServlet, "/async/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(599, "/error/599");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
         try (StacklessLogging ignore = new StacklessLogging(Dispatcher.class))
         {
-            String response = _connector.getResponse("GET /async/info?mode=SCD HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 599 599"));
-            assertThat(response, Matchers.containsString("ERROR_PAGE: /599"));
-            assertThat(response, Matchers.containsString("ERROR_CODE: 599"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-            assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$AsyncSendErrorServlet-"));
-            assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /async/info"));
-            assertTrue(__asyncSendErrorCompleted.await(10, TimeUnit.SECONDS));
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET /async/info?mode=%s HTTP/1.1\r\n".formatted(mode));
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(599));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+            String responseBody = response.getContent();
+
+            assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /599"));
+            assertThat(responseBody, Matchers.containsString("ERROR_CODE: 599"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+            assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + asyncServlet.getClass().getName()));
+            assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /async/info"));
+            assertTrue(asyncSendErrorCompleted.await(10, TimeUnit.SECONDS));
         }
     }
 
     @Test
     public void testNoop() throws Exception
     {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet appServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.getWriter().println("Got to the App");
+            }
+        };
+
+        contextHandler.addServlet(appServlet, "/app");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        Handler.Singleton noopHandler = new Handler.Wrapper()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                if (Request.getPathInContext(request).startsWith("/noop"))
+                    return false;
+                return super.handle(request, response, callback);
+            }
+        };
+        contextHandler.insertHandler(noopHandler);
+
+        startServer(contextHandler);
+
         // The ServletContextHandler does not handle so should go to the servers ErrorHandler.
-        String response = _connector.getResponse("GET /noop/info HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 404 Not Found"));
-        assertThat(response, not(Matchers.containsString("DISPATCH: ERROR")));
-        assertThat(response, not(Matchers.containsString("ERROR_PAGE: /GlobalErrorPage")));
-        assertThat(response, not(Matchers.containsString("ERROR_CODE: 404")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION: null")));
-        assertThat(response, not(Matchers.containsString("ERROR_EXCEPTION_TYPE: null")));
-        assertThat(response, not(Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.DefaultServlet-")));
-        assertThat(response, not(Matchers.containsString("ERROR_REQUEST_URI: /noop/info")));
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /noop/info HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, not(Matchers.containsString("DISPATCH: ERROR")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_PAGE: /GlobalErrorPage")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_CODE: 404")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_EXCEPTION: null")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_EXCEPTION_TYPE: null")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.DefaultServlet-")));
+        assertThat(responseBody, not(Matchers.containsString("ERROR_REQUEST_URI: /noop/info")));
     }
 
     @Test
     public void testNotEnough() throws Exception
     {
-        String response = _connector.getResponse("GET /notenough/info HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-        assertThat(response, Matchers.containsString("DISPATCH: ERROR"));
-        assertThat(response, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
-        assertThat(response, Matchers.containsString("ERROR_CODE: 500"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION: null"));
-        assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
-        assertThat(response, Matchers.containsString("ERROR_SERVLET: org.eclipse.jetty.ee10.servlet.ErrorPageTest$NotEnoughServlet-"));
-        assertThat(response, Matchers.containsString("ERROR_REQUEST_URI: /notenough/info"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet notEnoughServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.setContentLength(1000);
+                response.getOutputStream().write("SomeBytes".getBytes(StandardCharsets.UTF_8));
+            }
+        };
+
+        contextHandler.addServlet(notEnoughServlet, "/notenough/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /notenough/info HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(500));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, Matchers.containsString("DISPATCH: ERROR"));
+        assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /GlobalErrorPage"));
+        assertThat(responseBody, Matchers.containsString("ERROR_CODE: 500"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: null"));
+        assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + notEnoughServlet.getClass().getName()));
+        assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /notenough/info"));
     }
 
     @Test
     public void testNotEnoughCommitted() throws Exception
     {
-        String response = _connector.getResponse("GET /notenough/info?commit=true HTTP/1.0\r\n\r\n");
-        assertThat(response, Matchers.containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.containsString("Content-Length: 1000"));
-        assertThat(response, Matchers.endsWith("SomeBytes"));
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet notEnoughServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                response.setContentLength(1000);
+                response.getOutputStream().write("SomeBytes".getBytes(StandardCharsets.UTF_8));
+                response.flushBuffer();
+            }
+        };
+
+        contextHandler.addServlet(notEnoughServlet, "/notenough/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        StringBuilder rawRequest = new StringBuilder();
+        rawRequest.append("GET /notenough/commit HTTP/1.1\r\n");
+        rawRequest.append("Host: test\r\n");
+        rawRequest.append("Connection: close\r\n");
+        rawRequest.append("\r\n");
+
+        String rawResponse = _connector.getResponse(rawRequest.toString());
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("1000"));
+
+        String responseBody = response.getContent();
+        assertThat(responseBody, Matchers.endsWith("SomeBytes"));
     }
 
     @Test
     public void testPermanentlyUnavailable() throws Exception
     {
-        try (StacklessLogging ignore = new StacklessLogging(_context.getLogger()))
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        AtomicBoolean destroyed = new AtomicBoolean(false);
+
+        HttpServlet unavailableServlet = new HttpServlet()
         {
-            try (StacklessLogging ignore2 = new StacklessLogging(ServletChannel.class))
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
             {
-                __destroyed = new AtomicBoolean(false);
-                String response = _connector.getResponse("GET /unavailable/info HTTP/1.0\r\n\r\n");
-                assertThat(response, Matchers.containsString("HTTP/1.1 404 "));
-                _server.stop();
-                assertTrue(__destroyed.get());
+                throw new UnavailableException("testing permanent");
             }
+
+            @Override
+            public void destroy()
+            {
+                if (destroyed != null)
+                    destroyed.set(true);
+            }
+        };
+
+        contextHandler.addServlet(unavailableServlet, "/unavailable/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        try (StacklessLogging ignore = new StacklessLogging(contextHandler.getLogger(), LoggerFactory.getLogger(ServletChannel.class)))
+        {
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET /unavailable/info HTTP/1.1\r\n");
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(404));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+            _server.stop();
+            assertTrue(destroyed.get());
         }
     }
 
     @Test
     public void testUnavailable() throws Exception
     {
-        try (StacklessLogging ignore = new StacklessLogging(_context.getLogger()))
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        AtomicBoolean destroyed = new AtomicBoolean(false);
+
+        HttpServlet unavailableServlet = new HttpServlet()
         {
-            try (StacklessLogging ignore2 = new StacklessLogging(ServletChannel.class))
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
             {
-                __destroyed = new AtomicBoolean(false);
-                String response = _connector.getResponse("GET /unavailable/info?for=1 HTTP/1.0\r\n\r\n");
-                assertThat(response, Matchers.containsString("HTTP/1.1 503 "));
-                assertFalse(__destroyed.get());
+                String ok = request.getParameter("ok");
+                if (Boolean.parseBoolean(ok))
+                {
+                    response.setStatus(200);
+                    response.flushBuffer();
+                    return;
+                }
 
-                response = _connector.getResponse("GET /unavailable/info?ok=true HTTP/1.0\r\n\r\n");
-                assertThat(response, Matchers.containsString("HTTP/1.1 503 "));
-                assertFalse(__destroyed.get());
+                String f = request.getParameter("for");
+                if (f == null)
+                    throw new UnavailableException("testing permanent");
 
-                Thread.sleep(1500);
-
-                response = _connector.getResponse("GET /unavailable/info?ok=true HTTP/1.0\r\n\r\n");
-                assertThat(response, Matchers.containsString("HTTP/1.1 200 "));
-                assertFalse(__destroyed.get());
+                throw new UnavailableException("testing periodic", Integer.parseInt(f));
             }
+
+            @Override
+            public void destroy()
+            {
+                if (destroyed != null)
+                    destroyed.set(true);
+            }
+        };
+
+        contextHandler.addServlet(unavailableServlet, "/unavailable/*");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
+        try (StacklessLogging ignore = new StacklessLogging(contextHandler.getLogger(), LoggerFactory.getLogger(ServletChannel.class)))
+        {
+            String request = "GET /unavailable/info?for=1 HTTP/1.0\r\n\r\n";
+            HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+            assertThat(response.getStatus(), is(HttpStatus.SERVICE_UNAVAILABLE_503));
+            assertFalse(destroyed.get());
+
+            request = "GET /unavailable/info?ok=true HTTP/1.0\r\n\r\n";
+            response = HttpTester.parseResponse(_connector.getResponse(request));
+            assertThat(response.getStatus(), is(HttpStatus.SERVICE_UNAVAILABLE_503));
+            assertFalse(destroyed.get());
+
+            Thread.sleep(1500);
+
+            request = "GET /unavailable/info?ok=true HTTP/1.0\r\n\r\n";
+            response = HttpTester.parseResponse(_connector.getResponse(request));
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+            assertFalse(destroyed.get());
         }
     }
 
     @Test
     public void testNonUnwrappedMatchExceptionWithErrorPage() throws Exception
     {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        contextHandler.setContextPath("/");
+
+        HttpServlet exceptionServlet = new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                throw new TestServletException(new TestException("error page invoked"));
+            }
+        };
+
+        contextHandler.addServlet(exceptionServlet, "/exception-servlet");
+        contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(ErrorPageErrorHandler.GLOBAL_ERROR_PAGE, "/error/GlobalErrorPage");
+        errorPageErrorHandler.addErrorPage(TestServletException.class, "/error");
+        contextHandler.setErrorHandler(errorPageErrorHandler);
+
+        startServer(contextHandler);
+
         try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
         {
-            String response = _connector.getResponse("GET /exception-servlet HTTP/1.0\r\n\r\n");
-            assertThat(response, Matchers.containsString("HTTP/1.1 500 Server Error"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
-            assertThat(response, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
+            StringBuilder rawRequest = new StringBuilder();
+            rawRequest.append("GET /exception-servlet HTTP/1.1\r\n");
+            rawRequest.append("Host: test\r\n");
+            rawRequest.append("Connection: close\r\n");
+            rawRequest.append("\r\n");
+
+            String rawResponse = _connector.getResponse(rawRequest.toString());
+
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(500));
+            assertThat(response.get(HttpHeader.DATE), notNullValue());
+
+            String responseBody = response.getContent();
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
         }
     }
 
-    public static class AppServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            request.getRequestDispatcher("/longer.app/").forward(request, response);
-        }
-    }
-
-    public static class LongerAppServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            request.getParameterMap();
-            PrintWriter writer = response.getWriter();
-            writer.println(request.getRequestURI());
-        }
-    }
-
-    public static class SyncSendErrorServlet extends HttpServlet implements Servlet
-    {
-        public static final AtomicInteger COUNTER = new AtomicInteger();
-
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            int count = COUNTER.incrementAndGet();
-
-            PrintWriter writer = response.getWriter();
-            writer.println("this is the " + count + " time this error page is being accessed");
-            response.sendError(597, "loop #" + count);
-        }
-    }
-
-    public static class AsyncSendErrorServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            try
-            {
-                final CountDownLatch hold = new CountDownLatch(1);
-                final String mode = request.getParameter("mode");
-                switch (mode)
-                {
-                    case "DSC":
-                    case "SDC":
-                    case "SCD":
-                        break;
-                    default:
-                        throw new IllegalStateException(mode);
-                }
-
-                final boolean lateComplete = "true".equals(request.getParameter("latecomplete"));
-                AsyncContext async = request.startAsync();
-                async.start(() ->
-                {
-                    try
-                    {
-                        switch (mode)
-                        {
-                            case "SDC":
-                                response.sendError(599);
-                                break;
-                            case "SCD":
-                                response.sendError(599);
-                                async.complete();
-                                break;
-                            default:
-                                break;
-                        }
-
-                        // Complete after original servlet
-                        hold.countDown();
-
-                        // Wait until request async waiting
-                        while (ServletContextRequest.getServletContextRequest(request).getServletRequestState().getState() == ServletRequestState.State.HANDLING)
-                        {
-                            try
-                            {
-                                Thread.sleep(10);
-                            }
-                            catch (InterruptedException e)
-                            {
-                                e.printStackTrace();
-                            }
-                        }
-                        try
-                        {
-                            switch (mode)
-                            {
-                                case "DSC":
-                                    response.sendError(599);
-                                    async.complete();
-                                    break;
-                                case "SDC":
-                                    async.complete();
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                        catch (IllegalStateException e)
-                        {
-                            LOG.trace("IGNORED", e);
-                        }
-                        finally
-                        {
-                            __asyncSendErrorCompleted.countDown();
-                        }
-                    }
-                    catch (IOException e)
-                    {
-                        LOG.warn("Unable to send error", e);
-                    }
-                });
-                hold.await();
-            }
-            catch (InterruptedException e)
-            {
-                throw new ServletException(e);
-            }
-        }
-    }
-
-    public static class FailServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            String code = request.getParameter("code");
-            String message = request.getParameter("message");
-            if (code != null)
-            {
-                if (StringUtil.isBlank(message))
-                    response.sendError(Integer.parseInt(code));
-                else
-                    response.sendError(Integer.parseInt(code), message);
-            }
-            else
-            {
-                throw new ServletException(
-                    new IllegalStateException(message == null ? "Test Exception" : message));
-            }
-        }
-    }
-
-    public static class FailServletDoubleWrap extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            String code = request.getParameter("code");
-            if (code != null)
-                response.sendError(Integer.parseInt(code));
-            else
-                throw new ServletException(new ServletException(new IllegalStateException("Test Exception")));
-        }
-    }
-
-    public static class FailClosedServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.sendError(599);
-            // The below should result in no operation, as response should be closed.
-
-            try
-            {
-                response.setStatus(200); // this status code should not be seen
-                response.getWriter().append("This shouldn't be seen");
-                response.addIntHeader("BadHeader", 1234);
-            }
-            catch (Throwable ignore)
-            {
-                LOG.trace("IGNORED", ignore);
-            }
-        }
-    }
-
-    public static class FailResetBufferAfterCommit extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.getWriter().println("Some content");
-            response.flushBuffer(); //cause a commit
-
-            assertThrows(IllegalStateException.class,
-                () ->
-                {
-                    response.resetBuffer();
-                },
-            "Reset after response committed");
-        }
-    }
-
-    public static class FailSendErrorAfterCommit extends HttpServlet implements Servlet
-    {
-         @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-         {
-             response.getWriter().append("Response committed");
-             response.flushBuffer();
-
-             assertThrows(IllegalStateException.class,
-                 () -> response.sendError(599),
-                 "Cannot sendError after commit");
-         }
-    }
-
-    public static class ErrorContentTypeCharsetWriterInitializedServlet extends HttpServlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.setContentType("text/html; charset=US-ASCII");
-            PrintWriter writer = response.getWriter();
-            writer.println("Intentionally using sendError(595)");
-            response.sendError(595);
-        }
-    }
-
-    public static class ErrorAndStatusServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.sendError(594, "custom get error");
-            response.setStatus(200);
-        }
-    }
-
-    public static class DeleteServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.getWriter().append("This shouldn't be seen");
-            response.sendError(595, "custom delete");
-        }
-    }
-
-    public static class NotEnoughServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            response.setContentLength(1000);
-            response.getOutputStream().write("SomeBytes".getBytes(StandardCharsets.UTF_8));
-            if (Boolean.parseBoolean(request.getParameter("commit")))
-                response.flushBuffer();
-        }
-    }
-
-    public static class ErrorServlet extends HttpServlet implements Servlet
+    public static class ErrorDumpServlet extends HttpServlet
     {
         @Override
         protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -842,35 +1434,10 @@ public class ErrorPageTest
         }
     }
 
-    public static class UnavailableServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            String ok = request.getParameter("ok");
-            if (Boolean.parseBoolean(ok))
-            {
-                response.setStatus(200);
-                response.flushBuffer();
-                return;
-            }
-
-            String f = request.getParameter("for");
-            if (f == null)
-                throw new UnavailableException("testing permanent");
-
-            throw new UnavailableException("testing periodic", Integer.parseInt(f));
-        }
-
-        @Override
-        public void destroy()
-        {
-            if (__destroyed != null)
-                __destroyed.set(true);
-        }
-    }
-
-    public static class SingleDispatchFilter implements Filter
+    /**
+     * Regression test to ensure that double-dispatch does not occur.
+     */
+    public static class EnsureSingleDispatchFilter implements Filter
     {
         ConcurrentMap<Integer, Thread> dispatches = new ConcurrentHashMap<>();
 
@@ -917,15 +1484,6 @@ public class ErrorPageTest
         @Override
         public void destroy()
         {
-        }
-    }
-
-    public static class ExceptionServlet extends HttpServlet implements Servlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            throw new TestServletException(new TestException("error page invoked"));
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -1469,8 +1469,7 @@ public class ErrorPageTest
             assertThat(response.get(HttpHeader.DATE), notNullValue());
 
             String responseBody = response.getContent();
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.ee10.servlet.ErrorPageTest$TestServletException"));
+            assertThat(responseBody, Matchers.containsString("<h1>This is the 500 HTML</h1>"));
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -722,7 +722,6 @@ public class ErrorPageTest
         assertThat(responseBody, Matchers.containsString("<th>SERVLET:</th><td>%s".formatted(failServlet.getClass().getName())));
     }
 
-
     @Test
     public void testErrorMessage() throws Exception
     {


### PR DESCRIPTION
The `Dispatcher$ErrorRequest` wasn't allowing the `DefaultServlet` (and `ResourceService`) to see the error-page mapping properly.

``` xml
	<error-page>
		<error-code>500</error-code>
		<location>/500.html</location>
	</error-page>
```

The internal RequestDispatcher is essentially doing ...

``` java
RequestDispatcher dispatcher = servletContext.getRequestDispatcher("/500.html");
dispatcher.error(request, response);
```

The ERROR dispatch to the `DefaultServlet` (and `ResourceService`) were however processing the original request to `/exception-servlet` and seeing a request with no pathInfo, a requestURL of `/exception-servlet`, a requestURI of `/500.html` and getting confused, thinking this was a request for a directory and issuing a 302 redirect to `/500.html/` to handle the directory properly.