### PR TITLE
Issue #10383 - suppress stack traces from AsyncListenerTest

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -817,7 +817,10 @@ public class ServletChannelState
             }
             else if (_requestState != RequestState.COMPLETE)
             {
-                LOG.warn("unhandled in state {}", _requestState, new IllegalStateException(th));
+                if (QuietException.isQuiet(th))
+                    LOG.debug("unhandled in state {}", _requestState, th);
+                else
+                    LOG.warn("unhandled in state {}", _requestState, new IllegalStateException(th));
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
@@ -60,16 +60,9 @@ public class AsyncListenerTest
     }
 
     @BeforeEach
-    public void beforeAll()
+    public void before()
     {
         stacklessLogging = new StacklessLogging(ServletChannelState.class);
-    }
-
-    @AfterEach
-    public void afterAll()
-    {
-        stacklessLogging.close();
-        stacklessLogging = null;
     }
 
     @AfterEach
@@ -77,6 +70,9 @@ public class AsyncListenerTest
     {
         if (server != null)
             server.stop();
+
+        stacklessLogging.close();
+        stacklessLogging = null;
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
@@ -28,12 +28,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.io.QuietException;
-import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,7 +44,6 @@ public class AsyncListenerTest
     private QueuedThreadPool threadPool;
     private Server server;
     private LocalConnector connector;
-    private StacklessLogging stacklessLogging;
 
     public void startServer(ServletContextHandler context) throws Exception
     {
@@ -59,20 +56,11 @@ public class AsyncListenerTest
         server.start();
     }
 
-    @BeforeEach
-    public void before()
-    {
-        stacklessLogging = new StacklessLogging(ServletChannelState.class);
-    }
-
     @AfterEach
     public void dispose() throws Exception
     {
         if (server != null)
             server.stop();
-
-        stacklessLogging.close();
-        stacklessLogging = null;
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
@@ -28,10 +28,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.io.QuietException;
+import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,15 +46,30 @@ public class AsyncListenerTest
     private QueuedThreadPool threadPool;
     private Server server;
     private LocalConnector connector;
+    private StacklessLogging stacklessLogging;
 
     public void startServer(ServletContextHandler context) throws Exception
     {
         server = threadPool == null ? new Server() : new Server(threadPool);
+        server.setStopTimeout(1000);
         connector = new LocalConnector(server);
         connector.setIdleTimeout(20 * 60 * 1000L);
         server.addConnector(connector);
         server.setHandler(context);
         server.start();
+    }
+
+    @BeforeEach
+    public void beforeAll()
+    {
+        stacklessLogging = new StacklessLogging(ServletChannelState.class);
+    }
+
+    @AfterEach
+    public void afterAll()
+    {
+        stacklessLogging.close();
+        stacklessLogging = null;
     }
 
     @AfterEach

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncListenerTest.java
@@ -48,7 +48,6 @@ public class AsyncListenerTest
     public void startServer(ServletContextHandler context) throws Exception
     {
         server = threadPool == null ? new Server() : new Server(threadPool);
-        server.setStopTimeout(1000);
         connector = new LocalConnector(server);
         connector.setIdleTimeout(20 * 60 * 1000L);
         server.addConnector(connector);


### PR DESCRIPTION
closes #10383

these stacktraces are found in 10/11 as well

They come from `ServletChannelState#onError` because the RequestState is not `COMPLETE`. The `ServletChannel#handleException` method unwraps for quiet exceptions but passes the failure to the `ServletChannelState`.