### PR TITLE
Fix server HTTP buffer leak in `consumeAvailable()`

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1146,6 +1146,7 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
             Throwable result = HttpStream.consumeAvailable(this, getHttpConfiguration());
             if (result != null)
                 _generator.setPersistent(false);
+            releaseRequestBuffer();
             return result;
         }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1146,7 +1146,10 @@ public class HttpConnection extends AbstractConnection implements Runnable, Writ
             Throwable result = HttpStream.consumeAvailable(this, getHttpConfiguration());
             if (result != null)
                 _generator.setPersistent(false);
-            releaseRequestBuffer();
+            // If the parser is not at the end, an idle timeout occurred and nothing
+            // is ever going to release the buffer -> release it here.
+            if (!_parser.isState(HttpParser.State.END))
+                releaseRequestBuffer();
             return result;
         }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -18,8 +18,11 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
@@ -27,8 +30,12 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class HttpServerTestFixture
@@ -38,6 +45,7 @@ public class HttpServerTestFixture
 
     protected QueuedThreadPool _threadPool;
     protected Server _server;
+    protected ArrayByteBufferPool.Tracking _bufferPool;
     protected URI _serverURI;
     protected HttpConfiguration _httpConfiguration;
     protected ServerConnector _connector;
@@ -55,7 +63,8 @@ public class HttpServerTestFixture
     public void before()
     {
         _threadPool = new QueuedThreadPool();
-        _server = new Server(_threadPool);
+        _bufferPool = new ArrayByteBufferPool.Tracking();
+        _server = new Server(_threadPool, new ScheduledExecutorScheduler(), _bufferPool);
     }
 
     protected void initServer(ServerConnector connector) throws Exception
@@ -70,9 +79,20 @@ public class HttpServerTestFixture
     @AfterEach
     public void stopServer() throws Exception
     {
-        _server.stop();
-        _server.join();
-        _server.setConnectors(new Connector[]{});
+        try
+        {
+            Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> _bufferPool.getLeaks().size(), Matchers.is(0));
+        }
+        catch (Exception e)
+        {
+            fail(e.getMessage() + "\n---\nServer Leaks: " + _bufferPool.dumpLeaks() + "---\n");
+        }
+        finally
+        {
+            _server.stop();
+            _server.join();
+            _server.setConnectors(new Connector[]{});
+        }
     }
 
     protected void startServer(Handler handler) throws Exception

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestFixture.java
@@ -81,7 +81,7 @@ public class HttpServerTestFixture
     {
         try
         {
-            Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> _bufferPool.getLeaks().size(), Matchers.is(0));
+            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> _bufferPool.getLeaks().size(), Matchers.is(0));
         }
         catch (Exception e)
         {
@@ -90,8 +90,6 @@ public class HttpServerTestFixture
         finally
         {
             _server.stop();
-            _server.join();
-            _server.setConnectors(new Connector[]{});
         }
     }
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerTimeoutsTest.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,9 +94,6 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsAndTrueIdleTimeoutListeners")
-    @Tag("DisableLeakTracking:server:HTTP")
-    @Tag("DisableLeakTracking:server:HTTPS")
-    @Tag("DisableLeakTracking:server:UNIX_DOMAIN")
     public void testIdleTimeoutWithDemand(Transport transport, boolean listener) throws Exception
     {
         AtomicBoolean listenerCalled = new AtomicBoolean();


### PR DESCRIPTION
When `consumeAvailable()` is called, the connection may hold onto a buffer that must be released.

See https://github.com/eclipse/jetty.project/issues/10226