### PR TITLE
Fix #9169 refine idle timeout and failure

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -387,7 +387,7 @@ public class HttpChannelState implements HttpChannel, Components
                     {
                         if (onIdleTimeout.test(t))
                         {
-                            // If the idle timeout listener(s) return true, then we call onFailure and any task it returns.
+                            // If the idle timeout listener(s) return true, then we call onFailure and run any task it returns.
                             Runnable task = onFailure(t);
                             if (task != null)
                                 task.run();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -395,13 +395,12 @@ public class HttpChannelState implements HttpChannel, Components
                     });
                 }
 
-                // otherwise, we are going to fail the callback, either directly or by a call to onFailure, so ensure all future IO
-                // operations are failed as well
-                _failure = Content.Chunk.from(t, true);
-
-                // if there is no failure listener, then we can fail the callback directly without a double lock
+                // otherwise, if there is no failure listener, then we can fail the callback directly without a double lock
                 if (_onFailure == null && _request != null)
+                {
+                    _failure = Content.Chunk.from(t, true);
                     return () -> _request._callback.failed(t);
+                }
             }
         }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1177,6 +1177,7 @@ public class HttpChannelTest
                 request.addFailureListener(t -> error.set(null));
                 request.addFailureListener(t -> error.compareAndSet(null, t));
                 request.addFailureListener(t -> error.compareAndSet(null, new Throwable("WRONG")));
+                request.addFailureListener(callback::failed);
                 return true;
             }
         };

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -385,6 +385,7 @@ public class ServerTest
                 request.addFailureListener(t ->
                 {
                     assertThat(ContextHandler.getCurrentContext(), sameInstance(_context.getContext()));
+                    callback.failed(t);
                     latch.countDown();
                 });
                 return true;


### PR DESCRIPTION
Fix #9169 Only fail request callback if a failure has not been otherwise notified. Slight optimisation for failing idle timeouts by avoiding double lock.