### PR TITLE
Issue #10328 - Review ResourceFactory.newSystemResource

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -163,7 +163,7 @@ public interface ResourceFactory
      * @see #newClassLoaderResource(String, boolean)
      * @deprecated use {@link #newClassLoaderResource(String)} or {@link #newClassLoaderResource(String, boolean)} instead, will be removed in Jetty 12.1.0
      */
-    @Deprecated(since = "12.0.1", forRemoval = true)
+    @Deprecated(since = "12.0.2", forRemoval = true)
     default Resource newSystemResource(String resource)
     {
         return newClassLoaderResource(resource);
@@ -273,7 +273,7 @@ public interface ResourceFactory
      * @see #newClassLoaderResource(String, boolean)
      * @deprecated use {@link #newClassLoaderResource(String, boolean)} instead, will be removed in Jetty 12.1.0
      */
-    @Deprecated
+    @Deprecated(since = "12.0.2", forRemoval = true)
     default Resource newClassPathResource(String resource)
     {
         return newClassLoaderResource(resource, false);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -52,7 +52,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(WorkDirExtension.class)
@@ -454,91 +453,5 @@ public class ResourceTest
         assertThat(resource.exists(), is(true));
         assertThat(resource.isDirectory(), is(true));
         assertThat(resource.length(), is(0L));
-    }
-
-    /**
-     * Test a class path resource for existence.
-     */
-    @Test
-    public void testClassPathResourceClassRelative()
-    {
-        final String classPathName = "Resource.class";
-
-        Resource resource = resourceFactory.newClassPathResource(classPathName);
-
-        // A class path cannot be a directory
-        assertFalse(resource.isDirectory(), "Class path cannot be a directory.");
-
-        // A class path must exist
-        assertTrue(resource.exists(), "Class path resource does not exist.");
-    }
-
-    /**
-     * Test a class path resource for existence.
-     */
-    @Test
-    public void testClassPathResourceClassAbsolute()
-    {
-        final String classPathName = "/org/eclipse/jetty/util/resource/Resource.class";
-
-        Resource resource = resourceFactory.newClassPathResource(classPathName);
-
-        // A class path cannot be a directory
-        assertFalse(resource.isDirectory(), "Class path cannot be a directory.");
-
-        // A class path must exist
-        assertTrue(resource.exists(), "Class path resource does not exist.");
-    }
-
-    /**
-     * Test a class path resource for directories.
-     *
-     * @throws Exception failed test
-     */
-    @Test
-    public void testClassPathResourceDirectory() throws Exception
-    {
-        // If the test runs in the module-path, resource "/" cannot be found.
-        assumeFalse(Resource.class.getModule().isNamed());
-
-        final String classPathName = "/";
-
-        Resource resource = resourceFactory.newClassPathResource(classPathName);
-
-        // A class path must be a directory
-        assertTrue(resource.isDirectory(), "Class path must be a directory.");
-
-        assertTrue(Files.isDirectory(resource.getPath()), "Class path returned file must be a directory.");
-
-        // A class path must exist
-        assertTrue(resource.exists(), "Class path resource does not exist.");
-    }
-
-    /**
-     * Test a class path resource for a file.
-     *
-     * @throws Exception failed test
-     */
-    @Test
-    public void testClassPathResourceFile() throws Exception
-    {
-        final String fileName = "resource.txt";
-        final String classPathName = "/" + fileName;
-
-        // Will locate a resource in the class path
-        Resource resource = resourceFactory.newClassPathResource(classPathName);
-
-        // A class path cannot be a directory
-        assertFalse(resource.isDirectory(), "Class path must be a directory.");
-
-        assertNotNull(resource);
-
-        Path path = resource.getPath();
-
-        assertEquals(fileName, path.getFileName().toString(), "File name from class path is not equal.");
-        assertTrue(Files.isRegularFile(path), "File returned from class path should be a regular file.");
-
-        // A class path must exist
-        assertTrue(resource.exists(), "Class path resource does not exist.");
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java
@@ -199,7 +199,7 @@ public class SslContextFactoryTest
     public void testNoTsResourceKs() throws Exception
     {
         SslContextFactory.Server cf = new SslContextFactory.Server();
-        Resource keystoreResource = ResourceFactory.of(cf).newSystemResource("keystore.p12");
+        Resource keystoreResource = ResourceFactory.of(cf).newClassLoaderResource("keystore.p12");
 
         cf.setKeyStoreResource(keystoreResource);
         cf.setKeyStorePassword("storepwd");
@@ -215,8 +215,8 @@ public class SslContextFactoryTest
     public void testResourceTsResourceKs() throws Exception
     {
         SslContextFactory.Server cf = new SslContextFactory.Server();
-        Resource keystoreResource = ResourceFactory.of(cf).newSystemResource("keystore.p12");
-        Resource truststoreResource = ResourceFactory.of(cf).newSystemResource("keystore.p12");
+        Resource keystoreResource = ResourceFactory.of(cf).newClassLoaderResource("keystore.p12");
+        Resource truststoreResource = ResourceFactory.of(cf).newClassLoaderResource("keystore.p12");
 
         cf.setKeyStoreResource(keystoreResource);
         cf.setKeyStorePassword("storepwd");
@@ -232,8 +232,8 @@ public class SslContextFactoryTest
     public void testResourceTsWrongPWResourceKs() throws Exception
     {
         SslContextFactory.Server cf = new SslContextFactory.Server();
-        Resource keystoreResource = ResourceFactory.of(cf).newSystemResource("keystore.p12");
-        Resource truststoreResource = ResourceFactory.of(cf).newSystemResource("keystore.p12");
+        Resource keystoreResource = ResourceFactory.of(cf).newClassLoaderResource("keystore.p12");
+        Resource truststoreResource = ResourceFactory.of(cf).newClassLoaderResource("keystore.p12");
 
         cf.setKeyStoreResource(keystoreResource);
         cf.setKeyStorePassword("storepwd");
@@ -307,7 +307,7 @@ public class SslContextFactoryTest
     public void testSNICertificates() throws Exception
     {
         SslContextFactory.Server cf = new SslContextFactory.Server();
-        Resource keystoreResource = ResourceFactory.of(cf).newSystemResource("snikeystore.p12");
+        Resource keystoreResource = ResourceFactory.of(cf).newClassLoaderResource("snikeystore.p12");
 
         cf.setKeyStoreResource(keystoreResource);
         cf.setKeyStorePassword("storepwd");
@@ -348,14 +348,14 @@ public class SslContextFactoryTest
     public void testNonDefaultKeyStoreTypeUsedForTrustStore() throws Exception
     {
         SslContextFactory.Server cf = new SslContextFactory.Server();
-        cf.setKeyStoreResource(ResourceFactory.of(cf).newSystemResource("keystore.p12"));
+        cf.setKeyStoreResource(ResourceFactory.of(cf).newClassLoaderResource("keystore.p12"));
         cf.setKeyStoreType("pkcs12");
         cf.setKeyStorePassword("storepwd");
         cf.start();
         cf.stop();
 
         cf = new SslContextFactory.Server();
-        cf.setKeyStoreResource(ResourceFactory.of(cf).newSystemResource("keystore.jce"));
+        cf.setKeyStoreResource(ResourceFactory.of(cf).newClassLoaderResource("keystore.jce"));
         cf.setKeyStoreType("jceks");
         cf.setKeyStorePassword("storepwd");
         cf.start();
@@ -401,7 +401,7 @@ public class SslContextFactoryTest
             }
         };
         // This test requires a SNI keystore so that the X509ExtendedKeyManager is wrapped.
-        serverTLS.setKeyStoreResource(ResourceFactory.of(serverTLS).newSystemResource("keystore_sni.p12"));
+        serverTLS.setKeyStoreResource(ResourceFactory.of(serverTLS).newClassLoaderResource("keystore_sni.p12"));
         serverTLS.setKeyStorePassword("storepwd");
         serverTLS.setKeyManagerFactoryAlgorithm("PKIX");
         // Don't pick a default certificate if SNI does not match.

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/X509Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ssl/X509Test.java
@@ -163,7 +163,7 @@ public class X509Test
     public void testServerClassWithoutSni() throws Exception
     {
         SslContextFactory serverSsl = new SslContextFactory.Server();
-        Resource keystoreResource = ResourceFactory.root().newSystemResource("keystore.p12");
+        Resource keystoreResource = ResourceFactory.root().newClassLoaderResource("keystore.p12");
         serverSsl.setKeyStoreResource(keystoreResource);
         serverSsl.setKeyStorePassword("storepwd");
         serverSsl.start();
@@ -173,7 +173,7 @@ public class X509Test
     public void testClientClassWithoutSni() throws Exception
     {
         SslContextFactory clientSsl = new SslContextFactory.Client();
-        Resource keystoreResource = ResourceFactory.root().newSystemResource("keystore.p12");
+        Resource keystoreResource = ResourceFactory.root().newClassLoaderResource("keystore.p12");
         clientSsl.setKeyStoreResource(keystoreResource);
         clientSsl.setKeyStorePassword("storepwd");
         clientSsl.start();

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ExampleServerXml.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ExampleServerXml.java
@@ -28,7 +28,7 @@ public class ExampleServerXml
         // Find Jetty XML (in classpath) that configures and starts Server.
         // See src/main/resources/exampleserver.xml
         ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
-        Resource serverXml = resourceFactory.newSystemResource("exampleserver.xml");
+        Resource serverXml = resourceFactory.newClassLoaderResource("exampleserver.xml");
         XmlConfiguration xml = new XmlConfiguration(serverXml);
         xml.getProperties().put("http.port", Integer.toString(port));
         Server server = (Server)xml.configure();

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServerXml.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/FileServerXml.java
@@ -35,7 +35,7 @@ public class FileServerXml
         // Find Jetty XML (in classpath) that configures and starts Server.
         // See src/main/resources/fileserver.xml
         ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
-        Resource fileServerXml = resourceFactory.newSystemResource("fileserver.xml");
+        Resource fileServerXml = resourceFactory.newClassLoaderResource("fileserver.xml");
         Resource baseResource = resourceFactory.newResource(basePath);
         XmlConfiguration configuration = new XmlConfiguration(fileServerXml);
         configuration.getProperties().put("fileserver.baseResource", baseResource.toString());

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/OneWebAppWithJsp.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/OneWebAppWithJsp.java
@@ -77,7 +77,7 @@ public class OneWebAppWithJsp
         // can be started and stopped according to the lifecycle of the server
         // itself.
         String realmResourceName = "etc/realm.properties";
-        Resource realmResource = webapp.getResourceFactory().newClassPathResource(realmResourceName);
+        Resource realmResource = webapp.getResourceFactory().newClassLoaderResource(realmResourceName, false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/SecuredHelloHandler.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/SecuredHelloHandler.java
@@ -47,7 +47,7 @@ public class SecuredHelloHandler
         // In this example the name can be whatever you like since we are not
         // dealing with webapp realms.
         String realmResourceName = "etc/realm.properties";
-        Resource realmResource = ResourceFactory.of(server).newClassPathResource("etc/realm.properties");
+        Resource realmResource = ResourceFactory.of(server).newClassLoaderResource("etc/realm.properties", false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ServerWithAnnotations.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ServerWithAnnotations.java
@@ -71,7 +71,7 @@ public class ServerWithAnnotations
         // Configure a LoginService
         String realmResourceName = "etc/realm.properties";
 
-        org.eclipse.jetty.util.resource.Resource realmResource = webapp.getResourceFactory().newClassPathResource(realmResourceName);
+        org.eclipse.jetty.util.resource.Resource realmResource = webapp.getResourceFactory().newClassLoaderResource(realmResourceName, false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
@@ -46,7 +46,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String defaultsDescriptor = context.getDefaultsDescriptor();
         if (defaultsDescriptor != null && defaultsDescriptor.length() > 0)
         {
-            Resource dftResource = context.getResourceFactory().newSystemResource(defaultsDescriptor);
+            Resource dftResource = context.getResourceFactory().newClassLoaderResource(defaultsDescriptor);
             if (Resources.missing(dftResource))
             {
                 String pkg = WebXmlConfiguration.class.getPackageName().replace(".", "/") + "/";
@@ -80,7 +80,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         {
             if (overrideDescriptor != null && overrideDescriptor.length() > 0)
             {
-                Resource orideResource = context.getResourceFactory().newSystemResource(overrideDescriptor);
+                Resource orideResource = context.getResourceFactory().newClassLoaderResource(overrideDescriptor);
                 if (Resources.missing(orideResource))
                     orideResource = context.newResource(overrideDescriptor);
                 if (Resources.isReadableFile(orideResource))

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ExampleServerXml.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ExampleServerXml.java
@@ -28,7 +28,7 @@ public class ExampleServerXml
         // Find Jetty XML (in classpath) that configures and starts Server.
         // See src/main/resources/exampleserver.xml
         ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
-        Resource serverXml = resourceFactory.newSystemResource("exampleserver.xml");
+        Resource serverXml = resourceFactory.newClassLoaderResource("exampleserver.xml");
         XmlConfiguration xml = new XmlConfiguration(serverXml);
         xml.getProperties().put("http.port", Integer.toString(port));
         Server server = (Server)xml.configure();

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServerXml.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/FileServerXml.java
@@ -35,7 +35,7 @@ public class FileServerXml
         // Find Jetty XML (in classpath) that configures and starts Server.
         // See src/main/resources/fileserver.xml
         ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
-        Resource fileServerXml = resourceFactory.newSystemResource("fileserver.xml");
+        Resource fileServerXml = resourceFactory.newClassLoaderResource("fileserver.xml");
         Resource baseResource = resourceFactory.newResource(basePath);
         XmlConfiguration configuration = new XmlConfiguration(fileServerXml);
         configuration.getProperties().put("fileserver.baseResource", baseResource.toString());

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/OneWebAppWithJsp.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/OneWebAppWithJsp.java
@@ -77,7 +77,7 @@ public class OneWebAppWithJsp
         // can be started and stopped according to the lifecycle of the server
         // itself.
         String realmResourceName = "etc/realm.properties";
-        Resource realmResource = webapp.getResourceFactory().newClassPathResource(realmResourceName);
+        Resource realmResource = webapp.getResourceFactory().newClassLoaderResource(realmResourceName, false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/SecuredHelloHandler.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/SecuredHelloHandler.java
@@ -47,7 +47,7 @@ public class SecuredHelloHandler
         // In this example the name can be whatever you like since we are not
         // dealing with webapp realms.
         String realmResourceName = "etc/realm.properties";
-        Resource realmResource = ResourceFactory.of(server).newClassPathResource("etc/realm.properties");
+        Resource realmResource = ResourceFactory.of(server).newClassLoaderResource("etc/realm.properties", false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ServerWithAnnotations.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/ServerWithAnnotations.java
@@ -72,7 +72,7 @@ public class ServerWithAnnotations
         // Configure a LoginService
         String realmResourceName = "etc/realm.properties";
 
-        org.eclipse.jetty.util.resource.Resource realmResource = webapp.getResourceFactory().newClassPathResource(realmResourceName);
+        org.eclipse.jetty.util.resource.Resource realmResource = webapp.getResourceFactory().newClassLoaderResource(realmResourceName, false);
         if (realmResource == null)
             throw new FileNotFoundException("Unable to find " + realmResourceName);
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
@@ -50,7 +50,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String defaultsDescriptor = context.getDefaultsDescriptor();
         if (defaultsDescriptor != null && defaultsDescriptor.length() > 0)
         {
-            Resource dftResource = context.getResourceFactory().newSystemResource(defaultsDescriptor);
+            Resource dftResource = context.getResourceFactory().newClassLoaderResource(defaultsDescriptor);
             if (Resources.missing(dftResource))
             {
                 String pkg = WebXmlConfiguration.class.getPackageName().replace(".", "/") + "/";
@@ -84,7 +84,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         {
             if (overrideDescriptor != null && overrideDescriptor.length() > 0)
             {
-                Resource orideResource = context.getResourceFactory().newSystemResource(overrideDescriptor);
+                Resource orideResource = context.getResourceFactory().newClassLoaderResource(overrideDescriptor);
                 if (orideResource == null)
                     orideResource = context.newResource(overrideDescriptor);
                 context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));


### PR DESCRIPTION
+ Create a new `ResourceFactory.newClassLoaderResource(String, boolean)`
+ Make `.newSystemResource(String)` use it
+ Make `.newClassPathResource(String)` use it
+ Deprecate `.newSystemResource(String)`
+ Deprecate `.newClassPathResource(String)`
+ Adjust own codebase to not use deprecated methods