### PR TITLE
Align Logging Level for Listener Timeout Exceptions with Debug

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java
@@ -662,7 +662,7 @@ public class HttpChannelState
                             catch (Throwable x)
                             {
                                 if (LOG.isDebugEnabled())
-                                    LOG.warn("{} while invoking onTimeout listener {}", x.toString(), listener, x);
+                                    LOG.debug("{} while invoking onTimeout listener {}", x.toString(), listener, x);
                                 else
                                     LOG.warn("{} while invoking onTimeout listener {}", x.toString(), listener);
                             }


### PR DESCRIPTION
A very minor revision.
This PR aligns the logging level for exceptions thrown during the invocation of onTimeout listeners with the current debug state. The change is intended to ensure consistency in our logging practices.

To align with the rest of the code and the preceding if condition, this PR changes the log level from ```WARN``` to ```DEBUG``` when an exception is thrown during the invocation of ```onTimeout``` listeners. This ensures that these messages are only logged when the system is in debug mode, which is typically during development or troubleshooting periods.
