### PR TITLE
Cleanup of start properties usages in `jetty-10.0.x`

### DIFF
--- a/demos/demo-jndi-webapp/src/main/config/modules/demo.d/demo-jndi.xml
+++ b/demos/demo-jndi-webapp/src/main/config/modules/demo.d/demo-jndi.xml
@@ -3,7 +3,7 @@
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->
 <!-- =============================================================== -->
-<Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
+<Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
 
   <New id="tx" class="org.eclipse.jetty.plus.jndi.Transaction">
     <Arg>
@@ -21,7 +21,7 @@
   <!-- Define an env entry with Server scope for java:comp/env                   -->
   <New id="woggle" class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
-      <Property name='server' />
+      <Ref refid="Server" />
     </Arg>
     <Arg>woggle</Arg>
     <Arg type="java.lang.Integer">4000</Arg>
@@ -31,7 +31,7 @@
   <!-- Define an env entry with webapp scope for java:comp/env                   -->
   <New id="wiggle" class="org.eclipse.jetty.plus.jndi.EnvEntry">
     <Arg>
-      <Ref refid='wac' />
+      <Ref refid="wac" />
     </Arg>
     <Arg>wiggle</Arg>
     <Arg type="java.lang.Double">100</Arg>
@@ -41,7 +41,7 @@
   <!-- Mail Session setup                                          -->
   <New id="xxxmail" class="org.eclipse.jetty.plus.jndi.Resource">
     <Arg>
-      <Ref refid='wac' />
+      <Ref refid="wac" />
     </Arg>
     <Arg>mail/Session</Arg>
     <Arg>
@@ -63,7 +63,7 @@
   <!-- A mock DataSource                                           -->
   <New id="mydatasource" class="org.eclipse.jetty.plus.jndi.Resource">
     <Arg>
-      <Ref refid='wac' />
+      <Ref refid="wac" />
     </Arg>
     <Arg>jdbc/mydatasource</Arg>
     <Arg>

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -16,9 +16,6 @@ etc/jetty-deploy.xml
 [ini-template]
 # Monitored directory name (relative to $jetty.base)
 # jetty.deploy.monitoredDir=webapps
-# - OR -
-# Monitored directory path (fully qualified)
-# jetty.deploy.monitoredPath=/var/www/webapps
 
 # Defaults Descriptor for all deployed webapps
 # jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault.xml

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
@@ -37,4 +37,4 @@ jetty.session.hazelcast.hazelcastInstanceName=JETTY_DISTRIBUTED_SESSION_INSTANCE
 jetty.session.hazelcast.useQueries=false
 jetty.session.gracePeriod.seconds=3600
 jetty.session.savePeriod.seconds=0
-#jetty.session.hazelcast.configurationLocation
+#jetty.session.hazelcast.configurationLocation=

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
@@ -38,5 +38,5 @@ jetty.session.hazelcast.onlyClient=true
 jetty.session.hazelcast.useQueries=false
 jetty.session.gracePeriod.seconds=3600
 jetty.session.savePeriod.seconds=0
-#jetty.session.hazelcast.configurationLocation
+#jetty.session.hazelcast.configurationLocation=
 #jetty.session.hazelcast.addresses=

--- a/jetty-server/src/main/config/etc/jetty-debug.xml
+++ b/jetty-server/src/main/config/etc/jetty-debug.xml
@@ -9,7 +9,7 @@
   <New id="DebugListener" class="org.eclipse.jetty.server.DebugListener">
     <Arg name="outputStream">
       <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
-        <Arg type="String"><Property name="jetty.logs" default="./logs"/>/yyyy_mm_dd.debug.log</Arg>
+        <Arg type="String"><Property name="jetty.debug.logs" default="./logs"/>/yyyy_mm_dd.debug.log</Arg>
         <Arg type="boolean"><Property name="jetty.debug.append" default="true"/></Arg>
         <Arg type="int"><Property name="jetty.debug.retainDays" default="14"/></Arg>
         <Arg>

--- a/jetty-server/src/main/config/etc/jetty-debug.xml
+++ b/jetty-server/src/main/config/etc/jetty-debug.xml
@@ -9,7 +9,7 @@
   <New id="DebugListener" class="org.eclipse.jetty.server.DebugListener">
     <Arg name="outputStream">
       <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
-        <Arg type="String"><Property name="jetty.debug.logs" default="./logs"/>/yyyy_mm_dd.debug.log</Arg>
+        <Arg type="String"><Property name="jetty.debug.logs" deprecated="jetty.logs" default="./logs"/>/yyyy_mm_dd.debug.log</Arg>
         <Arg type="boolean"><Property name="jetty.debug.append" default="true"/></Arg>
         <Arg type="int"><Property name="jetty.debug.retainDays" default="14"/></Arg>
         <Arg>

--- a/jetty-server/src/main/config/etc/jetty-http.xml
+++ b/jetty-server/src/main/config/etc/jetty-http.xml
@@ -43,9 +43,6 @@
         <Set name="acceptedTcpNoDelay"><Property name="jetty.http.acceptedTcpNoDelay" default="true"/></Set>
         <Set name="acceptedReceiveBufferSize" property="jetty.http.acceptedReceiveBufferSize" />
         <Set name="acceptedSendBufferSize" property="jetty.http.acceptedSendBufferSize" />
-        <Get name="SelectorManager">
-          <Set name="connectTimeout"><Property name="jetty.http.connectTimeout" default="15000"/></Set>
-        </Get>
       </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/etc/jetty-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl.xml
@@ -36,9 +36,6 @@
         <Set name="acceptedTcpNoDelay"><Property name="jetty.ssl.acceptedTcpNoDelay" default="true"/></Set>
         <Set name="acceptedReceiveBufferSize" property="jetty.ssl.acceptedReceiveBufferSize" />
         <Set name="acceptedSendBufferSize" property="jetty.ssl.acceptedSendBufferSize" />
-        <Get name="SelectorManager">
-          <Set name="connectTimeout" property="jetty.ssl.connectTimeout"/>
-        </Get>
       </New>
     </Arg>
   </Call>

--- a/jetty-server/src/main/config/modules/debug.mod
+++ b/jetty-server/src/main/config/modules/debug.mod
@@ -23,6 +23,12 @@ etc/jetty-debug.xml
 ## How many days to retain old log files
 # jetty.debug.retainDays=14
 
+## Should existing log be appended to
+# jetty.debug.append=true
+
+## Log directory for jetty debug logs
+# jetty.debug.logs=./logs
+
 ## Timezone of the log entries
 # jetty.debug.timezone=GMT
 

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -18,9 +18,6 @@ etc/jetty-gzip.xml
 ## Minimum content length after which gzip is enabled
 # jetty.gzip.minGzipSize=32
 
-## Check whether a file with *.gz extension exists
-# jetty.gzip.checkGzExists=false
-
 ## Inflate request buffer size, or 0 for no request inflation
 # jetty.gzip.inflateBufferSize=0
 

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -39,7 +39,7 @@ etc/jetty.xml
 ## Max response content write length that is buffered (in bytes)
 # jetty.httpConfig.outputAggregationSize=8192
 
-## If HTTP/1.1 persistent connections should be enabled
+## If HTTP/1.x persistent connections should be enabled
 # jetty.httpConfig.persistentConnectionsEnabled=true
 
 ## Max request headers size (in bytes)

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -39,6 +39,9 @@ etc/jetty.xml
 ## Max response content write length that is buffered (in bytes)
 # jetty.httpConfig.outputAggregationSize=8192
 
+## If HTTP/1.1 persistent connections should be enabled
+# jetty.httpConfig.persistentConnectionsEnabled=true
+
 ## Max request headers size (in bytes)
 # jetty.httpConfig.requestHeaderSize=8192
 


### PR DESCRIPTION
Ensure that start properties exist back and forth between an XML and the MOD file.

Cleanup other property-alike mistakes too.