### PR TITLE
Issue #10508 - honor Servlet spec behaviors for null in addHeader / setHeader calls

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -196,30 +196,45 @@ public class ServletApiResponse implements HttpServletResponse
     @Override
     public void setDateHeader(String name, long date)
     {
+        if (name == null)
+            return; // Spec is to do nothing
+
         getResponse().getHeaders().putDate(name, date);
     }
 
     @Override
     public void addDateHeader(String name, long date)
     {
+        if (name == null)
+            return; // Spec is to do nothing
+
         getResponse().getHeaders().addDateField(name, date);
     }
 
     @Override
     public void setHeader(String name, String value)
     {
+        if (name == null)
+            return; // Spec is to do nothing
+
         getResponse().getHeaders().put(name, value);
     }
 
     @Override
     public void addHeader(String name, String value)
     {
+        if (name == null || value == null)
+            return; // Spec is to do nothing
+
         getResponse().getHeaders().add(name, value);
     }
 
     @Override
     public void setIntHeader(String name, int value)
     {
+        if (name == null)
+            return; // Spec is to do nothing
+
         // TODO do we need int versions?
         if (!isCommitted())
             getResponse().getHeaders().put(name, value);
@@ -228,6 +243,9 @@ public class ServletApiResponse implements HttpServletResponse
     @Override
     public void addIntHeader(String name, int value)
     {
+        if (name == null)
+            return; // Spec is to do nothing
+
         // TODO do we need a native version?
         if (!isCommitted())
             getResponse().getHeaders().add(name, Integer.toString(value));


### PR DESCRIPTION
* Rework ResponseHeadersTest in ee10 to modern standards
* Add testcases for addHeader / setHeader with nulls
* Add testcases for addDateHeader / setDateHeader with nulls
* Add testcases for addIntHeader / setIntHeader with nulls
* Implement fix in ServletApiResponse for what the Servlet spec apidocs say for null parameters.