### PR TITLE
Accurate implementation of FCGI `Request.beginNanoTime()`

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/BeginRequestContentParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/BeginRequestContentParser.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.fcgi.parser;
 import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.fcgi.FCGI;
+import org.eclipse.jetty.util.NanoTime;
 
 /**
  * <p>Parser for the BEGIN_REQUEST frame content.</p>
@@ -34,11 +35,17 @@ public class BeginRequestContentParser extends ContentParser
     private int cursor;
     private int role;
     private int flags;
+    private long beginNanoTime;
 
     public BeginRequestContentParser(HeaderParser headerParser, ServerParser.Listener listener)
     {
         super(headerParser);
         this.listener = listener;
+    }
+
+    public long getBeginNanoTime()
+    {
+        return beginNanoTime;
     }
 
     @Override
@@ -50,6 +57,7 @@ public class BeginRequestContentParser extends ContentParser
             {
                 case ROLE:
                 {
+                    beginNanoTime = NanoTime.now();
                     if (buffer.remaining() >= 2)
                     {
                         role = buffer.getShort();

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ServerParser.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/parser/ServerParser.java
@@ -29,6 +29,12 @@ public class ServerParser extends Parser
         contentParsers.put(FCGI.FrameType.STDIN, new StreamContentParser(headerParser, FCGI.StreamType.STD_IN, listener));
     }
 
+    public long getBeginNanoTime()
+    {
+        BeginRequestContentParser contentParser = (BeginRequestContentParser)contentParsers.get(FCGI.FrameType.BEGIN_REQUEST);
+        return contentParser.getBeginNanoTime();
+    }
+
     @Override
     protected ContentParser findContentParser(FCGI.FrameType frameType)
     {

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -105,8 +105,7 @@ public class HttpStreamOverFCGI implements HttpStream
     {
         String pathQuery = URIUtil.addPathQuery(_path, _query);
         HttpScheme scheme = StringUtil.isEmpty(_secure) ? HttpScheme.HTTP : HttpScheme.HTTPS;
-        ServerFCGIConnection serverFCGIConnection = (ServerFCGIConnection)getHttpChannel().getConnectionMetaData().getConnection();
-        MetaData.Request request = new MetaData.Request(serverFCGIConnection.getBeginNanoTime(), _method, scheme.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, -1); // TODO #9900 make beginNanoTime accurate
+        MetaData.Request request = new MetaData.Request(_connection.getBeginNanoTime(), _method, scheme.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, -1);
         Runnable task = _httpChannel.onRequest(request);
         _allHeaders.forEach(field -> _httpChannel.getRequest().setAttribute(field.getName(), field.getValue()));
         // TODO: here we just execute the task.

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -35,7 +35,6 @@ import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.thread.Invocable;
@@ -106,7 +105,8 @@ public class HttpStreamOverFCGI implements HttpStream
     {
         String pathQuery = URIUtil.addPathQuery(_path, _query);
         HttpScheme scheme = StringUtil.isEmpty(_secure) ? HttpScheme.HTTP : HttpScheme.HTTPS;
-        MetaData.Request request = new MetaData.Request(NanoTime.now(), _method, scheme.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, -1); // TODO #9900 make beginNanoTime accurate
+        ServerFCGIConnection serverFCGIConnection = (ServerFCGIConnection)getHttpChannel().getConnectionMetaData().getConnection();
+        MetaData.Request request = new MetaData.Request(serverFCGIConnection.getBeginNanoTime(), _method, scheme.asString(), hostPort, pathQuery, HttpVersion.fromString(_version), _headers, -1); // TODO #9900 make beginNanoTime accurate
         Runnable task = _httpChannel.onRequest(request);
         _allHeaders.forEach(field -> _httpChannel.getRequest().setAttribute(field.getName(), field.getValue()));
         // TODO: here we just execute the task.

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -70,6 +70,11 @@ public class ServerFCGIConnection extends AbstractConnection implements Connecti
         this.id = StringUtil.randomAlphaNumeric(16);
     }
 
+    public long getBeginNanoTime()
+    {
+        return parser.getBeginNanoTime();
+    }
+
     Flusher getFlusher()
     {
         return flusher;


### PR DESCRIPTION
The implementation is similar to H1: take a nano timestamp at the time the very first byte is parsed, then use that timestamp to create the `MetaData.Request`.

This is one of the implementations necessary to close #9900.