### PR TITLE
Issue #10158 Change ignored deployment message to WARN

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -197,8 +197,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
             }
         }
 
-        if (LOG.isDebugEnabled())
-            LOG.debug("{} ignored {}", this, app);
+        LOG.warn("{} no environment for {}, ignoring", this, app);
         return null;
     }
 


### PR DESCRIPTION
WRT #10158 I think it's better to change the DEBUG message about an ignored deployment due to lack of an environment to a WARN.