### PR TITLE
Fixes #10145 - WritePendingException over HTTP/2 tunnel

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -277,7 +277,7 @@ public abstract class WriteFlusher
             if (buffers != null)
             {
                 if (DEBUG)
-                    LOG.debug("flushed incomplete");
+                    LOG.debug("flush incomplete {}", this);
                 PendingState pending = new PendingState(callback, address, buffers);
                 if (updateState(__WRITING, pending))
                     onIncompleteFlush();

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/ProxyWithDynamicTransportTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/ProxyWithDynamicTransportTest.java
@@ -327,13 +327,13 @@ public class ProxyWithDynamicTransportTest
                 {
                     String id = p + "-" + i;
                     ContentResponse response = client.newRequest("localhost", serverPort)
-                    .scheme(scheme)
-                    .method(HttpMethod.POST)
-                    .path("/path/" + id)
-                    .version(serverProtocol)
-                    .body(new ByteBufferRequestContent(ByteBuffer.allocate(contentLength)))
-                    .timeout(5, TimeUnit.SECONDS)
-                    .send();
+                        .scheme(scheme)
+                        .method(HttpMethod.POST)
+                        .path("/path/" + id)
+                        .version(serverProtocol)
+                        .body(new ByteBufferRequestContent(ByteBuffer.allocate(contentLength)))
+                        .timeout(5, TimeUnit.SECONDS)
+                        .send();
 
                     assertEquals(HttpStatus.OK_200, response.getStatus());
                     assertEquals(contentLength, response.getContent().length);


### PR DESCRIPTION
Method HTTP2StreamEndPoint.flush() has a "no pending operation" semantic, but the previous implementation was calling stream.data(), which may become a pending operation if the stream is congested.

Changed the implementation of flush() to return false in the IDLE and PENDING cases. Now every flush() is converted to a write(), which has the same semantic as stream.data().