### PR TITLE
Fixes #10482 - RewriteHandler with multiple HeaderPatternRules.

### DIFF
--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/RewriteCustomizer.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.io.RuntimeIOException;
+import org.eclipse.jetty.rewrite.handler.Rule;
 import org.eclipse.jetty.rewrite.handler.RuleContainer;
 import org.eclipse.jetty.server.HttpConfiguration.Customizer;
 import org.eclipse.jetty.server.Request;
@@ -35,12 +36,20 @@ public class RewriteCustomizer extends RuleContainer implements Customizer
         try
         {
             // TODO: rule are able to complete the request/response, but customizers cannot.
-            Handler input = new Handler(request);
+            Handler input = new Input(request);
             return matchAndApply(input);
         }
         catch (IOException e)
         {
             throw new RuntimeIOException(e);
+        }
+    }
+
+    private static class Input extends Rule.Handler
+    {
+        private Input(Request request)
+        {
+            super(request);
         }
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
@@ -93,10 +93,10 @@ public class CookiePatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            protected boolean handle(Response response, Callback callback) throws Exception
             {
                 Response.addCookie(response, HttpCookie.from(_name, _value));
-                return super.handle(request, response, callback);
+                return super.handle(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
@@ -82,24 +82,21 @@ public class CookiePatternRule extends PatternRule
     @Override
     public Handler apply(Handler input) throws IOException
     {
-        // Check that cookie is not already set
+        // Check that the cookie is not already set.
         List<HttpCookie> cookies = Request.getCookies(input);
-        if (cookies != null)
+        for (HttpCookie cookie : cookies)
         {
-            for (HttpCookie cookie : cookies)
-            {
-                if (_name.equals(cookie.getName()) && _value.equals(cookie.getValue()))
-                    return null;
-            }
+            if (_name.equals(cookie.getName()) && _value.equals(cookie.getValue()))
+                return null;
         }
 
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
             {
                 Response.addCookie(response, HttpCookie.from(_name, _value));
-                return super.handle(response, callback);
+                return super.handle(request, response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -81,13 +80,13 @@ public class HeaderPatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            protected boolean handle(Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), getHeaderValue());
                 else
                     response.getHeaders().put(getHeaderName(), getHeaderValue());
-                return super.handle(request, response, callback);
+                return super.handle(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRule.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -65,8 +66,9 @@ public class HeaderPatternRule extends PatternRule
     }
 
     /**
-     * Set true to add the response header, false to put the response header..
-     * @param add true to add the response header, false to put the response header.
+     * Use {@code true} to add the response header, {@code false} to put the response header.
+     *
+     * @param add {@code true} to add the response header, {@code false} to put the response header.
      */
     public void setAdd(boolean add)
     {
@@ -79,13 +81,13 @@ public class HeaderPatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), getHeaderValue());
                 else
                     response.getHeaders().put(getHeaderName(), getHeaderValue());
-                return super.handle(response, callback);
+                return super.handle(request, response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 import java.util.regex.Matcher;
 
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -81,13 +80,13 @@ public class HeaderRegexRule extends RegexRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            protected boolean handle(Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), matcher.replaceAll(getHeaderValue()));
                 else
                     response.getHeaders().put(getHeaderName(), matcher.replaceAll(getHeaderValue()));
-                return super.handle(request, response, callback);
+                return super.handle(response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRule.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 import java.util.regex.Matcher;
 
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.annotation.Name;
@@ -80,13 +81,13 @@ public class HeaderRegexRule extends RegexRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
             {
                 if (isAdd())
                     response.getHeaders().add(getHeaderName(), matcher.replaceAll(getHeaderValue()));
                 else
                     response.getHeaders().put(getHeaderName(), matcher.replaceAll(getHeaderValue()));
-                return super.handle(response, callback);
+                return super.handle(request, response, callback);
             }
         };
     }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -97,7 +98,7 @@ public class InvalidURIRule extends Rule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback)
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))
@@ -107,7 +108,7 @@ public class InvalidURIRule extends Rule
                 }
                 else
                 {
-                    Response.writeError(this, response, callback, getCode(), message);
+                    Response.writeError(request, response, callback, getCode(), message);
                 }
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/InvalidURIRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -98,7 +97,7 @@ public class InvalidURIRule extends Rule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback)
+            protected boolean handle(Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))
@@ -108,7 +107,7 @@ public class InvalidURIRule extends Rule
                 }
                 else
                 {
-                    Response.writeError(request, response, callback, getCode(), message);
+                    Response.writeError(this, response, callback, getCode(), message);
                 }
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
@@ -84,11 +84,11 @@ public class RedirectPatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback)
+            protected boolean handle(Response response, Callback callback)
             {
                 String location = getLocation();
                 response.setStatus(getStatusCode());
-                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(request, location));
+                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(this, location));
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectPatternRule.java
@@ -84,11 +84,11 @@ public class RedirectPatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback)
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 String location = getLocation();
                 response.setStatus(getStatusCode());
-                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(this, location));
+                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(request, location));
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
@@ -82,11 +82,11 @@ public class RedirectRegexRule extends RegexRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback)
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 String target = matcher.replaceAll(getLocation());
                 response.setStatus(_statusCode);
-                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(this, target));
+                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(request, target));
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRule.java
@@ -82,11 +82,11 @@ public class RedirectRegexRule extends RegexRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback)
+            protected boolean handle(Response response, Callback callback)
             {
                 String target = matcher.replaceAll(getLocation());
                 response.setStatus(_statusCode);
-                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(request, target));
+                response.getHeaders().put(HttpHeader.LOCATION, Request.toRedirectURI(this, target));
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -84,7 +85,7 @@ public class ResponsePatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Response response, Callback callback)
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))
@@ -94,7 +95,7 @@ public class ResponsePatternRule extends PatternRule
                 }
                 else
                 {
-                    Response.writeError(this, response, callback, getCode(), message);
+                    Response.writeError(request, response, callback, getCode(), message);
                 }
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ResponsePatternRule.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.rewrite.handler;
 import java.io.IOException;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
@@ -85,7 +84,7 @@ public class ResponsePatternRule extends PatternRule
         return new Handler(input)
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback)
+            protected boolean handle(Response response, Callback callback)
             {
                 String message = getMessage();
                 if (StringUtil.isBlank(message))
@@ -95,7 +94,7 @@ public class ResponsePatternRule extends PatternRule
                 }
                 else
                 {
-                    Response.writeError(request, response, callback, getCode(), message);
+                    Response.writeError(this, response, callback, getCode(), message);
                 }
                 return true;
             }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -139,15 +139,15 @@ public class RewriteHandler extends Handler.Wrapper
 
         // At least one rule matched, link the last Rule.Handler
         // to invoke the child Handler of this RewriteHandler.
-        new Output(result, getHandler());
+        new LastRuleHandler(result, getHandler());
         return input.handle(response, callback);
     }
 
-    private static class Output extends Rule.Handler
+    private static class LastRuleHandler extends Rule.Handler
     {
         private final Handler _handler;
 
-        private Output(Rule.Handler ruleHandler, Handler handler)
+        private LastRuleHandler(Rule.Handler ruleHandler, Handler handler)
         {
             super(ruleHandler);
             _handler = handler;

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -101,6 +101,14 @@ public class RewriteHandler extends Handler.Wrapper
     }
 
     /**
+     * <p>Removes all the rules.</p>
+     */
+    public void clear()
+    {
+        _rules.clear();
+    }
+
+    /**
      * @see RuleContainer#getOriginalPathAttribute()
      */
     public String getOriginalPathAttribute()
@@ -122,15 +130,32 @@ public class RewriteHandler extends Handler.Wrapper
         if (!isStarted())
             return false;
 
-        Rule.Handler input = new Rule.Handler(request);
-        Rule.Handler output = _rules.matchAndApply(input);
+        Rule.Handler input = new Input(request, getHandler());
+        Rule.Handler output = getRuleContainer().matchAndApply(input);
 
         // No rule matched, call super with the original request.
         if (output == null)
             return super.handle(request, response, callback);
 
-        // At least one rule matched, call super with the result of the rule applications.
-        output.setHandler(getHandler());
+        // At least one rule matched, call handle()
+        // with the output of the rule applications.
         return output.handle(output, response, callback);
+    }
+
+    private static class Input extends Rule.Handler
+    {
+        private final Handler _handler;
+
+        private Input(Request request, Handler handler)
+        {
+            super(request);
+            _handler = handler;
+        }
+
+        @Override
+        public boolean handle(Request request, Response response, Callback callback) throws Exception
+        {
+            return _handler.handle(request, response, callback);
+        }
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
@@ -78,7 +78,7 @@ public abstract class Rule
      */
     public static class Handler extends Request.Wrapper
     {
-        private Rule.Handler _wrapper;
+        private Rule.Handler _nextRuleHandler;
 
         protected Handler(Request request)
         {
@@ -88,14 +88,14 @@ public abstract class Rule
         public Handler(Rule.Handler handler)
         {
             super(handler);
-            handler._wrapper = this;
+            handler._nextRuleHandler = this;
         }
 
         /**
          * <p>Handles this wrapped request together with the passed response and callback.</p>
          * <p>This method should be overridden only if the rule applies to the response,
          * or the rule completes the callback.
-         * By default this method forwards the handling to the next rule.
+         * By default this method forwards the handling to the next {@link Rule.Handler}.
          * If a rule that overrides this method is non-{@link #isTerminating() terminating},
          * it should call the {@code super} implementation to chain the rules.</p>
          *
@@ -105,7 +105,7 @@ public abstract class Rule
          */
         protected boolean handle(Response response, Callback callback) throws Exception
         {
-            return _wrapper.handle(response, callback);
+            return _nextRuleHandler.handle(response, callback);
         }
     }
 

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/Rule.java
@@ -29,30 +29,34 @@ public abstract class Rule
     private boolean _terminating;
 
     /**
-     * <p>Tests whether the given {@code Request} should apply, and if so the rule logic is triggered.</p>
+     * <p>Tests whether the given input {@code Handler} (which wraps a
+     * {@code Request}) matches the rule, and if so returns an output
+     * {@code Handler} that applies the rule logic.</p>
+     * <p>If the input does not match, {@code null} is returned.</p>
      *
-     * @param input the input {@code Request} and {@code Handler}
-     * @return the possibly wrapped {@code Request} and {@code Handler}, or {@code null} if the rule did not match
-     * @throws IOException if applying the rule failed
+     * @param input the input {@code Handler} that wraps the {@code Request}
+     * @return an output {@code Handler} that wraps the input {@code Handler},
+     * or {@code null} if the rule does not match
+     * @throws IOException if applying the rule fails
      */
     public abstract Handler matchAndApply(Handler input) throws IOException;
 
     /**
-     * @return when {@code true}, rules after this one are not invoked
+     * @return whether rules after this one are not invoked
      */
     public boolean isTerminating()
     {
         return _terminating;
     }
 
+    /**
+     * @param value whether rules after this one are not invoked
+     */
     public void setTerminating(boolean value)
     {
         _terminating = value;
     }
 
-    /**
-     * Returns the handling and terminating flag values.
-     */
     @Override
     public String toString()
     {
@@ -61,55 +65,54 @@ public abstract class Rule
 
     /**
      * <p>A {@link Request.Wrapper} that is also a {@link Handler},
-     * used to chain a sequence of {@link Rule}s together.
-     * The rule handler is initialized with the initial request, then it is
-     * passed to a chain of rules before the child {@code Handler} is
-     * passed in {@link #setHandler(Handler)}. Finally, the response
-     * and callback are provided in a call to {@link #handle(Request, Response, Callback)},
-     * which calls the {@link #handle(Response, Callback)}.</p>
+     * used to chain a sequence of {@link Rule}s together.</p>
+     * <p>The rule handler is initialized with the initial request,
+     * then it is passed to a chain of rules, which in turn chain
+     * rule handlers together. At the end of the rule applications,
+     * the last rule handler (which eventually wraps the initial
+     * request), the response and the callback are passed to the
+     * chain of rule handlers and finally to the child Handler
+     * of {@link RewriteHandler}.</p>
+     * <p>{@code Handler}s are chained as rules are applied,
+     * so that the first rule produces the innermost {@code Handler}
+     * and the last rule produces the outermost {@code Handler}.</p>
      */
     public static class Handler extends Request.Wrapper implements Request.Handler
     {
-        private volatile Handler _handler;
-
         public Handler(Request request)
         {
             super(request);
         }
 
+        /**
+         * <p>Handles this wrapped request together with the passed response and callback.</p>
+         * <p>This method should be overridden only if the rule applies to the response,
+         * or the rule completes the callback.</p>
+         * <p>By default this method for wards the handling to the next rule.</p>
+         * <p>Note that the {@code request} parameter and {@code "this"} are both wrappers
+         * of the initial request, but at different stages of the application of the rules.
+         * The {@code request} parameter is the outermost {@code Handler}, result of the
+         * application of all the rules.
+         * On the other hand, {@code "this"} is the {@code Handler} result of the application
+         * of the rules up to the rule that produced this {@code Handler}, and therefore
+         * represents only a partial application of the rules.</p>
+         *
+         * @param request the outermost {@code Handler} that eventually wraps the initial {@link Request}
+         * @param response the {@link Response}
+         * @param callback the {@link Callback}
+         * @throws Exception if there is a failure while handling the rules
+         */
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            return handle(response, callback);
-        }
-
-        /**
-         * <p>Handles this wrapped request together with the passed response and
-         * callback, using the handler set in {@link #setHandler(Handler)}.
-         * This method should be extended if additional handling of the wrapped
-         * request is required.</p>
-         * @param response The response
-         * @param callback The callback
-         * @throws Exception If there is a problem handling
-         * @see #setHandler(Handler)
-         */
-        protected boolean handle(Response response, Callback callback) throws Exception
-        {
-            Handler handler = _handler;
-            return handler != null && handler.handle(this, response, callback);
-        }
-
-        /**
-         * <p>Wraps the given {@code Handler} within this instance and returns this instance.</p>
-         *
-         * @param handler the {@code Handler} to wrap
-         */
-        public void setHandler(Handler handler)
-        {
-            _handler = handler;
+            Rule.Handler handler = (Rule.Handler)getWrapped();
+            return handler.handle(request, response, callback);
         }
     }
 
+    /**
+     * <p>A {@link Rule.Handler} that wraps a {@link Request} to return a different {@link HttpURI}.</p>
+     */
     public static class HttpURIHandler extends Handler
     {
         private final HttpURI _uri;

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RuleContainer.java
@@ -51,7 +51,7 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
      */
     public void setRules(List<Rule> rules)
     {
-        _rules.clear();
+        clear();
         _rules.addAll(rules);
     }
 
@@ -69,6 +69,14 @@ public class RuleContainer extends Rule implements Iterable<Rule>, Dumpable
     public void addRule(Rule rule)
     {
         _rules.add(rule);
+    }
+
+    /**
+     * <p>Removes all the rules.</p>
+     */
+    public void clear()
+    {
+        _rules.clear();
     }
 
     /**

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRuleTest.java
@@ -84,35 +84,4 @@ public class HeaderPatternRuleTest extends AbstractRuleTest
             stop();
         }
     }
-
-    @Test
-    public void testMultipleRulesWithSamePattern() throws Exception
-    {
-        HeaderPatternRule rule1 = new HeaderPatternRule("/*", "name1", "value1");
-        RewriteRegexRule rule2 = new RewriteRegexRule("/", "/rewritten");
-        HeaderPatternRule rule3 = new HeaderPatternRule("/*", "name2", "value2");
-        List.of(rule2, rule1, rule3).forEach(_rewriteHandler::addRule);
-        start(new Handler.Abstract()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                String pathInContext = Request.getPathInContext(request);
-                assertEquals("/rewritten", pathInContext);
-                callback.succeeded();
-                return true;
-            }
-        });
-
-        String request = """
-                GET / HTTP/1.1
-                Host: localhost
-                            
-                """;
-
-        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
-        assertEquals(200, response.getStatus());
-        assertEquals("value1", response.get("name1"));
-        assertEquals("value2", response.get("name2"));
-    }
 }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderPatternRuleTest.java
@@ -80,7 +80,39 @@ public class HeaderPatternRuleTest extends AbstractRuleTest
             assertEquals(200, response.getStatus());
             assertEquals(value, response.get(name));
 
+            _rewriteHandler.clear();
             stop();
         }
+    }
+
+    @Test
+    public void testMultipleRulesWithSamePattern() throws Exception
+    {
+        HeaderPatternRule rule1 = new HeaderPatternRule("/*", "name1", "value1");
+        RewriteRegexRule rule2 = new RewriteRegexRule("/", "/rewritten");
+        HeaderPatternRule rule3 = new HeaderPatternRule("/*", "name2", "value2");
+        List.of(rule2, rule1, rule3).forEach(_rewriteHandler::addRule);
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                String pathInContext = Request.getPathInContext(request);
+                assertEquals("/rewritten", pathInContext);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        String request = """
+                GET / HTTP/1.1
+                Host: localhost
+                            
+                """;
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertEquals(200, response.getStatus());
+        assertEquals("value1", response.get("name1"));
+        assertEquals("value2", response.get("name2"));
     }
 }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/HeaderRegexRuleTest.java
@@ -81,6 +81,7 @@ public class HeaderRegexRuleTest extends AbstractRuleTest
             assertEquals(200, response.getStatus());
             assertEquals(value, response.get(name));
 
+            _rewriteHandler.clear();
             stop();
         }
     }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MultipleRulesTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/MultipleRulesTest.java
@@ -1,0 +1,155 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.rewrite.handler;
+
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MultipleRulesTest extends AbstractRuleTest
+{
+    @Test
+    public void testMultipleRulesWithSamePattern() throws Exception
+    {
+        HeaderPatternRule rule1 = new HeaderPatternRule("/*", "name1", "value1");
+        RewriteRegexRule rule2 = new RewriteRegexRule("/", "/rewritten");
+        HeaderPatternRule rule3 = new HeaderPatternRule("/*", "name2", "value2");
+        List.of(rule2, rule1, rule3).forEach(_rewriteHandler::addRule);
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                String pathInContext = Request.getPathInContext(request);
+                assertEquals("/rewritten", pathInContext);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        String request = """
+            GET / HTTP/1.1
+            Host: localhost
+                        
+            """;
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertEquals(200, response.getStatus());
+        assertEquals("value1", response.get("name1"));
+        assertEquals("value2", response.get("name2"));
+    }
+
+    @Test
+    public void testMultipleRulesAppliesAndHandledInOrder() throws Exception
+    {
+        String requestHeaderName = "X-Request-Header";
+        String responseHeaderName = "X-Response-Header";
+        Rule rule1 = new Rule()
+        {
+            @Override
+            public Handler matchAndApply(Handler input)
+            {
+                // First rule, I should only see the client headers.
+                String value = input.getHeaders().get(requestHeaderName);
+                assertEquals("Request", value);
+
+                HttpFields newFields = HttpFields.build(input.getHeaders()).put(requestHeaderName, String.join(", ", value, "Rule1"));
+                return new Handler(input)
+                {
+                    @Override
+                    public HttpFields getHeaders()
+                    {
+                        return newFields;
+                    }
+
+                    @Override
+                    protected boolean handle(Response response, Callback callback) throws Exception
+                    {
+                        // Modify the response.
+                        response.getHeaders().put(responseHeaderName, "Rule1");
+                        // Chain the rules.
+                        return super.handle(response, callback);
+                    }
+                };
+            }
+        };
+        RewriteRegexRule rule2 = new RewriteRegexRule("/", "/rewritten");
+        Rule rule3 = new Rule()
+        {
+            @Override
+            public Handler matchAndApply(Handler input)
+            {
+                // Third rule, I should see the effects of the previous 2 rules.
+                String value = input.getHeaders().get(requestHeaderName);
+                assertEquals("Request, Rule1", value);
+
+                String pathInContext = Request.getPathInContext(input);
+                assertEquals("/rewritten", pathInContext);
+
+                HttpFields newFields = HttpFields.build(input.getHeaders()).put(requestHeaderName, String.join(", ", "Request", "Rule1", "Rule3"));
+                return new Handler(input)
+                {
+                    @Override
+                    public HttpFields getHeaders()
+                    {
+                        return newFields;
+                    }
+
+                    @Override
+                    protected boolean handle(Response response, Callback callback) throws Exception
+                    {
+                        assertEquals("Rule1", response.getHeaders().get(responseHeaderName));
+                        // Modify the response.
+                        response.getHeaders().put(responseHeaderName, String.join(", ", "Rule1", "Rule3"));
+                        // Chain the rules.
+                        return super.handle(response, callback);
+                    }
+                };
+            }
+        };
+        List.of(rule1, rule2, rule3).forEach(_rewriteHandler::addRule);
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                String pathInContext = Request.getPathInContext(request);
+                assertEquals("/rewritten", pathInContext);
+                assertEquals("Request, Rule1, Rule3", request.getHeaders().get(requestHeaderName));
+                assertEquals("Rule1, Rule3", response.getHeaders().get(responseHeaderName));
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        String request = """
+            GET / HTTP/1.1
+            Host: localhost
+            %s: Request
+                        
+            """.formatted(requestHeaderName);
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertEquals(200, response.getStatus());
+        assertEquals("Rule1, Rule3", response.get(responseHeaderName));
+    }
+}


### PR DESCRIPTION
Reviewed the implementation of RewriteHandler, that was broken for those rules that were overriding `Rule.Handler.handle()`.

The problem was that the handling was not forwarded along the chain of rules, so only the last one was applied.

Removed (a breaking change) `Rule.Handler.handle(Response, Callback)` because it is necessary that the outermost request wrapper is passed to the `RewriteHandler` child `Handler`. Updated implementations to override `handle(Request, Response, Callback)` instead, so that the request parameter is preserved along the chain.