### PR TITLE
Transitive Executable Comparator #10143

### DIFF
--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -125,16 +125,10 @@ public class XmlConfiguration
                     Class<?> t2 = p2[i].getType();
                     if (t1 != t2)
                     {
-                        // Favour derived type over base type
-                        compare = Boolean.compare(t1.isAssignableFrom(t2), t2.isAssignableFrom(t1));
-                        if (compare == 0)
-                        {
-                            // favour primitive type over reference
-                            compare = Boolean.compare(!t1.isPrimitive(), !t2.isPrimitive());
-                            if (compare == 0)
-                                // Use name to avoid non determinant sorting
-                                compare = t1.getName().compareTo(t2.getName());
-                        }
+                        // Compare distance from Object
+                        int d1 = distanceFromObject(t1);
+                        int d2 = distanceFromObject(t2);
+                        compare = Integer.compare(d2, d1);
 
                         // break on the first different parameter (should always be true)
                         if (compare != 0)
@@ -142,11 +136,23 @@ public class XmlConfiguration
                     }
                 }
             }
-            compare = Math.min(1, Math.max(compare, -1));
         }
-
+        if (compare == 0)
+            compare = e1.toGenericString().compareTo(e2.toGenericString());
+        compare = Math.min(1, Math.max(compare, -1));
         return compare;
     };
+
+    private static int distanceFromObject(Class<?> c)
+    {
+        int depth = 0;
+        while (c != null && c != Object.class)
+        {
+            depth++;
+            c = c.getSuperclass();
+        }
+        return depth;
+    }
 
     /**
      * Set the standard IDs and properties expected in a jetty XML file:

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -955,9 +955,10 @@ public class XmlConfiguration
                 throw new IllegalArgumentException("Method name cannot be blank");
 
             // Lets just try all methods for now
-
-            Method[] methods = oClass.getMethods();
-            Arrays.sort(methods, EXECUTABLE_COMPARATOR);
+            List<Method> methods = Arrays.stream(oClass.getMethods())
+                .filter(m -> m.getName().equals(methodName))
+                .sorted(EXECUTABLE_COMPARATOR)
+                .toList();
             for (Method method : methods)
             {
                 if (!method.getName().equals(methodName))

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -68,6 +68,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.xml.XmlConfiguration.EXECUTABLE_COMPARATOR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -784,7 +785,7 @@ public class XmlConfigurationTest
     {
         List<Method> methods = Arrays.stream(TestOrder.class.getMethods()).filter(m -> "call".equals(m.getName())).collect(Collectors.toList());
         Collections.shuffle(methods);
-        methods.sort(XmlConfiguration.EXECUTABLE_COMPARATOR);
+        methods.sort(EXECUTABLE_COMPARATOR);
         assertThat(methods, Matchers.contains(
             TestOrder.class.getMethod("call"),
             TestOrder.class.getMethod("call", int.class),
@@ -2037,5 +2038,45 @@ public class XmlConfigurationTest
     private interface ThrowableAction
     {
         void run() throws Exception;
+    }
+
+    @Test
+    public void testExecutableComparator() throws Throwable
+    {
+        xx(null);
+        yy(null);
+        zz(null);
+
+        List<Method> methods = Arrays.stream(XmlConfigurationTest.class.getMethods())
+            .filter(m -> m.getName().length() == 2)
+            .toList();
+
+        // The implementor must also ensure that the relation is transitive: ((compare(x, y)>0) && (compare(y, z)>0)) implies compare(x, z)>0
+        assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(1)), is(EXECUTABLE_COMPARATOR.compare(methods.get(1), methods.get(2))));
+        assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(1)), is(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(2))));
+    }
+
+    public void xx(XXX ignored)
+    {
+    }
+
+    public void yy(YYY ignored)
+    {
+    }
+
+    public void zz(ZZZ ignored)
+    {
+    }
+
+    public interface XXX
+    {
+    }
+
+    public static class YYY
+    {
+    }
+
+    public static class ZZZ implements XXX
+    {
     }
 }


### PR DESCRIPTION
Fix #10143 the executable comparator to always be transitive.