### PR TITLE
Make `ScheduledExecutorScheduler` more customizable

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ScheduledExecutorScheduler.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ScheduledExecutorScheduler.java
@@ -124,11 +124,13 @@ public class ScheduledExecutorScheduler extends AbstractLifeCycle implements Sch
     @Override
     protected void doStop() throws Exception
     {
-        scheduler.shutdownNow();
-        super.doStop();
         // If name is set to null, this means we got the scheduler from the constructor.
         if (name != null)
+        {
+            scheduler.shutdownNow();
             scheduler = null;
+        }
+        super.doStop();
     }
 
     @Override


### PR DESCRIPTION
`ScheduledExecutorScheduler` now accepts a `ScheduledExecutorService` instance as a constructor argument as an alternative to building its own.

This should help with https://github.com/cometd/cometd/issues/1490