### PR TITLE
Issue #10440 fix ClassCastException for <jettyEnvXml> in maven plugin

### DIFF
--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -469,6 +469,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
+    @Tag("DisableLeakTracking:client:HTTP")
+    @Tag("DisableLeakTracking:client:HTTPS")
+    @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     public void testInputStreamContentProviderThrowingWhileReading(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/pom.xml
@@ -117,6 +117,9 @@
                       </config>
                   </loginService>
               </loginServices>
+              <webApp>
+                <jettyEnvXml>${basedir}/src/config/jetty-env.xml</jettyEnvXml>
+              </webApp>
             </configuration>
           </execution>
         </executions>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty-env.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty-env.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_10_0.dtd">
+<Configure id='wac' class="org.eclipse.jetty.ee10.webapp.WebAppContext">
+
+  <!-- Add an EnvEntry only valid for this webapp               -->
+  <New id="foo"  class="org.eclipse.jetty.ee10.plus.jndi.EnvEntry">
+    <Arg><Ref refid='wac'/></Arg>
+    <Arg>fooBoolean</Arg>
+    <Arg type="java.lang.Double">100</Arg>
+    <Arg type="boolean">true</Arg>
+  </New>
+</Configure>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -313,13 +314,14 @@ public class MavenWebAppContext extends WebAppContext
     protected Configurations newConfigurations()
     {
         Configurations configurations = super.newConfigurations();
+
         if (getJettyEnvXml() != null)
         {
             // inject configurations with config from maven plugin
             for (Configuration c : configurations)
             {
                 if (c instanceof EnvConfiguration envConfiguration)
-                    setAttribute(EnvConfiguration.JETTY_ENV_XML, getJettyEnvXml());
+                    setAttribute(EnvConfiguration.JETTY_ENV_XML, this.getResourceFactory().newResource(getJettyEnvXml()));
             }
         }
 


### PR DESCRIPTION
Closes #10440 

Fix ClassCastException when setting `<jettyEnvXml>` with the jetty ee10 maven plugin. Ee9 and below is unaffected by this problem.