### PR TITLE
Backport #10540 to `jetty-10.0.x` Fixed deadlock in class initialization.

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/EmptyHttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/EmptyHttpFields.java
@@ -14,13 +14,32 @@
 package org.eclipse.jetty.http;
 
 import java.util.Collections;
-import java.util.ListIterator;
+import java.util.Iterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
-class EmptyHttpFields implements HttpFields
+class EmptyHttpFields extends HttpFields.Immutable
 {
-    @Override
-    public ListIterator<HttpField> listIterator(int index)
+    public EmptyHttpFields()
     {
-        return Collections.emptyListIterator();
+        super(new HttpField[0]);
+    }
+
+    @Override
+    public Iterator<HttpField> iterator()
+    {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super HttpField> action)
+    {
+        // no-op
+    }
+
+    @Override
+    public Stream<HttpField> stream()
+    {
+        return Stream.empty();
     }
 }

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/EmptyHttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/EmptyHttpFields.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+import java.util.Collections;
+import java.util.ListIterator;
+
+class EmptyHttpFields implements HttpFields
+{
+    @Override
+    public ListIterator<HttpField> listIterator(int index)
+    {
+        return Collections.emptyListIterator();
+    }
+}

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -38,7 +38,10 @@ import java.util.stream.Stream;
  */
 public interface HttpFields extends Iterable<HttpField>
 {
-    HttpFields EMPTY = build().asImmutable();
+    /**
+     * <p>A constant for an immutable and empty {@link HttpFields}.</p>
+     */
+    HttpFields EMPTY = new EmptyHttpFields();
 
     static Mutable build()
     {


### PR DESCRIPTION
Backport of PR #10540 for `jetty-10.0.x`

* Thread T1 may initialize HttpTester.Message that extends MutableHttpFields, so grabs the lock for the initialization of class MutableHttpFields.
* Thread T2 may initialize HttpFields, so grabs the lock for HttpFields and initializes field EMPTY, which calls new MutableHttpFields.
* To initialize MutableHttpFields, T1 must initialize HttpFields, but sees that its lock is taken and waits.
* To initialize HttpFields, T2 must create an instance and therefore initialize MutableHttpFields, but sees that its lock is taken and waits.
* Deadlock.

The solution is to use another class, EmptyHttpFields, to initialize HttpFields.EMPTY, so that there is no deadlock.