### PR TITLE
Jetty 9.4.x - Fixing javadoc proxy test failures

### DIFF
--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
@@ -174,7 +174,9 @@ public class DemoBaseTests extends AbstractDistributionTest
             startHttpClient(true);
             ContentResponse response = client.GET("http://localhost:" + httpPort + "/proxy/current/");
             assertEquals(HttpStatus.OK_200, response.getStatus());
-            assertThat("Expecting APIdoc contents", response.getContentAsString(), containsString("Jetty Util : Common Resource Utilities"));
+            String body = response.getContentAsString();
+            assertThat("Expecting APIdoc contents", body, containsString("All&nbsp;Classes"));
+            assertThat("Expecting APIdoc contents", body, containsString("<title>Overview (Jetty :: Project 9."));
         }
     }
 

--- a/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
@@ -8,11 +8,11 @@
     <servlet-class>org.eclipse.jetty.proxy.ProxyServlet$Transparent</servlet-class>
     <init-param>
       <param-name>proxyTo</param-name>
-      <param-value>https://www.eclipse.org/jetty/javadoc/jetty-11/index.html?overview-summary.html</param-value>
+      <param-value>https://eclipse.dev/jetty/javadoc/jetty-9/index.html?overview-summary.html</param-value>
     </init-param>
     <init-param>
       <param-name>hostHeader</param-name>
-      <param-value>www.eclipse.org</param-value>
+      <param-value>eclipse.dev</param-value>
     </init-param>
     <load-on-startup>1</load-on-startup>
     <async-supported>true</async-supported>

--- a/tests/test-webapps/test-proxy-webapp/src/test/java/org/eclipse/jetty/ProxyWebAppTest.java
+++ b/tests/test-webapps/test-proxy-webapp/src/test/java/org/eclipse/jetty/ProxyWebAppTest.java
@@ -91,6 +91,8 @@ public class ProxyWebAppTest
         // this proxy configuration, not redirected to the actual website.
         assertThat("response status", response.getStatus(), is(HttpStatus.OK_200));
         // Expecting a Javadoc / APIDoc response - look for something unique for APIdoc.
-        assertThat("response", response.getContentAsString(), containsString("All&nbsp;Classes"));
+        String body = response.getContentAsString();
+        assertThat(body, containsString("All&nbsp;Classes"));
+        assertThat(body, containsString("<title>Overview (Jetty :: Project 9."));
     }
 }


### PR DESCRIPTION
+ Using new eclipse.dev url
+ asserting different content