### PR TITLE
disable cache per default on CI...... :( (still possible to use it via label force-build-cache. yeah no need to rebuild everything jetty-util, jetty-io, jetty-server. jetty-client, all jetty-ee9 and jetty-ee10  when you only touch jetty-ee10-servlet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,7 +140,10 @@ def useBuildCache() {
     labelNoBuildCache = pullRequest.labels.contains("build-no-cache")
   }
   def noBuildCache = (env.BRANCH_NAME == 'jetty-12.0.x') || labelNoBuildCache;
-  return !noBuildCache;
+  if(pullRequest.labels.contains("force-build-cache")) {
+    return true;
+  }
+  return false; //!noBuildCache;
   // want to skip build cache
   // return false
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
     try {
       withEnv(["JAVA_HOME=${ tool "$jdk" }",
                "PATH+MAVEN=${ tool "$jdk" }/bin:${tool "$mvnName"}/bin",
-               "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
+               "MAVEN_OPTS=-Xms4g -Xmx6g -Djava.awt.headless=true"]) {
       configFileProvider(
         [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS'),
           configFile(fileId: 'maven-build-cache-config.xml', variable: 'MVN_BUILD_CACHE_CONFIG')]) {


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
