### PR TITLE
Merge 11.0.x back to 12.0.x

### DIFF
--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <bundle-symbolic-name>${project.groupId}.jaas</bundle-symbolic-name>
     <apacheds.version>2.0.0.AM26</apacheds.version>
-    <apache.directory.api.version>2.1.3</apache.directory.api.version>
+    <apache.directory.api.version>2.1.4</apache.directory.api.version>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.jaas.*</spotbugs.onlyAnalyze>
   </properties>
 

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -14,7 +14,7 @@
     <jetty-orbit-url>https://download.eclipse.org/jetty/orbit/</jetty-orbit-url>
     <assembly-directory>target/distribution</assembly-directory>
     <pax.exam.version>4.13.1</pax.exam.version>
-    <pax.url.version>2.6.2</pax.url.version>
+    <pax.url.version>2.6.14</pax.url.version>
     <swissbox.version>1.8.3</swissbox.version>
     <tinybundles.version>3.0.0</tinybundles.version>
     <injection.bundle.version>1.2</injection.bundle.version>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -91,6 +91,12 @@
       <artifactId>pax-url-aether</artifactId>
       <version>${pax.url.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>
     <hazelcast.version>5.2.1</hazelcast.version>
-    <infinispan.protostream.version>4.6.2.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.6.4.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>
     <jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>
     <hazelcast.version>5.2.1</hazelcast.version>
-    <infinispan.protostream.version>4.6.4.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>
     <jakarta.activation.api.version>2.0.1</jakarta.activation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <guice.version>7.0.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hazelcast.version>5.3.1</hazelcast.version>
-    <infinispan.protostream.version>4.65.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.15.2</jackson.version>
     <jakarta.activation.api.version>2.0.1</jakarta.activation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <testcontainers.version>1.19.0</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
-    <wildfly.elytron.version>2.2.1.Final</wildfly.elytron.version>
+    <wildfly.elytron.version>2.2.2.Final</wildfly.elytron.version>
     <xmemcached.version>2.4.7</xmemcached.version>
 
     <!-- some maven plugins versions -->


### PR DESCRIPTION
- Bump org.infinispan.protostream:protostream
- Bump apache.directory.api.version from 2.1.3 to 2.1.4
- Bump org.wildfly.security:wildfly-elytron
- Bump pax.url.version from 2.6.2 to 2.6.14
- exclude banned dependencies
- Bump org.infinispan.protostream:protostream (#10469)
- fix version number
