### PR TITLE
fix(sec): upgrade com.hazelcast:hazelcast to 5.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>
-    <hazelcast.version>5.2.1</hazelcast.version>
+    <hazelcast.version>5.3.0</hazelcast.version>
     <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.hazelcast:hazelcast 5.2.1
- [CVE-2023-33264](https://www.oscs1024.com/hd/CVE-2023-33264)


### What did I do？
Upgrade com.hazelcast:hazelcast from 5.2.1 to 5.3.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS