### PR TITLE
Issue #10164 - test to prove out FSPool mount vs reference count logic

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -258,15 +258,15 @@ public class FileSystemPool implements Dumpable
     }
 
     /**
-     * Used to test the reference count value for a URI during unit testing.
+     * Only used to test the reference count value for a URI during unit testing.
      * @param fsUri the filesystem URI to fetch
      * @return the reference count on that URI
      */
-    protected int getReferenceCount(URI fsUri)
+    int getReferenceCount(URI fsUri)
     {
         Bucket bucket = pool.get(fsUri);
         if (bucket == null)
-            return -1;
+            return 0;
         return bucket.counter.get();
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -258,6 +258,19 @@ public class FileSystemPool implements Dumpable
     }
 
     /**
+     * Used to test the reference count value for a URI during unit testing.
+     * @param fsUri the filesystem URI to fetch
+     * @return the reference count on that URI
+     */
+    protected int getReferenceCount(URI fsUri)
+    {
+        Bucket bucket = pool.get(fsUri);
+        if (bucket == null)
+            return -1;
+        return bucket.counter.get();
+    }
+
+    /**
      * Set a listener on the FileSystemPool to monitor for pool events.
      *
      * @param listener the listener for pool events

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -134,7 +134,10 @@ class ResourceFactoryInternals
         @Override
         public void dump(Appendable out, String indent) throws IOException
         {
-            Dumpable.dumpObjects(out, indent, this, new DumpableCollection("mounts", _compositeResourceFactory.getMounts()));
+            List<URI> referencedUris = _compositeResourceFactory.getMounts().stream()
+                .map(mount -> mount.root().getURI())
+                .toList();
+            Dumpable.dumpObjects(out, indent, this, new DumpableCollection("newResourceReferences", referencedUris));
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -366,10 +366,12 @@ public class MountedPathResourceTest
     /**
      * When mounting multiple points within the same JAR, only
      * 1 mount should be created, but have reference counts
-     * tracked separately.
+     * tracked separately.  Done via {@link ResourceFactory.Closeable}
+     * essentially a duplicate of {@link #testMountByJarNameLifeCycle()}
+     * to ensure parity in the two implementations.
      */
     @Test
-    public void testMountByJarName()
+    public void testMountByJarNameClosable()
     {
         Path jarPath = MavenPaths.findTestResourceFile("jar-file-resource.jar");
         URI uriRoot = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/"); // root
@@ -387,6 +389,42 @@ public class MountedPathResourceTest
             assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
             int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
             assertThat(mountCount, is(4));
+        }
+    }
+
+    /**
+     * When mounting multiple points within the same JAR, only
+     * 1 mount should be created, but have reference counts
+     * tracked separately.  Done via {@link ResourceFactory.LifeCycle}
+     * essentially a duplicate of {@link #testMountByJarNameClosable()}
+     * to ensure parity in the two implementations.
+     */
+    @Test
+    public void testMountByJarNameLifeCycle() throws Exception
+    {
+        Path jarPath = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        URI uriRoot = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/"); // root
+        URI uriRez = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/"); // dir
+        URI uriDeep = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/"); // dir
+        URI uriZzz = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/zzz"); // file
+
+        ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
+
+        try
+        {
+            resourceFactory.start();
+            Resource resRoot = resourceFactory.newResource(uriRoot);
+            Resource resRez = resourceFactory.newResource(uriRez);
+            Resource resDeep = resourceFactory.newResource(uriDeep);
+            Resource resZzz = resourceFactory.newResource(uriZzz);
+
+            assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
+            int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
+            assertThat(mountCount, is(4));
+        }
+        finally
+        {
+            resourceFactory.stop();
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -390,6 +390,10 @@ public class MountedPathResourceTest
             int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
             assertThat(mountCount, is(4));
         }
+
+        assertThat(FileSystemPool.INSTANCE.mounts().size(), is(0));
+        int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
+        assertThat(mountCount, is(0));
     }
 
     /**
@@ -431,6 +435,10 @@ public class MountedPathResourceTest
         finally
         {
             resourceFactory.stop();
+
+            assertThat(FileSystemPool.INSTANCE.mounts().size(), is(0));
+            int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
+            assertThat(mountCount, is(0));
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -421,6 +421,12 @@ public class MountedPathResourceTest
             assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
             int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
             assertThat(mountCount, is(4));
+            String dump = resourceFactory.dump();
+            assertThat(dump, containsString("newResourceReferences size=4"));
+            assertThat(dump, containsString(uriRoot.toASCIIString()));
+            assertThat(dump, containsString(uriRez.toASCIIString()));
+            assertThat(dump, containsString(uriDeep.toASCIIString()));
+            assertThat(dump, containsString(uriZzz.toASCIIString()));
         }
         finally
         {


### PR DESCRIPTION
Adding testcase to show FSPool mount vs reference count logic as it currently stands in 12.0.x HEAD (from  https://github.com/eclipse/jetty.project/issues/10164#issuecomment-1653959106)
