### PR TITLE
Cleaning up dependencies on WebSocket Server

### DIFF
--- a/jetty-websocket/websocket-jetty-server/pom.xml
+++ b/jetty-websocket/websocket-jetty-server/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-annotations</artifactId>
+      <artifactId>jetty-webapp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-websocket/websocket-jetty-tests/pom.xml
+++ b/jetty-websocket/websocket-jetty-tests/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>jetty-jmx</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Cleaning up dependencies on websocket to avoid pulling in annotations on websocket-server