### PR TITLE
Issue #10385 - fix NPE in GzipDefaultServletTest

### DIFF
--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
@@ -76,6 +76,7 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         gzipHandler.setIncludedMethods("POST", "WIBBLE", "GET", "HEAD");
 
         server = new Server();
+        server.setStopTimeout(1000);
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 


### PR DESCRIPTION
## Issue #10385

The test was stopping the server and closing the deflaterPool before the send callback had complete. So the deflater was being released after the server was stopped.