### PR TITLE
Issue #10547 - Allow Executor of WebSocketClient to be customized via HttpClient

### DIFF
--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -64,7 +64,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     private final List<WebSocketSessionListener> sessionListeners = new CopyOnWriteArrayList<>();
     private final SessionTracker sessionTracker = new SessionTracker();
     private final Configuration.ConfigurationCustomizer configurationCustomizer = new Configuration.ConfigurationCustomizer();
-    private final WebSocketComponents components = new WebSocketComponents();
+    private final WebSocketComponents components;
     private boolean stopAtShutdown = false;
     private long _stopTimeout = Long.MAX_VALUE;
 
@@ -83,6 +83,9 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
      */
     public WebSocketClient(HttpClient httpClient)
     {
+        ByteBufferPool bufferPool = httpClient != null ? httpClient.getByteBufferPool() : null;
+        Executor executor = httpClient != null ? httpClient.getExecutor() : null;
+        components = new WebSocketComponents(null, null, bufferPool, null, null, executor);
         coreClient = new WebSocketCoreClient(httpClient, components);
         addManaged(coreClient);
         frameHandlerFactory = new JettyWebSocketFrameHandlerFactory(this, components);

--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -83,9 +83,26 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
      */
     public WebSocketClient(HttpClient httpClient)
     {
-        ByteBufferPool bufferPool = httpClient != null ? httpClient.getByteBufferPool() : null;
-        Executor executor = httpClient != null ? httpClient.getExecutor() : null;
-        components = new WebSocketComponents(null, null, bufferPool, null, null, executor);
+        this (httpClient,
+            new WebSocketComponents(
+                null,
+                null,
+                httpClient != null ? httpClient.getByteBufferPool() : null,
+                null,
+                null,
+                httpClient != null ? httpClient.getExecutor() : null)
+        );
+    }
+
+    /**
+     * Instantiate a WebSocketClient using HttpClient for defaults
+     *
+     * @param httpClient the HttpClient to base internal defaults off of
+     * @param webSocketComponents the configured WebSocketComponents to use
+     */
+    public WebSocketClient(HttpClient httpClient, WebSocketComponents webSocketComponents)
+    {
+        components = webSocketComponents;
         coreClient = new WebSocketCoreClient(httpClient, components);
         addManaged(coreClient);
         frameHandlerFactory = new JettyWebSocketFrameHandlerFactory(this, components);
@@ -339,13 +356,13 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
 
     public ByteBufferPool getBufferPool()
     {
-        return getHttpClient().getByteBufferPool();
+        return components.getBufferPool();
     }
 
     @Override
     public Executor getExecutor()
     {
-        return getHttpClient().getExecutor();
+        return components.getExecutor();
     }
 
     public HttpClient getHttpClient()

--- a/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-websocket/websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -77,7 +77,13 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     }
 
     /**
-     * Instantiate a WebSocketClient using HttpClient for defaults
+     * <p>
+     * Instantiate a WebSocketClient.
+     * </p>
+     *
+     * <p>
+     *     HTTP behaviors of the WebSocket upgrade are taken from the HttpClient configuration.
+     * </p>
      *
      * @param httpClient the HttpClient to base internal defaults off of
      */
@@ -95,10 +101,17 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     }
 
     /**
-     * Instantiate a WebSocketClient using HttpClient for defaults
+     * <p>
+     * Instantiate a WebSocketClient.
+     * </p>
      *
-     * @param httpClient the HttpClient to base internal defaults off of
-     * @param webSocketComponents the configured WebSocketComponents to use
+     * <p>
+     *     HTTP behaviors of the WebSocket upgrade are taken from the {@link HttpClient} configuration.
+     *     WebSocket behaviors are taken from the {@link WebSocketComponents} configuration.
+     * </p>
+     *
+     * @param httpClient the HttpClient to use for the HTTP behaviors of WebSocket upgrade
+     * @param webSocketComponents the WebSocketComponents to use for WebSocket behaviors
      */
     public WebSocketClient(HttpClient httpClient, WebSocketComponents webSocketComponents)
     {

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.util.WSURI;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.WebSocketComponents;
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.websocket.tests.AnnoMaxMessageEndpoint;
 import org.eclipse.jetty.websocket.tests.CloseTrackingEndpoint;
@@ -129,6 +130,34 @@ public class WebSocketClientTest
         {
             httpClient.start();
             WebSocketClient webSocketClient = new WebSocketClient(httpClient);
+            try
+            {
+                webSocketClient.start();
+                Executor inuseExecutor = webSocketClient.getExecutor();
+                assertSame(executor, inuseExecutor);
+            }
+            finally
+            {
+                webSocketClient.stop();
+            }
+        }
+        finally
+        {
+            httpClient.stop();
+        }
+    }
+
+    @Test
+    public void testCustomizeWebSocketComponentsExecutor() throws Exception
+    {
+        HttpClient httpClient = new HttpClient();
+        try
+        {
+            httpClient.start();
+            Executor executor = Executors.newFixedThreadPool(50);
+            WebSocketComponents webSocketComponents = new WebSocketComponents(null, null,
+                null, null, null, executor);
+            WebSocketClient webSocketClient = new WebSocketClient(httpClient, webSocketComponents);
             try
             {
                 webSocketClient.start();


### PR DESCRIPTION
Add ability of WebSocketClient to pull Executor and ByteBufferPool from configured HttpClient