### PR TITLE
Issue #10402 - do not recycle ServletChannel if aborted

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -157,6 +157,7 @@ public class ServletChannel
         _request = request;
         _response = response;
         _callback = callback;
+        _state.open();
 
         if (LOG.isDebugEnabled())
             LOG.debug("associate {} -> {},{},{}",
@@ -189,6 +190,11 @@ public class ServletChannel
     public HttpInput getHttpInput()
     {
         return _httpInput;
+    }
+
+    public boolean isAborted()
+    {
+        return _state.isAborted();
     }
 
     public boolean isSendError()

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -157,7 +157,7 @@ public class ServletChannel
         _request = request;
         _response = response;
         _callback = callback;
-        _state.open();
+        _state.openOutput();
 
         if (LOG.isDebugEnabled())
             LOG.debug("associate {} -> {},{},{}",

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -168,7 +168,7 @@ public class ServletChannelState
         }
     }
 
-    public void open()
+    public void openOutput()
     {
         try (AutoLock ignored = lock())
         {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -1146,7 +1146,7 @@ public class ServletContextHandler extends ContextHandler
         Attributes cache = request.getComponents().getCache();
         Object cachedChannel = cache.getAttribute(ServletChannel.class.getName());
         ServletChannel servletChannel;
-        if (cachedChannel instanceof ServletChannel sc && sc.getContext() == getContext())
+        if (cachedChannel instanceof ServletChannel sc && sc.getContext() == getContext() && !sc.isAborted())
         {
             servletChannel = sc;
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -714,12 +714,14 @@ public class AsyncServletIOTest
                 @Override
                 public void onError(Throwable t)
                 {
+                    System.err.println("onError");
                     t.printStackTrace();
                 }
 
                 @Override
                 public void onDataAvailable() throws IOException
                 {
+                    System.err.println("onDataAvailable");
                     onDA.incrementAndGet();
 
                     boolean readF = false;
@@ -750,6 +752,7 @@ public class AsyncServletIOTest
                             @Override
                             public void onWritePossible() throws IOException
                             {
+                                System.err.println("onWritePossible");
                                 onWP.incrementAndGet();
 
                                 while (out.isReady())
@@ -785,6 +788,7 @@ public class AsyncServletIOTest
                 @Override
                 public void onAllDataRead() throws IOException
                 {
+                    System.err.println("onAllDataRead");
                     throw new IllegalStateException();
                 }
             });

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -714,14 +714,12 @@ public class AsyncServletIOTest
                 @Override
                 public void onError(Throwable t)
                 {
-                    System.err.println("onError");
                     t.printStackTrace();
                 }
 
                 @Override
                 public void onDataAvailable() throws IOException
                 {
-                    System.err.println("onDataAvailable");
                     onDA.incrementAndGet();
 
                     boolean readF = false;
@@ -752,7 +750,6 @@ public class AsyncServletIOTest
                             @Override
                             public void onWritePossible() throws IOException
                             {
-                                System.err.println("onWritePossible");
                                 onWP.incrementAndGet();
 
                                 while (out.isReady())
@@ -788,7 +785,6 @@ public class AsyncServletIOTest
                 @Override
                 public void onAllDataRead() throws IOException
                 {
-                    System.err.println("onAllDataRead");
                     throw new IllegalStateException();
                 }
             });


### PR DESCRIPTION
fixes #10402

The write callback was being completed after the channel had been recycled. So now we maintain an outputState of `ABORTED` and do not allow the `ServletChannel` to be reused.