### PR TITLE
Fix #10349 ContentType set twice

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -582,10 +582,13 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
                     {
                         if (!isCommitted())
                         {
-                            if (_locale == null)
-                                _characterEncoding = null;
                             _contentType = null;
                             _mimeType = null;
+                            _characterEncoding = switch (_encodingFrom)
+                            {
+                                case SET_CHARACTER_ENCODING, SET_LOCALE -> _characterEncoding;
+                                default -> null;
+                            };
                         }
                     }
                 }


### PR DESCRIPTION
Fix #10349 which was caused by a put of ContentType being intercepted as a remove followed by an add.  The remove was incorrectly forgetting the charset without reference to the source of the charset.