### PR TITLE
Fix #10416  Do not copy ee9 response headers

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -149,7 +149,7 @@ public class HttpChannelState implements HttpChannel, Components
             _request._httpChannelState = null;
 
             // Recycle.
-            _responseHeaders.reset();
+            _responseHeaders.recycle();
             _handling = null;
             _handled = false;
             _streamSendState = StreamSendState.SENDING;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -90,6 +90,9 @@ public class ResponseTest
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {
+                String date = response.getHeaders().get(HttpHeader.DATE);
+                String server = response.getHeaders().get(HttpHeader.SERVER);
+
                 response.getHeaders().add("Temp", "field");
                 response.getHeaders().add("Test", "before reset");
                 assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().remove(HttpHeader.SERVER));
@@ -128,7 +131,13 @@ public class ResponseTest
                 assertFalse(response.getHeaders().contains("Temp"));
 
                 response.getHeaders().add("Temp", "field");
+                response.getHeaders().put(HttpHeader.DATE, "1970-02-02");
+
                 response.reset();
+
+                assertThat(response.getHeaders().get(HttpHeader.DATE), is(date));
+                assertThat(response.getHeaders().get(HttpHeader.SERVER), is(server));
+
                 response.getHeaders().add("Test", "after reset");
 
                 response.getHeaders().putDate("Date", 1L);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -938,8 +938,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
     {
         _coreResponse = coreResponse;
         _coreCallback = coreCallback;
-
-        long idleTO = _configuration.getIdleTimeout();
+        _response.onResponse(coreResponse.getHeaders());
 
         if (LOG.isDebugEnabled())
         {
@@ -1081,7 +1080,6 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             if (response == null)
                 response = _response.newResponseMetaData();
             commit(response);
-            _request.onResponseCommit();
 
             // wrap callback to process informational responses
             final int status = response.getStatus();
@@ -1108,10 +1106,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
     {
         if (response != null)
         {
-            // TODO: why can't we just do _coreResponse.setMetaData(response), without copying?
             _coreResponse.setStatus(response.getStatus());
-            // TODO: at least avoid copying the headers?
-            _coreResponse.getHeaders().add(response.getHttpFields());
             _coreResponse.setTrailersSupplier(response.getTrailersSupplier());
         }
         _coreResponse.write(complete, content, callback);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1299,15 +1299,6 @@ public class Request implements HttpServletRequest
     }
 
     /**
-     * Called when a response is about to be committed, ie sent
-     * back to the client
-     */
-    public void onResponseCommit()
-    {
-        // TODO remove this method?
-    }
-
-    /**
      * Find a session that this request has already entered for the
      * given SessionHandler
      *

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -96,10 +96,10 @@ public class Response implements HttpServletResponse
     public static final String SET_INCLUDE_HEADER_PREFIX = "org.eclipse.jetty.server.include.";
 
     private final HttpChannel _channel;
-    private final HttpFields.Mutable _fields = HttpFields.build();
     private final AtomicBiInteger _errorSentAndIncludes = new AtomicBiInteger(); // hi is errorSent flag, lo is include count
     private final HttpOutput _out;
     private int _status = HttpStatus.OK_200;
+    private HttpFields.Mutable _fields;
     private String _reason;
     private Locale _locale;
     private MimeTypes.Type _mimeType;
@@ -158,10 +158,15 @@ public class Response implements HttpServletResponse
         return _channel;
     }
 
+    protected void onResponse(HttpFields.Mutable headers)
+    {
+        _fields = headers;
+    }
+
     protected void recycle()
     {
         // _channel need not be recycled
-        _fields.clear();
+        _fields = null;
         _errorSentAndIncludes.set(0);
         _out.recycle();
         _status = HttpStatus.OK_200;
@@ -1272,25 +1277,7 @@ public class Response implements HttpServletResponse
 
     protected MetaData.Response newResponseMetaData()
     {
-        return new MetaData.Response(getStatus(), getReason(), _channel.getRequest().getHttpVersion(), _fields, getLongContentLength(), getTrailers());
-    }
-
-    /**
-     * Get the MetaData.Response committed for this response.
-     * This may differ from the meta data in this response for
-     * exceptional responses (eg 4xx and 5xx responses generated
-     * by the container) and the committedMetaData should be used
-     * for logging purposes.
-     *
-     * @return The committed MetaData or a {@link #newResponseMetaData()}
-     * if not yet committed.
-     */
-    public MetaData.Response getCommittedMetaData()
-    {
-        MetaData.Response meta = _channel.getCommittedMetaData();
-        if (meta == null)
-            return newResponseMetaData();
-        return meta;
+        return new MetaData.Response(getStatus(), getReason(), _channel.getRequest().getHttpVersion(), _channel.getCoreResponse().getHeaders(), getLongContentLength(), getTrailers());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1946,6 +1946,7 @@ public class RequestTest
         String uri = "http://host/foo/something";
         HttpChannel httpChannel = new HttpChannel(_context, new MockConnectionMetaData(_connector));
         Request request = new MockRequest(httpChannel, new HttpInput(httpChannel));
+        request.getResponse().onResponse(HttpFields.build());
         request.getResponse().getHttpFields().add(new HttpCookieUtils.SetCookieHttpField(HttpCookie.from("good", "thumbsup", Map.of(HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(100))), CookieCompliance.RFC6265));
         request.getResponse().getHttpFields().add(new HttpCookieUtils.SetCookieHttpField(HttpCookie.from("bonza", "bewdy", Map.of(HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(1))), CookieCompliance.RFC6265));
         request.getResponse().getHttpFields().add(new HttpCookieUtils.SetCookieHttpField(HttpCookie.from("bad", "thumbsdown", Map.of(HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0))), CookieCompliance.RFC6265));
@@ -1995,6 +1996,7 @@ public class RequestTest
         };
         HttpFields.Mutable fields = HttpFields.build();
         request.onRequest(new TestCoreRequest(uri, fields));
+        request.getResponse().onResponse(HttpFields.build());
         assertTrue(request.isPushSupported());
         PushBuilder builder = request.newPushBuilder();
         assertNotNull(builder);

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ResponseTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ResponseTest.java
@@ -196,7 +196,7 @@ public class ResponseTest
         assertEquals("bar", en.next());
         assertFalse(en.hasNext());
 
-        response.recycle();
+        response = getResponse();
 
         response.setContentType("text/html");
         assertEquals("text/html", response.getContentType());
@@ -205,29 +205,29 @@ public class ResponseTest
         response.setContentType("foo2/bar2;charset=utf-8");
         assertEquals("foo2/bar2;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/xml;charset=ISO-8859-7");
         response.getWriter();
         assertEquals("text/xml;charset=ISO-8859-7", response.getContentType());
         response.setContentType("text/html;charset=UTF-8");
         assertEquals("text/html;charset=ISO-8859-7", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/html;charset=US-ASCII");
         response.getWriter();
         assertEquals("text/html;charset=US-ASCII", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/html; charset=UTF-8");
         response.getWriter();
         assertEquals("text/html;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/json");
         response.getWriter();
         assertEquals("text/json", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter();
@@ -246,37 +246,37 @@ public class ResponseTest
         response.setContentType("foo/bar");
         assertEquals("foo/bar;charset=xyz", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("foo/bar");
         response.setCharacterEncoding("xyz");
         assertEquals("foo/bar;charset=xyz", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setCharacterEncoding("xyz");
         response.setContentType("foo/bar;charset=abc");
         assertEquals("foo/bar;charset=abc", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("foo/bar;charset=abc");
         response.setCharacterEncoding("xyz");
         assertEquals("foo/bar;charset=xyz", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setCharacterEncoding("xyz");
         response.setContentType("foo/bar");
         response.setCharacterEncoding(null);
         assertEquals("foo/bar", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setCharacterEncoding("xyz");
         response.setCharacterEncoding(null);
         response.setContentType("foo/bar");
         assertEquals("foo/bar", response.getContentType());
-        response.recycle();
+        response = getResponse();
         response.addHeader("Content-Type", "text/something");
         assertEquals("text/something", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.addHeader("Content-Type", "application/json");
         response.getWriter();
         assertEquals("application/json", response.getContentType());
@@ -310,7 +310,7 @@ public class ResponseTest
         assertEquals("text/json", response.getContentType());
         assertEquals("utf-8", response.getCharacterEncoding());
 
-        response.recycle();
+        response = getResponse();
 
         // Assumed from encoding.properties
         assertNull(response.getContentType());
@@ -328,7 +328,7 @@ public class ResponseTest
 
         assertNull(response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/html;charset=utf-8;charset=UTF-8");
         response.getWriter();
         assertEquals("text/html;charset=utf-8;charset=UTF-8", response.getContentType());
@@ -349,7 +349,7 @@ public class ResponseTest
         response.setContentType("text/plain");
         assertEquals("text/plain;charset=ISO-8859-2", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.setContentType("text/plain");
         response.setCharacterEncoding("utf-8");
         response.setLocale(java.util.Locale.ITALIAN);
@@ -409,7 +409,7 @@ public class ResponseTest
         Response response = getResponse();
         assertThat("utf-16", Matchers.equalTo(response.getCharacterEncoding()));
 
-        response.recycle();
+        response = getResponse();
 
         //test that explicit overrides default
         response = getResponse();
@@ -419,7 +419,7 @@ public class ResponseTest
         response.getWriter();
         assertThat("ascii", Matchers.equalTo(response.getCharacterEncoding()));
 
-        response.recycle();
+        response = getResponse();
 
         //test that assumed overrides default
         response = getResponse();
@@ -429,7 +429,7 @@ public class ResponseTest
         //getWriter should not have modified character encoding
         assertThat("utf-8", Matchers.equalTo(response.getCharacterEncoding()));
 
-        response.recycle();
+        response = getResponse();
 
         //test that inferred overrides default
         response = getResponse();
@@ -439,7 +439,7 @@ public class ResponseTest
         response.getWriter();
         assertThat("utf-8", Matchers.equalTo(response.getCharacterEncoding()));
 
-        response.recycle();
+        response = getResponse();
 
         //test that without a default or any content type, use iso-8859-1
         response = getResponse();
@@ -521,7 +521,7 @@ public class ResponseTest
         response.setCharacterEncoding("ISO-8859-1");
         assertEquals("foo2/bar2;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
 
         response.setContentType("text/html");
         response.setCharacterEncoding("UTF-8");
@@ -559,7 +559,7 @@ public class ResponseTest
         response.setCharacterEncoding("ISO-8859-1");
         assertEquals("foo2/bar2;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
 
         response.setCharacterEncoding("utf-8");
         response.setContentType("text/html");
@@ -587,7 +587,7 @@ public class ResponseTest
         response.setCharacterEncoding("ISO-8859-1");
         assertEquals("foo2/bar2;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.reopen();
 
         response.setCharacterEncoding("utf16");
@@ -600,7 +600,7 @@ public class ResponseTest
         response.setCharacterEncoding("iso-8859-1");
         assertEquals("text/xml;charset=utf-8", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
         response.reopen();
         response.setCharacterEncoding("utf-16");
         response.setContentType("foo/bar");
@@ -1499,7 +1499,7 @@ public class ResponseTest
         response.setContentType("foo2/bar2");
         assertEquals("foo2/bar2;charset=iso-8859-1", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
 
         response.setCharacterEncoding("uTf-8");
         response.setContentType("text/html; other=xyz");
@@ -1521,7 +1521,7 @@ public class ResponseTest
         response.getWriter();
         assertEquals("foo/bar; charset=utf-8 other=xyz", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
 
         response.setCharacterEncoding("utf16");
         response.setContentType("text/html; other=xyz charset=utf-8");
@@ -1529,7 +1529,7 @@ public class ResponseTest
         response.getWriter();
         assertEquals("text/html; other=xyz charset=utf-8;charset=utf-16", response.getContentType());
 
-        response.recycle();
+        response = getResponse();
 
         response.setCharacterEncoding("utf16");
         response.setContentType("foo/bar; other=pq charset=utf-8 other=xyz");


### PR DESCRIPTION
Use the core response HttpFields directly as the ee9 response headers to avoid copy and retain persistent field behaviour.