### PR TITLE
Fixes #10218 - NPE in HttpChannelOverFCGI.receive()

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -62,6 +62,17 @@ public class HttpReceiverOverFCGI extends HttpReceiver
     }
 
     @Override
+    protected void dispose()
+    {
+        super.dispose();
+        if (chunk != null)
+        {
+            chunk.release();
+            chunk = null;
+        }
+    }
+
+    @Override
     public Content.Chunk read(boolean fillInterestIfNeeded)
     {
         Content.Chunk chunk = consumeChunk();

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -270,6 +270,8 @@ public class ServerFCGIConnection extends AbstractConnection implements Connecti
 
     private void releaseInputBuffer()
     {
+        if (networkBuffer == null)
+            return;
         boolean released = networkBuffer.release();
         if (LOG.isDebugEnabled())
             LOG.debug("releaseInputBuffer {} {}", released, this);
@@ -327,6 +329,9 @@ public class ServerFCGIConnection extends AbstractConnection implements Connecti
     @Override
     public boolean onIdleExpired(TimeoutException timeoutException)
     {
+        HttpStreamOverFCGI stream = this.stream;
+        if (stream == null)
+            return true;
         Runnable task = stream.getHttpChannel().onIdleTimeout(timeoutException);
         if (task != null)
             getExecutor().execute(task);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -59,11 +59,16 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractTest
 {
+    @RegisterExtension
+    public final BeforeTestExecutionCallback printMethodName = context ->
+        System.err.printf("Running %s.%s() %s%n", context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), context.getDisplayName());
     protected final HttpConfiguration httpConfig = new HttpConfiguration();
     protected SslContextFactory.Server sslContextFactoryServer;
     protected Server server;

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
-import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.internal.HttpChannelOverHTTP;
@@ -209,9 +208,9 @@ public class HttpChannelAssociationTest extends AbstractTest
                         return new HttpConnectionOverFCGI(endPoint, destination, promise)
                         {
                             @Override
-                            protected HttpChannelOverFCGI newHttpChannel(Request request)
+                            protected HttpChannelOverFCGI newHttpChannel()
                             {
-                                return new HttpChannelOverFCGI(this, getFlusher(), request.getIdleTimeout())
+                                return new HttpChannelOverFCGI(this)
                                 {
                                     @Override
                                     public boolean associate(HttpExchange exchange)


### PR DESCRIPTION
Simplified the code, removing all leftover cruft present since FCGI was multiplexed. Now the FCGI implementation is very similar to HTTP1.

Made HttpConnectionOverFCGI.channel final so that it cannot NPE anymore.

The client now properly handling server-side connection closes.