### PR TITLE
Improve BufferedResponseHandler

### DIFF
--- a/jetty-core/jetty-io/pom.xml
+++ b/jetty-core/jetty-io/pom.xml
@@ -49,5 +49,10 @@
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -1,0 +1,129 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.util.BufferUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Aggregates data into a single ByteBuffer of a specified maximum size.</p>
+ * <p>The buffer automatically grows as data is written to it, up until it reaches the specified maximum size.
+ * Once the buffer is full, the aggregator will not aggregate any more bytes until its buffer is taken out,
+ * after which a new aggregate/take buffer cycle can start.</p>
+ * <p>The buffers are taken from the supplied {@link ByteBufferPool} or freshly allocated if one is not supplied.</p>
+ */
+public class ByteBufferAggregator
+{
+    private static final Logger LOG = LoggerFactory.getLogger(ByteBufferAggregator.class);
+
+    private final ByteBufferPool _bufferPool;
+    private final boolean _direct;
+    private final int _maxSize;
+    private RetainableByteBuffer _retainableByteBuffer;
+    private int _aggregatedSize;
+    private int _currentSize;
+
+    /**
+     * Creates a ByteBuffer aggregator.
+     * @param bufferPool The {@link ByteBufferPool} from which to acquire the buffers
+     * @param direct whether to get direct buffers
+     * @param startSize the starting size of the buffer
+     * @param maxSize the maximum size of the buffer which must be greater than {@code startSize}
+     */
+    public ByteBufferAggregator(ByteBufferPool bufferPool, boolean direct, int startSize, int maxSize)
+    {
+        if (maxSize <= 0)
+            throw new IllegalArgumentException("maxSize must be > 0, was: " + maxSize);
+        if (startSize <= 0)
+            throw new IllegalArgumentException("startSize must be > 0, was: " + startSize);
+        if (startSize > maxSize)
+            throw new IllegalArgumentException("maxSize (" + maxSize + ") must be >= startSize (" + startSize + ")");
+        _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
+        _direct = direct;
+        _maxSize = maxSize;
+        _currentSize = startSize;
+    }
+
+    /**
+     * Copies the given ByteBuffer into this aggregator. The buffer will aggregate bytes up to
+     * the specified maximum size, at which time this method returns false and
+     * {@link #takeRetainableByteBuffer()} must be called for this method to accept copying again.
+     * @param buffer the buffer to copy into this aggregator
+     * @return true if the aggregator's buffer is full and should be taken, false otherwise
+     */
+    public boolean copyBuffer(ByteBuffer buffer)
+    {
+        ensureBufferCapacity(buffer.remaining());
+        if (_retainableByteBuffer == null)
+        {
+            _retainableByteBuffer = _bufferPool.acquire(_currentSize, _direct);
+            BufferUtil.flipToFill(_retainableByteBuffer.getByteBuffer());
+        }
+        int prevPos = buffer.position();
+        int copySize = Math.min(_currentSize - _aggregatedSize, buffer.remaining());
+
+        _retainableByteBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer().position(), buffer, buffer.position(), copySize);
+        _retainableByteBuffer.getByteBuffer().position(_retainableByteBuffer.getByteBuffer().position() + copySize);
+        buffer.position(buffer.position() + copySize);
+        _aggregatedSize += buffer.position() - prevPos;
+        return _aggregatedSize == _maxSize;
+    }
+
+    private void ensureBufferCapacity(int remaining)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("ensureBufferCapacity remaining: {} _currentSize: {} _accumulatedSize={}", remaining, _currentSize, _aggregatedSize);
+        if (_currentSize == _maxSize)
+            return;
+        int capacityLeft = _currentSize - _aggregatedSize;
+        if (remaining <= capacityLeft)
+            return;
+        int need = remaining - capacityLeft;
+        _currentSize = Math.min(_maxSize, ceilToNextPowerOfTwo(_currentSize + need));
+
+        if (_retainableByteBuffer != null)
+        {
+            BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
+            RetainableByteBuffer newBuffer = _bufferPool.acquire(_currentSize, _direct);
+            BufferUtil.flipToFill(newBuffer.getByteBuffer());
+            newBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer());
+            _retainableByteBuffer.release();
+            _retainableByteBuffer = newBuffer;
+        }
+    }
+
+    private static int ceilToNextPowerOfTwo(int val)
+    {
+        int result = 1 << Integer.SIZE - Integer.numberOfLeadingZeros(val - 1);
+        return result > 0 ? result : Integer.MAX_VALUE;
+    }
+
+    /**
+     * Takes the buffer out of the aggregator. Once the buffer has been taken out,
+     * the aggregator resets itself and a new buffer will be acquired from the pool
+     * during the next {@link #copyBuffer(ByteBuffer)} call.
+     * @return the aggregated buffer
+     */
+    public RetainableByteBuffer takeRetainableByteBuffer()
+    {
+        BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
+        RetainableByteBuffer result = _retainableByteBuffer;
+        _retainableByteBuffer = null;
+        _aggregatedSize = 0;
+        return result;
+    }
+}

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -59,13 +59,14 @@ public class ByteBufferAggregator
     }
 
     /**
-     * Copies the given ByteBuffer into this aggregator. The buffer will aggregate bytes up to
-     * the specified maximum size, at which time this method returns false and
-     * {@link #takeRetainableByteBuffer()} must be called for this method to accept copying again.
-     * @param buffer the buffer to copy into this aggregator
+     * Copies the given ByteBuffer into this aggregator. This will aggregate bytes up to the
+     * specified maximum size, at which time this method returns false and
+     * {@link #takeRetainableByteBuffer()} must be called for this method to accept aggregating again.
+     * @param buffer the buffer to copy into this aggregator; its position is updated according to
+     * the number of aggregated bytes
      * @return true if the aggregator's buffer is full and should be taken, false otherwise
      */
-    public boolean copyBuffer(ByteBuffer buffer)
+    public boolean aggregate(ByteBuffer buffer)
     {
         ensureBufferCapacity(buffer.remaining());
         if (_retainableByteBuffer == null)
@@ -115,7 +116,7 @@ public class ByteBufferAggregator
     /**
      * Takes the buffer out of the aggregator. Once the buffer has been taken out,
      * the aggregator resets itself and a new buffer will be acquired from the pool
-     * during the next {@link #copyBuffer(ByteBuffer)} call.
+     * during the next {@link #aggregate(ByteBuffer)} call.
      * @return the aggregated buffer, or null if nothing has been buffered yet
      */
     public RetainableByteBuffer takeRetainableByteBuffer()

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -60,7 +60,7 @@ public class ByteBufferAggregator
 
     /**
      * Copies the given ByteBuffer into this aggregator. This will aggregate bytes up to the
-     * specified maximum size, at which time this method returns false and
+     * specified maximum size, at which time this method returns true and
      * {@link #takeRetainableByteBuffer()} must be called for this method to accept aggregating again.
      * @param buffer the buffer to copy into this aggregator; its position is updated according to
      * the number of aggregated bytes
@@ -74,13 +74,13 @@ public class ByteBufferAggregator
             _retainableByteBuffer = _bufferPool.acquire(_currentSize, _direct);
             BufferUtil.flipToFill(_retainableByteBuffer.getByteBuffer());
         }
-        int prevPos = buffer.position();
         int copySize = Math.min(_currentSize - _aggregatedSize, buffer.remaining());
 
-        _retainableByteBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer().position(), buffer, buffer.position(), copySize);
-        _retainableByteBuffer.getByteBuffer().position(_retainableByteBuffer.getByteBuffer().position() + copySize);
+        ByteBuffer byteBuffer = _retainableByteBuffer.getByteBuffer();
+        byteBuffer.put(byteBuffer.position(), buffer, buffer.position(), copySize);
+        byteBuffer.position(byteBuffer.position() + copySize);
         buffer.position(buffer.position() + copySize);
-        _aggregatedSize += buffer.position() - prevPos;
+        _aggregatedSize += copySize;
         return _aggregatedSize == _maxSize;
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -68,7 +68,7 @@ public class ByteBufferAggregator
      */
     public boolean aggregate(ByteBuffer buffer)
     {
-        ensureBufferCapacity(buffer.remaining());
+        tryExpandBufferCapacity(buffer.remaining());
         if (_retainableByteBuffer == null)
         {
             _retainableByteBuffer = _bufferPool.acquire(_currentSize, _direct);
@@ -84,10 +84,10 @@ public class ByteBufferAggregator
         return _aggregatedSize == _maxSize;
     }
 
-    private void ensureBufferCapacity(int remaining)
+    private void tryExpandBufferCapacity(int remaining)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("ensureBufferCapacity remaining: {} _currentSize: {} _accumulatedSize={}", remaining, _currentSize, _aggregatedSize);
+            LOG.debug("tryExpandBufferCapacity remaining: {} _currentSize: {} _accumulatedSize={}", remaining, _currentSize, _aggregatedSize);
         if (_currentSize == _maxSize)
             return;
         int capacityLeft = _currentSize - _aggregatedSize;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -116,14 +116,22 @@ public class ByteBufferAggregator
      * Takes the buffer out of the aggregator. Once the buffer has been taken out,
      * the aggregator resets itself and a new buffer will be acquired from the pool
      * during the next {@link #copyBuffer(ByteBuffer)} call.
-     * @return the aggregated buffer
+     * @return the aggregated buffer, or null if nothing has been buffered yet
      */
     public RetainableByteBuffer takeRetainableByteBuffer()
     {
+        if (_retainableByteBuffer == null)
+            return null;
         BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
         RetainableByteBuffer result = _retainableByteBuffer;
         _retainableByteBuffer = null;
         _aggregatedSize = 0;
         return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "%s@%x{a=%d c=%d b=%s}".formatted(getClass().getSimpleName(), hashCode(), _aggregatedSize, _currentSize, _retainableByteBuffer);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -59,9 +59,9 @@ public class ByteBufferAggregator
     }
 
     /**
-     * Copies the given ByteBuffer into this aggregator. This will aggregate bytes up to the
-     * specified maximum size, at which time this method returns true and
-     * {@link #takeRetainableByteBuffer()} must be called for this method to accept aggregating again.
+     * Aggregates the given ByteBuffer. This copies bytes up to the specified maximum size, at which
+     * time this method returns {@code true} and {@link #takeRetainableByteBuffer()} must be called
+     * for this method to accept aggregating again.
      * @param buffer the buffer to copy into this aggregator; its position is updated according to
      * the number of aggregated bytes
      * @return true if the aggregator's buffer is full and should be taken, false otherwise

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -109,7 +109,7 @@ public class ByteBufferAggregator
 
     private static int ceilToNextPowerOfTwo(int val)
     {
-        int result = 1 << Integer.SIZE - Integer.numberOfLeadingZeros(val - 1);
+        int result = 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(val - 1));
         return result > 0 ? result : Integer.MAX_VALUE;
     }
 
@@ -133,6 +133,6 @@ public class ByteBufferAggregator
     @Override
     public String toString()
     {
-        return "%s@%x{a=%d c=%d b=%s}".formatted(getClass().getSimpleName(), hashCode(), _aggregatedSize, _currentSize, _retainableByteBuffer);
+        return "%s@%x{a=%d c=%d m=%d b=%s}".formatted(getClass().getSimpleName(), hashCode(), _aggregatedSize, _currentSize, _maxSize, _retainableByteBuffer);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 
+import org.eclipse.jetty.io.content.BufferedContentSink;
 import org.eclipse.jetty.io.content.ContentSinkOutputStream;
 import org.eclipse.jetty.io.content.ContentSinkSubscriber;
 import org.eclipse.jetty.io.content.ContentSourceInputStream;
@@ -411,6 +412,20 @@ public class Content
      */
     public interface Sink
     {
+        /**
+         * <p>Wraps the given content sink with a buffering sink.</p>
+         *
+         * @param sink the sink to write to
+         * @param bufferPool the {@link org.eclipse.jetty.io.ByteBufferPool} to use
+         * @param direct true to use direct buffers, false to use heap buffers
+         * @param maxBufferSize the maximum size of the buffer
+         * @return a Sink that writes to the given content sink
+         */
+        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize)
+        {
+            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize);
+        }
+
         /**
          * <p>Wraps the given content sink with an {@link OutputStream}.</p>
          *

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -418,12 +418,13 @@ public class Content
          * @param sink the sink to write to
          * @param bufferPool the {@link org.eclipse.jetty.io.ByteBufferPool} to use
          * @param direct true to use direct buffers, false to use heap buffers
+         * @param minBufferSize the minimum size of the buffer
          * @param maxBufferSize the maximum size of the buffer
          * @return a Sink that writes to the given content sink
          */
-        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize)
+        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int minBufferSize, int maxBufferSize)
         {
-            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize);
+            return new BufferedContentSink(sink, bufferPool, direct, minBufferSize, maxBufferSize);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -418,13 +418,12 @@ public class Content
          * @param sink the sink to write to
          * @param bufferPool the {@link org.eclipse.jetty.io.ByteBufferPool} to use
          * @param direct true to use direct buffers, false to use heap buffers
-         * @param minBufferSize the minimum size of the buffer
          * @param maxBufferSize the maximum size of the buffer
          * @return a Sink that writes to the given content sink
          */
-        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int minBufferSize, int maxBufferSize)
+        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize)
         {
-            return new BufferedContentSink(sink, bufferPool, direct, minBufferSize, maxBufferSize);
+            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -416,16 +416,16 @@ public class Content
          * <p>Wraps the given content sink with a buffering sink.</p>
          *
          * @param sink the sink to write to
-         * @param bufferPool the {@link org.eclipse.jetty.io.ByteBufferPool} to use
+         * @param bufferPool the {@link ByteBufferPool} to use
          * @param direct true to use direct buffers, false to use heap buffers
-         * @param maxBufferSize the maximum size of the buffer
          * @param maxAggregationSize the maximum size that can be buffered in a single write;
          * any size above this threshold triggers a buffer flush
+         * @param maxBufferSize the maximum size of the buffer
          * @return a Sink that writes to the given content sink
          */
-        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize, int maxAggregationSize)
+        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxAggregationSize, int maxBufferSize)
         {
-            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize, maxAggregationSize);
+            return new BufferedContentSink(sink, bufferPool, direct, maxAggregationSize, maxBufferSize);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -419,11 +419,13 @@ public class Content
          * @param bufferPool the {@link org.eclipse.jetty.io.ByteBufferPool} to use
          * @param direct true to use direct buffers, false to use heap buffers
          * @param maxBufferSize the maximum size of the buffer
+         * @param maxAggregationSize the maximum size that can be buffered in a single write;
+         * any size above this threshold triggers a buffer flush
          * @return a Sink that writes to the given content sink
          */
-        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize)
+        static Sink asBuffered(Sink sink, ByteBufferPool bufferPool, boolean direct, int maxBufferSize, int maxAggregationSize)
         {
-            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize);
+            return new BufferedContentSink(sink, bufferPool, direct, maxBufferSize, maxAggregationSize);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
@@ -1,0 +1,133 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io.content;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IteratingNestedCallback;
+
+/**
+ * <p>A {@link Content.Sink} backed by another {@link Content.Sink}.
+ * Any content written to this {@link Content.Sink} is buffered,
+ * then written to the delegate's
+ * {@link Content.Sink#write(boolean, ByteBuffer, Callback)}. </p>
+ */
+public class BufferedContentSink implements Content.Sink
+{
+    private final Content.Sink _delegate;
+    private final ByteBufferPool _bufferPool;
+    private final boolean _direct;
+    private final int _maxBufferSize;
+    private CountingByteBufferAccumulator _accumulator;
+    private boolean _firstWrite = true;
+    private boolean _lastWritten;
+
+    public BufferedContentSink(Content.Sink delegate, ByteBufferPool bufferPool, boolean direct, int maxBufferSize)
+    {
+        if (maxBufferSize <= 0)
+            throw new IllegalArgumentException("maxBufferSize must be > 0, was: " + maxBufferSize);
+        _delegate = delegate;
+        _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
+        _direct = direct;
+        _maxBufferSize = maxBufferSize;
+    }
+
+    @Override
+    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+    {
+        if (_lastWritten)
+        {
+            callback.failed(new IOException("complete"));
+            return;
+        }
+        if (_firstWrite)
+        {
+            _accumulator = new CountingByteBufferAccumulator(_bufferPool, _direct, _maxBufferSize);
+            _firstWrite = false;
+        }
+        _lastWritten |= last;
+
+        ByteBuffer current = byteBuffer != null ? byteBuffer : BufferUtil.EMPTY_BUFFER;
+        IteratingNestedCallback writer = new IteratingNestedCallback(callback)
+        {
+            private boolean complete;
+
+            @Override
+            protected Action process()
+            {
+                if (complete)
+                    return Action.SUCCEEDED;
+                boolean write = _accumulator.copyBuffer(current);
+                complete = last && !current.hasRemaining();
+                if (write || complete)
+                {
+                    RetainableByteBuffer buffer = _accumulator.takeRetainableByteBuffer();
+                    _delegate.write(complete, buffer.getByteBuffer(), Callback.from(this, buffer::release));
+                    return Action.SCHEDULED;
+                }
+                return Action.SUCCEEDED;
+            }
+        };
+        writer.iterate();
+    }
+
+    private static class CountingByteBufferAccumulator
+    {
+        private final ByteBufferPool _bufferPool;
+        private final boolean _direct;
+        private final int _maxSize;
+        private RetainableByteBuffer _retainableByteBuffer;
+        private int _accumulatedSize;
+
+        private CountingByteBufferAccumulator(ByteBufferPool bufferPool, boolean direct, int maxSize)
+        {
+            if (maxSize <= 0)
+                throw new IllegalArgumentException("maxSize must be > 0, was: " + maxSize);
+            _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
+            _direct = direct;
+            _maxSize = maxSize;
+        }
+
+        private boolean copyBuffer(ByteBuffer buffer)
+        {
+            if (_retainableByteBuffer == null)
+            {
+                _retainableByteBuffer = _bufferPool.acquire(_maxSize, _direct);
+                BufferUtil.flipToFill(_retainableByteBuffer.getByteBuffer());
+            }
+            int prevPos = buffer.position();
+            int copySize = Math.min(buffer.remaining(), _maxSize);
+            _retainableByteBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer().position(), buffer, buffer.position(), copySize);
+            _retainableByteBuffer.getByteBuffer().position(_retainableByteBuffer.getByteBuffer().position() + copySize);
+            buffer.position(buffer.position() + copySize);
+            _accumulatedSize += buffer.position() - prevPos;
+            return _accumulatedSize == _maxSize;
+        }
+
+        public RetainableByteBuffer takeRetainableByteBuffer()
+        {
+            BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
+            RetainableByteBuffer result = _retainableByteBuffer;
+            _retainableByteBuffer = null;
+            _accumulatedSize = 0;
+            return result;
+        }
+    }
+}

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
@@ -127,7 +127,7 @@ public class BufferedContentSink implements Content.Sink
      */
     private void aggregateAndWrite(boolean last, ByteBuffer currentBuffer, Callback callback)
     {
-        boolean write = _aggregator.copyBuffer(currentBuffer);
+        boolean write = _aggregator.aggregate(currentBuffer);
         boolean complete = last && !currentBuffer.hasRemaining();
         if (LOG.isDebugEnabled())
             LOG.debug("aggregated current buffer, write={}, complete={}, bytes left={}, aggregator={}", write, complete, currentBuffer.remaining(), _aggregator);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
@@ -61,8 +61,15 @@ public class BufferedContentSink implements Content.Sink
         }
         if (_firstWrite)
         {
-            _accumulator = new CountingByteBufferAccumulator(_bufferPool, _direct, _maxBufferSize);
             _firstWrite = false;
+            if (last)
+            {
+                // No need to buffer if this is both the first and the last write.
+                _lastWritten = true;
+                _delegate.write(true, byteBuffer, callback);
+                return;
+            }
+            _accumulator = new CountingByteBufferAccumulator(_bufferPool, _direct, _maxBufferSize);
         }
         _lastWritten |= last;
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
@@ -49,7 +49,7 @@ public class BufferedContentSink implements Content.Sink
     private boolean _firstWrite = true;
     private boolean _lastWritten;
 
-    public BufferedContentSink(Content.Sink delegate, ByteBufferPool bufferPool, boolean direct, int maxBufferSize, int maxAggregationSize)
+    public BufferedContentSink(Content.Sink delegate, ByteBufferPool bufferPool, boolean direct, int maxAggregationSize, int maxBufferSize)
     {
         if (maxBufferSize <= 0)
             throw new IllegalArgumentException("maxBufferSize must be > 0, was: " + maxBufferSize);

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
@@ -57,23 +57,10 @@ public class BufferedContentSinkTest
     }
 
     @Test
-    public void testWrongMinBufferSize()
-    {
-        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 0, 4096));
-        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, -1, 4096));
-    }
-
-    @Test
     public void testWrongMaxBufferSize()
     {
-        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 16, 0));
-        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 16, -1));
-    }
-
-    @Test
-    public void testMinBufferSizeGreatherThanMax()
-    {
-        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 1024, 16));
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 0));
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, -1));
     }
 
     @Test
@@ -81,7 +68,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             CountDownLatch latch = new CountDownLatch(1);
             async.demand(latch::countDown);
@@ -102,7 +89,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -125,7 +112,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -147,7 +134,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -172,7 +159,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             buffered.write(false, ByteBuffer.wrap("one ".getBytes(UTF_8)), Callback.NOOP);
             Content.Chunk chunk = async.read();
@@ -204,7 +191,7 @@ public class BufferedContentSinkTest
 
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, maxBufferSize, maxBufferSize);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, maxBufferSize);
 
             buffered.write(false, ByteBuffer.wrap(input1), Callback.from(() ->
                 buffered.write(true, ByteBuffer.wrap(input2), Callback.NOOP)));
@@ -248,22 +235,15 @@ public class BufferedContentSinkTest
 
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
 
             buffered.write(false, ByteBuffer.wrap(input1), Callback.from(() ->
                 buffered.write(true, ByteBuffer.wrap(input2), Callback.NOOP)));
 
-            // We expect 4 buffer flushes: 1024b + 2048b + 4096b + 2832b == 10_000b.
+            // We expect 3 buffer flushes: 4096b + 4096b + 1808b == 10_000b.
             Content.Chunk chunk = async.read();
             assertThat(chunk, notNullValue());
-            assertThat(chunk.remaining(), is(1024));
-            accumulatingBuffer.put(chunk.getByteBuffer());
-            assertThat(chunk.release(), is(true));
-            assertThat(chunk.isLast(), is(false));
-
-            chunk = async.read();
-            assertThat(chunk, notNullValue());
-            assertThat(chunk.remaining(), is(2048));
+            assertThat(chunk.remaining(), is(4096));
             accumulatingBuffer.put(chunk.getByteBuffer());
             assertThat(chunk.release(), is(true));
             assertThat(chunk.isLast(), is(false));
@@ -277,7 +257,7 @@ public class BufferedContentSinkTest
 
             chunk = async.read();
             assertThat(chunk, notNullValue());
-            assertThat(chunk.remaining(), is(2832));
+            assertThat(chunk.remaining(), is(1808));
             accumulatingBuffer.put(chunk.getByteBuffer());
             assertThat(chunk.release(), is(true));
             assertThat(chunk.isLast(), is(true));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BufferedContentSinkTest
@@ -56,11 +57,31 @@ public class BufferedContentSinkTest
     }
 
     @Test
+    public void testWrongMinBufferSize()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 0, 4096));
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, -1, 4096));
+    }
+
+    @Test
+    public void testWrongMaxBufferSize()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 16, 0));
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 16, -1));
+    }
+
+    @Test
+    public void testMinBufferSizeGreatherThanMax()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new BufferedContentSink(new AsyncContent(), _bufferPool, true, 1024, 16));
+    }
+
+    @Test
     public void testWriteInvokesDemandCallback() throws Exception
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             CountDownLatch latch = new CountDownLatch(1);
             async.demand(latch::countDown);
@@ -81,7 +102,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -104,7 +125,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -126,7 +147,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             AtomicInteger successCounter = new AtomicInteger();
             AtomicReference<Throwable> failureRef = new AtomicReference<>();
@@ -151,7 +172,7 @@ public class BufferedContentSinkTest
     {
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             buffered.write(false, ByteBuffer.wrap("one ".getBytes(UTF_8)), Callback.NOOP);
             Content.Chunk chunk = async.read();
@@ -183,7 +204,7 @@ public class BufferedContentSinkTest
 
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, maxBufferSize);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, maxBufferSize, maxBufferSize);
 
             buffered.write(false, ByteBuffer.wrap(input1), Callback.from(() ->
                 buffered.write(true, ByteBuffer.wrap(input2), Callback.NOOP)));
@@ -227,7 +248,7 @@ public class BufferedContentSinkTest
 
         try (AsyncContent async = new AsyncContent())
         {
-            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 1024, 4096);
 
             buffered.write(false, ByteBuffer.wrap(input1), Callback.from(() ->
                 buffered.write(true, ByteBuffer.wrap(input2), Callback.NOOP)));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/BufferedContentSinkTest.java
@@ -1,0 +1,212 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.io.content.AsyncContent;
+import org.eclipse.jetty.io.content.BufferedContentSink;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BufferedContentSinkTest
+{
+    private ArrayByteBufferPool.Tracking _bufferPool;
+
+    @BeforeEach
+    public void setUp()
+    {
+        _bufferPool = new ArrayByteBufferPool.Tracking();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        assertThat("Leaks: " + _bufferPool.dumpLeaks(), _bufferPool.getLeaks().size(), is(0));
+    }
+
+    @Test
+    public void testWriteInvokesDemandCallback() throws Exception
+    {
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+
+            CountDownLatch latch = new CountDownLatch(1);
+            async.demand(latch::countDown);
+            assertFalse(latch.await(250, TimeUnit.MILLISECONDS));
+
+            buffered.write(true, UTF_8.encode("one"), Callback.NOOP);
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+            Content.Chunk chunk = async.read();
+            assertNotNull(chunk);
+            chunk.release();
+        }
+    }
+
+    @Test
+    public void testChunkReleaseSucceedsWriteCallback()
+    {
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+
+            AtomicInteger successCounter = new AtomicInteger();
+            AtomicReference<Throwable> failureRef = new AtomicReference<>();
+
+            buffered.write(true, ByteBuffer.wrap(new byte[1]), Callback.from(successCounter::incrementAndGet, failureRef::set));
+
+            Content.Chunk chunk = async.read();
+            assertThat(successCounter.get(), is(0));
+            chunk.retain();
+            assertThat(chunk.release(), is(false));
+            assertThat(successCounter.get(), is(0));
+            assertThat(chunk.release(), is(true));
+            assertThat(successCounter.get(), is(1));
+            assertThat(failureRef.get(), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void testEmptyChunkReadSucceedsWriteCallback()
+    {
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+
+            AtomicInteger successCounter = new AtomicInteger();
+            AtomicReference<Throwable> failureRef = new AtomicReference<>();
+
+            buffered.write(true, ByteBuffer.wrap(new byte[0]), Callback.from(successCounter::incrementAndGet, failureRef::set));
+
+            Content.Chunk chunk = async.read();
+            assertThat(successCounter.get(), is(1));
+            assertThat(chunk.isLast(), is(true));
+            assertThat(chunk.hasRemaining(), is(false));
+            assertThat(chunk.release(), is(true));
+            assertThat(successCounter.get(), is(1));
+            assertThat(failureRef.get(), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void testWriteAfterWriteLast()
+    {
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+
+            AtomicInteger successCounter = new AtomicInteger();
+            AtomicReference<Throwable> failureRef = new AtomicReference<>();
+
+            buffered.write(true, ByteBuffer.wrap(new byte[0]), Callback.from(successCounter::incrementAndGet, failureRef::set));
+
+            Content.Chunk chunk = async.read();
+            assertThat(chunk.isLast(), is(true));
+            assertThat(chunk.release(), is(true));
+
+            assertThat(successCounter.get(), is(1));
+            assertThat(failureRef.get(), is(nullValue()));
+
+            buffered.write(false, ByteBuffer.wrap(new byte[0]), Callback.from(successCounter::incrementAndGet, failureRef::set));
+            assertThat(successCounter.get(), is(1));
+            assertThat(failureRef.get(), instanceOf(IOException.class));
+        }
+    }
+
+    @Test
+    public void testLargeBuffer()
+    {
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 4096);
+
+            buffered.write(false, ByteBuffer.wrap("one\n".getBytes(UTF_8)), Callback.NOOP);
+            Content.Chunk chunk = async.read();
+            assertThat(chunk, nullValue());
+
+            buffered.write(false, ByteBuffer.wrap("two\n".getBytes(UTF_8)), Callback.NOOP);
+            chunk = async.read();
+            assertThat(chunk, nullValue());
+
+            buffered.write(true, null, Callback.NOOP);
+            chunk = async.read();
+            assertThat(chunk.isLast(), is(true));
+            assertThat(BufferUtil.toString(chunk.getByteBuffer(), UTF_8), is("one\ntwo\n"));
+            assertThat(chunk.release(), is(true));
+        }
+    }
+
+    @Test
+    public void testSmallBuffer()
+    {
+        byte[] input1 = new byte[1024];
+        Arrays.fill(input1, (byte)'1');
+        byte[] input2 = new byte[1023];
+        Arrays.fill(input2, (byte)'2');
+
+        ByteBuffer accumulatingBuffer = BufferUtil.allocate(4096);
+        BufferUtil.flipToFill(accumulatingBuffer);
+
+        try (AsyncContent async = new AsyncContent())
+        {
+            BufferedContentSink buffered = new BufferedContentSink(async, _bufferPool, true, 16);
+
+            buffered.write(false, ByteBuffer.wrap(input1), Callback.from(() ->
+                buffered.write(true, ByteBuffer.wrap(input2), Callback.NOOP)));
+
+            while (true)
+            {
+                Content.Chunk chunk = async.read();
+                assertThat(chunk, notNullValue());
+                accumulatingBuffer.put(chunk.getByteBuffer());
+                assertThat(chunk.release(), is(true));
+                if (chunk.isLast())
+                    break;
+            }
+
+            BufferUtil.flipToFlush(accumulatingBuffer, 0);
+            assertThat(accumulatingBuffer.remaining(), is(input1.length + input2.length));
+            for (byte b : input1)
+            {
+                assertThat(accumulatingBuffer.get(), is(b));
+            }
+            for (byte b : input2)
+            {
+                assertThat(accumulatingBuffer.get(), is(b));
+            }
+        }
+    }
+}

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
@@ -1,0 +1,88 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ByteBufferAggregatorTest
+{
+    private ArrayByteBufferPool.Tracking bufferPool;
+
+    @BeforeEach
+    public void before()
+    {
+        bufferPool = new ArrayByteBufferPool.Tracking();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
+    }
+
+    @Test
+    public void testConstructor()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, 1, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, -1, 0));
+        assertThrows(IllegalArgumentException.class, () -> new ByteBufferAggregator(bufferPool, true, 2, 1));
+    }
+
+    @Test
+    public void testFullInSingleShot()
+    {
+        ByteBufferAggregator aggregator = new ByteBufferAggregator(bufferPool, true, 1, 16);
+
+        ByteBuffer byteBuffer1 = ByteBuffer.wrap(new byte[16]);
+        assertThat(aggregator.copyBuffer(byteBuffer1), is(true));
+        assertThat(byteBuffer1.remaining(), is(0));
+
+        ByteBuffer byteBuffer2 = ByteBuffer.wrap(new byte[16]);
+        assertThat(aggregator.copyBuffer(byteBuffer2), is(true));
+        assertThat(byteBuffer2.remaining(), is(16));
+
+        RetainableByteBuffer retainableByteBuffer = aggregator.takeRetainableByteBuffer();
+        assertThat(retainableByteBuffer.getByteBuffer().remaining(), is(16));
+        assertThat(retainableByteBuffer.release(), is(true));
+    }
+
+    @Test
+    public void testFullInMultipleShots()
+    {
+        ByteBufferAggregator aggregator = new ByteBufferAggregator(bufferPool, true, 1, 16);
+
+        ByteBuffer byteBuffer1 = ByteBuffer.wrap(new byte[15]);
+        assertThat(aggregator.copyBuffer(byteBuffer1), is(false));
+        assertThat(byteBuffer1.remaining(), is(0));
+
+        ByteBuffer byteBuffer2 = ByteBuffer.wrap(new byte[16]);
+        assertThat(aggregator.copyBuffer(byteBuffer2), is(true));
+        assertThat(byteBuffer2.remaining(), is(15));
+
+        RetainableByteBuffer retainableByteBuffer = aggregator.takeRetainableByteBuffer();
+        assertThat(retainableByteBuffer.getByteBuffer().remaining(), is(16));
+        assertThat(retainableByteBuffer.release(), is(true));
+    }
+}

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
@@ -56,11 +56,11 @@ public class ByteBufferAggregatorTest
         ByteBufferAggregator aggregator = new ByteBufferAggregator(bufferPool, true, 1, 16);
 
         ByteBuffer byteBuffer1 = ByteBuffer.wrap(new byte[16]);
-        assertThat(aggregator.copyBuffer(byteBuffer1), is(true));
+        assertThat(aggregator.aggregate(byteBuffer1), is(true));
         assertThat(byteBuffer1.remaining(), is(0));
 
         ByteBuffer byteBuffer2 = ByteBuffer.wrap(new byte[16]);
-        assertThat(aggregator.copyBuffer(byteBuffer2), is(true));
+        assertThat(aggregator.aggregate(byteBuffer2), is(true));
         assertThat(byteBuffer2.remaining(), is(16));
 
         RetainableByteBuffer retainableByteBuffer = aggregator.takeRetainableByteBuffer();
@@ -74,11 +74,11 @@ public class ByteBufferAggregatorTest
         ByteBufferAggregator aggregator = new ByteBufferAggregator(bufferPool, true, 1, 16);
 
         ByteBuffer byteBuffer1 = ByteBuffer.wrap(new byte[15]);
-        assertThat(aggregator.copyBuffer(byteBuffer1), is(false));
+        assertThat(aggregator.aggregate(byteBuffer1), is(false));
         assertThat(byteBuffer1.remaining(), is(0));
 
         ByteBuffer byteBuffer2 = ByteBuffer.wrap(new byte[16]);
-        assertThat(aggregator.copyBuffer(byteBuffer2), is(true));
+        assertThat(aggregator.aggregate(byteBuffer2), is(true));
         assertThat(byteBuffer2.remaining(), is(15));
 
         RetainableByteBuffer retainableByteBuffer = aggregator.takeRetainableByteBuffer();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -536,9 +536,8 @@ public interface Response extends Content.Sink
      * <p>Wraps a {@link Response} as a {@link OutputStream} that performs buffering. The necessary
      * {@link ByteBufferPool} is taken from the request's connector while the size and direction of the buffer
      * is read from the request's {@link HttpConfiguration}.</p>
-     * <p>This is equivalent to:<pre>
-     * Content.Sink.asOutputStream(Response.asBufferedSink(request, response))
-     * </pre></p>
+     * <p>This is equivalent to:</p>
+     * <p>{@code Content.Sink.asOutputStream(Response.asBufferedSink(request, response))}</p>
      * @param request the request from which to get the buffering sink's settings
      * @param response the response to wrap
      * @return a buffering {@link OutputStream}

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.server;
 
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ListIterator;
 import java.util.concurrent.CompletableFuture;
@@ -529,6 +530,22 @@ public interface Response extends Content.Sink
         if (originalResponse instanceof HttpChannelState.ChannelResponse channelResponse)
             return channelResponse.getContentBytesWritten();
         return -1;
+    }
+
+    /**
+     * <p>Wraps a {@link Response} as a {@link OutputStream} that performs buffering. The necessary
+     * {@link ByteBufferPool} is taken from the request's connector while the size and direction of the buffer
+     * is read from the request's {@link HttpConfiguration}.</p>
+     * <p>This is equivalent to:<pre>
+     * Content.Sink.asOutputStream(Response.asBufferedSink(request, response))
+     * </pre></p>
+     * @param request the request from which to get the buffering sink's settings
+     * @param response the response to wrap
+     * @return a buffering {@link OutputStream}
+     */
+    static OutputStream asBufferedOutputStream(Request request, Response response)
+    {
+        return Content.Sink.asOutputStream(Response.asBufferedSink(request, response));
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -558,28 +558,12 @@ public interface Response extends Content.Sink
     static Content.Sink asBufferedSink(Request request, Response response)
     {
         ConnectionMetaData connectionMetaData = request.getConnectionMetaData();
+        ByteBufferPool bufferPool = connectionMetaData.getConnector().getByteBufferPool();
         HttpConfiguration httpConfiguration = connectionMetaData.getHttpConfiguration();
         int bufferSize = httpConfiguration.getOutputBufferSize();
         boolean useOutputDirectByteBuffers = httpConfiguration.isUseOutputDirectByteBuffers();
         int outputAggregationSize = httpConfiguration.getOutputAggregationSize();
-        return asBufferedSink(request, response, bufferSize, useOutputDirectByteBuffers, outputAggregationSize);
-    }
-
-    /**
-     * Wraps a {@link Response} as a {@link Content.Sink} that performs buffering.
-     * @param request the request from which to get the connector's {@link ByteBufferPool} used to get the buffer
-     * @param response the response to wrap
-     * @param bufferSize the size of the buffer
-     * @param direct whether to use direct buffers or not
-     * @param maxAggregationSize the maximum size that can be buffered in a single write;
-     * any size above this threshold triggers a buffer flush
-     * @return a buffering {@link Content.Sink}
-     */
-    static Content.Sink asBufferedSink(Request request, Response response, int bufferSize, boolean direct, int maxAggregationSize)
-    {
-        ConnectionMetaData connectionMetaData = request.getConnectionMetaData();
-        ByteBufferPool bufferPool = connectionMetaData.getConnector().getByteBufferPool();
-        return Content.Sink.asBuffered(response, bufferPool, direct, bufferSize, maxAggregationSize);
+        return Content.Sink.asBuffered(response, bufferPool, useOutputDirectByteBuffers, bufferSize, outputAggregationSize);
     }
 
     class Wrapper implements Response

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -563,7 +563,7 @@ public interface Response extends Content.Sink
         int bufferSize = httpConfiguration.getOutputBufferSize();
         boolean useOutputDirectByteBuffers = httpConfiguration.isUseOutputDirectByteBuffers();
         int outputAggregationSize = httpConfiguration.getOutputAggregationSize();
-        return Content.Sink.asBuffered(response, bufferPool, useOutputDirectByteBuffers, bufferSize, outputAggregationSize);
+        return Content.Sink.asBuffered(response, bufferPool, useOutputDirectByteBuffers, outputAggregationSize, bufferSize);
     }
 
     class Wrapper implements Response

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -203,7 +203,7 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
             attribute = request.getAttribute(BufferedResponseHandler.MAX_AGGREGATION_SIZE_ATTRIBUTE_NAME);
             int maxAggregationSize = attribute instanceof Integer ? (int)attribute : httpConfiguration.getOutputAggregationSize();
             boolean direct = httpConfiguration.isUseOutputDirectByteBuffers();
-            return Content.Sink.asBuffered(getWrapped(), bufferPool, direct, bufferSize, maxAggregationSize);
+            return Content.Sink.asBuffered(getWrapped(), bufferPool, direct, maxAggregationSize, bufferSize);
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
-import org.eclipse.jetty.io.ByteBufferAccumulator;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.server.ConnectionMetaData;
@@ -55,10 +54,12 @@ import org.slf4j.LoggerFactory;
 public class BufferedResponseHandler extends ConditionalHandler.Abstract
 {
     public static final String BUFFER_SIZE_ATTRIBUTE_NAME = BufferedResponseHandler.class.getName() + ".buffer-size";
+    public static final int DEFAULT_BUFFER_SIZE = 16384;
 
     private static final Logger LOG = LoggerFactory.getLogger(BufferedResponseHandler.class);
 
     private final IncludeExclude<String> _mimeTypes = new IncludeExclude<>();
+    private int bufferSize = DEFAULT_BUFFER_SIZE;
 
     public BufferedResponseHandler()
     {
@@ -97,6 +98,16 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         if (isStarted())
             throw new IllegalStateException(getState());
         _mimeTypes.exclude(mimeTypes);
+    }
+
+    public int getBufferSize()
+    {
+        return bufferSize;
+    }
+
+    public void setBufferSize(int bufferSize)
+    {
+        this.bufferSize = bufferSize;
     }
 
     protected boolean isMimeTypeBufferable(String mimetype)
@@ -217,7 +228,7 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         private int getBufferSize()
         {
             Object attribute = getRequest().getAttribute(BufferedResponseHandler.BUFFER_SIZE_ATTRIBUTE_NAME);
-            return attribute instanceof Integer ? (int)attribute : Integer.MAX_VALUE;
+            return attribute instanceof Integer ? (int)attribute : bufferSize;
         }
 
         @Override
@@ -250,53 +261,53 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
 
     private static class CountingByteBufferAccumulator implements AutoCloseable
     {
-        private final ByteBufferAccumulator _accumulator;
+        private final ByteBufferPool _bufferPool;
+        private final boolean _direct;
         private final int _maxSize;
-        private int _accumulatedCount;
+        private RetainableByteBuffer _retainableByteBuffer;
+        private int _accumulatedSize;
 
         private CountingByteBufferAccumulator(ByteBufferPool bufferPool, boolean direct, int maxSize)
         {
             if (maxSize <= 0)
                 throw new IllegalArgumentException("maxSize must be > 0, was: " + maxSize);
+            _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
+            _direct = direct;
             _maxSize = maxSize;
-            _accumulator = new ByteBufferAccumulator(bufferPool, direct);
         }
 
         private boolean copyBuffer(ByteBuffer buffer)
         {
-            int remainingCapacity = space();
-            if (buffer.remaining() >= remainingCapacity)
+            if (_retainableByteBuffer == null)
             {
-                _accumulatedCount += remainingCapacity;
-                int end = buffer.position() + remainingCapacity;
-                _accumulator.copyBuffer(buffer.duplicate().limit(end));
-                buffer.position(end);
-                return true;
+                _retainableByteBuffer = _bufferPool.acquire(_maxSize, _direct);
+                BufferUtil.flipToFill(_retainableByteBuffer.getByteBuffer());
             }
-            else
-            {
-                _accumulatedCount += buffer.remaining();
-                _accumulator.copyBuffer(buffer);
-                return false;
-            }
+            int prevPos = buffer.position();
+            int copySize = Math.min(buffer.remaining(), _maxSize);
+            _retainableByteBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer().position(), buffer, buffer.position(), copySize);
+            _retainableByteBuffer.getByteBuffer().position(_retainableByteBuffer.getByteBuffer().position() + copySize);
+            buffer.position(buffer.position() + copySize);
+            _accumulatedSize += buffer.position() - prevPos;
+            return _accumulatedSize == _maxSize;
         }
 
-        private int space()
+        public RetainableByteBuffer takeRetainableByteBuffer()
         {
-            return _maxSize - _accumulatedCount;
-        }
-
-        private RetainableByteBuffer takeRetainableByteBuffer()
-        {
-            _accumulatedCount = 0;
-            return _accumulator.takeRetainableByteBuffer();
+            BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
+            RetainableByteBuffer result = _retainableByteBuffer;
+            _retainableByteBuffer = null;
+            return result;
         }
 
         @Override
         public void close()
         {
-            _accumulatedCount = 0;
-            _accumulator.close();
+            if (_retainableByteBuffer != null)
+            {
+                _retainableByteBuffer.release();
+                _retainableByteBuffer = null;
+            }
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -55,6 +55,10 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
      * The name of the request attribute used to control the buffer size of a particular request.
      */
     public static final String BUFFER_SIZE_ATTRIBUTE_NAME = BufferedResponseHandler.class.getName() + ".buffer-size";
+    /**
+     * The name of the request attribute used to control the max aggregation size of a particular request.
+     */
+    public static final String MAX_AGGREGATION_SIZE_ATTRIBUTE_NAME = BufferedResponseHandler.class.getName() + ".max-aggregation-size";
 
     private static final Logger LOG = LoggerFactory.getLogger(BufferedResponseHandler.class);
 
@@ -174,27 +178,25 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         {
             if (_firstWrite)
             {
-                if (shouldBuffer(this, last))
-                {
-                    Request request = getRequest();
-                    _bufferedContentSink = Response.asBufferedSink(request, getWrapped(), getBufferSize(request), useDirectBuffers(request));
-                }
                 _firstWrite = false;
+                if (shouldBuffer(this, last))
+                    _bufferedContentSink = createBufferedSink();
             }
             _lastWritten |= last;
             Content.Sink destSink = _bufferedContentSink != null ? _bufferedContentSink : getWrapped();
             destSink.write(last, byteBuffer, callback);
         }
 
-        private static boolean useDirectBuffers(Request request)
+        private Content.Sink createBufferedSink()
         {
-            return request.getConnectionMetaData().getHttpConfiguration().isUseOutputDirectByteBuffers();
-        }
-
-        private static int getBufferSize(Request request)
-        {
+            Request request = getRequest();
+            HttpConfiguration httpConfiguration = request.getConnectionMetaData().getHttpConfiguration();
             Object attribute = request.getAttribute(BufferedResponseHandler.BUFFER_SIZE_ATTRIBUTE_NAME);
-            return attribute instanceof Integer ? (int)attribute : request.getConnectionMetaData().getHttpConfiguration().getOutputBufferSize();
+            int bufferSize = attribute instanceof Integer ? (int)attribute : httpConfiguration.getOutputBufferSize();
+            attribute = request.getAttribute(BufferedResponseHandler.MAX_AGGREGATION_SIZE_ATTRIBUTE_NAME);
+            int maxAggregationSize = attribute instanceof Integer ? (int)attribute : httpConfiguration.getOutputAggregationSize();
+            boolean direct = httpConfiguration.isUseOutputDirectByteBuffers();
+            return Response.asBufferedSink(request, getWrapped(), bufferSize, direct, maxAggregationSize);
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -20,15 +20,13 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.ByteBufferPool;
-import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IncludeExclude;
-import org.eclipse.jetty.util.IteratingNestedCallback;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -170,8 +168,9 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
     private class BufferedResponse extends Response.Wrapper implements Callback
     {
         private final Callback _callback;
-        private CountingByteBufferAccumulator _accumulator;
+        private Content.Sink _bufferedContentSink;
         private boolean _firstWrite = true;
+        private boolean _lastWritten;
 
         private BufferedResponse(Request request, Response response, Callback callback)
         {
@@ -189,40 +188,13 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
                     ConnectionMetaData connectionMetaData = getRequest().getConnectionMetaData();
                     ByteBufferPool bufferPool = connectionMetaData.getConnector().getByteBufferPool();
                     boolean useOutputDirectByteBuffers = connectionMetaData.getHttpConfiguration().isUseOutputDirectByteBuffers();
-                    _accumulator = new CountingByteBufferAccumulator(bufferPool, useOutputDirectByteBuffers, getBufferSize());
+                    _bufferedContentSink = Content.Sink.asBuffered(getWrapped(), bufferPool, useOutputDirectByteBuffers, getBufferSize());
                 }
                 _firstWrite = false;
             }
-
-            if (_accumulator != null)
-            {
-                ByteBuffer current = byteBuffer != null ? byteBuffer : BufferUtil.EMPTY_BUFFER;
-                IteratingNestedCallback writer = new IteratingNestedCallback(callback)
-                {
-                    private boolean complete;
-
-                    @Override
-                    protected Action process()
-                    {
-                        if (complete)
-                            return Action.SUCCEEDED;
-                        boolean write = _accumulator.copyBuffer(current);
-                        complete = last && !current.hasRemaining();
-                        if (write || complete)
-                        {
-                            RetainableByteBuffer buffer = _accumulator.takeRetainableByteBuffer();
-                            BufferedResponse.super.write(complete, buffer.getByteBuffer(), Callback.from(this, buffer::release));
-                            return Action.SCHEDULED;
-                        }
-                        return Action.SUCCEEDED;
-                    }
-                };
-                writer.iterate();
-            }
-            else
-            {
-                super.write(last, byteBuffer, callback);
-            }
+            _lastWritten |= last;
+            Content.Sink destSink = _bufferedContentSink != null ? _bufferedContentSink : getWrapped();
+            destSink.write(last, byteBuffer, callback);
         }
 
         private int getBufferSize()
@@ -234,80 +206,18 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         @Override
         public void succeeded()
         {
-            // TODO pass all accumulated buffers as an array instead of allocating & copying into a single one.
-            if (_accumulator != null)
-            {
-                RetainableByteBuffer buffer = _accumulator.takeRetainableByteBuffer();
-                super.write(true, buffer.getByteBuffer(), Callback.from(_callback, () ->
-                {
-                    buffer.release();
-                    _accumulator.close();
-                }));
-            }
+            if (_bufferedContentSink != null && !_lastWritten)
+                _bufferedContentSink.write(true, null, _callback);
             else
-            {
                 _callback.succeeded();
-            }
         }
 
         @Override
         public void failed(Throwable x)
         {
-            if (_accumulator != null)
-                _accumulator.close();
+            if (_bufferedContentSink != null && !_lastWritten)
+                _bufferedContentSink.write(true, null, Callback.NOOP);
             _callback.failed(x);
-        }
-    }
-
-    private static class CountingByteBufferAccumulator implements AutoCloseable
-    {
-        private final ByteBufferPool _bufferPool;
-        private final boolean _direct;
-        private final int _maxSize;
-        private RetainableByteBuffer _retainableByteBuffer;
-        private int _accumulatedSize;
-
-        private CountingByteBufferAccumulator(ByteBufferPool bufferPool, boolean direct, int maxSize)
-        {
-            if (maxSize <= 0)
-                throw new IllegalArgumentException("maxSize must be > 0, was: " + maxSize);
-            _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
-            _direct = direct;
-            _maxSize = maxSize;
-        }
-
-        private boolean copyBuffer(ByteBuffer buffer)
-        {
-            if (_retainableByteBuffer == null)
-            {
-                _retainableByteBuffer = _bufferPool.acquire(_maxSize, _direct);
-                BufferUtil.flipToFill(_retainableByteBuffer.getByteBuffer());
-            }
-            int prevPos = buffer.position();
-            int copySize = Math.min(buffer.remaining(), _maxSize);
-            _retainableByteBuffer.getByteBuffer().put(_retainableByteBuffer.getByteBuffer().position(), buffer, buffer.position(), copySize);
-            _retainableByteBuffer.getByteBuffer().position(_retainableByteBuffer.getByteBuffer().position() + copySize);
-            buffer.position(buffer.position() + copySize);
-            _accumulatedSize += buffer.position() - prevPos;
-            return _accumulatedSize == _maxSize;
-        }
-
-        public RetainableByteBuffer takeRetainableByteBuffer()
-        {
-            BufferUtil.flipToFlush(_retainableByteBuffer.getByteBuffer(), 0);
-            RetainableByteBuffer result = _retainableByteBuffer;
-            _retainableByteBuffer = null;
-            return result;
-        }
-
-        @Override
-        public void close()
-        {
-            if (_retainableByteBuffer != null)
-            {
-                _retainableByteBuffer.release();
-                _retainableByteBuffer = null;
-            }
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -189,8 +189,7 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
                     ConnectionMetaData connectionMetaData = getRequest().getConnectionMetaData();
                     ByteBufferPool bufferPool = connectionMetaData.getConnector().getByteBufferPool();
                     boolean useOutputDirectByteBuffers = connectionMetaData.getHttpConfiguration().isUseOutputDirectByteBuffers();
-                    int bufferSize = getBufferSize();
-                    _bufferedContentSink = Content.Sink.asBuffered(getWrapped(), bufferPool, useOutputDirectByteBuffers, bufferSize, bufferSize);
+                    _bufferedContentSink = Content.Sink.asBuffered(getWrapped(), bufferPool, useOutputDirectByteBuffers, getBufferSize());
                 }
                 _firstWrite = false;
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -189,7 +189,8 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
                     ConnectionMetaData connectionMetaData = getRequest().getConnectionMetaData();
                     ByteBufferPool bufferPool = connectionMetaData.getConnector().getByteBufferPool();
                     boolean useOutputDirectByteBuffers = connectionMetaData.getHttpConfiguration().isUseOutputDirectByteBuffers();
-                    _bufferedContentSink = Content.Sink.asBuffered(getWrapped(), bufferPool, useOutputDirectByteBuffers, getBufferSize());
+                    int bufferSize = getBufferSize();
+                    _bufferedContentSink = Content.Sink.asBuffered(getWrapped(), bufferPool, useOutputDirectByteBuffers, bufferSize, bufferSize);
                 }
                 _firstWrite = false;
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -52,7 +52,8 @@ import org.slf4j.LoggerFactory;
 public class BufferedResponseHandler extends ConditionalHandler.Abstract
 {
     public static final String BUFFER_SIZE_ATTRIBUTE_NAME = BufferedResponseHandler.class.getName() + ".buffer-size";
-    public static final int DEFAULT_BUFFER_SIZE = 16384;
+
+    private static final int DEFAULT_BUFFER_SIZE = 16384;
 
     private static final Logger LOG = LoggerFactory.getLogger(BufferedResponseHandler.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -46,8 +46,11 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * Note also that the size of the buffer can be controlled by setting the
- * {@link #BUFFER_SIZE_ATTRIBUTE_NAME} request attribute to an integer.
- * In the absence of such header, the {@link HttpConfiguration#getOutputBufferSize()}
+ * {@link #BUFFER_SIZE_ATTRIBUTE_NAME} request attribute to an integer;
+ * in the absence of such header, the {@link HttpConfiguration#getOutputBufferSize()}
+ * config setting is used, while the maximum aggregation size can be controlled
+ * by setting the {@link #MAX_AGGREGATION_SIZE_ATTRIBUTE_NAME} request attribute to an integer,
+ * in the absence of such header, the {@link HttpConfiguration#getOutputAggregationSize()}
  * config setting is used.
  * </p>
  */

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
@@ -46,7 +46,6 @@ public class BufferedResponseHandlerTest
         _server = new Server();
         HttpConfiguration config = new HttpConfiguration();
         config.setOutputBufferSize(1024);
-        config.setOutputAggregationSize(256);
         _local = new LocalConnector(_server, new HttpConnectionFactory(config));
         _server.addConnector(_local);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
@@ -46,6 +46,7 @@ public class BufferedResponseHandlerTest
         _server = new Server();
         HttpConfiguration config = new HttpConfiguration();
         config.setOutputBufferSize(1024);
+        config.setOutputAggregationSize(256);
         _local = new LocalConnector(_server, new HttpConnectionFactory(config));
         _server.addConnector(_local);
 
@@ -136,6 +137,7 @@ public class BufferedResponseHandlerTest
     @Test
     public void testBufferSizeSmall() throws Exception
     {
+        _test._aggregationSize = 16;
         _test._bufferSize = 16;
         String response = _local.getResponse("GET /ctx/include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assertThat(response, containsString(" 200 OK"));
@@ -200,6 +202,7 @@ public class BufferedResponseHandlerTest
 
     public static class TestHandler extends Handler.Abstract
     {
+        int _aggregationSize = -1;
         int _bufferSize = -1;
         String _mimeType;
         byte[] _content = new byte[128];
@@ -220,6 +223,8 @@ public class BufferedResponseHandlerTest
 
             if (_bufferSize > 0)
                 request.setAttribute(BufferedResponseHandler.BUFFER_SIZE_ATTRIBUTE_NAME, _bufferSize);
+            if (_aggregationSize > 0)
+                request.setAttribute(BufferedResponseHandler.MAX_AGGREGATION_SIZE_ATTRIBUTE_NAME, _aggregationSize);
             if (_mimeType != null)
                 response.getHeaders().put(HttpHeader.CONTENT_TYPE, _mimeType);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
@@ -87,6 +87,7 @@ public class BufferedResponseHandlerTest
     @Test
     public void testIncluded() throws Exception
     {
+        _test._bufferSize = 2048;
         String response = _local.getResponse("GET /ctx/include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assertThat(response, containsString(" 200 OK"));
         assertThat(response, containsString("Write: 0"));
@@ -125,6 +126,7 @@ public class BufferedResponseHandlerTest
     public void testFlushed() throws Exception
     {
         _test._flush = true;
+        _test._bufferSize = 2048;
         String response = _local.getResponse("GET /ctx/include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assertThat(response, containsString(" 200 OK"));
         assertThat(response, containsString("Write: 0"));
@@ -188,6 +190,7 @@ public class BufferedResponseHandlerTest
     public void testReset() throws Exception
     {
         _test._reset = true;
+        _test._bufferSize = 2048;
         String response = _local.getResponse("GET /ctx/include/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
         assertThat(response, containsString(" 200 OK"));
         assertThat(response, containsString("Write: 0"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
@@ -92,6 +92,7 @@ public class BufferedResponseHandlerTest
         assertThat(response, containsString("Write: 0"));
         assertThat(response, containsString("Write: 9"));
         assertThat(response, containsString("Written: true"));
+        assertThat(response, containsString("Content-Length: "));
     }
 
     @Test

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/BufferedResponseHandlerTest.java
@@ -239,8 +239,8 @@ public class BufferedResponseHandlerTest
                         outputStream.flush();
                 }
                 response.getHeaders().add("Written", "true");
-                callback.succeeded();
             }
+            callback.succeeded();
 
             return true;
         }


### PR DESCRIPTION
 - Change default buffer size from 2 GB to 16 KB
 - Make max buffer size settable
 - Introduce `BufferedSink` with all the buffering logic
   - It now does only one buffer copy instead of two
   - It starts with a small buffer and grows it if needed
 - Refactor `BufferedResponseHandler` to delegate all buffering work to `BufferedSink`

Fixes #10476