### PR TITLE
Issue #10066 - Allow customization of `SAXParserFactory` and `SAXParser` in `XmlParser`

### DIFF
--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
@@ -101,7 +101,10 @@ public class DeploymentTempDirTest
     public void testTmpDirectory() throws Exception
     {
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
-        String deploymentXml = "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
+        String deploymentXml =
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://eclipse.dev/jetty/configure.dtd\">\n" +
+            "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +
             "<Set name=\"persistTempDirectory\">false</Set>\n" +
@@ -141,7 +144,10 @@ public class DeploymentTempDirTest
     public void testPersistentTmpDirectory() throws Exception
     {
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
-        String deploymentXml = "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
+        String deploymentXml =
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://eclipse.dev/jetty/configure.dtd\">\n" +
+            "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +
             "<Set name=\"persistTempDirectory\">true</Set>\n" +

--- a/jetty-deploy/src/test/resources/context-binding-test-1.xml
+++ b/jetty-deploy/src/test/resources/context-binding-test-1.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 
   <Call name="addServerClass">

--- a/jetty-deploy/src/test/resources/jetty.xml
+++ b/jetty-deploy/src/test/resources/jetty.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->

--- a/jetty-documentation/src/main/asciidoc/quick-start/configuring/what-to-configure.adoc
+++ b/jetty-documentation/src/main/asciidoc/quick-start/configuring/what-to-configure.adoc
@@ -141,10 +141,10 @@ The deployer discovers and hot deploys context IoC descriptors like the followin
 
 [source, xml]
 ----
-<?xml version="1.0"  encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC
-    "-//Mort Bay Consulting//DTD Configure//EN"
-    "http://www.eclipse.org/jetty/configure_9_3.dtd">
+    "-//Jetty//Configure//EN"
+    "https://eclipse.org/jetty/configure_9_3.dtd">
 
 <!--
   Configure a custom context for serving javadoc as static resources
@@ -202,10 +202,10 @@ To set the contextPath from within the WAR file, you can include a `WEB-INF/jett
 
 [source, xml]
 ----
-<?xml version="1.0"  encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC
-    "-//Mort Bay Consulting//DTD Configure//EN"
-    "http://www.eclipse.org/jetty/configure_9_3.dtd">
+    "-//Jetty//Configure//EN"
+    "https://eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/contextpath</Set>
@@ -217,10 +217,10 @@ Instead of allowing the WAR file to be discovered by the deployer, an IoC XML fi
 
 [source, xml]
 ----
-<?xml version="1.0"  encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC
-    "-//Mort Bay Consulting//DTD Configure//EN"
-    "http://www.eclipse.org/jetty/configure_9_3.dtd">
+    "-//Jetty//Configure//EN"
+    "https://eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="war"><SystemProperty name="jetty.home" default="."/>/webapps/test.war</Set>

--- a/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/config/jetty.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/main/jettyconf/context.xml
+++ b/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/main/jettyconf/context.xml
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Call name="setInitParameter">
     <Arg>org.eclipse.jetty.servlet.Default.useFileMappedBuffer</Arg>

--- a/jetty-start/src/test/resources/bogus.xml
+++ b/jetty-start/src/test/resources/bogus.xml
@@ -1,2 +1,3 @@
 <?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
 <Configure />

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -67,6 +67,7 @@ import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.resource.Resource;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * <p>Configures objects from XML.</p>
@@ -225,6 +226,10 @@ public class XmlConfiguration
             _location = resource;
             setConfig(parser.parse(inputStream));
             _dtd = parser.getDTD();
+        }
+        catch (SAXParseException e)
+        {
+            throw new SAXException("Unable to parse: " + resource + " ", e);
         }
     }
 
@@ -1942,14 +1947,21 @@ public class XmlConfiguration
             redirectEntity("http://jetty.mortbay.org/configure.dtd", config93);
             redirectEntity("http://jetty.eclipse.org/configure.dtd", config93);
             redirectEntity("https://jetty.eclipse.org/configure.dtd", config93);
-            redirectEntity("http://www.eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("https://www.eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("http://eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("https://eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("http://www.eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("https://www.eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("http://eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("https://eclipse.dev/jetty/configure.dtd", config93);
+
+            String[] schemes = {"http", "https"};
+            String[] hosts = {"www.eclipse.org", "eclipse.org", "www.eclipse.dev", "eclipse.dev"};
+            String[] paths = {"/jetty/configure.dtd", "/jetty/configure_9_3.dtd"};
+
+            for (String scheme : schemes)
+            {
+                for (String host : hosts)
+                {
+                    for (String path : paths)
+                    {
+                        redirectEntity(scheme + "://" + host + path, config93);
+                    }
+                }
+            }
             redirectEntity("-//Mort Bay Consulting//DTD Configure//EN", config93);
             redirectEntity("-//Jetty//Configure//EN", config93);
         }

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1944,6 +1944,12 @@ public class XmlConfiguration
             redirectEntity("https://jetty.eclipse.org/configure.dtd", config93);
             redirectEntity("http://www.eclipse.org/jetty/configure.dtd", config93);
             redirectEntity("https://www.eclipse.org/jetty/configure.dtd", config93);
+            redirectEntity("http://eclipse.org/jetty/configure.dtd", config93);
+            redirectEntity("https://eclipse.org/jetty/configure.dtd", config93);
+            redirectEntity("http://www.eclipse.dev/jetty/configure.dtd", config93);
+            redirectEntity("https://www.eclipse.dev/jetty/configure.dtd", config93);
+            redirectEntity("http://eclipse.dev/jetty/configure.dtd", config93);
+            redirectEntity("https://eclipse.dev/jetty/configure.dtd", config93);
             redirectEntity("-//Mort Bay Consulting//DTD Configure//EN", config93);
             redirectEntity("-//Jetty//Configure//EN", config93);
         }

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -231,7 +231,7 @@ public class XmlConfiguration
         }
         catch (SAXParseException e)
         {
-            throw new SAXException("Unable to parse: " + resource + " ", e);
+            throw new SAXParseException("Unable to parse: " + resource, null, e);
         }
         finally
         {

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -271,18 +271,10 @@ public class XmlParser
         if (pid != null)
             entity = _redirectMap.get(pid);
         if (entity == null)
-            entity = _redirectMap.get(sid);
-        if (entity == null)
-        {
-            String dtd = sid;
-            if (dtd.lastIndexOf('/') >= 0)
-                dtd = dtd.substring(dtd.lastIndexOf('/') + 1);
+            entity = (URL)_redirectMap.get(sid);
 
-            if (LOG.isDebugEnabled())
-                LOG.debug("Can't exact match entity in redirect map, trying " + dtd);
-            entity = _redirectMap.get(dtd);
-        }
-
+        // Only serve entity if found.
+        // We don't want to serve from unknown hosts or random paths.
         if (entity != null)
         {
             try
@@ -299,6 +291,9 @@ public class XmlParser
                 LOG.ignore(e);
             }
         }
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Entity not found for PID:{} / SID:{}", pid, sid);
         return null;
     }
 

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -69,9 +69,9 @@ public class XmlParser
      */
     public XmlParser()
     {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        boolean validatingDft = factory.getClass().toString().startsWith("org.apache.xerces.");
-        String validatingProp = System.getProperty("org.eclipse.jetty.xml.XmlParser.Validating", validatingDft ? "true" : "false");
+        SAXParserFactory factory = newSAXParserFactory();
+        boolean validatingDefault = factory.getClass().toString().contains("org.apache.xerces.");
+        String validatingProp = System.getProperty("org.eclipse.jetty.xml.XmlParser.Validating", validatingDefault ? "true" : "false");
         boolean validating = Boolean.valueOf(validatingProp).booleanValue();
         setValidating(validating);
     }
@@ -81,11 +81,16 @@ public class XmlParser
         setValidating(validating);
     }
 
+    protected SAXParserFactory newSAXParserFactory()
+    {
+        return SAXParserFactory.newInstance();
+    }
+
     public void setValidating(boolean validating)
     {
         try
         {
-            SAXParserFactory factory = SAXParserFactory.newInstance();
+            SAXParserFactory factory = newSAXParserFactory();
             factory.setValidating(validating);
             _parser = factory.newSAXParser();
 
@@ -125,6 +130,11 @@ public class XmlParser
     public boolean isValidating()
     {
         return _parser.isValidating();
+    }
+
+    public SAXParser getSAXParser()
+    {
+        return _parser;
     }
 
     public synchronized void redirectEntity(String name, URL entity)

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +48,6 @@ import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.log.StdErrLog;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -274,10 +274,15 @@ public class XmlConfigurationTest
 
     public XmlConfiguration asXmlConfiguration(String filename, String rawXml) throws IOException, SAXException
     {
+        if (!rawXml.contains("!DOCTYPE"))
+            rawXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://eclipse.org/jetty/configure.dtd\">\n" +
+                rawXml;
         Path testFile = workDir.getEmptyPathDir().resolve(filename);
-        try (BufferedWriter writer = Files.newBufferedWriter(testFile, UTF_8))
+        try (BufferedWriter writer = Files.newBufferedWriter(testFile, UTF_8, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))
         {
             writer.write(rawXml);
+            writer.flush();
         }
         return new XmlConfiguration(new PathResource(testFile));
     }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -19,10 +19,17 @@
 package org.eclipse.jetty.xml;
 
 import java.net.URL;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class XmlParserTest
 {
@@ -44,5 +51,33 @@ public class XmlParserTest
 
         assertTrue(testDocStr.startsWith("<Configure"));
         assertTrue(testDocStr.endsWith("</Configure>"));
+    }
+
+    /**
+     * Customize SAXParserFactory behavior.
+     */
+    @Test
+    public void testNewSAXParserFactory() throws SAXException
+    {
+        XmlParser xmlParser = new XmlParser()
+        {
+            @Override
+            protected SAXParserFactory newSAXParserFactory()
+            {
+                SAXParserFactory saxParserFactory = super.newSAXParserFactory();
+                // Configure at factory level
+                saxParserFactory.setXIncludeAware(false);
+                return saxParserFactory;
+            }
+        };
+
+        SAXParser saxParser = xmlParser.getSAXParser();
+        assertNotNull(saxParser);
+
+        XMLReader xmlReader = saxParser.getXMLReader();
+        // Only run testcase if Xerces is being used.
+        assumeTrue(xmlReader.getClass().getName().contains("org.apache.xerces."));
+        // look to see it was set at XMLReader level
+        assertFalse(xmlReader.getFeature("http://apache.org/xml/features/xinclude"));
     }
 }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -41,7 +41,7 @@ public class XmlParserTest
         URL configURL = XmlConfiguration.class.getClassLoader().getResource("org/eclipse/jetty/xml/configure_9_3.dtd");
         parser.redirectEntity("configure.dtd", configURL);
         parser.redirectEntity("configure_9_3.dtd", configURL);
-        //parser.redirectEntity("http://www.eclipse.org/jetty/configure_9_3.dtd", configURL);
+        parser.redirectEntity("http://www.eclipse.org/jetty/configure_9_3.dtd", configURL);
         parser.redirectEntity("http://jetty.eclipse.org/configure.dtd", configURL);
         parser.redirectEntity("-//Mort Bay Consulting//DTD Configure//EN", configURL);
 

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/mortbay.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/mortbay.xml
@@ -1,2 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.org/jetty/configure_9_3.dtd">
 <Configure class="java.lang.Object"></Configure>

--- a/tests/test-integration/src/test/resources/RFC2616Base.xml
+++ b/tests/test-integration/src/test/resources/RFC2616Base.xml
@@ -47,7 +47,7 @@
                  </Array>
                </Set>
                <Set name="ResourceBase"><Property name="test.docroot.base"/>/virtualhost</Set>
-               <Set name="Handler"><New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
+               <Set name="Handler"><New id="reshandlervirt" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
                <Set name="DisplayName">virtual</Set>
              </New>
            </Item>
@@ -55,7 +55,7 @@
              <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
                <Set name="contextPath">/tests</Set>
                <Set name="ResourceBase"><Property name="test.docroot.base"/>/default</Set>
-               <Set name="Handler"><New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
+               <Set name="Handler"><New id="reshandlerdefault" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
                <Set name="DisplayName">default</Set>
              </New>
            </Item>

--- a/tests/test-integration/src/test/resources/ssl.xml
+++ b/tests/test-integration/src/test/resources/ssl.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Set name="KeyStorePath"><Property name="jetty.home" default="." />/<Property name="jetty.sslContext.keyStorePath" default="keystore"/></Set>
   <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>

--- a/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
@@ -1,4 +1,6 @@
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <!-- Rename this file to jetty-web.xml if the cdi-spi module is not used-->
   <Get id="wal" name="classLoader"/>


### PR DESCRIPTION
Backport of PR #10067 to `jetty-9.4.x`

* Allow customization of SAXParserFactory / SAXParser in XmlParser
* Introduce method `.getSAXParser()`