### PR TITLE
Issue #10279 - Update to setuid 2.0.0-SNAPSHOT

### DIFF
--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -15,7 +15,7 @@
     <assembly-directory>${basedir}/target/jetty-home</assembly-directory>
     <source-assembly-directory>${basedir}/target/jetty-home-sources</source-assembly-directory>
     <docs-assembly-directory>${basedir}/target/jetty-home-with-docs</docs-assembly-directory>
-    <jetty-setuid-version>1.0.4</jetty-setuid-version>
+    <jetty-setuid-version>2.0.0-SNAPSHOT</jetty-setuid-version>
     <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
@@ -111,6 +111,7 @@
                   <outputDirectory>${assembly-directory}/lib/setuid</outputDirectory>
                   <destFileName>libsetuid-linux.so</destFileName>
                 </artifactItem>
+                <!-- no OSX build for lib-setuid (yet)
                 <artifactItem>
                   <groupId>org.eclipse.jetty.toolchain.setuid</groupId>
                   <artifactId>libsetuid-osx</artifactId>
@@ -120,6 +121,7 @@
                   <outputDirectory>${assembly-directory}/lib/setuid</outputDirectory>
                   <destFileName>libsetuid-osx.so</destFileName>
                 </artifactItem>
+                 -->
               </artifactItems>
             </configuration>
           </execution>

--- a/jetty-home/src/main/resources/modules/setuid.mod
+++ b/jetty-home/src/main/resources/modules/setuid.mod
@@ -9,7 +9,7 @@ changing to a restricted user (e.g. Jetty).
 server
 
 [lib]
-lib/setuid/jetty-setuid-java-1.0.4.jar
+lib/setuid/jetty-setuid-java-2.0.0-SNAPSHOT.jar
 
 [xml]
 etc/jetty-setuid.xml

--- a/pom.xml
+++ b/pom.xml
@@ -2402,4 +2402,18 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <repositories>
+    <!-- Enable Jetty SNAPSHOT access -->
+    <repository>
+      <id>jetty-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
 </project>


### PR DESCRIPTION
Update to use 2.0.0-SNAPSHOT versions of jetty-setuid.

Disabled setuid-osx, as we don't have a machine to build the intel and arch versions.