### PR TITLE
Fixes #10160 - Verify PROXY_AUTHENTICATION is sent to forward proxies

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.util.BufferingResponseListener;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.QuotedCSV;
 import org.eclipse.jetty.util.NanoTime;
@@ -205,14 +206,9 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
 
                 conversation.setAttribute(authenticationAttribute, true);
 
-                URI requestURI = request.getURI();
-                String path = null;
-                if (requestURI == null)
-                {
-                    requestURI = resolveURI(request, null);
-                    path = request.getPath();
-                }
-                Request newRequest = client.copyRequest(request, requestURI);
+                Request newRequest = client.copyRequest(request, request.getURI());
+                if (HttpMethod.CONNECT.is(newRequest.getMethod()))
+                    newRequest.path(request.getPath());
 
                 // Adjust the timeout of the new request, taking into account the
                 // timeout of the previous request and the time already elapsed.
@@ -231,9 +227,6 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
                         return;
                     }
                 }
-
-                if (path != null)
-                    newRequest.path(path);
 
                 authnResult.apply(newRequest);
                 // Copy existing, explicitly set, authorization headers.

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.client.api.AuthenticationStore;
@@ -467,59 +466,12 @@ public class HttpClient extends ContainerLifeCycle
 
     protected Request copyRequest(HttpRequest oldRequest, URI newURI)
     {
-        HttpRequest newRequest = newHttpRequest(oldRequest.getConversation(), newURI);
-        newRequest.method(oldRequest.getMethod())
-            .version(oldRequest.getVersion())
-            .body(oldRequest.getBody())
-            .idleTimeout(oldRequest.getIdleTimeout(), TimeUnit.MILLISECONDS)
-            .timeout(oldRequest.getTimeout(), TimeUnit.MILLISECONDS)
-            .followRedirects(oldRequest.isFollowRedirects())
-            .tag(oldRequest.getTag());
-        for (HttpField field : oldRequest.getHeaders())
-        {
-            HttpHeader header = field.getHeader();
-            // We have a new URI, so skip the host header if present.
-            if (HttpHeader.HOST == header)
-                continue;
-
-            // Remove expectation headers.
-            if (HttpHeader.EXPECT == header)
-                continue;
-
-            // Remove cookies.
-            if (HttpHeader.COOKIE == header)
-                continue;
-
-            // Remove authorization headers.
-            if (HttpHeader.AUTHORIZATION == header ||
-                HttpHeader.PROXY_AUTHORIZATION == header)
-                continue;
-
-            if (!newRequest.getHeaders().contains(field))
-                newRequest.addHeader(field);
-        }
-        return newRequest;
+        return oldRequest.copy(newURI);
     }
 
     protected HttpRequest newHttpRequest(HttpConversation conversation, URI uri)
     {
-        return new HttpRequest(this, conversation, checkHost(uri));
-    }
-
-    /**
-     * <p>Checks {@code uri} for the host to be non-null host.</p>
-     * <p>URIs built from strings that have an internationalized domain name (IDN)
-     * are parsed without errors, but {@code uri.getHost()} returns null.</p>
-     *
-     * @param uri the URI to check for non-null host
-     * @return the same {@code uri} if the host is non-null
-     * @throws IllegalArgumentException if the host is null
-     */
-    private URI checkHost(URI uri)
-    {
-        if (uri.getHost() == null)
-            throw new IllegalArgumentException(String.format("Invalid URI host: null (authority: %s)", uri.getRawAuthority()));
-        return uri;
+        return new HttpRequest(this, conversation, uri);
     }
 
     public Destination resolveDestination(Request request)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.client.util.BytesRequestContent;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.util.Attachable;
@@ -152,7 +153,9 @@ public abstract class HttpConnection implements IConnection, Attachable
         }
 
         ProxyConfiguration.Proxy proxy = destination.getProxy();
-        if (proxy instanceof HttpProxy && !HttpClient.isSchemeSecure(request.getScheme()))
+        // RFC 9112, section 3.2.2: when making a request to a proxy other than CONNECT,
+        // the client must send the target URI in absolute-form as the request target.
+        if (proxy instanceof HttpProxy && !HttpMethod.CONNECT.is(request.getMethod()))
         {
             URI uri = request.getURI();
             if (uri != null)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -152,10 +152,10 @@ public abstract class HttpConnection implements IConnection, Attachable
             request.path(path);
         }
 
-        ProxyConfiguration.Proxy proxy = destination.getProxy();
         // RFC 9112, section 3.2.2: when making a request to a proxy other than CONNECT,
         // the client must send the target URI in absolute-form as the request target.
-        if (proxy instanceof HttpProxy && !HttpMethod.CONNECT.is(request.getMethod()))
+        ProxyConfiguration.Proxy proxy = destination.getProxy();
+        if (proxy instanceof HttpProxy && !HttpMethod.CONNECT.is(request.getMethod()) && !HttpClient.isSchemeSecure(request.getScheme()))
         {
             URI uri = request.getURI();
             if (uri != null)

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -119,30 +119,9 @@ public class HttpProxy extends ProxyConfiguration.Proxy
         {
             HttpDestination destination = (HttpDestination)context.get(HttpClientTransport.HTTP_DESTINATION_CONTEXT_KEY);
             if (requiresTunnel(destination.getOrigin()))
-            {
-                @SuppressWarnings("unchecked")
-                Promise<Connection> promise = (Promise<Connection>)context.get(HttpClientTransport.HTTP_CONNECTION_PROMISE_CONTEXT_KEY);
-                Promise<Connection> wrapped = promise;
-                if (promise instanceof Promise.Wrapper)
-                    wrapped = ((Promise.Wrapper<Connection>)promise).unwrap();
-                if (wrapped instanceof TunnelPromise)
-                {
-                    // TODO: review this, may not be necessary!
-                    // In case the server closes the tunnel (e.g. proxy authentication
-                    // required: 407 + Connection: close), we will open another tunnel
-                    // so we need to tell the promise about the new EndPoint.
-                    ((TunnelPromise)wrapped).setEndPoint(endPoint);
-                    return connectionFactory.newConnection(endPoint, context);
-                }
-                else
-                {
-                    return newProxyConnection(endPoint, context);
-                }
-            }
+                return newProxyConnection(endPoint, context);
             else
-            {
                 return connectionFactory.newConnection(endPoint, context);
-            }
         }
 
         private org.eclipse.jetty.io.Connection newProxyConnection(EndPoint endPoint, Map<String, Object> context) throws IOException

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -324,6 +324,10 @@ public class HttpRedirector
                     headers.remove(HttpHeader.CONTENT_TYPE);
                 });
             }
+            else if (HttpMethod.CONNECT.is(method))
+            {
+                redirect.path(httpRequest.getPath());
+            }
 
             Request.Content body = redirect.getBody();
             if (body != null && !body.isReproducible())

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -56,6 +57,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.URIUtil;
 
 public class HttpRequest implements Request
 {
@@ -92,6 +94,10 @@ public class HttpRequest implements Request
 
     protected HttpRequest(HttpClient client, HttpConversation conversation, URI uri)
     {
+        // URIs built from strings that have an internationalized domain name (IDN)
+        // are parsed without errors, but uri.getHost() returns null.
+        if (uri.getHost() == null)
+            throw new IllegalArgumentException(String.format("Invalid URI host: null (authority: %s)", uri.getRawAuthority()));
         this.client = client;
         this.conversation = conversation;
         scheme = uri.getScheme();
@@ -108,6 +114,47 @@ public class HttpRequest implements Request
         HttpField userAgentField = client.getUserAgentField();
         if (userAgentField != null)
             headers.put(userAgentField);
+    }
+
+    HttpRequest copy(URI newURI)
+    {
+        if (newURI == null)
+        {
+            StringBuilder builder = new StringBuilder(64);
+            URIUtil.appendSchemeHostPort(builder, getScheme(), getHost(), getPort());
+            newURI = URI.create(builder.toString());
+        }
+
+        HttpRequest newRequest = copyInstance(newURI);
+        newRequest.method(getMethod())
+            .version(getVersion())
+            .body(getBody())
+            .idleTimeout(getIdleTimeout(), TimeUnit.MILLISECONDS)
+            .timeout(getTimeout(), TimeUnit.MILLISECONDS)
+            .followRedirects(isFollowRedirects())
+            .tag(getTag())
+            .headers(h -> h.clear().add(getHeaders())
+                // Remove the headers that depend on the URI.
+                .remove(EnumSet.of(
+                    HttpHeader.HOST,
+                    HttpHeader.EXPECT,
+                    HttpHeader.COOKIE,
+                    HttpHeader.AUTHORIZATION,
+                    HttpHeader.PROXY_AUTHORIZATION
+                ))
+            );
+
+        return newRequest;
+    }
+
+    HttpRequest copyInstance(URI newURI)
+    {
+        return new HttpRequest(getHttpClient(), getConversation(), newURI);
+    }
+
+    HttpClient getHttpClient()
+    {
+        return client;
     }
 
     public HttpConversation getConversation()

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
@@ -20,7 +20,7 @@ import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.util.Callback;
 
 /**
- * <p>A HTTP/2 specific handler of events for normal and tunneled exchanges.</p>
+ * <p>A HTTP/2 specific handler of events for normal and tunnelled exchanges.</p>
  */
 public interface HTTP2Channel
 {

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/ProxyWithDynamicTransportTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/ProxyWithDynamicTransportTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http.client;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -38,8 +40,10 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Destination;
 import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
 import org.eclipse.jetty.client.http.HttpClientConnectionFactory;
+import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.ByteBufferRequestContent;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
@@ -146,6 +150,11 @@ public class ProxyWithDynamicTransportTest
 
     private void startProxy(ConnectHandler connectHandler) throws Exception
     {
+        startProxy(connectHandler, new ForwardProxyServlet());
+    }
+
+    private void startProxy(ConnectHandler connectHandler, ForwardProxyServlet proxyServlet) throws Exception
+    {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setKeyStorePath("src/test/resources/keystore.p12");
         sslContextFactory.setKeyStorePassword("storepwd");
@@ -173,17 +182,7 @@ public class ProxyWithDynamicTransportTest
 
         proxy.setHandler(connectHandler);
         ServletContextHandler context = new ServletContextHandler(connectHandler, "/");
-        ServletHolder holder = new ServletHolder(new AsyncProxyServlet()
-        {
-            @Override
-            protected HttpClient newHttpClient(ClientConnector clientConnector)
-            {
-                ClientConnectionFactory.Info h1 = HttpClientConnectionFactory.HTTP11;
-                HTTP2Client http2Client = new HTTP2Client(clientConnector);
-                ClientConnectionFactory.Info http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client);
-                return new HttpClient(new HttpClientTransportDynamic(clientConnector, h1, http2));
-            }
-        });
+        ServletHolder holder = new ServletHolder(proxyServlet);
         context.addServlet(holder, "/*");
         proxy.start();
         LOG.info("Started proxy on :{} and :{}", proxyConnector.getLocalPort(), proxyTLSConnector.getLocalPort());
@@ -343,6 +342,70 @@ public class ProxyWithDynamicTransportTest
                     throw new RuntimeException(x);
                 }
             }));
+    }
+
+    @ParameterizedTest(name = "proxyProtocol={0}, proxySecure={1}, serverProtocol={2}, serverSecure={3}")
+    @MethodSource("testParams")
+    public void testProxyAuthentication(Origin.Protocol proxyProtocol, boolean proxySecure, HttpVersion serverProtocol, boolean serverSecure) throws Exception
+    {
+        int status = HttpStatus.NO_CONTENT_204;
+        startServer(new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response)
+            {
+                response.setStatus(status);
+            }
+        });
+        startProxy(new ConnectHandler()
+        {
+            @Override
+            protected void handleConnect(Request baseRequest, HttpServletRequest request, HttpServletResponse response, String serverAddress)
+            {
+                // Handle proxy authentication for tunneled requests.
+                String proxyAuthorization = request.getHeader(HttpHeader.PROXY_AUTHORIZATION.asString());
+                if (proxyAuthorization == null)
+                {
+                    baseRequest.setHandled(true);
+                    response.setStatus(HttpStatus.FORBIDDEN_403);
+                }
+                else
+                {
+                    super.handleConnect(baseRequest, request, response, serverAddress);
+                }
+            }
+        }, new ForwardProxyServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            {
+                // Handle proxy authentication for non-tunneled requests.
+                String proxyAuthorization = request.getHeader(HttpHeader.PROXY_AUTHORIZATION.asString());
+                if (proxyAuthorization == null)
+                    response.sendError(HttpStatus.FORBIDDEN_403);
+                else
+                    super.service(request, response);
+            }
+        });
+        startClient();
+
+        String proxyScheme = proxySecure ? "https" : "http";
+        int proxyPort = proxySecure ? proxyTLSConnector.getLocalPort() : proxyConnector.getLocalPort();
+        Origin.Address proxyAddress = new Origin.Address("localhost", proxyPort);
+        HttpProxy proxy = new HttpProxy(proxyAddress, proxySecure, proxyProtocol);
+        client.getProxyConfiguration().addProxy(proxy);
+
+        URI uri = URI.create(proxyScheme + "://" + proxyAddress.asString());
+        client.getAuthenticationStore().addAuthenticationResult(new BasicAuthentication.BasicResult(uri, HttpHeader.PROXY_AUTHORIZATION, "jetty", "jetty"));
+
+        String serverScheme = serverSecure ? "https" : "http";
+        int serverPort = serverSecure ? serverTLSConnector.getLocalPort() : serverConnector.getLocalPort();
+        ContentResponse response = client.newRequest("localhost", serverPort)
+            .scheme(serverScheme)
+            .version(serverProtocol)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+        assertEquals(status, response.getStatus());
     }
 
     @Test
@@ -628,5 +691,17 @@ public class ProxyWithDynamicTransportTest
         assertTrue(resetLatch.await(5, TimeUnit.SECONDS));
         // Tunnel must be closed.
         assertTrue(closeLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    private static class ForwardProxyServlet extends AsyncProxyServlet
+    {
+        @Override
+        protected HttpClient newHttpClient(ClientConnector clientConnector)
+        {
+            ClientConnectionFactory.Info h1 = HttpClientConnectionFactory.HTTP11;
+            HTTP2Client http2Client = new HTTP2Client(clientConnector);
+            ClientConnectionFactory.Info http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client);
+            return new HttpClient(new HttpClientTransportDynamic(clientConnector, h1, http2));
+        }
     }
 }


### PR DESCRIPTION
Now TunnelRequest.getURI() does not return null, so normalizeRequest() can properly apply the authentication headers.