### PR TITLE
Fix Junit usage issues

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
@@ -45,7 +45,7 @@ public class LargeDeflateTest
     private final EventSocket _serverSocket = new EventSocket();
 
     @BeforeEach
-    void before() throws Exception
+    public void before() throws Exception
     {
         _server = new Server();
         _connector = new ServerConnector(_server);
@@ -71,7 +71,7 @@ public class LargeDeflateTest
     }
 
     @AfterEach
-    void after() throws Exception
+    public void after() throws Exception
     {
         _client.stop();
         _server.stop();

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
@@ -78,7 +78,7 @@ public class LargeDeflateTest
     }
 
     @Test
-    void testDeflate() throws Exception
+    public void testDeflate() throws Exception
     {
         ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
         upgradeRequest.addExtensions("permessage-deflate");

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -792,7 +792,7 @@ public class WebAppContextTest
     }
 
     @Test
-    void testSetServerPropagation()
+    public void testSetServerPropagation()
     {
         Server server = new Server();
         WebAppContext context = new WebAppContext();

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/OrderingTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ExtendWith(WorkDirExtension.class)
 public class OrderingTest
 {
-    WorkDir workDir;
+    public WorkDir workDir;
 
     private Resource newTestableDirResource(String name) throws IOException
     {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/LargeDeflateTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/LargeDeflateTest.java
@@ -74,7 +74,7 @@ public class LargeDeflateTest
     }
 
     @Test
-    void testDeflate() throws Exception
+    public void testDeflate() throws Exception
     {
         ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
         upgradeRequest.addExtensions("permessage-deflate");
@@ -94,7 +94,7 @@ public class LargeDeflateTest
     }
 
     @Test
-    void testDeflateLargerThanMaxMessage() throws Exception
+    public void testDeflateLargerThanMaxMessage() throws Exception
     {
         ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
         upgradeRequest.addExtensions("permessage-deflate");

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/LargeDeflateTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/LargeDeflateTest.java
@@ -45,7 +45,7 @@ public class LargeDeflateTest
     private final EventSocket _serverSocket = new EventSocket();
 
     @BeforeEach
-    void before() throws Exception
+    public void before() throws Exception
     {
         _server = new Server();
         _connector = new ServerConnector(_server);
@@ -67,7 +67,7 @@ public class LargeDeflateTest
     }
 
     @AfterEach
-    void after() throws Exception
+    public void after() throws Exception
     {
         _client.stop();
         _server.stop();


### PR DESCRIPTION
There are some methods / test classes that are using Junit improperly.
Fix those classes to have the correct (field and method) modifiers to work with Junit.