### PR TITLE
Issue #8329 - support wildcards in proxy exclusion hosts

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-proxy.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/client/http/client-http-proxy.adoc
@@ -31,7 +31,7 @@ The following is a typical configuration:
 include::../../{doc_code}/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tag=proxy]
 ----
 
-You specify the proxy host and proxy port, and optionally also the addresses that you do not want to be proxied, and then add the proxy configuration on the `ProxyConfiguration` instance.
+You specify the proxy host and proxy port, and optionally also the addresses that you do not want to be proxied (with wildcard '*' supported at the start and end), and then add the proxy configuration on the `ProxyConfiguration` instance.
 
 Configured in this way, `HttpClient` makes requests to the HTTP proxy (for plain-text HTTP requests) or establishes a tunnel via HTTP `CONNECT` (for encrypted HTTPS requests).
 

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -658,6 +658,8 @@ public class HTTPClientDocs
 
         // Do not proxy requests for localhost:8080.
         proxy.getExcludedAddresses().add("localhost:8080");
+        // Do not proxy requests for any address starting with "127.".
+        proxy.getExcludedAddresses().add("127.*");
 
         // Add the new proxy to the list of proxies already registered.
         ProxyConfiguration proxyConfig = httpClient.getProxyConfiguration();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyConfiguration.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyConfiguration.java
@@ -99,6 +99,7 @@ public class ProxyConfiguration
         private final Set<String> included = new HashSet<>();
         private final Set<String> excluded = new HashSet<>();
         private final Map<String, Pattern> _exludedPatterns = new HashMap<>();
+        private final Map<String, HostPort> _hostPorts = new HashMap<>();
         private final Origin origin;
         private final SslContextFactory.Client sslContextFactory;
 
@@ -214,7 +215,7 @@ public class ProxyConfiguration
         private boolean matches(Origin.Address address, String pattern)
         {
             // TODO: add support for CIDR notation like 192.168.0.0/24, see DoSFilter
-            HostPort hostPort = new HostPort(pattern);
+            HostPort hostPort = _hostPorts.computeIfAbsent(pattern, HostPort::new);
             String host = hostPort.getHost();
             int port = hostPort.getPort();
             return host.equals(address.getHost()) && (port <= 0 || port == address.getPort());
@@ -222,7 +223,7 @@ public class ProxyConfiguration
 
         private boolean matchesWithWildcards(Origin.Address address, String pattern)
         {
-            HostPort hostPort = new HostPort(pattern);
+            HostPort hostPort = _hostPorts.computeIfAbsent(pattern, HostPort::new);
             String host = hostPort.getHost();
             int port = hostPort.getPort();
             Pattern hostPattern = _exludedPatterns.computeIfAbsent(host, this::compileHostRegex);

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/ProxyConfigurationTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/ProxyConfigurationTest.java
@@ -75,4 +75,56 @@ public class ProxyConfigurationTest
         assertTrue(proxy.matches(new Origin("http", "[1::2:3:4]", 0)));
         assertFalse(proxy.matches(new Origin("http", "[1::2:3:4]", 5)));
     }
+
+    @Test
+    public void testProxyMatchesWithExclusionsWithWildcardAtEnd()
+    {
+        HttpProxy proxy = new HttpProxy("host", 0);
+        proxy.getExcludedAddresses().add("1.2.*");
+
+        assertFalse(proxy.matches(new Origin("http", "1.2.3.4", 0)));
+        assertFalse(proxy.matches(new Origin("http", "1.2.3.5", 0)));
+        assertFalse(proxy.matches(new Origin("http", "1.2.4.4", 0)));
+        assertFalse(proxy.matches(new Origin("http", "1.2.4.5", 0)));
+    }
+
+    @Test
+    public void testProxyMatchesWithExclusionsWithWildcardAtStart()
+    {
+        HttpProxy proxy = new HttpProxy("host", 0);
+        proxy.getExcludedAddresses().add("*.localhost");
+
+        assertFalse(proxy.matches(new Origin("http", "local.localhost", 0)));
+        assertFalse(proxy.matches(new Origin("http", "local.test.localhost", 0)));
+        assertTrue(proxy.matches(new Origin("http", "1.2.4.5", 0)));
+    }
+
+    @Test
+    public void testProxyMatchesWithExclusionsWithWildcardAtStartAndEnd()
+    {
+        HttpProxy proxy = new HttpProxy("host", 0);
+        proxy.getExcludedAddresses().add("*.local*");
+
+        assertFalse(proxy.matches(new Origin("http", "local.localhost", 0)));
+        assertFalse(proxy.matches(new Origin("http", "local.test.localhost.test", 0)));
+        assertTrue(proxy.matches(new Origin("http", "1.2.4.5", 0)));
+    }
+
+    @Test
+    public void testProxyMatchesWithExclusionsWithWildcardAndPort()
+    {
+        HttpProxy proxy = new HttpProxy("host", 0);
+        proxy.getExcludedAddresses().add("1.2.3.*:5");
+
+        assertFalse(proxy.matches(new Origin("http", "1.2.3.4", 5)));
+    }
+
+    @Test
+    public void testProxyMatchesWithExclusionWithWildcardOnly()
+    {
+        HttpProxy proxy = new HttpProxy("host", 0);
+        proxy.getExcludedAddresses().add("*");
+
+        assertFalse(proxy.matches(new Origin("http", "1.2.3.4", 0)));
+    }
 }


### PR DESCRIPTION
Proxy configuration: Allow for "*" wildcard at the start and the end of excluded hosts.