### PR TITLE
Fixes #10324 - Improve migration from Servlets to Handler.

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/migration/migration-11-to-12.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/migration/migration-11-to-12.adoc
@@ -99,6 +99,7 @@
 
 Web applications written using the Servlet APIs may be re-written using the Jetty `Handler` APIs.
 The sections below outline the Jetty `Handler` APIs that correspond to the Servlet APIs.
+For more information about why using the Jetty `Handler` APIs instead of the Servlet APIs, refer to xref:pg-server-http[this section].
 
 To replace the functionalities of Servlet Filters, refer to xref:pg-server-http-handler[this section].
 

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http.adoc
@@ -20,6 +20,17 @@ The Jetty server libraries allow you to write web applications components using 
 These components can then be programmatically assembled together, without the need of creating a `+*.war+` file, added to a Jetty ``Server`` instance that is then started.
 This result in your web applications to be available to HTTP clients as if you deployed your `+*.war+` files in a standalone Jetty server.
 
+Jetty `Handler` APIs pros:
+
+* Simple minimalist asynchronous APIs.
+* Very low overhead, only configure the features you use.
+* Faster turnaround to implement new APIs or new standards.
+* Normal classloading behavior (web application classloading isolation also available).
+
+Servlet APIs pros:
+
+* Standard, well known, APIs.
+
 The Maven artifact coordinates are:
 
 [source,xml,subs="verbatim,attributes"]

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/HandlerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/HandlerDocs.java
@@ -180,7 +180,7 @@ public class HandlerDocs
             response.setStatus(200);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, request.getHeaders().get(HttpHeader.CONTENT_TYPE));
 
-            long contentLength = request.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
+            long contentLength = request.getLength();
             if (contentLength >= 0)
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, contentLength);
 

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -789,7 +789,7 @@ public class HTTPServerDocs
                 if (requestHeaders.contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
                 {
                     // Analyze the request and decide whether to receive the content.
-                    long contentLength = requestHeaders.getLongField(HttpHeader.CONTENT_LENGTH);
+                    long contentLength = request.getLength();
                     if (contentLength > 0 && contentLength < 1024)
                     {
                         // Small request content, ask to send it by

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -162,6 +162,19 @@ public class Content
         }
 
         /**
+         * <p>Reads, non-blocking, the whole content source into a {@link ByteBuffer}.</p>
+         *
+         * @param source the source to read
+         * @return the {@link CompletableFuture} to notify when the whole content has been read
+         */
+        static CompletableFuture<ByteBuffer> asByteBufferAsync(Source source)
+        {
+            Promise.Completable<ByteBuffer> completable = new Promise.Completable<>();
+            asByteBuffer(source, completable);
+            return completable;
+        }
+
+        /**
          * <p>Reads, non-blocking, the whole content source into a {@link String}, converting the bytes
          * using the given {@link Charset}.</p>
          *

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
@@ -17,15 +17,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
 
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.ByteBufferAccumulator;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
@@ -551,33 +548,6 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
         }
     }
 
-    protected static class HugeResponseHandler extends Handler.Abstract
-    {
-        private final int iterations;
-
-        public HugeResponseHandler(int iterations)
-        {
-            this.iterations = iterations;
-        }
-
-        @Override
-        public boolean handle(Request request, Response response, Callback callback) throws Exception
-        {
-            response.setStatus(200);
-            // Create a big single buffer
-            byte[] buffer = new byte[iterations * 1024 * 1024];
-            Arrays.fill(buffer, (byte)'x');
-            // Toss in an LF after every iteration
-            for (int i = 0; i < iterations * 1024; i++)
-            {
-                buffer[i * 1024 + 1023] = '\n';
-            }
-            // Write it as a single buffer
-            response.write(true, ByteBuffer.wrap(buffer), callback);
-            return true;
-        }
-    }
-
     protected static class WaitHandler extends Handler.Abstract
     {
         @Override
@@ -616,7 +586,7 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            long expectedContentLength = request.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
+            long expectedContentLength = request.getLength();
             if (expectedContentLength <= 0)
             {
                 callback.succeeded();

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
@@ -57,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public abstract class RFC2616BaseTest
 {
-    
     public static class EchoHandler extends Handler.Abstract.NonBlocking
     {
         @Override
@@ -74,7 +73,7 @@ public abstract class RFC2616BaseTest
                 response.setTrailersSupplier(() -> responseTrailers);
             }
 
-            long contentLength = request.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
+            long contentLength = request.getLength();
             if (contentLength >= 0)
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, contentLength);
 
@@ -93,29 +92,6 @@ public abstract class RFC2616BaseTest
     private static final boolean STRICT = false;
 
     private HttpTesting http;
-
-    class TestFile
-    {
-        String name;
-        String modDate;
-        String data;
-        long length;
-
-        public TestFile(String name)
-        {
-            this.name = name;
-            // HTTP-Date format - see RFC 2616 section 14.29
-            SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
-            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-            this.modDate = sdf.format(new Date());
-        }
-
-        public void setData(String data)
-        {
-            this.data = data;
-            this.length = data.length();
-        }
-    }
 
     public static XmlBasedJettyServer setUpServer(XmlBasedJettyServer testableserver, Class<?> testclazz, Path tmpPath) throws Exception
     {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616BaseTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616BaseTest.java
@@ -65,29 +65,6 @@ public abstract class RFC2616BaseTest
 
     private HttpTesting http;
 
-    class TestFile
-    {
-        String name;
-        String modDate;
-        String data;
-        long length;
-
-        public TestFile(String name)
-        {
-            this.name = name;
-            // HTTP-Date format - see RFC 2616 section 14.29
-            SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
-            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-            this.modDate = sdf.format(new Date());
-        }
-
-        public void setData(String data)
-        {
-            this.data = data;
-            this.length = data.length();
-        }
-    }
-    
     public static class EchoHandler extends Handler.Abstract.NonBlocking
     {
         @Override
@@ -104,7 +81,7 @@ public abstract class RFC2616BaseTest
                 response.setTrailersSupplier(() -> responseTrailers);
             }
 
-            long contentLength = request.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
+            long contentLength = request.getLength();
             if (contentLength >= 0)
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, contentLength);
 


### PR DESCRIPTION
* Using request.getLength() instead of looking up the Content-Length header.
* Jetty Handler vs Servlet pros.
* Using CompletableFuture (not Promise) in examples.
* Removed unused cruft from tests.