### PR TITLE
jetty 12.0.x merge from 11.0.x

### DIFF
--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -12,7 +12,7 @@
   <description>Generates a (maven based) P2 Updatesite</description>
   <packaging>pom</packaging>
   <properties>
-    <tycho-version>4.0.1</tycho-version>
+    <tycho-version>4.0.2</tycho-version>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
-    <testcontainers.version>1.18.3</testcontainers.version>
+    <testcontainers.version>1.19.0</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
     <wildfly.elytron.version>2.2.1.Final</wildfly.elytron.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.5.3.Final</jboss.logging.version>
-    <jboss-logmanager.version>3.0.1.Final</jboss-logmanager.version>
+    <jboss-logmanager.version>3.0.2.Final</jboss-logmanager.version>
     <jboss-threads.version>3.5.0.Final</jboss-threads.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <!-- dependency versions -->
     <alpn.agent.version>2.0.10</alpn.agent.version>
-    <ant.version>1.10.13</ant.version>
+    <ant.version>1.10.14</ant.version>
     <apache.avro.version>1.11.2</apache.avro.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <apache.avro.version>1.11.2</apache.avro.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
-    <asciidoctorj-diagram.version>2.2.10</asciidoctorj-diagram.version>
+    <asciidoctorj-diagram.version>2.2.11</asciidoctorj-diagram.version>
     <asciidoctorj.version>2.5.6</asciidoctorj.version>
     <mina.core.version>2.2.2</mina.core.version>
     <asm.version>9.5</asm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.6.0</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
-    <maven.enforcer.plugin.version>3.3.0</maven.enforcer.plugin.version>
+    <maven.enforcer.plugin.version>3.4.0</maven.enforcer.plugin.version>
     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
     <maven.gpg.plugin.version>3.1.0</maven.gpg.plugin.version>
     <maven.install.plugin.version>3.1.1</maven.install.plugin.version>


### PR DESCRIPTION
- Bump org.asciidoctor:asciidoctorj-diagram from 2.2.10 to 2.2.11
- Bump org.testcontainers:testcontainers-bom from 1.18.3 to 1.19.0
- Bump ant.version from 1.10.13 to 1.10.14
- Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.3.0 to 3.4.0
- Bump org.eclipse.tycho:tycho-p2-repository-plugin from 4.0.1 to 4.0.2
- Bump org.jboss.logmanager:jboss-logmanager
