### PR TITLE
Ensure @BeforeEach and @AfterEach are public methods (not protected)

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/test/java/org/eclipse/jetty/quic/quiche/foreign/incubator/LowLevelQuicheClientCertTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/test/java/org/eclipse/jetty/quic/quiche/foreign/incubator/LowLevelQuicheClientCertTest.java
@@ -62,7 +62,7 @@ public class LowLevelQuicheClientCertTest
     private Certificate[] serverCertificateChain;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         clientSocketAddress = new InetSocketAddress("localhost", 9999);
         serverSocketAddress = new InetSocketAddress("localhost", 8888);
@@ -113,7 +113,7 @@ public class LowLevelQuicheClientCertTest
     }
 
     @AfterEach
-    protected void tearDown()
+    public void tearDown()
     {
         connectionsToDisposeOf.forEach(ForeignIncubatorQuicheConnection::dispose);
         connectionsToDisposeOf.clear();

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/test/java/org/eclipse/jetty/quic/quiche/foreign/incubator/LowLevelQuicheTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/test/java/org/eclipse/jetty/quic/quiche/foreign/incubator/LowLevelQuicheTest.java
@@ -64,7 +64,7 @@ public class LowLevelQuicheTest
     private Certificate[] serverCertificateChain;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         clientSocketAddress = new InetSocketAddress("localhost", 9999);
         serverSocketAddress = new InetSocketAddress("localhost", 8888);
@@ -111,7 +111,7 @@ public class LowLevelQuicheTest
     }
 
     @AfterEach
-    protected void tearDown()
+    public void tearDown()
     {
         connectionsToDisposeOf.forEach(ForeignIncubatorQuicheConnection::dispose);
         connectionsToDisposeOf.clear();

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/test/java/org/eclipse/jetty/quic/quiche/jna/LowLevelQuicheClientCertTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/test/java/org/eclipse/jetty/quic/quiche/jna/LowLevelQuicheClientCertTest.java
@@ -61,7 +61,7 @@ public class LowLevelQuicheClientCertTest
     private Certificate[] serverCertificateChain;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         clientSocketAddress = new InetSocketAddress("localhost", 9999);
         serverSocketAddress = new InetSocketAddress("localhost", 8888);
@@ -112,7 +112,7 @@ public class LowLevelQuicheClientCertTest
     }
 
     @AfterEach
-    protected void tearDown()
+    public void tearDown()
     {
         connectionsToDisposeOf.forEach(JnaQuicheConnection::dispose);
         connectionsToDisposeOf.clear();

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/test/java/org/eclipse/jetty/quic/quiche/jna/LowLevelQuicheTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/test/java/org/eclipse/jetty/quic/quiche/jna/LowLevelQuicheTest.java
@@ -59,7 +59,7 @@ public class LowLevelQuicheTest
     private Certificate[] serverCertificateChain;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         clientSocketAddress = new InetSocketAddress("localhost", 9999);
         serverSocketAddress = new InetSocketAddress("localhost", 8888);
@@ -106,7 +106,7 @@ public class LowLevelQuicheTest
     }
 
     @AfterEach
-    protected void tearDown()
+    public void tearDown()
     {
         connectionsToDisposeOf.forEach(JnaQuicheConnection::dispose);
         connectionsToDisposeOf.clear();

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletCacheTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppDefaultServletCacheTest.java
@@ -34,7 +34,7 @@ public class WebAppDefaultServletCacheTest
     private Path resourcePath;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    public void setUp() throws Exception
     {
         server = new Server();
         connector = new LocalConnector(server);
@@ -48,7 +48,7 @@ public class WebAppDefaultServletCacheTest
     }
 
     @AfterEach
-    protected void tearDown() throws Exception
+    public void tearDown() throws Exception
     {
         server.stop();
     }


### PR DESCRIPTION
Address junit warnings during IDE execution of testcase