### PR TITLE
Fix #10321 to avoid multiple warnings about skipped deployment due to missing / unsupported environment

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/App.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/App.java
@@ -143,6 +143,6 @@ public class App
     @Override
     public String toString()
     {
-        return "App@%x[%s,%s,%s]".formatted(hashCode(), getEnvironmentName(), _context, _path);
+        return "%s@%x[%s,%s,%s]".formatted(getClass().getSimpleName(), hashCode(), getEnvironmentName(), _context, _path);
     }
 }

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -178,7 +178,8 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
             }
         }
 
-        LOG.warn("{} no environment for {}, ignoring", this, app);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} no environment for {}, default environment {}: deploy skipped", this, app, defaultEnvironmentName);
         return null;
     }
 
@@ -397,6 +398,6 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     @Override
     public String toString()
     {
-        return String.format("%s@%x%s", this.getClass(), hashCode(), _monitored);
+        return String.format("%s@%x[%s,%s]", getClass().getSimpleName(), hashCode(), getEnvironmentName(), _monitored);
     }
 }


### PR DESCRIPTION
The warning message was causing confusion in case of multiple deployers. See also #10437.