### PR TITLE
Fixes #8926 - HttpClient GZIPContentDecoder should remove Content-Len…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
@@ -22,6 +22,10 @@ import java.nio.ByteBuffer;
  */
 public interface ContentDecoder
 {
+    public default void beforeDecoding(HttpExchange exchange)
+    {
+    }
+
     /**
      * <p>Decodes the bytes in the given {@code buffer} and returns decoded bytes, if any.</p>
      *
@@ -36,6 +40,10 @@ public interface ContentDecoder
      * @param decoded the ByteBuffer returned by {@link #decode(ByteBuffer)}
      */
     public default void release(ByteBuffer decoded)
+    {
+    }
+
+    public default void afterDecoding(HttpExchange exchange)
     {
     }
 

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
@@ -22,6 +22,14 @@ import java.nio.ByteBuffer;
  */
 public interface ContentDecoder
 {
+    /**
+     * <p>Processes the exchange just before the decoding of the response content.</p>
+     * <p>Typical processing may involve modifying the response headers, for example
+     * by temporarily removing the {@code Content-Length} header, or modifying the
+     * {@code Content-Encoding} header.</p>
+     *
+     * @param exchange the exchange to process before decoding the response content
+     */
     public default void beforeDecoding(HttpExchange exchange)
     {
     }
@@ -43,6 +51,14 @@ public interface ContentDecoder
     {
     }
 
+    /**
+     * <p>Processes the exchange after the response content has been decoded.</p>
+     * <p>Typical processing may involve modifying the response headers, for example
+     * updating the {@code Content-Length} header to the length of the decoded
+     * response content.
+     *
+     * @param exchange the exchange to process after decoding the response content
+     */
     public default void afterDecoding(HttpExchange exchange)
     {
     }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
@@ -87,6 +87,11 @@ public class HttpResponse implements Response
         return headers.asImmutable();
     }
 
+    protected HttpFields.Mutable headers()
+    {
+        return headers;
+    }
+
     public void clearHeaders()
     {
         headers.clear();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpResponse.java
@@ -87,11 +87,6 @@ public class HttpResponse implements Response
         return headers.asImmutable();
     }
 
-    protected HttpFields.Mutable headers()
-    {
-        return headers;
-    }
-
     public void clearHeaders()
     {
         headers.clear();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -422,6 +422,12 @@ public interface Request
     Request onResponseHeader(Response.HeaderListener listener);
 
     /**
+     * <p>Registers a listener for the headers event.</p>
+     * <p>Note that the response headers at this event
+     * may be different from the headers received in
+     * {@link #onResponseHeader(Response.HeaderListener)}
+     * as specified in {@link Response#getHeaders()}.</p>
+     *
      * @param listener a listener for response headers event
      * @return this request object
      */

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Response.java
@@ -65,6 +65,18 @@ public interface Response
     String getReason();
 
     /**
+     * <p>Returns the headers of this response.</p>
+     * <p>Some headers sent by the server may not be present,
+     * or be present but modified, while the content is being
+     * processed.
+     * A typical example is the {@code Content-Length} header
+     * when the content is sent compressed by the server and
+     * automatically decompressed by the client: the
+     * {@code Content-Length} header will be removed.</p>
+     * <p>Similarly, the {@code Content-Encoding} header
+     * may be removed or modified, as the content is
+     * decoded by the client.</p>
+     *
      * @return the headers of this response
      */
     HttpFields getHeaders();

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
@@ -390,7 +390,7 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
             IO.copy(input, output);
         }
         assertArrayEquals(content, output.toByteArray());
-        // After the content has been coded, the length is known again.
+        // After the content has been decoded, the length is known again.
         assertEquals(content.length, response.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH));
     }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.client;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,6 +23,8 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -79,6 +82,76 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
         assertNull(responseHeaders.get(HttpHeader.CONTENT_ENCODING));
         // The Content-Length must be the decoded one.
         assertEquals(data.length, responseHeaders.getLongField(HttpHeader.CONTENT_LENGTH));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMultipleContentEncodingsFooGZIP(Scenario scenario) throws Exception
+    {
+        final byte[] data = "HELLO WORLD".getBytes(StandardCharsets.UTF_8);
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                response.setHeader("Content-Encoding", "foo,gzip");
+                GZIPOutputStream gzipOutput = new GZIPOutputStream(response.getOutputStream());
+                gzipOutput.write(data);
+                gzipOutput.finish();
+            }
+        });
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertArrayEquals(data, response.getContent());
+        HttpFields responseHeaders = response.getHeaders();
+        // The content has been decoded, so Content-Encoding must be only be "foo".
+        assertEquals("foo", responseHeaders.get(HttpHeader.CONTENT_ENCODING));
+        // The Content-Length must be the decoded one.
+        assertEquals(data.length, responseHeaders.getLongField(HttpHeader.CONTENT_LENGTH));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMultipleContentEncodingsGZIPFoo(Scenario scenario) throws Exception
+    {
+        final byte[] data = "HELLO WORLD".getBytes(StandardCharsets.UTF_8);
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(String target, Request jettyRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                response.setHeader("Content-Encoding", "gzip,foo");
+                GZIPOutputStream gzipOutput = new GZIPOutputStream(response.getOutputStream());
+                gzipOutput.write(data);
+                gzipOutput.finish();
+            }
+        });
+
+        // There is no "foo" content decoder factory, so content must remain gzipped.
+        AtomicLong encodedContentLength = new AtomicLong();
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onResponseHeader((r, field) ->
+            {
+                if (field.getHeader() == HttpHeader.CONTENT_LENGTH)
+                    encodedContentLength.set(field.getLongValue());
+                return true;
+            })
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(200, response.getStatus());
+
+        byte[] content = IO.readBytes(new GZIPInputStream(new ByteArrayInputStream(response.getContent())));
+        assertArrayEquals(data, content);
+        HttpFields responseHeaders = response.getHeaders();
+        assertEquals("gzip,foo", responseHeaders.get(HttpHeader.CONTENT_ENCODING));
+        assertEquals(encodedContentLength.get(), responseHeaders.getLongField(HttpHeader.CONTENT_LENGTH));
     }
 
     @ParameterizedTest

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/ContentLengthTest.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/ContentLengthTest.java
@@ -20,13 +20,15 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContentLengthTest extends AbstractTest
 {
@@ -94,7 +96,10 @@ public class ContentLengthTest extends AbstractTest
             .send();
 
         HttpFields responseHeaders = response.getHeaders();
-        long contentLength = responseHeaders.getLongField(HttpHeader.CONTENT_LENGTH.asString());
-        assertTrue(0 < contentLength && contentLength < data.length);
+        long contentLength = responseHeaders.getLongField(HttpHeader.CONTENT_LENGTH);
+        if (HttpMethod.HEAD.is(method))
+            assertThat(contentLength, lessThan((long)data.length));
+        else
+            assertEquals(data.length, contentLength);
     }
 }

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -105,7 +105,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             String[] argsStart = {
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
                 "jetty.ssl.port=" + httpsPort
             };
 
@@ -149,7 +148,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             String[] argsStart = {
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
                 "jetty.ssl.port=" + httpsPort
             };
 
@@ -205,7 +203,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             String[] argsStart = {
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
                 "jetty.ssl.port=" + httpsPort
             };
 
@@ -260,7 +257,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             String[] argsStart = {
                 "--jpms",
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
                 "jetty.ssl.port=" + httpsPort
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
@@ -301,7 +297,6 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             int httpsPort = distribution.freePort();
             String[] argsStart = {
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpsPort,
                 "jetty.ssl.port=" + httpsPort
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/GzipModuleTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/GzipModuleTests.java
@@ -55,8 +55,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpPort
+                "jetty.http.port=" + httpPort
             };
 
             File war = distribution.resolveArtifact("org.eclipse.jetty.demos:demo-simple-webapp:war:" + jettyVersion);
@@ -70,7 +69,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/demo/index.html");
                 String responseDetails = toResponseDetails(response);
                 assertEquals(HttpStatus.OK_200, response.getStatus(), responseDetails);
-                assertThat(responseDetails, response.getHeaders().get(HttpHeader.CONTENT_ENCODING), containsString("gzip"));
+                assertThat(responseDetails, containsString("Hello"));
             }
         }
     }
@@ -99,8 +98,7 @@ public class GzipModuleTests extends AbstractJettyHomeTest
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
-                "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpPort
+                "jetty.http.port=" + httpPort
             };
 
             File war = distribution.resolveArtifact("org.eclipse.jetty.demos:demo-simple-webapp:war:" + jettyVersion);
@@ -145,7 +143,6 @@ public class GzipModuleTests extends AbstractJettyHomeTest
 
             String[] argsStart = {
                 "jetty.http.port=" + httpPort,
-                "jetty.httpConfig.port=" + httpPort,
                 "jetty.gzip.excludedMimeTypeList=image/vnd.microsoft.icon"
             };
 


### PR DESCRIPTION
…gth and Content-Encoding: gzip

Now Content-Length and Content-Encoding are removed/modified by the decoder. In this way, applications have a correct sets of headers to decide whether to decode the content themselves.