### PR TITLE
Issue #10473 - Revert jetty.sh pgrep, and update started checks

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -140,25 +140,24 @@ started()
   # wait till timeout to see "STARTED" in state file, needs --module=state as argument
   for ((T = 0; T < $STARTTIMEOUT; T++))
   do
+    echo -n "."
     sleep 1
     if [ -r $STATEFILE ] ; then
       STATENOW=$(tail -1 $STATEFILE)
       (( DEBUG )) && echo "State (now): $STATENOW"
       case "$STATENOW" in
         STARTED*)
-          echo "."
+          echo " started"
           return 0;;
         STOPPED*)
-          echo "!"
+          echo " stopped"
           return 1;;
         FAILED*)
-          echo "!!"
+          echo " failed"
           return 1;;
       esac
-      echo -n "-"
     else
       (( DEBUG )) && echo "Unable to read State File: $STATEFILE"
-      echo -n ":"
     fi
   done
   (( DEBUG )) && echo "Timeout $STARTTIMEOUT expired waiting for start state from $STATEFILE"

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -132,7 +132,7 @@ running()
 
 started()
 {
-  # wait for 60s to see "STARTED" in PID file, needs jetty-started.xml as argument
+  # wait for 60s to see "STARTED" in PID file, needs jetty-state.xml as argument
   for ((T = 0; T < $(($3 / 4)); T++))
   do
     sleep 4
@@ -506,7 +506,7 @@ case "$ACTION" in
 
     fi
 
-    if expr "${JETTY_ARGS[*]}" : '.*jetty-started.xml.*' >/dev/null
+    if expr "${JETTY_ARGS[*]}" : '.*jetty-state.xml.*' >/dev/null
     then
       if started "$JETTY_STATE" "$JETTY_PID" "$JETTY_START_TIMEOUT"
       then

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -138,9 +138,9 @@ started()
   local PIDFILE=$2
   local STARTTIMEOUT=$3
   # wait till timeout to see "STARTED" in state file, needs --module=state as argument
-  for ((T = 0; T < $(($STARTTIMEOUT / 4)); T++))
+  for ((T = 0; T < $STARTTIMEOUT; T++))
   do
-    sleep 4
+    sleep 1
     if [ -r $STATEFILE ] ; then
       STATENOW=$(tail -1 $STATEFILE)
       (( DEBUG )) && echo "State (now): $STATENOW"
@@ -189,8 +189,10 @@ pidKill()
         (( DEBUG )) && echo "PID=$PID is running, sending kill signal=KILL (TIMEOUT=$TIMEOUT)"
         kill -KILL "$PID" 2>/dev/null
       fi
+      echo -n "."
       sleep 1
     done
+    echo "Killed $PID"
     return 0
   else
     (( DEBUG )) && echo "Unable to read PID File: $PIDFILE"

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -497,11 +497,11 @@ case "$ACTION" in
         su - "$JETTY_USER" $SU_SHELL -c "
           cd \"$JETTY_BASE\"
           echo ${RUN_ARGS[*]} start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
-          disown $(pgrep -P $!)"
+          disown \$!"
       else
         # Startup if not switching users
         echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
-        disown $(pgrep -P $!)
+        disown $!
       fi
 
     fi

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -130,16 +130,20 @@ running()
   return 1
 }
 
+# Test state file (after timeout) for started state
 started()
 {
-  # wait for 60s to see "STARTED" in PID file, needs jetty-state.xml as argument
-  for ((T = 0; T < $(($3 / 4)); T++))
+  STATEFILE=$1
+  PIDFILE=$2
+  STARTTIMEOUT=$3
+  # wait for 60s to see "STARTED" in state file, needs --module=state as argument
+  for ((T = 0; T < $(($STARTTIMEOUT / 4)); T++))
   do
     sleep 4
-    [ -z "$(tail -1 $1 | grep STARTED 2>/dev/null)" ] || return 0
-    [ -z "$(tail -1 $1 | grep STOPPED 2>/dev/null)" ] || return 1
-    [ -z "$(tail -1 $1 | grep FAILED 2>/dev/null)" ] || return 1
-    local PID=$(cat "$2" 2>/dev/null) || return 1
+    [ -z "$(tail -1 $STATEFILE | grep STARTED 2>/dev/null)" ] || return 0
+    [ -z "$(tail -1 $STATEFILE | grep STOPPED 2>/dev/null)" ] || return 1
+    [ -z "$(tail -1 $STATEFILE | grep FAILED 2>/dev/null)" ] || return 1
+    local PID=$(cat "$PIDFILE" 2>/dev/null) || return 1
     kill -0 "$PID" 2>/dev/null || return 1
     echo -n ". "
   done
@@ -506,7 +510,7 @@ case "$ACTION" in
 
     fi
 
-    if expr "${JETTY_ARGS[*]}" : '.*jetty-state.xml.*' >/dev/null
+    if expr "${JETTY_ARGS[*]}" : '.*jetty\.state=.*' >/dev/null
     then
       if started "$JETTY_STATE" "$JETTY_PID" "$JETTY_START_TIMEOUT"
       then

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -146,10 +146,13 @@ started()
       (( DEBUG )) && echo "State (now): $STATENOW"
       case "$STATENOW" in
         STARTED*)
+          echo "."
           return 0;;
         STOPPED*)
+          echo "!"
           return 1;;
         FAILED*)
+          echo "!!"
           return 1;;
       esac
       echo -n "-"
@@ -158,6 +161,8 @@ started()
       echo -n ":"
     fi
   done
+  (( DEBUG )) && echo "Timeout $STARTTIMEOUT expired waiting for start state from $STATEFILE"
+  echo " timeout"
   return 1;
 }
 

--- a/jetty-server/src/main/config/modules/state.mod
+++ b/jetty-server/src/main/config/modules/state.mod
@@ -9,6 +9,9 @@ start
 [depends]
 server
 
+[before]
+deploy
+
 [xml]
 etc/jetty-state.xml
 

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/StateLifeCycleListener.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/StateLifeCycleListener.java
@@ -32,7 +32,7 @@ import static java.nio.file.StandardOpenOption.WRITE;
  * A LifeCycle Listener that writes state changes to a file.
  * <p>This can be used with the jetty.sh script to wait for successful startup.
  */
-public class StateLifeCycleListener extends Thread implements LifeCycle.Listener
+public class StateLifeCycleListener implements LifeCycle.Listener
 {
     private static final Logger LOG = LoggerFactory.getLogger(StateLifeCycleListener.class);
 
@@ -55,22 +55,6 @@ public class StateLifeCycleListener extends Thread implements LifeCycle.Listener
 
         // Create file
         Files.writeString(stateFile, "INIT " + this + "\n", UTF_8, WRITE, CREATE_NEW);
-
-        // JVM shutdown should clean up state file
-        Runtime.getRuntime().addShutdownHook(this);
-    }
-
-    @Override
-    public void run()
-    {
-        try
-        {
-            Files.deleteIfExists(stateFile);
-        }
-        catch (Throwable t)
-        {
-            LOG.info("Unable to remove State file: {}", stateFile, t);
-        }
     }
 
     private void appendStateChange(String action, Object obj)

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/StateLifeCycleListener.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/StateLifeCycleListener.java
@@ -57,12 +57,6 @@ public class StateLifeCycleListener implements LifeCycle.Listener
         Files.writeString(_filename, "INIT " + this + "\n", UTF_8, WRITE, CREATE_NEW);
     }
 
-    @Override
-    public String toString()
-    {
-        return String.format("%s@%h", this.getClass().getSimpleName(), this);
-    }
-
     private void appendStateChange(String action, Object obj)
     {
         try (Writer out = Files.newBufferedWriter(_filename, UTF_8, WRITE, APPEND))
@@ -108,5 +102,11 @@ public class StateLifeCycleListener implements LifeCycle.Listener
     public void lifeCycleStopped(LifeCycle event)
     {
         appendStateChange("STOPPED", event);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%h", this.getClass().getSimpleName(), this);
     }
 }

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -156,6 +156,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             }
 
             await().atMost(Duration.ofSeconds(10)).until(() -> !Files.exists(pidfile));
+            await().atMost(Duration.ofSeconds(10)).until(() -> !Files.exists(statefile));
         }
     }
 


### PR DESCRIPTION
Revert the jetty.sh pgrep usage.
Add distribution test for jetty.conf.
Update "started" function in jetty.sh.
Ensure "state" module executes before setuid or deploy kicks in.
Ensure state file is initialized early.