### PR TITLE
Fixes #9386 - SSL reports deprecated setting, but ssl.ini still uses it.

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/module-ssl.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/module-ssl.adoc
@@ -50,7 +50,7 @@ include::{JETTY_HOME}/modules/ssl.mod[tags=documentation-ssl-context]
 Among the configurable properties, the most relevant are:
 
 `jetty.sslContext.keyStorePath`::
-The KeyStore path on the file system relative to `$JETTY_BASE` -- defaults to `$JETTY_BASE/etc/keystore.p12`.
+The KeyStore path on the file system, either an absolute path or a relative path to `$JETTY_BASE` -- defaults to `$JETTY_BASE/etc/keystore.p12`.
 `jetty.sslContext.keyStorePassword`::
 The KeyStore password, which you want to explicitly configure.
 The password may be obfuscated with the xref:og-password[Jetty Password Tool].

--- a/jetty-server/src/main/config/modules/ssl.mod
+++ b/jetty-server/src/main/config/modules/ssl.mod
@@ -86,15 +86,11 @@ etc/jetty-ssl-context.xml
 ## The JSSE Provider.
 # jetty.sslContext.provider=
 
-## The KeyStore file path (relative to $JETTY_BASE).
+## The KeyStore file path, either an absolute path or a relative path to $JETTY_BASE.
 # jetty.sslContext.keyStorePath=etc/keystore.p12
-## The KeyStore absolute file path.
-# jetty.sslContext.keyStoreAbsolutePath=${jetty.base}/etc/keystore.p12
 
-## The TrustStore file path (relative to $JETTY_BASE).
+## The TrustStore file path, either an absolute path or a relative path to $JETTY_BASE.
 # jetty.sslContext.trustStorePath=etc/keystore.p12
-## The TrustStore absolute file path.
-# jetty.sslContext.trustStoreAbsolutePath=${jetty.base}/etc/keystore.p12
 
 ## The KeyStore password.
 # jetty.sslContext.keyStorePassword=


### PR DESCRIPTION
Removed references to deprecated properties `jetty.sslContext.[key|trust]StoreAbsolutePath`. Updated documentation to explicitly report that the path can be absolute.