### PR TITLE
Restore leak tracking in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,6 +118,9 @@ def mavenBuild(jdk, cmdline, mvnName) {
             echo "Not using build cache"
             extraArgs = " -Dmaven.test.failure.ignore=true -Dmaven.build.cache.enabled=false "
           }
+          if (pullRequest.labels.contains("build-all-tests")) {
+            extraArgs = " -Dmaven.test.failure.ignore=true "
+          }
           sh "mvn $extraArgs -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -s $GLOBAL_MVN_SETTINGS -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
         }
       }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -85,9 +85,9 @@ public class HttpClientProxyProtocolTest
     {
         LifeCycle.stop(client);
         LifeCycle.stop(server);
-        Set<ArrayByteBufferPool.Tracking.TrackingBuffer> serverLeaks = serverBufferPool.getLeaks();
+        Set<ArrayByteBufferPool.Tracking.Buffer> serverLeaks = serverBufferPool.getLeaks();
         assertEquals(0, serverLeaks.size(), serverBufferPool.dumpLeaks());
-        Set<ArrayByteBufferPool.Tracking.TrackingBuffer> clientLeaks = clientBufferPool.getLeaks();
+        Set<ArrayByteBufferPool.Tracking.Buffer> clientLeaks = clientBufferPool.getLeaks();
         assertEquals(0, clientLeaks.size(), clientBufferPool.dumpLeaks());
     }
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -85,9 +85,9 @@ public class HttpClientProxyProtocolTest
     {
         LifeCycle.stop(client);
         LifeCycle.stop(server);
-        Set<ArrayByteBufferPool.Tracking.Buffer> serverLeaks = serverBufferPool.getLeaks();
+        Set<ArrayByteBufferPool.Tracking.TrackingBuffer> serverLeaks = serverBufferPool.getLeaks();
         assertEquals(0, serverLeaks.size(), serverBufferPool.dumpLeaks());
-        Set<ArrayByteBufferPool.Tracking.Buffer> clientLeaks = clientBufferPool.getLeaks();
+        Set<ArrayByteBufferPool.Tracking.TrackingBuffer> clientLeaks = clientBufferPool.getLeaks();
         assertEquals(0, clientLeaks.size(), clientBufferPool.dumpLeaks());
     }
 

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
@@ -22,6 +22,8 @@
           <argLine>
             @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.fcgi.server=org.eclipse.jetty.logging
+            --add-reads org.eclipse.jetty.fcgi.server=java.management
+            --add-reads org.eclipse.jetty.fcgi.server=jdk.management
           </argLine>
         </configuration>
       </plugin>
@@ -59,6 +61,11 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-unixdomain-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/pom.xml
@@ -22,8 +22,6 @@
           <argLine>
             @{argLine} ${jetty.surefire.argLine}
             --add-reads org.eclipse.jetty.fcgi.server=org.eclipse.jetty.logging
-            --add-reads org.eclipse.jetty.fcgi.server=java.management
-            --add-reads org.eclipse.jetty.fcgi.server=jdk.management
           </argLine>
         </configuration>
       </plugin>

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/AbstractHttpClientServerTest.java
@@ -13,23 +13,18 @@
 
 package org.eclipse.jetty.fcgi.server;
 
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
-import org.eclipse.jetty.client.LeakTrackingConnectionPool;
 import org.eclipse.jetty.fcgi.client.transport.HttpClientTransportOverFCGI;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
-import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.util.LeakDetector;
 import org.eclipse.jetty.util.ProcessorUtils;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -38,9 +33,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public abstract class AbstractHttpClientServerTest
 {
-    private ByteBufferPool serverBufferPool;
-    protected ByteBufferPool clientBufferPool;
-    private final AtomicLong connectionLeaks = new AtomicLong();
+    private ArrayByteBufferPool.Tracking serverBufferPool;
+    protected ArrayByteBufferPool.Tracking clientBufferPool;
     protected Server server;
     protected ServerConnector connector;
     protected HttpClient client;
@@ -52,8 +46,7 @@ public abstract class AbstractHttpClientServerTest
         serverThreads.setName("server");
         server = new Server(serverThreads);
         ServerFCGIConnectionFactory fcgiConnectionFactory = new ServerFCGIConnectionFactory(new HttpConfiguration());
-        // TODO: restore leak tracking.
-        serverBufferPool = new ArrayByteBufferPool();
+        serverBufferPool = new ArrayByteBufferPool.Tracking();
         connector = new ServerConnector(server, null, null, serverBufferPool,
             1, Math.max(1, ProcessorUtils.availableProcessors() / 2), fcgiConnectionFactory);
         server.addConnector(connector);
@@ -65,33 +58,28 @@ public abstract class AbstractHttpClientServerTest
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
         clientConnector.setExecutor(clientThreads);
-        // TODO: restore leak tracking.
         if (clientBufferPool == null)
-            clientBufferPool = new ArrayByteBufferPool();
+            clientBufferPool = new ArrayByteBufferPool.Tracking();
         clientConnector.setByteBufferPool(clientBufferPool);
         HttpClientTransport transport = new HttpClientTransportOverFCGI(clientConnector, "");
-        transport.setConnectionPoolFactory(destination -> new LeakTrackingConnectionPool(destination, client.getMaxConnectionsPerDestination())
-        {
-            @Override
-            protected void leaked(LeakDetector<Connection>.LeakInfo leakInfo)
-            {
-                connectionLeaks.incrementAndGet();
-            }
-        });
         client = new HttpClient(transport);
         client.start();
     }
 
     @AfterEach
-    public void dispose() throws Exception
+    public void dispose()
     {
-        System.gc();
-
-        assertThat("Connection Leaks", connectionLeaks.get(), Matchers.is(0L));
-
-        if (client != null)
-            client.stop();
-        if (server != null)
-            server.stop();
+        try
+        {
+            if (serverBufferPool != null)
+                assertThat("Server Leaks: " + serverBufferPool.getLeaks(), serverBufferPool.getLeaks().size(), Matchers.is(0));
+            if (clientBufferPool != null)
+                assertThat("Client Leaks: " + clientBufferPool.getLeaks(), clientBufferPool.getLeaks().size(), Matchers.is(0));
+        }
+        finally
+        {
+            LifeCycle.stop(client);
+            LifeCycle.stop(server);
+        }
     }
 }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/AbstractHttpClientServerTest.java
@@ -75,32 +75,26 @@ public abstract class AbstractHttpClientServerTest
         try
         {
             if (serverBufferPool != null)
-            {
-                try
-                {
-                    Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> serverBufferPool.getLeaks().size(), Matchers.is(0));
-                }
-                catch (Exception e)
-                {
-                    fail(e.getMessage() + "\n---\nServer Leaks: " + serverBufferPool.dumpLeaks() + "---\n");
-                }
-            }
+                assertNoLeaks(serverBufferPool, "\n---\nServer Leaks: " + serverBufferPool.dumpLeaks() + "---\n");
             if (clientBufferPool != null)
-            {
-                try
-                {
-                    Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> clientBufferPool.getLeaks().size(), Matchers.is(0));
-                }
-                catch (Exception e)
-                {
-                    fail(e.getMessage() + "\n---\nClient Leaks: " + clientBufferPool.dumpLeaks() + "---\n");
-                }
-            }
+                assertNoLeaks(clientBufferPool, "\n---\nClient Leaks: " + clientBufferPool.dumpLeaks() + "---\n");
         }
         finally
         {
             LifeCycle.stop(client);
             LifeCycle.stop(server);
+        }
+    }
+
+    private void assertNoLeaks(ArrayByteBufferPool.Tracking bufferPool, String msg)
+    {
+        try
+        {
+            Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> bufferPool.getLeaks().size(), Matchers.is(0));
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage() + msg);
         }
     }
 }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/HttpClientTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/HttpClientTest.java
@@ -239,8 +239,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 Content.Sink.write(response, false, UTF_8.encode(paramValue1));
                 String paramValue2 = fields.getValue(paramName2);
                 assertEquals("", paramValue2);
-                Content.Sink.write(response, true, UTF_8.encode("empty"));
-                callback.succeeded();
+                Content.Sink.write(response, true, "empty", callback);
                 return true;
             }
         });
@@ -274,8 +273,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                     Content.Sink.write(response, false, UTF_8.encode(paramValue));
                 }
                 String paramValue2 = fields.getValue(paramName2);
-                Content.Sink.write(response, true, UTF_8.encode(paramValue2));
-                callback.succeeded();
+                Content.Sink.write(response, true, paramValue2, callback);
                 return true;
             }
         });
@@ -771,8 +769,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
             {
                 Content.Sink.write(response, false, UTF_8.encode("A"));
-                Content.Sink.write(response, true, UTF_8.encode("B"));
-                callback.succeeded();
+                Content.Sink.write(response, true, "B", callback);
                 return true;
             }
         });

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java
@@ -422,6 +422,9 @@ public class GZIPContentDecoder implements Destroyable
      */
     public RetainableByteBuffer acquire(int capacity)
     {
+        // Zero-capacity buffers aren't released, they MUST NOT come from the pool.
+        if (capacity == 0)
+            return RetainableByteBuffer.EMPTY;
         return _pool.acquire(capacity, false);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -577,14 +577,14 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
      * <p>A variant of {@link ArrayByteBufferPool} that tracks buffer
      * acquires/releases, useful to identify buffer leaks.</p>
      * <p>Use {@link #getLeaks()} when the system is idle to get
-     * the {@link TrackingBuffer}s that have been leaked, which contain
+     * the {@link Buffer}s that have been leaked, which contain
      * the stack trace information of where the buffer was acquired.</p>
      */
     public static class Tracking extends ArrayByteBufferPool
     {
         private static final Logger LOG = LoggerFactory.getLogger(Tracking.class);
 
-        private final Set<TrackingBuffer> buffers = ConcurrentHashMap.newKeySet();
+        private final Set<Buffer> buffers = ConcurrentHashMap.newKeySet();
 
         public Tracking()
         {
@@ -605,14 +605,14 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         public RetainableByteBuffer acquire(int size, boolean direct)
         {
             RetainableByteBuffer buffer = super.acquire(size, direct);
-            TrackingBuffer wrapper = new TrackingBuffer(buffer, size);
+            Buffer wrapper = new Buffer(buffer, size);
             if (LOG.isDebugEnabled())
                 LOG.debug("acquired {}", wrapper);
             buffers.add(wrapper);
             return wrapper;
         }
 
-        public Set<TrackingBuffer> getLeaks()
+        public Set<Buffer> getLeaks()
         {
             return buffers;
         }
@@ -620,11 +620,11 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         public String dumpLeaks()
         {
             return getLeaks().stream()
-                .map(TrackingBuffer::dump)
+                .map(Buffer::dump)
                 .collect(Collectors.joining(System.lineSeparator()));
         }
 
-        public class TrackingBuffer extends RetainableByteBuffer.Wrapper
+        public class Buffer extends RetainableByteBuffer.Wrapper
         {
             private final int size;
             private final Instant acquireInstant;
@@ -632,7 +632,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             private final List<Throwable> retainStacks = new CopyOnWriteArrayList<>();
             private final List<Throwable> releaseStacks = new CopyOnWriteArrayList<>();
 
-            private TrackingBuffer(RetainableByteBuffer wrapped, int size)
+            private Buffer(RetainableByteBuffer wrapped, int size)
             {
                 super(wrapped);
                 this.size = size;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -691,7 +691,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 {
                     releaseStack.printStackTrace(pw);
                 }
-                return "%s@%x of %d bytes on %s acquired at %s".formatted(getClass().getSimpleName(), hashCode(), getSize(), getAcquireInstant(), w);
+                return "%s@%x of %d bytes on %s wrapping %s acquired at %s".formatted(getClass().getSimpleName(), hashCode(), getSize(), getAcquireInstant(), getWrapped(), w);
             }
         }
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -37,6 +37,11 @@ import org.eclipse.jetty.util.BufferUtil;
 public interface RetainableByteBuffer extends Retainable
 {
     /**
+     * A Zero-capacity, non-retainable {@code RetainableByteBuffer}.
+     */
+    public static RetainableByteBuffer EMPTY = wrap(BufferUtil.EMPTY_BUFFER);
+
+    /**
      * <p>Returns a non-retainable {@code RetainableByteBuffer} that wraps
      * the given {@code ByteBuffer}.</p>
      * <p>Use this method to wrap user-provided {@code ByteBuffer}s, or

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/ServerConnectorSslServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/ServerConnectorSslServerTest.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ServerConnectorSslServerTest extends HttpServerTestBase
 {
     private SSLContext _sslContext;
+    private ArrayByteBufferPool.Tracking trackingBufferPool;
 
     public ServerConnectorSslServerTest()
     {
@@ -73,10 +74,10 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setKeyStorePath(keystorePath);
         sslContextFactory.setKeyStorePassword("storepwd");
-        ArrayByteBufferPool.Tracking pool = new ArrayByteBufferPool.Tracking();
+        trackingBufferPool = new ArrayByteBufferPool.Tracking();
 
         HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory();
-        ServerConnector connector = new ServerConnector(_server, null, null, pool, 1, 1, AbstractConnectionFactory.getFactories(sslContextFactory, httpConnectionFactory));
+        ServerConnector connector = new ServerConnector(_server, null, null, trackingBufferPool, 1, 1, AbstractConnectionFactory.getFactories(sslContextFactory, httpConnectionFactory));
         SecureRequestCustomizer secureRequestCustomer = new SecureRequestCustomizer();
         secureRequestCustomer.setSslSessionAttribute("SSL_SESSION");
         httpConnectionFactory.getHttpConfiguration().addCustomizer(secureRequestCustomer);
@@ -110,8 +111,7 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
     @AfterEach
     public void dispose() throws Exception
     {
-        ArrayByteBufferPool.Tracking byteBufferPool = (ArrayByteBufferPool.Tracking)_server.getConnectors()[0].getByteBufferPool();
-        assertThat("Server Leaks: " + byteBufferPool.dumpLeaks(), byteBufferPool.getLeaks().size(), Matchers.is(0));
+        assertThat("Server Leaks: " + trackingBufferPool.dumpLeaks(), trackingBufferPool.getLeaks().size(), Matchers.is(0));
     }
 
     @Override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -126,36 +126,28 @@ public class AbstractTest
         try
         {
             if (serverBufferPool != null && !isLeakTrackingDisabled(testInfo, "server"))
-            {
-                try
-                {
-                    Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> serverBufferPool.getLeaks().size(), Matchers.is(0));
-                }
-                catch (Exception e)
-                {
-                    String className = testInfo.getTestClass().orElseThrow().getName();
-                    dumpHeap("server-" + className);
-                    fail(e.getMessage() + "\n---\nServer Leaks: " + serverBufferPool.dumpLeaks() + "---\n");
-                }
-            }
+                assertNoLeaks(serverBufferPool, testInfo, "server-", "\n---\nServer Leaks: " + serverBufferPool.dumpLeaks() + "---\n");
             if (clientBufferPool != null && !isLeakTrackingDisabled(testInfo, "client"))
-            {
-                try
-                {
-                    Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> clientBufferPool.getLeaks().size(), Matchers.is(0));
-                }
-                catch (Exception e)
-                {
-                    String className = testInfo.getTestClass().orElseThrow().getName();
-                    dumpHeap("client-" + className);
-                    fail(e.getMessage() + "\n---\nClient Leaks: " + clientBufferPool.dumpLeaks() + "---\n");
-                }
-            }
+                assertNoLeaks(clientBufferPool, testInfo, "client-", "\n---\nClient Leaks: " + clientBufferPool.dumpLeaks() + "---\n");
         }
         finally
         {
             LifeCycle.stop(client);
             LifeCycle.stop(server);
+        }
+    }
+
+    private void assertNoLeaks(ArrayByteBufferPool.Tracking bufferPool, TestInfo testInfo, String prefix, String msg) throws Exception
+    {
+        try
+        {
+            Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> bufferPool.getLeaks().size(), Matchers.is(0));
+        }
+        catch (Exception e)
+        {
+            String className = testInfo.getTestClass().orElseThrow().getName();
+            dumpHeap(prefix + className + msg);
+            fail(e.getMessage());
         }
     }
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -146,8 +146,8 @@ public class AbstractTest
         catch (Exception e)
         {
             String className = testInfo.getTestClass().orElseThrow().getName();
-            dumpHeap(prefix + className + msg);
-            fail(e.getMessage());
+            dumpHeap(prefix + className);
+            fail(e.getMessage() + msg);
         }
     }
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -34,6 +35,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking")
     public void testClientIdleTimeout(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -69,6 +71,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking")
     public void testRequestIdleTimeout(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
@@ -35,7 +35,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:server:FCGI")
     public void testClientIdleTimeout(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -71,7 +71,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:server:FCGI")
     public void testRequestIdleTimeout(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -342,9 +342,7 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking:client:H2C")
-    @Tag("DisableLeakTracking:client:H3")
-    @Tag("DisableLeakTracking:client:FCGI")
+    @Tag("DisableLeakTracking:client")
     public void testInputStreamResponseListenerClosedWhileWaiting(Transport transport) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1};

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -78,6 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("DisableLeakTracking")
 public class HttpClientStreamTest extends AbstractTest
 {
     @ParameterizedTest

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -541,7 +541,9 @@ public class HttpClientStreamTest extends AbstractTest
     public void testDownloadWithCloseMiddleOfContent(Transport transport) throws Exception
     {
         byte[] data1 = new byte[1024];
+        Arrays.fill(data1, (byte)1);
         byte[] data2 = new byte[1024];
+        Arrays.fill(data2, (byte)2);
         CountDownLatch latch = new CountDownLatch(1);
         start(transport, new Handler.Abstract()
         {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -78,7 +78,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Tag("DisableLeakTracking")
 public class HttpClientStreamTest extends AbstractTest
 {
     @ParameterizedTest
@@ -215,6 +214,8 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:H2")
+    @Tag("DisableLeakTracking:client:H2C")
     public void testDownloadWithFailure(Transport transport) throws Exception
     {
         byte[] data = new byte[64 * 1024];
@@ -266,6 +267,7 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testInputStreamResponseListenerClosedBeforeReading(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -294,6 +296,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:HTTP")
+    @Tag("DisableLeakTracking:client:FCGI")
+    @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     public void testInputStreamResponseListenerClosedBeforeContent(Transport transport) throws Exception
     {
         AtomicReference<HandlerContext> contextRef = new AtomicReference<>();
@@ -337,6 +342,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:H2C")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testInputStreamResponseListenerClosedWhileWaiting(Transport transport) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1};
@@ -389,6 +397,7 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testInputStreamResponseListenerFailedWhileWaiting(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -491,6 +500,8 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:client:FCGI")
     @Tag("flaky")
     public void testDownloadWithCloseBeforeContent(Transport transport) throws Exception
     {
@@ -538,6 +549,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @Tag("flaky")
+    @Tag("DisableLeakTracking:client:HTTP")
+    @Tag("DisableLeakTracking:client:FCGI")
+    @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     @MethodSource("transports")
     public void testDownloadWithCloseMiddleOfContent(Transport transport) throws Exception
     {
@@ -962,6 +976,11 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:server:HTTP")
+    @Tag("DisableLeakTracking:server:HTTPS")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:server:FCGI")
+    @Tag("DisableLeakTracking:server:UNIX_DOMAIN")
     public void testUploadWithConcurrentServerCloseClosesStream(Transport transport) throws Exception
     {
         CountDownLatch serverLatch = new CountDownLatch(1);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -297,6 +297,7 @@ public class HttpClientStreamTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client:HTTP")
+    @Tag("DisableLeakTracking:client:HTTPS")
     @Tag("DisableLeakTracking:client:FCGI")
     @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     public void testInputStreamResponseListenerClosedBeforeContent(Transport transport) throws Exception
@@ -395,7 +396,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:HTTP")
+    @Tag("DisableLeakTracking:client:HTTPS")
     @Tag("DisableLeakTracking:client:FCGI")
+    @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     public void testInputStreamResponseListenerFailedWhileWaiting(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -58,6 +58,7 @@ import org.eclipse.jetty.util.IteratingNestedCallback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -289,6 +290,7 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking")
     public void testRequestAfterFailedRequest(Transport transport) throws Exception
     {
         int length = FlowControlStrategy.DEFAULT_WINDOW_SIZE;
@@ -835,6 +837,7 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking")
     public void testContentSourceListenersFailure(Transport transport) throws Exception
     {
         int totalBytes = 1024;
@@ -991,6 +994,7 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking")
     public void testParallelContentSourceListenersTotalFailure(Transport transport) throws Exception
     {
         start(transport, new TestHandler(1024));

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -290,7 +290,8 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testRequestAfterFailedRequest(Transport transport) throws Exception
     {
         int length = FlowControlStrategy.DEFAULT_WINDOW_SIZE;
@@ -837,7 +838,8 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testContentSourceListenersFailure(Transport transport) throws Exception
     {
         int totalBytes = 1024;
@@ -994,7 +996,8 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:client:H3")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testParallelContentSourceListenersTotalFailure(Transport transport) throws Exception
     {
         start(transport, new TestHandler(1024));

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTimeoutTest.java
@@ -386,6 +386,7 @@ public class HttpClientTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:FCGI")
     public void testVeryShortTimeout(Transport transport) throws Exception
     {
         start(transport, new EmptyServerHandler());

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
@@ -95,7 +95,9 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsAndTrueIdleTimeoutListeners")
-    @Tag("DisableLeakTracking")
+    @Tag("DisableLeakTracking:server:HTTP")
+    @Tag("DisableLeakTracking:server:HTTPS")
+    @Tag("DisableLeakTracking:server:UNIX_DOMAIN")
     public void testIdleTimeoutWithDemand(Transport transport, boolean listener) throws Exception
     {
         AtomicBoolean listenerCalled = new AtomicBoolean();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -94,6 +95,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsAndTrueIdleTimeoutListeners")
+    @Tag("DisableLeakTracking")
     public void testIdleTimeoutWithDemand(Transport transport, boolean listener) throws Exception
     {
         AtomicBoolean listenerCalled = new AtomicBoolean();


### PR DESCRIPTION
- Restore leak tracking in every test where that makes sense.
- Improve the leak tracking buffer pool to collect more data.
- Add the ability to dump the heap when a leak is detected.
- Add the ability to disable leak tracking for a particular test or an entire test class with `@Tag("DisableLeakTracking")`, only for server or client or only for specific transports.
- Fix some detected leaks.
- Disable leak tracking for the remaining detected leaks.

See #10226.