### PR TITLE
Various cleanups in HttpParser (CVE-2023-40167)

### DIFF
--- a/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
@@ -210,6 +210,7 @@ public class HttpReceiverOverHTTPTest
         ExecutionException e = assertThrows(ExecutionException.class, () -> listener.get(5, TimeUnit.SECONDS));
         assertThat(e.getCause(), instanceOf(HttpResponseException.class));
         assertThat(e.getCause().getCause(), instanceOf(BadMessageException.class));
+        e.printStackTrace();
         assertThat(e.getCause().getCause().getCause(), instanceOf(NumberFormatException.class));
     }
 

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
@@ -210,7 +210,6 @@ public class HttpReceiverOverHTTPTest
         ExecutionException e = assertThrows(ExecutionException.class, () -> listener.get(5, TimeUnit.SECONDS));
         assertThat(e.getCause(), instanceOf(HttpResponseException.class));
         assertThat(e.getCause().getCause(), instanceOf(BadMessageException.class));
-        e.printStackTrace();
         assertThat(e.getCause().getCause().getCause(), instanceOf(NumberFormatException.class));
     }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1112,7 +1112,6 @@ public class HttpParser
         long value = 0;
         int length = valueString.length();
 
-
         for (int i = 0; i < length; i++)
         {
             char c = valueString.charAt(i);

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -489,7 +489,7 @@ public class HttpParser
     /* Quick lookahead for the start state looking for a request method or an HTTP version,
      * otherwise skip white space until something else to parse.
      */
-    private boolean quickStart(ByteBuffer buffer)
+    private void quickStart(ByteBuffer buffer)
     {
         if (_requestHandler != null)
         {
@@ -500,7 +500,7 @@ public class HttpParser
                 buffer.position(buffer.position() + _methodString.length() + 1);
 
                 setState(State.SPACE1);
-                return false;
+                return;
             }
         }
         else if (_responseHandler != null)
@@ -510,7 +510,7 @@ public class HttpParser
             {
                 buffer.position(buffer.position() + _version.asString().length() + 1);
                 setState(State.SPACE1);
-                return false;
+                return;
             }
         }
 
@@ -531,7 +531,7 @@ public class HttpParser
                     _string.setLength(0);
                     _string.append(t.getChar());
                     setState(_requestHandler != null ? State.METHOD : State.RESPONSE_VERSION);
-                    return false;
+                    return;
                 }
                 case OTEXT:
                 case SPACE:
@@ -549,7 +549,6 @@ public class HttpParser
                 throw new BadMessageException(HttpStatus.BAD_REQUEST_400);
             }
         }
-        return false;
     }
 
     private void setString(String s)
@@ -755,6 +754,8 @@ public class HttpParser
                         case LF:
                             _fieldCache.prepare();
                             setState(State.HEADER);
+                            if (_responseHandler == null)
+                                throw new BadMessageException("Bad status");
                             _responseHandler.startResponse(_version, _responseStatus, null);
                             break;
 
@@ -916,6 +917,8 @@ public class HttpParser
                             String reason = takeString();
                             _fieldCache.prepare();
                             setState(State.HEADER);
+                            if (_responseHandler == null)
+                                throw new BadMessageException("Bad reason");
                             _responseHandler.startResponse(_version, _responseStatus, reason);
                             continue;
 
@@ -970,22 +973,19 @@ public class HttpParser
                     case CONTENT_LENGTH:
                         if (_hasTransferEncoding)
                             checkViolation(TRANSFER_ENCODING_WITH_CONTENT_LENGTH);
-
+                        long contentLength = convertContentLength(_valueString);
                         if (_hasContentLength)
                         {
                             checkViolation(MULTIPLE_CONTENT_LENGTHS);
-                            if (convertContentLength(_valueString) != _contentLength)
+                            if (contentLength != _contentLength)
                                 throw new BadMessageException(HttpStatus.BAD_REQUEST_400, MULTIPLE_CONTENT_LENGTHS.getDescription());
                         }
                         _hasContentLength = true;
 
                         if (_endOfContent != EndOfContent.CHUNKED_CONTENT)
                         {
-                            _contentLength = convertContentLength(_valueString);
-                            if (_contentLength <= 0)
-                                _endOfContent = EndOfContent.NO_CONTENT;
-                            else
-                                _endOfContent = EndOfContent.CONTENT_LENGTH;
+                            _contentLength = contentLength;
+                            _endOfContent = EndOfContent.CONTENT_LENGTH;
                         }
                         break;
 
@@ -1039,7 +1039,6 @@ public class HttpParser
                         _parsedHost = _valueString;
                         if (!(_field instanceof HostPortHttpField) && _valueString != null && !_valueString.isEmpty())
                         {
-                            HostPort hostPort;
                             if (UNSAFE_HOST_HEADER.isAllowedBy(_complianceMode))
                             {
                                 _field = new HostPortHttpField(_header,
@@ -1111,15 +1110,22 @@ public class HttpParser
 
     private long convertContentLength(String valueString)
     {
-        try
+        if (valueString == null || valueString.length() == 0)
+            throw new BadMessageException("Invalid Content-Length Value");
+
+        long value = 0;
+        int length = valueString.length();
+
+
+        for (int i = 0; i < length; i++)
         {
-            return Long.parseLong(valueString);
+            char c = valueString.charAt(i);
+            if (c < '0' || c > '9')
+                throw new BadMessageException("Invalid Content-Length Value");
+
+            value = Math.addExact(Math.multiplyExact(value, 10), c - '0');
         }
-        catch (NumberFormatException e)
-        {
-            LOG.trace("IGNORED", e);
-            throw new BadMessageException(HttpStatus.BAD_REQUEST_400, "Invalid Content-Length Value", e);
-        }
+        return value;
     }
 
     /*
@@ -1516,12 +1522,11 @@ public class HttpParser
                 _methodString = null;
                 _endOfContent = EndOfContent.UNKNOWN_CONTENT;
                 _header = null;
-                if (quickStart(buffer))
-                    return true;
+                quickStart(buffer);
             }
 
             // Request/response line
-            if (_state.ordinal() >= State.START.ordinal() && _state.ordinal() < State.HEADER.ordinal())
+            if (_state.ordinal() < State.HEADER.ordinal())
             {
                 if (parseLine(buffer))
                     return true;
@@ -2020,7 +2025,6 @@ public class HttpParser
         void startResponse(HttpVersion version, int status, String reason);
     }
 
-    @SuppressWarnings("serial")
     private static class IllegalCharacterException extends BadMessageException
     {
         private IllegalCharacterException(State state, HttpTokens.Token token, ByteBuffer buffer)

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1111,7 +1111,7 @@ public class HttpParser
     private long convertContentLength(String valueString)
     {
         if (valueString == null || valueString.length() == 0)
-            throw new BadMessageException("Invalid Content-Length Value");
+            throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
 
         long value = 0;
         int length = valueString.length();
@@ -1121,7 +1121,7 @@ public class HttpParser
         {
             char c = valueString.charAt(i);
             if (c < '0' || c > '9')
-                throw new BadMessageException("Invalid Content-Length Value");
+                throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
 
             value = Math.addExact(Math.multiplyExact(value, 10), c - '0');
         }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -754,8 +754,6 @@ public class HttpParser
                         case LF:
                             _fieldCache.prepare();
                             setState(State.HEADER);
-                            if (_responseHandler == null)
-                                throw new BadMessageException("Bad status");
                             _responseHandler.startResponse(_version, _responseStatus, null);
                             break;
 
@@ -917,8 +915,6 @@ public class HttpParser
                             String reason = takeString();
                             _fieldCache.prepare();
                             setState(State.HEADER);
-                            if (_responseHandler == null)
-                                throw new BadMessageException("Bad reason");
                             _responseHandler.startResponse(_version, _responseStatus, reason);
                             continue;
 


### PR DESCRIPTION
Various cleanups in HttpParser:
  + removed dead branches
  + improved efficiency of conversions (to address CVE-2023-40167)
  + parameterised tests