### PR TITLE
Dependency rollup for `jetty-9.4.x`

### DIFF
--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -20,7 +20,7 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram</artifactId>
-            <version>2.2.11</version>
+            <version>2.2.13</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <osgi-version>3.18.400</osgi-version>
+    <osgi-version>3.18.500</osgi-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -13,7 +13,7 @@
     <bundle-symbolic-name>${project.groupId}.boot.test.osgi</bundle-symbolic-name>
     <jetty-orbit-url>https://download.eclipse.org/jetty/orbit/</jetty-orbit-url>
     <assembly-directory>target/distribution</assembly-directory>
-    <exam.version>4.13.1</exam.version>
+    <exam.version>4.13.5</exam.version>
     <url.version>2.6.14</url.version>
     <bnd.version>5.3.0</bnd.version>
     <swissbox.version>1.8.3</swissbox.version>

--- a/jetty-spring/pom.xml
+++ b/jetty-spring/pom.xml
@@ -9,7 +9,7 @@
   <name>Example :: Jetty Spring</name>
 
   <properties>
-    <spring-version>5.3.29</spring-version>
+    <spring-version>5.3.30</spring-version>
     <dependencies>target/dependencies</dependencies>
     <bundle-symbolic-name>${project.groupId}.spring</bundle-symbolic-name>
     <jacoco.skip>true</jacoco.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <ant.version>1.10.14</ant.version>
     <apache.avro.version>1.11.2</apache.avro.version>
-    <mina.core.version>2.2.2</mina.core.version>
+    <mina.core.version>2.2.3</mina.core.version>
     <asm.version>9.5</asm.version>
     <bndlib.version>6.3.1</bndlib.version>
     <build-support.version>1.5</build-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <logback.version>1.2.12</logback.version>
     <maven.plugin-tools.version>3.8.2</maven.plugin-tools.version>
-    <maven.resolver.version>1.9.15</maven.resolver.version>
+    <maven.resolver.version>1.9.16</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
     <mongodb.version>2.14.3</mongodb.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <alpn.agent.version>2.0.10</alpn.agent.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <ant.version>1.10.14</ant.version>
-    <apache.avro.version>1.11.2</apache.avro.version>
+    <apache.avro.version>1.11.3</apache.avro.version>
     <mina.core.version>2.2.2</mina.core.version>
     <asm.version>9.5</asm.version>
     <bndlib.version>6.3.1</bndlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.6.0</maven.dependency.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
-    <maven.enforcer.plugin.version>3.4.0</maven.enforcer.plugin.version>
+    <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
     <maven.jxr.plugin.version>3.3.1</maven.jxr.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <guice.version>5.1.0</guice.version>
     <hawtio.version>2.15.0</hawtio.version>
     <hazelcast.version>3.12.12</hazelcast.version>
-    <infinispan.protostream.version>4.4.4.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.annotations.version>2.14.2</jackson.annotations.version>
     <jackson.core.version>2.14.2</jackson.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>9.3</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>
-    <commons.compress.version>1.23.0</commons.compress.version>
+    <commons.compress.version>1.24.0</commons.compress.version>
     <commons.io.version>2.13.0</commons.io.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <guice.version>5.1.0</guice.version>
     <hawtio.version>2.15.0</hawtio.version>
     <hazelcast.version>3.12.12</hazelcast.version>
-    <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.4.4.Final</infinispan.protostream.version>
     <infinispan.version>11.0.17.Final</infinispan.version>
     <jackson.annotations.version>2.14.2</jackson.annotations.version>
     <jackson.core.version>2.14.2</jackson.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <javax.transaction.api.version>1.3</javax.transaction.api.version>
     <javax.websocket.api.version>1.0</javax.websocket.api.version>
     <jboss.logging.version>3.4.3.Final</jboss.logging.version>
-    <jboss.threads.version>3.5.0.Final</jboss.threads.version>
+    <jboss.threads.version>3.5.1.Final</jboss.threads.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>
     <jetty.schemas.version>3.1.2</jetty.schemas.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <maven.release.plugin.version>3.0.1</maven.release.plugin.version>
     <maven.remote-resources.plugin.version>3.1.0</maven.remote-resources.plugin.version>
     <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
-    <maven.shade.plugin.version>3.5.0</maven.shade.plugin.version>
+    <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>


### PR DESCRIPTION
Rollup of outstanding dependencies for `jetty-9.4.x` in prep for Jetty 9.4.53 release