### PR TITLE
Fixes #10347 - Ensure documentation snippets for XML don't have their doctype hot-linked

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jndi.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jndi.adoc
@@ -18,7 +18,7 @@ A web application may _reference_ a JNDI entry, such as a JDBC `DataSource` from
 The JNDI entry must be _defined_ in a xref:og-jndi-xml[Jetty XML file], for example a context XML like so:
 
 .mywebapp.xml
-[source,xml,subs=normal]
+[source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
@@ -193,7 +193,7 @@ The `class` attribute (or `<Class>` element) can also be used to specify the Jav
 This is necessary when the object in scope, onto which the `<Call>` would be applied, is an instance of a class that is not visible to Jetty classes, or not accessible because it is not `public`.
 For example:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
@@ -378,7 +378,7 @@ The `default` attribute allows you to specify a default value for the property, 
 
 For example, you may want to configure the context path of your web application in this way:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/arch-jmx.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/arch-jmx.adoc
@@ -29,7 +29,7 @@ Similarly, when a component is removed from the tree, `MBeanContainer` is notifi
 
 The Maven coordinates for the Jetty JMX support are:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-intro.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-intro.adoc
@@ -46,7 +46,7 @@ Out of the box features that you get with the Jetty HTTP client include:
 The Jetty artifact that provides the main HTTP client implementation is `jetty-client`.
 The Maven artifact coordinates are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http2/client-http2.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http2/client-http2.adoc
@@ -27,7 +27,7 @@ See also the correspondent xref:pg-server-http2[HTTP/2 server library].
 
 The Maven artifact coordinates for the HTTP/2 client library are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.http2</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http3/client-http3.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http3/client-http3.adoc
@@ -27,7 +27,7 @@ See also the correspondent xref:pg-server-http3[HTTP/3 server library].
 
 The Maven artifact coordinates for the HTTP/3 client library are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.http3</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/websocket/client-websocket.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/websocket/client-websocket.adoc
@@ -23,7 +23,7 @@ Since the first step of establishing a WebSocket communication is an HTTP reques
 
 The Maven artifact coordinates are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.websocket</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
@@ -192,7 +192,7 @@ Server
 
 The Maven artifact coordinates are:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty</groupId>
@@ -320,7 +320,7 @@ Jetty will send an HTTP `404` response anyway if `DefaultHandler` is not used.
 
 The Maven artifact coordinates are:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http.adoc
@@ -22,7 +22,7 @@ This result in your web applications to be available to HTTP clients as if you d
 
 The Maven artifact coordinates are:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http2/server-http2.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http2/server-http2.adoc
@@ -25,7 +25,7 @@ See also the correspondent xref:pg-client-http2[HTTP/2 client library].
 
 The Maven artifact coordinates for the HTTP/2 client library are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.http2</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http3/server-http3.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http3/server-http3.adoc
@@ -25,7 +25,7 @@ See also the correspondent xref:pg-client-http3[HTTP/3 client library].
 
 The Maven artifact coordinates for the HTTP/3 client library are the following:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.http3</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/websocket/server-websocket-jetty.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/websocket/server-websocket-jetty.adoc
@@ -19,7 +19,7 @@ However, at runtime you need to have the _implementation_ of the Jetty WebSocket
 
 Jetty's WebSocket APIs are provided by the following Maven artifact:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.websocket</groupId>
@@ -30,7 +30,7 @@ Jetty's WebSocket APIs are provided by the following Maven artifact:
 
 Jetty's implementation of the Jetty WebSocket APIs is provided by the following Maven artifact (and its transitive dependencies):
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.websocket</groupId>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/websocket/server-websocket-standard.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/websocket/server-websocket-standard.adoc
@@ -19,7 +19,7 @@ However, at runtime you need to have an implementation of the standard APIs in y
 
 The standard `javax.websocket` APIs are provided by the following Maven artifact:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>javax.websocket</groupId>
@@ -32,7 +32,7 @@ However, the artifact above lacks a proper JPMS `module-info.class` file, and th
 
 If you want to use JPMS for your application, you can use this Maven artifact instead:
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.toolchain</groupId>
@@ -47,7 +47,7 @@ At runtime, you also need an implementation of the standard `javax.websocket` AP
 
 Jetty's implementation of the standard `javax.websocket` APIs is provided by the following Maven artifact (and its transitive dependencies):
 
-[source,xml,subs=normal]
+[source,xml]
 ----
 <dependency>
   <groupId>org.eclipse.jetty.websocket</groupId>


### PR DESCRIPTION
Generate correct xml doctype statements in documentation.