### PR TITLE
Address transitive dependencies with open CVEs

### DIFF
--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -401,6 +401,10 @@
       <artifactId>jetty-ee8-glassfish-jstl</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>javax.el</groupId>
           <artifactId>el-api</artifactId>
         </exclusion>
@@ -409,6 +413,10 @@
           <artifactId>jakarta.el-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -257,6 +257,11 @@
           <version>1.2.5</version>
         </dependency>
         <dependency>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+          <version>2.7.3</version>
+        </dependency>
+        <dependency>
           <groupId>org.eclipse.jetty.toolchain</groupId>
           <artifactId>jetty-javax-websocket-api</artifactId>
           <version>${jakarta.websocket.api.version}</version>

--- a/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -42,6 +42,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.22.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1016,6 +1016,11 @@
         <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${apache.avro.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
-    <wildfly.elytron.version>2.2.1.Final</wildfly.elytron.version>
+    <wildfly.elytron.version>1.20.4.Final</wildfly.elytron.version>
     <xmemcached.version>2.4.7</xmemcached.version>
 
     <!-- some maven plugins versions -->
@@ -1677,6 +1677,11 @@
         <groupId>org.jboss.threads</groupId>
         <artifactId>jboss-threads</artifactId>
         <version>${jboss-threads.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron</artifactId>
+        <version>${wildfly.elytron.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <maven.resolver.version>1.9.15</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
     <mongodb.version>3.12.11</mongodb.version>
+    <netty.version>4.1.95.Final</netty.version>
     <openpojo.version>0.9.1</openpojo.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>8.0.0</org.osgi.core.version>
@@ -1126,6 +1127,11 @@
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-tools-api</artifactId>
         <version>${maven.plugin-tools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>10.6.0</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>
-    <commons.compress.version>1.23.0</commons.compress.version>
+    <commons-compress.version>1.23.0</commons-compress.version>
     <commons.io.version>2.13.0</commons.io.version>
     <commons-lang3.version>3.13.0</commons-lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>
@@ -1009,6 +1009,11 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>


### PR DESCRIPTION
Update various transitive dependencies that are marked as vulnerable by the Checkmarx project.

