### PR TITLE
Revert "Issue #10385 - fix NPE in GzipDefaultServletTest"

### DIFF
--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/GzipDefaultServletTest.java
@@ -76,7 +76,6 @@ public class GzipDefaultServletTest extends AbstractGzipTest
         gzipHandler.setIncludedMethods("POST", "WIBBLE", "GET", "HEAD");
 
         server = new Server();
-        server.setStopTimeout(1000);
         LocalConnector localConnector = new LocalConnector(server);
         server.addConnector(localConnector);
 


### PR DESCRIPTION
<strike>Reverts eclipse/jetty.project#10391

Looks this will cause a test failure, so we should revert this change while I debug.</strike>