### PR TITLE
Upgrade testcontainers 1.19.0 (fix local issue with upgraded docker version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <spifly.version>1.3.6</spifly.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
-    <testcontainers.version>1.18.3</testcontainers.version>
+    <testcontainers.version>1.19.0</testcontainers.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
     <wildfly.elytron.version>1.20.4.Final</wildfly.elytron.version>
     <xmemcached.version>2.4.7</xmemcached.version>
@@ -202,7 +202,8 @@
     <mongo.docker.version>3.2.20</mongo.docker.version>
     <settingsPath>src/it/settings.xml</settingsPath>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
-    <!-- if changing this version please update default in RemoteInfinispanTestSupport you will get thanks from Eclipse IDE users -->
+    <!-- if changing this version please update default in RemoteInfinispanTestSupport/InfinispanSessionDistributionTests
+    you will get thanks from Eclipse IDE users -->
     <!-- but hey we have no more strange people?? :P -->
     <infinispan.docker.image.version>11.0.14.Final</infinispan.docker.image.version>
 

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -70,7 +70,7 @@ public class RemoteInfinispanTestSupport
                 .withEnv("MGMT_PASS", "admin")
                 .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                 .waitingFor(Wait.forListeningPorts(11222))
-                .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
+                //.waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
                 .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                 .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
                 .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -70,7 +70,6 @@ public class RemoteInfinispanTestSupport
                 .withEnv("MGMT_PASS", "admin")
                 .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                 .waitingFor(Wait.forListeningPorts(11222))
-                //.waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
                 .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                 .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
                 .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -69,6 +69,7 @@ public class RemoteInfinispanTestSupport
                 .withEnv("MGMT_USER", "admin")
                 .withEnv("MGMT_PASS", "admin")
                 .withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                .waitingFor(Wait.forListeningPorts(11222))
                 .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
                 .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                 .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
@@ -52,7 +52,8 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
 
     private GenericContainer<?> hazelcast = new GenericContainer<>("hazelcast/hazelcast:" + System.getProperty("hazelcast.version", "4.2.2"))
             .withExposedPorts(5701)
-            .waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
+            .waitingFor(Wait.forListeningPorts(5701))
+            //.waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
             .withLogConsumer(new Slf4jLogConsumer(HAZELCAST_LOG));
 
     private Path hazelcastJettyPath;
@@ -124,9 +125,10 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
         env.put("JAVA_OPTS", "-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml");
         try (GenericContainer<?> hazelcast =
                  new GenericContainer<>("hazelcast/hazelcast:" + System.getProperty("hazelcast.version", "4.1"))
-                     .withExposedPorts(5701, 5705)
+                     .withExposedPorts(5701)
                      .withEnv(env)
-                     .waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
+                     .waitingFor(Wait.forListeningPorts(5701))
+                     //.waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
                      //.withNetworkMode("host")
                      //.waitingFor(Wait.forListeningPort())
                      .withClasspathResourceMapping("hazelcast-server.xml",

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/HazelcastSessionDistributionTests.java
@@ -53,7 +53,6 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
     private GenericContainer<?> hazelcast = new GenericContainer<>("hazelcast/hazelcast:" + System.getProperty("hazelcast.version", "4.2.2"))
             .withExposedPorts(5701)
             .waitingFor(Wait.forListeningPorts(5701))
-            //.waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
             .withLogConsumer(new Slf4jLogConsumer(HAZELCAST_LOG));
 
     private Path hazelcastJettyPath;
@@ -65,7 +64,7 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
         {
             hazelcast.start();
         }
-        String hazelcastHost = hazelcast.getContainerIpAddress();
+        String hazelcastHost = hazelcast.getHost();
         int hazelcastPort = hazelcast.getMappedPort(5701);
 
         LOGGER.info("hazelcast started on {}:{}", hazelcastHost, hazelcastPort);
@@ -128,25 +127,20 @@ public class HazelcastSessionDistributionTests extends AbstractSessionDistributi
                      .withExposedPorts(5701)
                      .withEnv(env)
                      .waitingFor(Wait.forListeningPorts(5701))
-                     //.waitingFor(Wait.forLogMessage(".*is STARTED.*", 1))
-                     //.withNetworkMode("host")
-                     //.waitingFor(Wait.forListeningPort())
                      .withClasspathResourceMapping("hazelcast-server.xml",
                          "/opt/hazelcast/config_ext/hazelcast.xml",
                          BindMode.READ_ONLY)
                      .withLogConsumer(new Slf4jLogConsumer(HAZELCAST_LOG)))
         {
             hazelcast.start();
-            String hazelcastHost = InetAddress.getByName(hazelcast.getContainerIpAddress()).getHostAddress(); // hazelcast.getContainerIpAddress();
+            String hazelcastHost = InetAddress.getByName(hazelcast.getHost()).getHostAddress();
             int hazelcastPort = hazelcast.getMappedPort(5701);
-//            int hazelcastMultiCastPort = hazelcast.getMappedPort(54327);
 
             LOGGER.info("hazelcast started on {}:{}", hazelcastHost, hazelcastPort);
 
             Map<String, String> tokenValues = new HashMap<>();
             tokenValues.put("hazelcast_ip", hazelcastHost);
             tokenValues.put("hazelcast_port", Integer.toString(hazelcastPort));
-//            tokenValues.put("hazelcast_multicast_port", Integer.toString(hazelcastMultiCastPort));
             Path hazelcastJettyPath = Paths.get("target/hazelcast-jetty.xml");
             transformFileWithHostAndPort(Paths.get("src/test/resources/hazelcast-jetty.xml"),
                 hazelcastJettyPath,

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
@@ -69,7 +69,6 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                         .withEnv("MGMT_PASS", "admin")
                         .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(Wait.forListeningPorts(11222))
-                        //.waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                         .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
                         .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.session.infinispan.InfinispanSerializationContextInitializer;
 import org.eclipse.jetty.util.IO;
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.configuration.XMLStringConfiguration;
@@ -68,7 +69,7 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                         .withEnv("MGMT_PASS", "admin")
                         .withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(Wait.forListeningPorts(11222))
-                        .waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
+                        //.waitingFor(Wait.forLogMessage(".*Infinispan Server.*started in.*\\s", 1))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                         .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
                         .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
@@ -89,6 +90,7 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
         properties.put("infinispan.client.hotrod.sasl_mechanism", "DIGEST-MD5");
         properties.put("infinispan.client.hotrod.auth_username", "theuser");
         properties.put("infinispan.client.hotrod.auth_password", "foobar");
+        properties.put("infinispan.client.hotrod.client_intelligence", "BASIC");
 
         Path hotrod = Path.of(resourcesDirectory.toString(), "hotrod-client.properties");
         Files.deleteIfExists(hotrod);
@@ -104,6 +106,7 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                 .addContextInitializer(new InfinispanSerializationContextInitializer())
                 .security().authentication().saslMechanism("DIGEST-MD5")
                 .username("theuser").password("foobar")
+                .clientIntelligence(ClientIntelligence.BASIC)
                 .build();
 
         RemoteCacheManager remoteCacheManager = new RemoteCacheManager(configuration);
@@ -171,6 +174,8 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
             writer.write("infinispan.client.hotrod.auth_username=theuser");
             writer.newLine();
             writer.write("infinispan.client.hotrod.auth_password=foobar");
+            writer.newLine();
+            writer.write("infinispan.client.hotrod.client_intelligence=BASIC");
             writer.newLine();
         }
     }


### PR DESCRIPTION
- add some debug
- force use infinispan.client.hotrod.client_intelligence=BASIC looks to fix issue locally after docker upgrade, use new forListeningPorts to check infinispan start
- use Wait.forListeningPorts to wait docker image start
- cleanup commented code
