### PR TITLE
Backport `Request.beginNanoTime()` from 12.0.x

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http.HttpTokens.EndOfContent;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Index;
+import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.slf4j.Logger;
@@ -249,6 +250,7 @@ public class HttpParser
     private ByteBuffer _contentChunk;
     private int _length;
     private final StringBuilder _string = new StringBuilder();
+    private long _beginNanoTime = Long.MIN_VALUE;
 
     private static HttpCompliance compliance()
     {
@@ -298,6 +300,11 @@ public class HttpParser
         _maxHeaderBytes = maxHeaderBytes;
         _complianceMode = compliance;
         _complianceListener = (ComplianceViolation.Listener)(_handler instanceof ComplianceViolation.Listener ? _handler : null);
+    }
+
+    public long getBeginNanoTime()
+    {
+        return _beginNanoTime;
     }
 
     public HttpHandler getHandler()
@@ -1517,6 +1524,8 @@ public class HttpParser
                 _methodString = null;
                 _endOfContent = EndOfContent.UNKNOWN_CONTENT;
                 _header = null;
+                if (buffer.hasRemaining())
+                    _beginNanoTime = NanoTime.now();
                 quickStart(buffer);
             }
 

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.Supplier;
 
+import org.eclipse.jetty.util.NanoTime;
+
 public class MetaData implements Iterable<HttpField>
 {
     /**
@@ -115,6 +117,7 @@ public class MetaData implements Iterable<HttpField>
     {
         private final String _method;
         private final HttpURI _uri;
+        private final long _beginNanoTime;
 
         public Request(HttpFields fields)
         {
@@ -126,11 +129,19 @@ public class MetaData implements Iterable<HttpField>
             this(method, uri, version, fields, Long.MIN_VALUE);
         }
 
+        public Request(long beginNanoTime, String method, HttpURI uri, HttpVersion version, HttpFields fields)
+        {
+            this(beginNanoTime, method, uri, version, fields, Long.MIN_VALUE);
+        }
+
         public Request(String method, HttpURI uri, HttpVersion version, HttpFields fields, long contentLength)
         {
-            super(version, fields, contentLength);
-            _method = method;
-            _uri = uri.asImmutable();
+            this(method, uri.asImmutable(), version, fields, contentLength, null);
+        }
+
+        public Request(long beginNanoTime, String method, HttpURI uri, HttpVersion version, HttpFields fields, long contentLength)
+        {
+            this(beginNanoTime, method, uri.asImmutable(), version, fields, contentLength, null);
         }
 
         public Request(String method, String scheme, HostPortHttpField authority, String uri, HttpVersion version, HttpFields fields, long contentLength)
@@ -142,9 +153,20 @@ public class MetaData implements Iterable<HttpField>
 
         public Request(String method, HttpURI uri, HttpVersion version, HttpFields fields, long contentLength, Supplier<HttpFields> trailers)
         {
+            this(NanoTime.now(), method, uri, version, fields, contentLength, trailers);
+        }
+
+        public Request(long beginNanoTime, String method, HttpURI uri, HttpVersion version, HttpFields fields, long contentLength, Supplier<HttpFields> trailers)
+        {
             super(version, fields, contentLength, trailers);
             _method = method;
             _uri = uri;
+            _beginNanoTime = beginNanoTime;
+        }
+
+        public long getBeginNanoTime()
+        {
+            return _beginNanoTime;
         }
 
         @Override

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnection.java
@@ -107,6 +107,11 @@ public class HttpConnection extends AbstractConnection implements Runnable, Http
             LOG.debug("New HTTP Connection {}", this);
     }
 
+    public long getBeginNanoTime()
+    {
+        return _parser.getBeginNanoTime();
+    }
+
     public HttpConfiguration getHttpConfiguration()
     {
         return _config;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1709,6 +1709,16 @@ public class Request implements HttpServletRequest
         _secure = secure;
     }
 
+    /**
+     * <p>Get the nanoTime at which the request arrived to a connector, obtained via {@link System#nanoTime()}.
+     * This method can be used when measuring latencies.</p>
+     * @return The nanoTime at which the request was received/created in nanoseconds
+     */
+    public long getBeginNanoTime()
+    {
+        return _metaData.getBeginNanoTime();
+    }
+
     @Override
     public boolean isUserInRole(String role)
     {


### PR DESCRIPTION
This new API will allow us to very precisely compare latencies across Jetty 10, 11 and 12.

This PR only implements HTTP.

Fixes #9928 