### PR TITLE
Issue #10449 - Improve jetty-documentation artifacts

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -58,6 +58,11 @@
             <goal>install</goal>
           </goals>
         </goalsList>
+        <goalsList artifactId="maven-deploy-plugin">
+          <goals>
+            <goal>deploy</goal>
+          </goals>
+        </goalsList>
       </goalsLists>
     </runAlways>
     <reconcile>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -9,12 +9,14 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jetty-documentation</artifactId>
   <name>Documentation :: Guides</name>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <properties>
     <bundle-symbolic-name>${project.groupId}</bundle-symbolic-name>
     <asciidoctor.skip>${skipTests}</asciidoctor.skip>
     <jacoco.skip>true</jacoco.skip>
+    <javadoc.skip>true</javadoc.skip>
+    <sources.skip>true</sources.skip>
   </properties>
 
   <profiles>
@@ -88,6 +90,7 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <configuration>
           <fail>false</fail>
@@ -140,11 +143,9 @@
             <project-version>${project.version}</project-version>
             <maven-local-repo>${session.repositorySession.localRepository.basedir.absolutePath}</maven-local-repo>
             <version>${project.version}</version>
-<!--            <SRCDIR>./src/main/asciidoc</SRCDIR>-->
             <prog-guide>../programming-guide/index.html</prog-guide>
             <op-guide>../operations-guide/index.html</op-guide>
             <javadoc-url>https://eclipse.dev/jetty/javadoc/jetty-12</javadoc-url>
-<!--            <TIMESTAMP>2023-07-31T06:06:52Z</TIMESTAMP>-->
           </attributes>
         </configuration>
         <executions>
@@ -232,9 +233,23 @@
               <outputDirectory>${project.build.directory}/</outputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-javadoc-jar</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeGroupIds>org.eclipse.jetty</includeGroupIds>
+              <includeArtifactIds>javadoc</includeArtifactIds>
+              <classifier>javadoc</classifier>
+              <outputDirectory>${project.build.directory}/other-artifacts/</outputDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>
@@ -248,6 +263,28 @@
             <goals>
               <goal>single</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/other-artifacts/javadoc-${project.version}-javadoc.jar</file>
+                  <type>jar</type>
+                  <classifier>javadoc</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -357,6 +394,13 @@
       <artifactId>jetty-home</artifactId>
       <version>${project.version}</version>
       <type>zip</type>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>javadoc</artifactId>
+      <version>${project.version}</version>
+      <classifier>javadoc</classifier>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -401,6 +401,7 @@
       <artifactId>javadoc</artifactId>
       <version>${project.version}</version>
       <classifier>javadoc</classifier>
+      <type>jar</type>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}</bundle-symbolic-name>
-    <asciidoctor.skip>${skipTests}</asciidoctor.skip>
     <jacoco.skip>true</jacoco.skip>
     <javadoc.skip>true</javadoc.skip>
     <sources.skip>true</sources.skip>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -143,8 +143,8 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <executions>
           <execution>
-            <id>build-javadoc</id>
-            <phase>prepare-package</phase>
+            <id>javadoc-build</id>
+            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -2339,6 +2339,7 @@
       <id>fast</id>
       <properties>
         <skipTests>true</skipTests>
+        <asciidoctor.skip>true</asciidoctor.skip>
         <checkstyle.skip>true</checkstyle.skip>
         <enforcer.skip>true</enforcer.skip>
         <license.skip>true</license.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <maven.invoker.plugin.version>3.6.0</maven.invoker.plugin.version>
     <groovy.version>4.0.6</groovy.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
+    <maven.javadoc.plugin.version>3.6.0</maven.javadoc.plugin.version>
     <maven.plugin-tools.version>3.9.0</maven.plugin-tools.version>
     <maven-plugin.plugin.version>3.9.0</maven-plugin.plugin.version>
     <maven.release.plugin.version>3.0.1</maven.release.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2097,11 +2097,6 @@
         <maven.repo.uri>https://repo.maven.apache.org/maven2/</maven.repo.uri>
         <home.start.timeout>120</home.start.timeout>
       </properties>
-      <modules>
-      <!-- FIXME: Do we want to keep this?
-        <module>javadoc</module>
-        -->
-      </modules>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
+ `jetty-documentation-<ver>-html.zip` now has content
+ `jetty-documentation-<ver>-javadoc.jar` not produced locally
+ `jetty-documentation-<ver>-source.jar` not produced locally
+ attaching `org.eclipse.jetty:javadoc:javadoc` to `jetty-documentation-<ver>-javadoc.jar` instead