### PR TITLE
Fixes #10123 - MultiPartByteRanges request gets stuck

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -139,6 +139,7 @@ public class MultiPartByteRanges
     public static class PathContentSource extends org.eclipse.jetty.io.content.PathContentSource
     {
         private final ByteRange byteRange;
+        private long toRead;
 
         public PathContentSource(Path path, ByteRange byteRange)
         {
@@ -151,6 +152,7 @@ public class MultiPartByteRanges
         {
             SeekableByteChannel channel = super.open();
             channel.position(byteRange.first());
+            toRead = byteRange.getLength();
             return channel;
         }
 
@@ -158,12 +160,12 @@ public class MultiPartByteRanges
         protected int read(SeekableByteChannel channel, ByteBuffer byteBuffer) throws IOException
         {
             int read = super.read(channel, byteBuffer);
-            if (read < 0)
+            if (read <= 0)
                 return read;
 
-            read = (int)Math.min(read, byteRange.getLength());
+            read = (int)Math.min(read, toRead);
+            toRead -= read;
             byteBuffer.position(read);
-
             return read;
         }
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.jetty.tests.distribution;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Supplier;
 
@@ -22,8 +20,6 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.io.ClientConnector;
-import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -53,6 +49,7 @@ public class AbstractJettyHomeTest
         {
             SslContextFactory.Client sslContextFactory = new SslContextFactory.Client(true);
             ClientConnector clientConnector = new ClientConnector();
+            clientConnector.setSelectors(1);
             clientConnector.setSslContextFactory(sslContextFactory);
             HttpClientTransportOverHTTP httpClientTransportOverHTTP = new HttpClientTransportOverHTTP(clientConnector);
             startHttpClient(() -> new HttpClient(httpClientTransportOverHTTP));
@@ -69,7 +66,7 @@ public class AbstractJettyHomeTest
 
     public WorkDir workDir;
 
-    public Path newTestJettyBaseDirectory() throws IOException
+    public Path newTestJettyBaseDirectory()
     {
         return workDir.getEmptyPathDir();
     }
@@ -81,7 +78,7 @@ public class AbstractJettyHomeTest
             client.stop();
     }
 
-    protected class ResponseDetails implements Supplier<String>
+    protected static class ResponseDetails implements Supplier<String>
     {
         private final ContentResponse response;
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1512,7 +1512,8 @@ public class DistributionTests extends AbstractJettyHomeTest
                 startHttpClient();
                 ContentResponse response = client.newRequest("localhost", httpPort)
                     .path(contextPath + "/jetty.png")
-                    .headers(headers -> headers.put(HttpHeader.RANGE, "bytes=110-230,3600-4100"))
+                    // Use a range bigger than 4096, which is the default buffer size.
+                    .headers(headers -> headers.put(HttpHeader.RANGE, "bytes=1-100,101-5000"))
                     .timeout(15, TimeUnit.SECONDS)
                     .send();
                 assertEquals(HttpStatus.PARTIAL_CONTENT_206, response.getStatus());
@@ -1522,9 +1523,9 @@ public class DistributionTests extends AbstractJettyHomeTest
                 Content.Source multiPartContent = new ByteBufferContentSource(ByteBuffer.wrap(response.getContent()));
                 MultiPartByteRanges.Parts parts = new MultiPartByteRanges.Parser(boundary).parse(multiPartContent).get();
                 assertThat(parts.size(), is(2));
-                // Ranges are inclusive, so 110-230 is 121 bytes.
-                assertThat(parts.get(0).getLength(), is(121L));
-                assertThat(parts.get(1).getLength(), is(501L));
+                // Ranges are inclusive, so 1-100 is 100 bytes.
+                assertThat(parts.get(0).getLength(), is(100L));
+                assertThat(parts.get(1).getLength(), is(4900L));
             }
         }
     }


### PR DESCRIPTION
The handling of reads in MultiPartByteRanges.PathContentSource was broken for ranges that were larger than the read buffer size.

Fixed by properly counting how many bytes are left to read.