### PR TITLE
Improved Handler javadocs.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Handler.java
@@ -35,27 +35,26 @@ import org.slf4j.LoggerFactory;
  * <p>{@code Handler}s may wrap the {@link Request}, {@link Response} and/or {@link Callback} and
  * then forward the wrapped instances to their children, so that they see a modified request;
  * and/or to intercept the read of the request content; and/or intercept the generation of the
- * response; and/or to intercept the completion of the callback.
+ * response; and/or to intercept the completion of the callback.</p>
  * <p>A {@code Handler} is an {@link Invocable} and implementations must respect
  * the {@link InvocationType} they declare within calls to
  * {@link #handle(Request, Response, Callback)}.</p>
  * <p>A minimal tree structure could be:</p>
- * <pre>
+ * <pre>{@code
  * Server
  * `- YourCustomHandler
- * </pre>
+ * }</pre>
  * <p>A more sophisticated tree structure:</p>
- * <pre>
+ * <pre>{@code
  * Server
- * `- DelayedHandler.UntilContent
- *    `- GzipHandler
- *       `- ContextHandlerCollection
- *          +- ContextHandler (contextPath="/user")
- *          |  `- YourUserHandler
- *          |- ContextHandler (contextPath="/admin")
- *          |  `- YourAdminHandler
- *          `- DefaultHandler
- * </pre>
+ * `- GzipHandler
+ *    `- ContextHandlerCollection
+ *       +- ContextHandler (contextPath="/user")
+ *       |  `- YourUserHandler
+ *       |- ContextHandler (contextPath="/admin")
+ *       |  `- YourAdminHandler
+ *       `- DefaultHandler
+ * }</pre>
  * <p>A simple {@code Handler} implementation could be:</p>
  * <pre>{@code
  * class SimpleHandler extends Handler.Abstract.NonBlocking
@@ -83,7 +82,7 @@ import org.slf4j.LoggerFactory;
  *             // The request is for this Handler
  *             response.setStatus(200);
  *             // The callback is completed when the write is completed.
- *             response.write(true, callback, "hello");
+ *             response.write(true, UTF_8.encode("hello"), callback);
  *             return true;
  *         }
  *         return false;
@@ -91,7 +90,7 @@ import org.slf4j.LoggerFactory;
  * }
  * }</pre>
  * <p>An example of a {@code Handler} that decides whether to pass the request to
- * a child:
+ * a child:</p>
  * <pre>{@code
  * class ConditionalHandler extends Handler.Wrapper
  * {
@@ -102,7 +101,7 @@ import org.slf4j.LoggerFactory;
  *             return super.handle(request, response, callback);
  *         if (request.getHttpURI().getPath().startsWith("/wrong"))
  *         {
- *             Response.writeError(request, response, callback, 400);
+ *             Response.writeError(request, response, callback, HttpStatus.BAD_REQUEST_400);
  *             return true;
  *         }
  *         return false;
@@ -126,11 +125,11 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
      */
     void setServer(Server server);
 
-    @Override
-    void destroy();
-
     /**
-     * <p>A {@code Handler} that contains one or more other {@code Handler}s.
+     * <p>A {@code Handler} that contains one or more other {@code Handler}s.</p>
+     *
+     * @see Singleton
+     * @see Collection
      */
     interface Container extends Handler
     {
@@ -149,10 +148,8 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         }
 
         /**
-         * Get a list of descendants of the passed type.
-         * The default implementation is not memory efficient and should be overridden.
-         * @param type the type of {@code Handler}
-         * @param <T> the type of {@code Handler}
+         * @param type the class of the descendant {@code Handler}
+         * @param <T> the type of the descendant {@code Handler}
          * @return an immutable collection of {@code Handler}s of the given type, descendants of this {@code Handler}
          */
         default <T extends Handler> List<T> getDescendants(Class<T> type)
@@ -173,8 +170,8 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         }
 
         /**
-         * @param type the type of {@code Handler}
-         * @param <T> the type of {@code Handler}
+         * @param type the class of the descendant {@code Handler}
+         * @param <T> the type of the descendant{@code Handler}
          * @return the first {@code Handler} of the given type, descendants of this {@code Handler},
          * or null if no such {@code Handler} exist
          */
@@ -199,10 +196,11 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         }
 
         /**
-         * @param handler the child {@code Handler}
-         * @param type the type of {@code Handler}
-         * @param <T> the type of {@code Handler}
-         * @return the {@code Handler.Container} of the given type, parent of the given {@code Handler}
+         * @param handler the descendant {@code Handler}
+         * @param type the class of the container {@code Handler}
+         * @param <T> the type of the container {@code Handler}
+         * @return the {@code Handler.Container} descendant of this {@code Handler}
+         * that is the ancestor of the given {@code Handler}
          */
         default <T extends Handler.Container> T getContainer(Handler handler, Class<T> type)
         {
@@ -220,46 +218,95 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
 
     /**
      * <p>A {@link Handler.Container} that can contain multiple other {@link Handler}s.</p>
+     *
      * @see Sequence for an implementation of {@link Collection}.
+     * @see Singleton
      */
     interface Collection extends Container
     {
-        void addHandler(Handler handler);
+        /**
+         * <p>Adds the given {@code Handler} to this collection of {@code Handler}s.</p>
+         *
+         * @param handler the {@code Handler} to add
+         */
+        default void addHandler(Handler handler)
+        {
+            List<Handler> list = new ArrayList<>(getHandlers());
+            list.add(handler);
+            setHandlers(list);
+        }
 
+        /**
+         * <p>Removes the given {@code Handler} from this collection of {@code Handler}s.</p>
+         *
+         * @param handler the {@code Handler} to remove
+         * @return whether the {@code Handler} was removed
+         */
+        default boolean removeHandler(Handler handler)
+        {
+            List<Handler> list = new ArrayList<>(getHandlers());
+            boolean removed = list.remove(handler);
+            if (removed)
+                setHandlers(list);
+            return removed;
+        }
+
+        /**
+         * <p>Adds the {@code Handler} supplied by the given {@code Supplier}
+         * to this collection of {@code Handler}s.</p>
+         *
+         * @param supplier the {@code Handler} supplier
+         */
         default void addHandler(Supplier<Handler> supplier)
         {
             addHandler(supplier.get());
         }
 
+        /**
+         * <p>Sets the given {@code Handler}s as children of this collection of {@code Handler}s.</p>
+         * <p>The list is copied and any subsequent modification to the list does not have any
+         * effect on this {@code Handler}.</p>
+         * <p>Any existing children {@code Handler} is removed.</p>
+         *
+         * @param handlers the {@code Handler} to set as children
+         */
         void setHandlers(List<Handler> handlers);
 
+        /**
+         * <p>Similar to {@link #setHandlers(List)}.</p>
+         *
+         * @param handlers the {@code Handler} to set as children
+         */
         default void setHandlers(Handler... handlers)
         {
-            setHandlers(handlers.length == 0 ? null : List.of(handlers));
+            setHandlers(handlers == null || handlers.length == 0 ? List.of() : List.of(handlers));
         }
     }
 
     /**
-     * <p>A {@link Handler.Container} that can contain a single other {@code Handler}.</p>
-     * <p>This is "singleton" in the sense of {@link Collections#singleton(Object)} and not
+     * <p>A {@link Handler.Container} that can contain one single other {@code Handler}.</p>
+     * <p>This is a "singleton" in the sense of {@link Collections#singleton(Object)} and not
      * in the sense of the singleton pattern of a single instance per JVM.</p>
+     *
      * @see Wrapper for an implementation of {@link Singleton}.
+     * @see Collection
      */
     interface Singleton extends Container
     {
+        /**
+         * @return the child {@code Handler}
+         */
         Handler getHandler();
 
         /**
-         * Set the nested handler.
-         * Implementations should check for loops, set the server and update any {@link ContainerLifeCycle} beans, all
-         * of which can be done by using the utility method {@link #updateHandler(Singleton, Handler)}
-         * @param handler The handler to set.
+         * @param handler The {@code Handler} to set as a child
          */
         void setHandler(Handler handler);
 
         /**
-         * Set the nested handler from a supplier.  This allows for Handler type conversion.
-         * @param supplier A supplier of a Handler.
+         * <p>Sets the child {@code Handler} supplied by the given {@code Supplier}.</p>
+         *
+         * @param supplier the {@code Handler} supplier
          */
         default void setHandler(Supplier<Handler> supplier)
         {
@@ -273,6 +320,15 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
             return (next == null) ? Collections.emptyList() : Collections.singletonList(next);
         }
 
+        /**
+         * <p>Inserts the given {@code Handler} (and its chain of {@code Handler}s)
+         * in front of the child of this {@code Handler}.</p>
+         * <p>For example, if this {@code Handler} {@code A} has a child {@code B},
+         * inserting {@code Handler} {@code X} built as a chain {@code Handler}s
+         * {@code X-Y-Z} results in the structure {@code A-X-Y-Z-B}.</p>
+         *
+         * @param handler the {@code Handler} to insert
+         */
         default void insertHandler(Singleton handler)
         {
             Singleton tail = handler;
@@ -288,7 +344,7 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         }
 
         /**
-         * @return The tail {@link Singleton} of a chain of {@link Singleton}s
+         * @return the tail {@link Singleton} of a chain of {@link Singleton}s
          */
         default Singleton getTail()
         {
@@ -299,15 +355,19 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         }
 
         /**
-         * Utility method to: <ul>
-         *     <li>Check the server state and invocation type</li>
-         *     <li>Check for handler loops</li>
-         *     <li>Set the server on the handler</li>
-         *     <li>Update the beans on if the Nests is a {@link ContainerLifeCycle} </li>
+         * <p>Utility method to perform sanity checks before adding the given {@code Handler} to
+         * the given {@code Singleton}, typically used in implementations of {@link #setHandler(Handler)}.</p>
+         * <p>The sanity checks are:</p>
+         * <ul>
+         *   <li>Check for the server start state and whether the invocation type is compatible</li>
+         *   <li>Check for {@code Handler} loops</li>
+         *   <li>Sets the {@code Server} on the {@code Handler}</li>
+         *   <li>Update the beans on the {@code Singleton} if it is a {@link ContainerLifeCycle}</li>
          * </ul>
-         * @param wrapper The Nested implementation to update
-         * @param handler The handle to set
-         * @return The set handler.
+         *
+         * @param wrapper the {@code Singleton} to set the {@code Handler}
+         * @param handler the {@code Handler} to set
+         * @return The {@code Handler} to set
          */
         static Handler updateHandler(Singleton wrapper, Handler handler)
         {
@@ -328,7 +388,7 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
             // Check for loops.
             if (handler == wrapper || (handler instanceof Handler.Container container &&
                 container.getDescendants().contains(wrapper)))
-                throw new IllegalStateException("setHandler loop");
+                throw new IllegalStateException("Handler loop");
 
             if (handler != null && server != null)
                 handler.setServer(server);
@@ -342,9 +402,11 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
 
     /**
      * <p>An abstract implementation of {@link Handler} that is a {@link ContainerLifeCycle}.</p>
-     * <p>The {@link InvocationType} is by default {@link InvocationType#BLOCKING} unless a
-     * {@code NonBlocking} variant has been extended or a specific
-     * {@link InvocationType} passed to a constructor.</p>
+     * <p>The {@link InvocationType} is by default {@link InvocationType#BLOCKING} unless the
+     * {@code NonBlocking} variant is used or a specific {@link InvocationType} is passed to
+     * the constructor.</p>
+     *
+     * @see NonBlocking
      */
     abstract class Abstract extends ContainerLifeCycle implements Handler
     {
@@ -353,11 +415,20 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         private final InvocationType _invocationType;
         private Server _server;
 
+        /**
+         * <p>Creates a {@code Handler} with invocation type {@link InvocationType#BLOCKING}.</p>
+         */
         public Abstract()
         {
             this(InvocationType.BLOCKING);
         }
 
+        /**
+         * <p>Creates a {@code Handler} with the given invocation type.</p>
+         *
+         * @param type the {@link InvocationType} of this {@code Handler}
+         * @see AbstractContainer
+         */
         public Abstract(InvocationType type)
         {
             _invocationType = type;
@@ -411,6 +482,10 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
             super.destroy();
         }
 
+        /**
+         * <p>An abstract {@code Handler} with a {@link InvocationType#NON_BLOCKING}
+         * invocation type.</p>
+         */
         public abstract static class NonBlocking extends Abstract
         {
             public NonBlocking()
@@ -422,31 +497,46 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
 
     /**
      * <p>A {@link Handler.Abstract} that implements {@link Handler.Container}.</p>
+     * <p>An {@link AbstractContainer} may be dynamic, that is allow {@code Handler}s
+     * to be added after it has been started.</p>
+     * <p>If this {@link AbstractContainer} is dynamic, then its invocation type
+     * is by default {@link InvocationType#BLOCKING}.</p>
+     *
+     * @see Abstract
      */
     abstract class AbstractContainer extends Abstract implements Container
     {
         private boolean _dynamic;
 
+        /**
+         * <p>Creates an instance that is dynamic.</p>
+         */
         protected AbstractContainer()
         {
             this(true);
         }
 
         /**
-         * @param dynamic If true, then handlers may be added to the container dynamically when started,
-         *                thus the InvocationType is assumed to be BLOCKING,
-         *                otherwise handlers cannot be modified once the container is started.
+         * <p>Creates an instance with the given dynamic argument.</p>
+         *
+         * @param dynamic whether this container is dynamic
          */
         protected AbstractContainer(boolean dynamic)
         {
             _dynamic = dynamic;
         }
 
+        /**
+         * @return whether this container is dynamic
+         */
         public boolean isDynamic()
         {
             return _dynamic;
         }
 
+        /**
+         * @param dynamic whether this container is dynamic
+         */
         public void setDynamic(boolean dynamic)
         {
             if (isStarted())
@@ -548,27 +638,53 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
     }
 
     /**
-     * An implementation of {@link Singleton}, which is a {@link Handler.Container} that wraps a single other {@link Handler}.
+     * <p>An implementation of {@link Singleton}, which is a {@link Container}
+     * that wraps one single other {@link Handler}.</p>
+     * <p>A {@link Wrapper} may be dynamic, that is allow {@code Handler}s
+     * to be set after it has been started.</p>
+     * <p>If this {@link Wrapper} is dynamic, then its invocation type
+     * is by default {@link InvocationType#BLOCKING}.</p>
      */
     class Wrapper extends AbstractContainer implements Singleton
     {
         private Handler _handler;
 
+        /**
+         * <p>Creates a wrapper with no wrapped {@code Handler}.</p>
+         */
         public Wrapper()
         {
             this(null);
         }
 
+        /**
+         * <p>Creates a wrapper with no wrapped {@code Handler} with the given
+         * {@code dynamic} parameter.</p>
+         *
+         * @param dynamic whether this container is dynamic
+         */
         public Wrapper(boolean dynamic)
         {
             this(dynamic, null);
         }
 
+        /**
+         * <p>Creates a non-dynamic wrapper of the given {@code Handler}.</p>
+         *
+         * @param handler the {@code Handler} to wrap
+         */
         public Wrapper(Handler handler)
         {
             this(false, handler);
         }
 
+        /**
+         * <p>Creates a wrapper with the given dynamic parameter wrapping the
+         * given {@code Handler}.</p>
+         *
+         * @param dynamic whether this container is dynamic
+         * @param handler the {@code Handler} to wrap
+         */
         public Wrapper(boolean dynamic, Handler handler)
         {
             super(dynamic);
@@ -607,35 +723,44 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
     }
 
     /**
-     * <p>A {@link Handler.Container} that contains a list of other {@link Handler}s
+     * <p>A {@link Handler.Container} that contains an ordered list of children {@link Handler}s
      * whose {@link Handler#handle(Request, Response, Callback)} method is invoked
-     * in sequence until {@code true} is returned.</p>
+     * in sequence on each child until a child returns {@code true}.</p>
      */
     class Sequence extends AbstractContainer implements Collection
     {
         private volatile List<Handler> _handlers = new ArrayList<>();
 
+        /**
+         * <p>Creates a {@code Sequence} with the given {@code Handler}s.</p>
+         * <p>The created sequence is dynamic only if the {@code Handler}
+         * array is {@code null} or empty.</p>
+         *
+         * @param handlers the {@code Handler}s of this {@code Sequence}
+         */
         public Sequence(Handler... handlers)
         {
-            this(handlers.length == 0, List.of(handlers));
+            this(handlers == null || handlers.length == 0, handlers == null ? List.of() : List.of(handlers));
         }
 
-        public Sequence(boolean dynamic)
-        {
-            this(dynamic, Collections.emptyList());
-        }
-
+        /**
+         * <p>Creates a {@code Sequence} with the given {@code Handler}s.</p>
+         * <p>The created sequence is dynamic only if the {@code Handler}
+         * list is {@code null} or empty.</p>
+         *
+         * @param handlers the {@code Handler}s of this {@code Sequence}
+         */
         public Sequence(List<Handler> handlers)
         {
-            this(handlers == null || handlers.size() == 0, handlers);
+            this(handlers == null || handlers.isEmpty(), handlers);
         }
 
          /**
-         * @param dynamic If true, then handlers may be added dynamically once started,
-         *                so the InvocationType is assumed to be BLOCKING, otherwise
-         *                handlers cannot be modified once started.
-         *
-         * @param handlers The handlers to add.
+          * <p>Creates a {@code Sequence} with the given {@code dynamic} parameter
+          * and the given {@code Handler}s.</p>
+          *
+          * @param dynamic whether this {@code Sequence} is dynamic
+          * @param handlers the {@code Handler}s of this {@code Sequence}
          */
         public Sequence(boolean dynamic, List<Handler> handlers)
         {
@@ -712,20 +837,6 @@ public interface Handler extends LifeCycle, Destroyable, Request.Handler
         protected List<Handler> newHandlers(List<Handler> handlers)
         {
             return handlers == null ? List.of() : List.copyOf(handlers);
-        }
-
-        public void addHandler(Handler handler)
-        {
-            List<Handler> list = new ArrayList<>(getHandlers());
-            list.add(handler);
-            setHandlers(list);
-        }
-
-        public void removeHandler(Handler handler)
-        {
-            List<Handler> list = new ArrayList<>(getHandlers());
-            if (list.remove(handler))
-                setHandlers(list);
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandlerCollection.java
@@ -62,9 +62,7 @@ public class ContextHandlerCollection extends Handler.Sequence
      */
     public ContextHandlerCollection(boolean dynamic, ContextHandler... contexts)
     {
-        super(dynamic);
-        if (contexts.length > 0)
-            setHandlers(contexts);
+        super(dynamic, List.of(contexts));
     }
 
     /**


### PR DESCRIPTION
With the occasion, I moved `Sequence.removeHandler()` to `Handler.Collection`, where I think it belongs.

Also partially fixes #10293.