### PR TITLE
Fix RequestLogWriter contains not existed directory #10305

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java
@@ -229,13 +229,32 @@ public class RolloverFileOutputStream extends OutputStream
         File backupFile = null;
         try (AutoLock l = _lock.lock())
         {
+            if (_filename == null)
+            {
+                throw new IOException("Log directory name is null");
+            }
+            _filename = _filename.trim();
+            if (_filename.isEmpty())
+            {
+                throw new IOException("Log directory name is empty");
+            }
             // Check directory
             File file = new File(_filename);
             _filename = file.getCanonicalPath();
             file = new File(_filename);
-            File dir = new File(file.getParent());
-            if (!dir.isDirectory() || !dir.canWrite())
+            File dir = file.getParentFile();
+            if (!dir.exists())
+            {
+                throw new IOException("Log directory does not exist. Path=" + dir);
+            }
+            else if (!dir.isDirectory())
+            {
+                throw new IOException("Path for Log directory is not a directory. Path=" + dir);
+            }
+            else if (!dir.canWrite())
+            {
                 throw new IOException("Cannot write log directory " + dir);
+            }
 
             // Is this a rollover file?
             String filename = file.getName();

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -160,7 +160,7 @@ public class RolloverFileOutputStreamTest
 
         assertSequence(midnight, expected);
     }
-
+   
     @Test
     public void testMidnightRolloverCalcSydneyDSTEnd()
     {
@@ -180,6 +180,47 @@ public class RolloverFileOutputStreamTest
 
         assertSequence(midnight, expected);
     }
+
+    @Test
+    public void testMissingDirectory()
+    {
+
+        ZoneId zone = toZoneId("Australia/Sydney");
+        ZonedDateTime now = toDateTime("2016.04.10-08:30:12.3 AM AEDT", zone);
+        String templateString = "missingDir/test-rofos-yyyy_mm_dd.log";
+        String excMessageExpected = "Log directory does not exist.";
+
+        try (RolloverFileOutputStream rofos =
+                 new RolloverFileOutputStream(templateString, false, 3, TimeZone.getTimeZone(zone), null, null, now))
+        {
+            rofos.write("TICK".getBytes());
+            rofos.flush();
+        }
+        catch (Exception ex)
+        {
+            boolean exClassOK = false;
+            if (ex instanceof java.io.IOException)
+            {
+                exClassOK = true;
+            }
+            assertThat("Exception Type", exClassOK, is(true));
+
+            String excMessageActual = ex.getMessage();
+            boolean messageOK = false;
+            if (excMessageActual != null)
+            {
+                excMessageActual = excMessageActual.trim();
+                if (!excMessageActual.isEmpty())
+                {
+                    if (excMessageActual.contains(excMessageExpected))
+                    {
+                        messageOK = true;
+                    }
+                }
+            }
+            assertThat("Exception Message", messageOK, is(true));
+        }
+    }        
 
     @Test
     public void testFileHandling() throws Exception


### PR DESCRIPTION
Fix for bug #10305  "Embedded Jetty server fails to start when requests log path in RequestLogWriter contains not existed directory"