### PR TITLE
Merge `release/12.0.0` back into `jetty-12.0.x`

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,3 +1,5 @@
+jetty-12.0.1-SNAPSHOT
+
 jetty-12.0.0 - 07 August 2023
  + 8405 Servlet 3.1 ReadListener.onAllDataRead() is called twice under h2 or
    h2c if the server doesn't respond within 30s

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,4 +1,22 @@
-jetty-12.0.0-SNAPSHOT
+jetty-12.0.0 - 07 August 2023
+ + 8405 Servlet 3.1 ReadListener.onAllDataRead() is called twice under h2 or
+   h2c if the server doesn't respond within 30s
+ + 9386 SSL reports deprecated setting, but ssl.ini still uses it
+ + 9720 Http2Session.streamIdleTimeout should permit being disabled from
+   AbstractHTTP2ServerConnectionFactory
+ + 10121 ee9 to ee8 conversion not working for JSP files with jakarta imports
+ + 10135 Websocket: Using PerMessageDeflateExtension and flush in batchMode
+   send FLUSH_FRAME to client. 
+ + 10155 EE10 Servlet include after `HttpServletResponse.getWriter().println()`
+   omits `Content-Length` from the response
+ + 10160 Verify PROXY_AUTHENTICATION is sent to forward proxies
+ + 10164 Needless META-INF/resources and web-fragment.xml mounts
+ + 10211 NPE in ArrayByteBufferPool.findOldestEntry()
+ + 10227 EE10 Unable to use Cookie attributes with
+   `HttpServletResponse.addCookie(jakarta.servlet.http.Cookie)`
+ + 10229 HttpConfiguration.setIdleTimeout() breaks long running requests
+ + 10231 DefaultServlet no longer supports POST and OPTIONS and returns a 405
+   instead 
 
 jetty-12.0.0.beta4 - 26 July 2023
  + 8556 ServletContext.getSessionTimeout() incorrectly throws

--- a/build/build-resources/pom.xml
+++ b/build/build-resources/pom.xml
@@ -7,7 +7,7 @@
     -->
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>build-resources</artifactId>
-  <version>12.0.0-SNAPSHOT</version>
+  <version>12.0.0</version>
   <name>Build :: Resources</name>
   <packaging>jar</packaging>
 

--- a/build/build-resources/pom.xml
+++ b/build/build-resources/pom.xml
@@ -7,7 +7,7 @@
     -->
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>build-resources</artifactId>
-  <version>12.0.0</version>
+  <version>12.0.1-SNAPSHOT</version>
   <name>Build :: Resources</name>
   <packaging>jar</packaging>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/jetty-asciidoctor-extensions/pom.xml
+++ b/documentation/jetty-asciidoctor-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/jetty-asciidoctor-extensions/pom.xml
+++ b/documentation/jetty-asciidoctor-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-client</artifactId>

--- a/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-client</artifactId>

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-server</artifactId>

--- a/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-core/jetty-alpn/jetty-alpn-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn-server</artifactId>

--- a/jetty-core/jetty-alpn/pom.xml
+++ b/jetty-core/jetty-alpn/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn</artifactId>

--- a/jetty-core/jetty-alpn/pom.xml
+++ b/jetty-core/jetty-alpn/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-alpn</artifactId>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-bom</artifactId>
@@ -42,277 +42,277 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-tools</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-keystore</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-openid</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-osgi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-slf4j-impl</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-start</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixdomain-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.demos</groupId>
         <artifactId>jetty-demo-handler</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-client-transport</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-hpack</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-client-transport</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-qpack</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-foreign-incubator</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-jna</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-bom</artifactId>
@@ -42,277 +42,277 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-tools</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-keystore</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-openid</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-osgi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-slf4j-impl</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-start</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixdomain-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.demos</groupId>
         <artifactId>jetty-demo-handler</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>jetty-fcgi-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-client-transport</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-hpack</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>jetty-http2-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-client-transport</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-qpack</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>jetty-http3-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-foreign-incubator</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-quiche-jna</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>jetty-quic-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-core/jetty-client/pom.xml
+++ b/jetty-core/jetty-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-client/pom.xml
+++ b/jetty-core/jetty-client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-demos/jetty-demo-handler/pom.xml
+++ b/jetty-core/jetty-demos/jetty-demo-handler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>jetty-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-demo-handler</artifactId>

--- a/jetty-core/jetty-demos/jetty-demo-handler/pom.xml
+++ b/jetty-core/jetty-demos/jetty-demo-handler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>jetty-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-demo-handler</artifactId>

--- a/jetty-core/jetty-demos/pom.xml
+++ b/jetty-core/jetty-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-demos/pom.xml
+++ b/jetty-core/jetty-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-deploy/pom.xml
+++ b/jetty-core/jetty-deploy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-deploy/pom.xml
+++ b/jetty-core/jetty-deploy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>jetty-fcgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/pom.xml
+++ b/jetty-core/jetty-fcgi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-fcgi/pom.xml
+++ b/jetty-core/jetty-fcgi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http-spi/pom.xml
+++ b/jetty-core/jetty-http-spi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-http-spi</artifactId>

--- a/jetty-core/jetty-http-spi/pom.xml
+++ b/jetty-core/jetty-http-spi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-http-spi</artifactId>

--- a/jetty-core/jetty-http-tools/pom.xml
+++ b/jetty-core/jetty-http-tools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http-tools/pom.xml
+++ b/jetty-core/jetty-http-tools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http/pom.xml
+++ b/jetty-core/jetty-http/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http/pom.xml
+++ b/jetty-core/jetty-http/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-client/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-client/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-common/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-common/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-hpack/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-hpack/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-server/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-server/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
+++ b/jetty-core/jetty-http2/jetty-http2-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>jetty-http2</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/pom.xml
+++ b/jetty-core/jetty-http2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http2/pom.xml
+++ b/jetty-core/jetty-http2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-client/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-client/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-common/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-common/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-qpack/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-qpack/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-server/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-server/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>jetty-http3</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/pom.xml
+++ b/jetty-core/jetty-http3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-http3/pom.xml
+++ b/jetty-core/jetty-http3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-io/pom.xml
+++ b/jetty-core/jetty-io/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-io</artifactId>

--- a/jetty-core/jetty-io/pom.xml
+++ b/jetty-core/jetty-io/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-io</artifactId>

--- a/jetty-core/jetty-jmx/pom.xml
+++ b/jetty-core/jetty-jmx/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jmx</artifactId>

--- a/jetty-core/jetty-jmx/pom.xml
+++ b/jetty-core/jetty-jmx/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-jmx</artifactId>

--- a/jetty-core/jetty-jndi/pom.xml
+++ b/jetty-core/jetty-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-jndi/pom.xml
+++ b/jetty-core/jetty-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-keystore/pom.xml
+++ b/jetty-core/jetty-keystore/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-keystore</artifactId>

--- a/jetty-core/jetty-keystore/pom.xml
+++ b/jetty-core/jetty-keystore/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-keystore</artifactId>

--- a/jetty-core/jetty-openid/pom.xml
+++ b/jetty-core/jetty-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-openid/pom.xml
+++ b/jetty-core/jetty-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-osgi/pom.xml
+++ b/jetty-core/jetty-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-osgi/pom.xml
+++ b/jetty-core/jetty-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-proxy/pom.xml
+++ b/jetty-core/jetty-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-proxy/pom.xml
+++ b/jetty-core/jetty-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-client/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-client/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-common/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-common/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic-quiche</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-server/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/jetty-quic-server/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>jetty-quic</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/pom.xml
+++ b/jetty-core/jetty-quic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-quic/pom.xml
+++ b/jetty-core/jetty-quic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-rewrite/pom.xml
+++ b/jetty-core/jetty-rewrite/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-rewrite/pom.xml
+++ b/jetty-core/jetty-rewrite/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-security/pom.xml
+++ b/jetty-core/jetty-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-security/pom.xml
+++ b/jetty-core/jetty-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-server/pom.xml
+++ b/jetty-core/jetty-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-server/pom.xml
+++ b/jetty-core/jetty-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-session/pom.xml
+++ b/jetty-core/jetty-session/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-session/pom.xml
+++ b/jetty-core/jetty-session/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-slf4j-impl/pom.xml
+++ b/jetty-core/jetty-slf4j-impl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-slf4j-impl/pom.xml
+++ b/jetty-core/jetty-slf4j-impl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-start/pom.xml
+++ b/jetty-core/jetty-start/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-start</artifactId>

--- a/jetty-core/jetty-start/pom.xml
+++ b/jetty-core/jetty-start/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-start</artifactId>

--- a/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-tests/pom.xml
+++ b/jetty-core/jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-tests/pom.xml
+++ b/jetty-core/jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-unixdomain-server/pom.xml
+++ b/jetty-core/jetty-unixdomain-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-unixdomain-server/pom.xml
+++ b/jetty-core/jetty-unixdomain-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-util-ajax/pom.xml
+++ b/jetty-core/jetty-util-ajax/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util-ajax</artifactId>

--- a/jetty-core/jetty-util-ajax/pom.xml
+++ b/jetty-core/jetty-util-ajax/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util-ajax</artifactId>

--- a/jetty-core/jetty-util/pom.xml
+++ b/jetty-core/jetty-util/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util</artifactId>

--- a/jetty-core/jetty-util/pom.xml
+++ b/jetty-core/jetty-util/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-util</artifactId>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>jetty-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/pom.xml
+++ b/jetty-core/jetty-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-websocket/pom.xml
+++ b/jetty-core/jetty-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/jetty-xml/pom.xml
+++ b/jetty-core/jetty-xml/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-xml</artifactId>

--- a/jetty-core/jetty-xml/pom.xml
+++ b/jetty-core/jetty-xml/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-xml</artifactId>

--- a/jetty-core/pom.xml
+++ b/jetty-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-core/pom.xml
+++ b/jetty-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-annotations/pom.xml
+++ b/jetty-ee10/jetty-ee10-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-annotations/pom.xml
+++ b/jetty-ee10/jetty-ee10-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-bom/pom.xml
+++ b/jetty-ee10/jetty-ee10-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee10-bom</artifactId>
@@ -43,132 +43,132 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-annotations</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-apache-jsp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-cdi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-fcgi-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-glassfish-jstl</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jaspi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jndi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jspc-maven-plugin</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-plus</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-quickstart</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-runner</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlets</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-alpn</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-boot</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee10/jetty-ee10-bom/pom.xml
+++ b/jetty-ee10/jetty-ee10-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee10-bom</artifactId>
@@ -43,132 +43,132 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-annotations</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-apache-jsp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-cdi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-fcgi-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-glassfish-jstl</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jaspi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jndi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-jspc-maven-plugin</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-plus</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-quickstart</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-runner</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-servlets</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-alpn</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-boot</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.osgi</groupId>
         <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee10.websocket</groupId>
         <artifactId>jetty-ee10-websocket-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee10/jetty-ee10-cdi/pom.xml
+++ b/jetty-ee10/jetty-ee10-cdi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-cdi</artifactId>

--- a/jetty-ee10/jetty-ee10-cdi/pom.xml
+++ b/jetty-ee10/jetty-ee10-cdi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-cdi</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/jetty-ee10-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-embedded</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-embedded</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jaas-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-demo-jaas-webapp</artifactId>
   <name>EE10 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jaas-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-demo-jaas-webapp</artifactId>
   <name>EE10 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-jetty-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-jetty-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jndi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-demo-jndi-webapp</artifactId>
   <name>EE10 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jndi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-demo-jndi-webapp</artifactId>
   <name>EE10 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-mock-resources/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE10 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee10-demo-mock-resources</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-mock-resources/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE10 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee10-demo-mock-resources</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-proxy-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-demo-proxy-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-simple-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-simple-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-container-initializer/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee10-demo-container-initializer</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-container-initializer/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee10-demo-container-initializer</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-spec-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <name>EE10 :: Demo :: Servlet Spec :: WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-spec-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <name>EE10 :: Demo :: Servlet Spec :: WebApp</name>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-web-fragment/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-web-fragment/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/jetty-ee10-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE10 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee10-demo-spec</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE10 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee10-demo-spec</artifactId>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-template/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-template/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-template/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-template/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.demos</groupId>
     <artifactId>jetty-ee10-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-demos/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-examples/pom.xml
+++ b/jetty-ee10/jetty-ee10-examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-examples/pom.xml
+++ b/jetty-ee10/jetty-ee10-examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-fcgi-proxy/pom.xml
+++ b/jetty-ee10/jetty-ee10-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-fcgi-proxy/pom.xml
+++ b/jetty-ee10/jetty-ee10-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-glassfish-jstl</artifactId>

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-glassfish-jstl</artifactId>

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-jaspi/pom.xml
+++ b/jetty-ee10/jetty-ee10-jaspi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-jaspi/pom.xml
+++ b/jetty-ee10/jetty-ee10-jaspi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-jndi/pom.xml
+++ b/jetty-ee10/jetty-ee10-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-jndi/pom.xml
+++ b/jetty-ee10/jetty-ee10-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-jspc-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-jspc-maven-plugin</artifactId>

--- a/jetty-ee10/jetty-ee10-jspc-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-jspc-maven-plugin</artifactId>

--- a/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <!-- TODO: review if this module is still needed -->

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-alpn/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <!-- TODO: review if this module is still needed -->

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-osgi-boot-jsp</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-osgi-boot</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-osgi-boot</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-fragment</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-fragment/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-fragment</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-server</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-server</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-webapp-resources</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi-webapp-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi-webapp-resources</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi</artifactId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.osgi</groupId>
     <artifactId>jetty-ee10-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee10-osgi</artifactId>

--- a/jetty-ee10/jetty-ee10-plus/pom.xml
+++ b/jetty-ee10/jetty-ee10-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-plus/pom.xml
+++ b/jetty-ee10/jetty-ee10-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-proxy/pom.xml
+++ b/jetty-ee10/jetty-ee10-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-proxy/pom.xml
+++ b/jetty-ee10/jetty-ee10-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-quickstart/pom.xml
+++ b/jetty-ee10/jetty-ee10-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-quickstart/pom.xml
+++ b/jetty-ee10/jetty-ee10-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-runner/pom.xml
+++ b/jetty-ee10/jetty-ee10-runner/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-runner</artifactId>

--- a/jetty-ee10/jetty-ee10-runner/pom.xml
+++ b/jetty-ee10/jetty-ee10-runner/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-runner</artifactId>

--- a/jetty-ee10/jetty-ee10-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-servlets/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-servlets/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-bad-websocket-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-bad-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-bad-websocket-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-bad-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-badinit-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-badinit-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee10-test-badinit-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-badinit-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-badinit-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee10-test-badinit-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi-common-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi-common-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi-common-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi-common-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-cdi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-felix-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-felix-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-felix-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-felix-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-http2-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-http2-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-http2-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-http2-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-integration</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-integration</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp-it/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp-it/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-jmx</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-jmx-webapp-it</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp-it/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp-it/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-jmx</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-jmx-webapp-it</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-jmx</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-jmx</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-jmx</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-jmx</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jndi/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jndi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jndi/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jndi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-loginservice</artifactId>
   <name>EE10 :: Tests :: Login Service</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-loginservice</artifactId>
   <name>EE10 :: Tests :: Login Service</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-openid-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-openid-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-openid-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-openid-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-owb-cdi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-owb-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-owb-cdi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-owb-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-quickstart</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee10-test-quickstart</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-common</artifactId>
   <name>EE10 :: Tests :: Sessions :: Common</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-common</artifactId>
   <name>EE10 :: Tests :: Sessions :: Common</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-file</artifactId>
   <name>EE10 :: Tests :: Sessions :: File</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-file/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-file</artifactId>
   <name>EE10 :: Tests :: Sessions :: File</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-gcloud/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-gcloud/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-gcloud</artifactId>
   <name>EE10 :: Tests :: Sessions :: GCloud</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-gcloud/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-gcloud/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-gcloud</artifactId>
   <name>EE10 :: Tests :: Sessions :: GCloud</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-hazelcast</artifactId>
   <name>EE10 :: Tests :: Sessions :: Hazelcast</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-hazelcast/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-hazelcast</artifactId>
   <name>EE10 :: Tests :: Sessions :: Hazelcast</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-infinispan</artifactId>
   <name>EE10 :: Tests :: Sessions :: Infinispan</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-infinispan</artifactId>
   <name>EE10 :: Tests :: Sessions :: Infinispan</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-jdbc</artifactId>
   <name>EE10 :: Tests :: Sessions :: JDBC</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-jdbc</artifactId>
   <name>EE10 :: Tests :: Sessions :: JDBC</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-memcached/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-memcached/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-memcached</artifactId>
   <name>EE10 :: Tests :: Sessions :: Memcached</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-memcached/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-memcached/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-memcached</artifactId>
   <name>EE10 :: Tests :: Sessions :: Memcached</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-mongodb</artifactId>
   <name>EE10 :: Tests :: Sessions :: Mongo</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions-mongodb</artifactId>
   <name>EE10 :: Tests :: Sessions :: Mongo</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions</artifactId>
   <name>EE10 :: Tests :: Sessions</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-sessions</artifactId>
   <name>EE10 :: Tests :: Sessions</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-simple-session-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee10-test-simple-session-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-simple-session-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee10-test-simple-session-webapp</artifactId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-webapp-rfc2616/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee10-test-webapp-rfc2616</artifactId>
   <name>EE10 :: Tests :: RFC2616 WebApp</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-webapp-rfc2616/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee10-test-webapp-rfc2616</artifactId>
   <name>EE10 :: Tests :: RFC2616 WebApp</name>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-provided-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-provided-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-provided-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-provided-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-weld-cdi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-weld-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-weld-cdi-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-weld-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee10/jetty-ee10-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10.websocket</groupId>
     <artifactId>jetty-ee10-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/jetty-ee10-websocket/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee10</groupId>
     <artifactId>jetty-ee10</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-annotations/pom.xml
+++ b/jetty-ee8/jetty-ee8-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-annotations/pom.xml
+++ b/jetty-ee8/jetty-ee8-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
+++ b/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
+++ b/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee8-bom</artifactId>
@@ -43,117 +43,117 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-annotations</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-apache-jsp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-glassfish-jstl</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-jndi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-nested</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-openid</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-plus</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-quickstart</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-security</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-servlets</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-api</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee8-bom</artifactId>
@@ -43,117 +43,117 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-annotations</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-apache-jsp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-glassfish-jstl</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-jndi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-nested</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-openid</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-plus</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-quickstart</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-security</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-servlets</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-javax-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-api</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-jetty-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>
         <artifactId>jetty-ee8-websocket-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-jar/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-jar/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/jetty-ee8-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jaas-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee8-demo-jaas-webapp</artifactId>
   <name>EE8 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jaas-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee8-demo-jaas-webapp</artifactId>
   <name>EE8 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jetty-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-demo-jetty-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jetty-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-demo-jetty-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jndi-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee8-demo-jndi-webapp</artifactId>
   <name>EE8 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jndi-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee8-demo-jndi-webapp</artifactId>
   <name>EE8 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-mock-resources/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE8 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee8-demo-mock-resources</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-mock-resources/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE8 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee8-demo-mock-resources</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-proxy-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-demo-proxy-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-proxy-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-demo-proxy-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-simple-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-simple-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-container-initializer/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee8-demo-container-initializer</artifactId>
   <packaging>jar</packaging>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-container-initializer/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee8-demo-container-initializer</artifactId>
   <packaging>jar</packaging>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-spec-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE8 :: Demo :: Servlet Spec :: WebApp</name>
   <artifactId>jetty-ee8-demo-spec-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-spec-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE8 :: Demo :: Servlet Spec :: WebApp</name>
   <artifactId>jetty-ee8-demo-spec-webapp</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-web-fragment/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <name>EE8 :: Demo :: Servlet Spec :: Fragment Jar</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-web-fragment/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/jetty-ee8-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demo-spec</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <name>EE8 :: Demo :: Servlet Spec :: Fragment Jar</name>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE8 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee8-demo-spec</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.demos</groupId>
     <artifactId>jetty-ee8-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE8 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee8-demo-spec</artifactId>

--- a/jetty-ee8/jetty-ee8-demos/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-demos/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
+++ b/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-glassfish-jstl</artifactId>

--- a/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
+++ b/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-glassfish-jstl</artifactId>

--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-home</artifactId>

--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-home</artifactId>

--- a/jetty-ee8/jetty-ee8-jndi/pom.xml
+++ b/jetty-ee8/jetty-ee8-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-jndi/pom.xml
+++ b/jetty-ee8/jetty-ee8-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-jspc-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>

--- a/jetty-ee8/jetty-ee8-jspc-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>

--- a/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-maven-plugin</artifactId>

--- a/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee8-maven-plugin</artifactId>

--- a/jetty-ee8/jetty-ee8-nested/pom.xml
+++ b/jetty-ee8/jetty-ee8-nested/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-nested/pom.xml
+++ b/jetty-ee8/jetty-ee8-nested/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-openid/pom.xml
+++ b/jetty-ee8/jetty-ee8-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-openid/pom.xml
+++ b/jetty-ee8/jetty-ee8-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-plus/pom.xml
+++ b/jetty-ee8/jetty-ee8-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-plus/pom.xml
+++ b/jetty-ee8/jetty-ee8-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-proxy/pom.xml
+++ b/jetty-ee8/jetty-ee8-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-proxy/pom.xml
+++ b/jetty-ee8/jetty-ee8-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-quickstart/pom.xml
+++ b/jetty-ee8/jetty-ee8-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-quickstart/pom.xml
+++ b/jetty-ee8/jetty-ee8-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-security/pom.xml
+++ b/jetty-ee8/jetty-ee8-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-security/pom.xml
+++ b/jetty-ee8/jetty-ee8-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-servlets/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-servlets/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-javax-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-api/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-api/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-common/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-common/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-server/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/jetty-ee8-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8.websocket</groupId>
     <artifactId>jetty-ee8-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/jetty-ee8-websocket/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/jetty-ee8-websocket/pom.xml
+++ b/jetty-ee8/jetty-ee8-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee8</groupId>
     <artifactId>jetty-ee8</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-annotations/pom.xml
+++ b/jetty-ee9/jetty-ee9-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-annotations/pom.xml
+++ b/jetty-ee9/jetty-ee9-annotations/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-bom/pom.xml
+++ b/jetty-ee9/jetty-ee9-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee9-bom</artifactId>
@@ -43,147 +43,147 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-annotations</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-apache-jsp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-cdi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-fcgi-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-glassfish-jstl</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-jaspi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-jndi</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-nested</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-openid</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-plus</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-proxy</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-quickstart</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-runner</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-security</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-servlets</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.osgi</groupId>
         <artifactId>jetty-ee9-osgi-boot</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.osgi</groupId>
         <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-api</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-client</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-common</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-server</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-servlet</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee9/jetty-ee9-bom/pom.xml
+++ b/jetty-ee9/jetty-ee9-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee9-bom</artifactId>
@@ -43,147 +43,147 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-annotations</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-apache-jsp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-cdi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-fcgi-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-glassfish-jstl</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-jaspi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-jndi</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-nested</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-openid</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-plus</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-proxy</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-quickstart</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-runner</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-security</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-servlets</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.osgi</groupId>
         <artifactId>jetty-ee9-osgi-boot</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.osgi</groupId>
         <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jakarta-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-api</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-client</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-client-webapp</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-common</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-jetty-server</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee9.websocket</groupId>
         <artifactId>jetty-ee9-websocket-servlet</artifactId>
-        <version>12.0.0</version>
+        <version>12.0.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jetty-ee9/jetty-ee9-cdi/pom.xml
+++ b/jetty-ee9/jetty-ee9-cdi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-cdi</artifactId>

--- a/jetty-ee9/jetty-ee9-cdi/pom.xml
+++ b/jetty-ee9/jetty-ee9-cdi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-cdi</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-jar/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/jetty-ee9-demo-async-rest-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demo-async-rest</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-async-rest/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-embedded</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-embedded</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jaas-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-demo-jaas-webapp</artifactId>
   <name>EE9 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jaas-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-demo-jaas-webapp</artifactId>
   <name>EE9 :: Demo :: JAAS WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-jetty-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-jetty-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jndi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-demo-jndi-webapp</artifactId>
   <name>EE9 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jndi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-demo-jndi-webapp</artifactId>
   <name>EE9 :: Demo :: JNDI WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-mock-resources/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE9 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee9-demo-mock-resources</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-mock-resources/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-mock-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE9 :: Demo :: Mock Resources</name>
   <artifactId>jetty-ee9-demo-mock-resources</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-proxy-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-demo-proxy-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-simple-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-simple-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-simple-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-container-initializer/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee9-demo-container-initializer</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-container-initializer/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-container-initializer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee9-demo-container-initializer</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-spec-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <name>EE9 :: Demo :: Servlet Spec :: WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-spec-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <name>EE9 :: Demo :: Servlet Spec :: WebApp</name>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-web-fragment/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-web-fragment/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/jetty-ee9-demo-web-fragment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <name>EE9 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee9-demo-spec</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <name>EE9 :: Demo :: Servlet Spec</name>
   <artifactId>jetty-ee9-demo-spec</artifactId>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-template/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-template/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-template/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-template/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.demos</groupId>
     <artifactId>jetty-ee9-demos</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-demos/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-fcgi-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-fcgi-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-fcgi-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-glassfish-jstl/pom.xml
+++ b/jetty-ee9/jetty-ee9-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-glassfish-jstl</artifactId>

--- a/jetty-ee9/jetty-ee9-glassfish-jstl/pom.xml
+++ b/jetty-ee9/jetty-ee9-glassfish-jstl/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-glassfish-jstl</artifactId>

--- a/jetty-ee9/jetty-ee9-home/pom.xml
+++ b/jetty-ee9/jetty-ee9-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-home</artifactId>

--- a/jetty-ee9/jetty-ee9-home/pom.xml
+++ b/jetty-ee9/jetty-ee9-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-home</artifactId>

--- a/jetty-ee9/jetty-ee9-jaspi/pom.xml
+++ b/jetty-ee9/jetty-ee9-jaspi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-jaspi/pom.xml
+++ b/jetty-ee9/jetty-ee9-jaspi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-jndi/pom.xml
+++ b/jetty-ee9/jetty-ee9-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-jndi/pom.xml
+++ b/jetty-ee9/jetty-ee9-jndi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-jspc-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-jspc-maven-plugin</artifactId>

--- a/jetty-ee9/jetty-ee9-jspc-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-jspc-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-jspc-maven-plugin</artifactId>

--- a/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-maven-plugin</artifactId>

--- a/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
+++ b/jetty-ee9/jetty-ee9-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-maven-plugin</artifactId>

--- a/jetty-ee9/jetty-ee9-nested/pom.xml
+++ b/jetty-ee9/jetty-ee9-nested/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-nested/pom.xml
+++ b/jetty-ee9/jetty-ee9-nested/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-openid/pom.xml
+++ b/jetty-ee9/jetty-ee9-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-openid/pom.xml
+++ b/jetty-ee9/jetty-ee9-openid/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot-jsp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-osgi-boot-jsp</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-osgi-boot</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-osgi-boot</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-fragment</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-fragment/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-fragment</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-server</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-server</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-webapp-resources</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi-webapp-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi-webapp-resources</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi</artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.osgi</groupId>
     <artifactId>jetty-ee9-osgi</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-jetty-ee9-osgi</artifactId>

--- a/jetty-ee9/jetty-ee9-plus/pom.xml
+++ b/jetty-ee9/jetty-ee9-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-plus/pom.xml
+++ b/jetty-ee9/jetty-ee9-plus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-proxy/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-quickstart/pom.xml
+++ b/jetty-ee9/jetty-ee9-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-quickstart/pom.xml
+++ b/jetty-ee9/jetty-ee9-quickstart/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-runner/pom.xml
+++ b/jetty-ee9/jetty-ee9-runner/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-runner</artifactId>

--- a/jetty-ee9/jetty-ee9-runner/pom.xml
+++ b/jetty-ee9/jetty-ee9-runner/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-runner</artifactId>

--- a/jetty-ee9/jetty-ee9-security/pom.xml
+++ b/jetty-ee9/jetty-ee9-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-security/pom.xml
+++ b/jetty-ee9/jetty-ee9-security/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-servlets/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-servlets/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-bad-websocket-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-bad-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-bad-websocket-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-bad-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-badinit-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-badinit-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee9-test-badinit-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-badinit-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-badinit-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee9-test-badinit-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi-common-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi-common-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi-common-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi-common-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-cdi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-felix-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-felix-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-felix-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-felix-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-http2-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-http2-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-http2-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-http2-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-integration</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-integration</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp-it/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp-it/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-jmx</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-jmx-webapp-it</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp-it/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp-it/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-jmx</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-jmx-webapp-it</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-jmx</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-jmx</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-jmx</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-jmx</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jndi/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jndi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jndi/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jndi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-loginservice</artifactId>
   <name>EE9 :: Tests :: Login Service</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-loginservice</artifactId>
   <name>EE9 :: Tests :: Login Service</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-openid-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-openid-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-openid-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-openid-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-quickstart</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-ee9-test-quickstart</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-common</artifactId>
   <name>EE9 :: Tests :: Sessions :: Common</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-common</artifactId>
   <name>EE9 :: Tests :: Sessions :: Common</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-file</artifactId>
   <name>EE9 :: Tests :: Sessions :: File</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-file/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-file</artifactId>
   <name>EE9 :: Tests :: Sessions :: File</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-gcloud/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-gcloud/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-gcloud</artifactId>
   <name>EE9 :: Tests :: Sessions :: GCloud</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-gcloud/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-gcloud/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-gcloud</artifactId>
   <name>EE9 :: Tests :: Sessions :: GCloud</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-hazelcast</artifactId>
   <name>EE9 :: Tests :: Sessions :: Hazelcast</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-hazelcast/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-hazelcast</artifactId>
   <name>EE9 :: Tests :: Sessions :: Hazelcast</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee9-test-sessions-infinispan</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-ee9-test-sessions-infinispan</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-jdbc</artifactId>
   <name>EE9 :: Tests :: Sessions :: JDBC</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-jdbc</artifactId>
   <name>EE9 :: Tests :: Sessions :: JDBC</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-memcached/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-memcached/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-memcached</artifactId>
   <name>EE9 :: Tests :: Sessions :: Memcached</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-memcached/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-memcached/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-memcached</artifactId>
   <name>EE9 :: Tests :: Sessions :: Memcached</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-mongodb</artifactId>
   <name>EE9 :: Tests :: Sessions :: Mongo</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-test-sessions</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions-mongodb</artifactId>
   <name>EE9 :: Tests :: Sessions :: Mongo</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions</artifactId>
   <name>EE9 :: Tests :: Sessions</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-sessions</artifactId>
   <name>EE9 :: Tests :: Sessions</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-simple-session-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-ee9-test-simple-session-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-simple-session-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <artifactId>jetty-ee9-test-simple-session-webapp</artifactId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-webapp-rfc2616/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-webapp-rfc2616</artifactId>
   <name>EE9 :: Tests :: RFC2616 WebApp</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-webapp-rfc2616/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <artifactId>jetty-ee9-test-webapp-rfc2616</artifactId>
   <name>EE9 :: Tests :: RFC2616 WebApp</name>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-provided-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-provided-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-provided-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-provided-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-websocket-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-weld-cdi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-weld-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-weld-cdi-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-weld-cdi-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-webapp/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9.websocket</groupId>
     <artifactId>jetty-ee9-websocket</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/jetty-ee9-websocket/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/jetty-ee9-websocket/pom.xml
+++ b/jetty-ee9/jetty-ee9-websocket/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>jetty-project</artifactId>
     <groupId>org.eclipse.jetty</groupId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>jetty-gcloud</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>jetty-gcloud</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-gcloud/pom.xml
+++ b/jetty-integrations/jetty-gcloud/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-gcloud/pom.xml
+++ b/jetty-integrations/jetty-gcloud/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-hazelcast/pom.xml
+++ b/jetty-integrations/jetty-hazelcast/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-hazelcast/pom.xml
+++ b/jetty-integrations/jetty-hazelcast/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-common/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-common</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-common/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-common</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded-query/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded-query/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-embedded-query</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded-query/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded-query/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-embedded-query</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-embedded</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-embedded/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-embedded</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-remote-query/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-remote-query/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-remote-query</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-remote-query/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-remote-query/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-remote-query</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-remote/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-remote/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-remote</artifactId>

--- a/jetty-integrations/jetty-infinispan/jetty-infinispan-remote/pom.xml
+++ b/jetty-integrations/jetty-infinispan/jetty-infinispan-remote/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-infinispan</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-infinispan-remote</artifactId>

--- a/jetty-integrations/jetty-infinispan/pom.xml
+++ b/jetty-integrations/jetty-infinispan/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-infinispan/pom.xml
+++ b/jetty-integrations/jetty-infinispan/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-integrations/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>jetty-memcached</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-integrations/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>jetty-memcached</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-memcached/pom.xml
+++ b/jetty-integrations/jetty-memcached/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-memcached/pom.xml
+++ b/jetty-integrations/jetty-memcached/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/jetty-nosql/pom.xml
+++ b/jetty-integrations/jetty-nosql/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-nosql</artifactId>

--- a/jetty-integrations/jetty-nosql/pom.xml
+++ b/jetty-integrations/jetty-nosql/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-integrations</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-nosql</artifactId>

--- a/jetty-integrations/pom.xml
+++ b/jetty-integrations/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jetty-integrations/pom.xml
+++ b/jetty-integrations/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-project</artifactId>
-  <version>12.0.0-SNAPSHOT</version>
+  <version>12.0.0</version>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-project</artifactId>
-  <version>12.0.0</version>
+  <version>12.0.1-SNAPSHOT</version>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>
   <packaging>pom</packaging>

--- a/tests/jetty-home-tester/pom.xml
+++ b/tests/jetty-home-tester/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/jetty-home-tester/pom.xml
+++ b/tests/jetty-home-tester/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/jetty-test-session-common/pom.xml
+++ b/tests/jetty-test-session-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/jetty-test-session-common/pom.xml
+++ b/tests/jetty-test-session-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <groupId>org.eclipse.jetty.tests</groupId>
   <artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.tests</groupId>
   <artifactId>tests</artifactId>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-ee10-distribution/pom.xml
+++ b/tests/test-distribution/test-ee10-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-ee10-distribution/pom.xml
+++ b/tests/test-distribution/test-ee10-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-ee9-distribution/pom.xml
+++ b/tests/test-distribution/test-ee9-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-distribution/test-ee9-distribution/pom.xml
+++ b/tests/test-distribution/test-ee9-distribution/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-distribution</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-integration</artifactId>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests</artifactId>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-integration</artifactId>


### PR DESCRIPTION
This will merge the `release/12.0.0` branch back into `jetty-12.0.x` and update the version to `12.0.1-SNAPSHOT`