### PR TITLE
Issue #10473 - Better warnings in `jetty.sh` on filesystem permission issues

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -526,8 +526,6 @@ fi
 ##################################################
 case "$ACTION" in
   start)
-    echo -n "Starting Jetty: "
-
     if (( NO_START )); then
       echo "Not starting ${NAME} - NO_START=1";
       exit
@@ -546,6 +544,8 @@ case "$ACTION" in
       echo "          Correct issues preventing use of \$JETTY_STATE and try again."
       exit 1
     fi
+
+    echo -n "Starting Jetty: "
 
     # Startup from a service file
     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -368,13 +368,14 @@ fi
 if [ -z "$JETTY_RUN" ]
 then
   JETTY_RUN=$(findDirectory -w /var/run /usr/var/run $JETTY_BASE /tmp)/jetty
-  if [ ! -d "$JETTY_RUN" ] ; then
-    if ! mkdir $JETTY_RUN
-    then
-      echo "** ERROR: Unable to create directory: $JETTY_RUN"
-      echo "          Correct issues preventing use of \$JETTY_RUN and try again."
-      exit 1
-    fi
+fi
+
+if [ ! -d "$JETTY_RUN" ] ; then
+  if ! mkdir $JETTY_RUN
+  then
+    echo "** ERROR: Unable to create directory: $JETTY_RUN"
+    echo "          Correct issues preventing use of \$JETTY_RUN and try again."
+    exit 1
   fi
 fi
 

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -374,7 +374,7 @@ if [ ! -d "$JETTY_RUN" ] ; then
   if ! mkdir $JETTY_RUN
   then
     echo "** ERROR: Unable to create directory: $JETTY_RUN"
-    echo "          Correct issues preventing use of \$JETTY_RUN and try again."
+    echo "          Correct issues preventing the creation of \$JETTY_RUN and try again."
     exit 1
   fi
 fi
@@ -565,7 +565,7 @@ case "$ACTION" in
        --make-pidfile \
        --startas "$JAVA" \
        --
-      (( DEBUG )) && echo "Starting: start-stop-daemon usage"
+      (( DEBUG )) && echo "Starting: start-stop-daemon"
     else
 
       if running $JETTY_PID
@@ -589,7 +589,7 @@ case "$ACTION" in
           echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
           PID=\$!
           disown \$PID"
-        (( DEBUG )) && echo "Starting: su shell (w/user) on PID $PID"
+        (( DEBUG )) && echo "Starting: su shell (w/user $JETTY_USER) on PID $PID"
       else
         # Startup if not switching users
         echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} > /dev/null &

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -137,6 +137,13 @@ started()
   local STATEFILE=$1
   local PIDFILE=$2
   local STARTTIMEOUT=$3
+
+  if (( DEBUG )) ; then
+    echo "Looking for $STATEFILE"
+    echo -n "State Parent Directory: "
+    ls -lad $(dirname $STATEFILE)
+  fi
+
   # wait till timeout to see "STARTED" in state file, needs --module=state as argument
   for ((T = 0; T < $STARTTIMEOUT; T++))
   do
@@ -162,6 +169,11 @@ started()
   done
   (( DEBUG )) && echo "Timeout $STARTTIMEOUT expired waiting for start state from $STATEFILE"
   echo " timeout"
+  if running "$PIDFILE" ; then
+    echo "INFO: Server process is running"
+  else
+    echo "** ERROR: Server process is NOT running"
+  fi
   return 1;
 }
 
@@ -173,7 +185,7 @@ pidKill()
   if [ -r $PIDFILE ] ; then
     local PID=$(tail -1 "$PIDFILE")
     if [ -z "$PID" ] ; then
-      echo "ERROR: no pid found in $PIDFILE"
+      echo "** ERROR: no pid found in $PIDFILE"
       return 1
     fi
 
@@ -204,7 +216,6 @@ pidKill()
   fi
 }
 
-
 readConfig()
 {
   (( DEBUG )) && echo "Reading $1.."
@@ -213,24 +224,23 @@ readConfig()
 
 dumpEnv()
 {
-    echo "JAVA                  =  $JAVA"
-    echo "JAVA_OPTIONS          =  ${JAVA_OPTIONS[*]}"
-    echo "JETTY_HOME            =  $JETTY_HOME"
-    echo "JETTY_BASE            =  $JETTY_BASE"
-    echo "START_D               =  $START_D"
-    echo "START_INI             =  $START_INI"
-    echo "JETTY_START           =  $JETTY_START"
-    echo "JETTY_CONF            =  $JETTY_CONF"
-    echo "JETTY_ARGS            =  ${JETTY_ARGS[*]}"
-    echo "JETTY_RUN             =  $JETTY_RUN"
-    echo "JETTY_PID             =  $JETTY_PID"
-    echo "JETTY_START_LOG       =  $JETTY_START_LOG"
-    echo "JETTY_STATE           =  $JETTY_STATE"
-    echo "JETTY_START_TIMEOUT   =  $JETTY_START_TIMEOUT"
-    echo "JETTY_SYS_PROPS       =  $JETTY_SYS_PROPS"
-    echo "RUN_ARGS              =  ${RUN_ARGS[*]}"
+  echo "JAVA                  =  $JAVA"
+  echo "JAVA_OPTIONS          =  ${JAVA_OPTIONS[*]}"
+  echo "JETTY_HOME            =  $JETTY_HOME"
+  echo "JETTY_BASE            =  $JETTY_BASE"
+  echo "START_D               =  $START_D"
+  echo "START_INI             =  $START_INI"
+  echo "JETTY_START           =  $JETTY_START"
+  echo "JETTY_CONF            =  $JETTY_CONF"
+  echo "JETTY_ARGS            =  ${JETTY_ARGS[*]}"
+  echo "JETTY_RUN             =  $JETTY_RUN"
+  echo "JETTY_PID             =  $JETTY_PID"
+  echo "JETTY_START_LOG       =  $JETTY_START_LOG"
+  echo "JETTY_STATE           =  $JETTY_STATE"
+  echo "JETTY_START_TIMEOUT   =  $JETTY_START_TIMEOUT"
+  echo "JETTY_SYS_PROPS       =  $JETTY_SYS_PROPS"
+  echo "RUN_ARGS              =  ${RUN_ARGS[*]}"
 }
-
 
 
 ##################################################
@@ -358,7 +368,14 @@ fi
 if [ -z "$JETTY_RUN" ]
 then
   JETTY_RUN=$(findDirectory -w /var/run /usr/var/run $JETTY_BASE /tmp)/jetty
-  [ -d "$JETTY_RUN" ] || mkdir $JETTY_RUN
+  if [ ! -d "$JETTY_RUN" ] ; then
+    if ! mkdir $JETTY_RUN
+    then
+      echo "** ERROR: Unable to create directory: $JETTY_RUN"
+      echo "          Correct issues preventing use of \$JETTY_RUN and try again."
+      exit 1
+    fi
+  fi
 fi
 
 #####################################################
@@ -495,6 +512,11 @@ RUN_ARGS=($JETTY_SYS_PROPS ${JETTY_DRY_RUN[@]})
 
 if (( DEBUG ))
 then
+  if expr "${RUN_ARGS[*]}" : '.*/etc/console-capture.xml.*' > /dev/null
+  then
+    echo "WARNING: Disable console-capture module for best DEBUG results"
+  fi
+  echo "IDs are $(id)"
   dumpEnv
 fi
 
@@ -510,6 +532,20 @@ case "$ACTION" in
       exit
     fi
 
+    if ! touch "$JETTY_PID"
+    then
+      echo "** ERROR: Unable to touch file: $JETTY_PID"
+      echo "          Correct issues preventing use of \$JETTY_PID and try again."
+      exit 1
+    fi
+
+    if ! touch "$JETTY_STATE"
+    then
+      echo "** ERROR: Unable to touch file: $JETTY_STATE"
+      echo "          Correct issues preventing use of \$JETTY_STATE and try again."
+      exit 1
+    fi
+
     # Startup from a service file
     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
     then
@@ -519,15 +555,16 @@ case "$ACTION" in
         CH_USER="--chuid $JETTY_USER"
       fi
 
-      echo ${RUN_ARGS[@]} start-log-file="$JETTY_START_LOG" | xargs start-stop-daemon \
+      echo ${RUN_ARGS[@]} --start-log-file="$JETTY_START_LOG" | xargs start-stop-daemon \
        --start $CH_USER \
        --pidfile "$JETTY_PID" \
        --chdir "$JETTY_BASE" \
        --background \
+       --output "${JETTY_RUN}/start-stop.log"
        --make-pidfile \
        --startas "$JAVA" \
        --
-
+      (( DEBUG )) && echo "Starting: start-stop-daemon usage"
     else
 
       if running $JETTY_PID
@@ -545,16 +582,19 @@ case "$ACTION" in
           SU_SHELL="-s $JETTY_SHELL"
         fi
 
-        touch "$JETTY_PID"
         chown "$JETTY_USER" "$JETTY_PID"
         su - "$JETTY_USER" $SU_SHELL -c "
           cd \"$JETTY_BASE\"
-          echo ${RUN_ARGS[*]} start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
-          disown \$!"
+          echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
+          PID=\$!
+          disown \$PID"
+        (( DEBUG )) && echo "Starting: su shell (w/user) on PID $PID"
       else
         # Startup if not switching users
-        echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
-        disown $!
+        echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} > /dev/null &
+        PID=$!
+        disown $PID
+        (( DEBUG )) && echo "Starting: java command on PID $PID"
       fi
 
     fi
@@ -592,7 +632,7 @@ case "$ACTION" in
     else
       # Stop from a non-service path
       if [ ! -r "$JETTY_PID" ] ; then
-        echo "ERROR: no pid found at $JETTY_PID"
+        echo "** ERROR: no pid found at $JETTY_PID"
         exit 1
       fi
 


### PR DESCRIPTION
Adding more checks in `jetty.sh` for common file system permission issues.

Examples:

**Don't have write/create access to JETTY_RUN directory path**

``` shell
[jetty-base]$ export JETTY_RUN=/var/run/jetty-no-exist
[jetty-base]$ ../jetty-home-10.0.17-SNAPSHOT/bin/jetty.sh start
mkdir: cannot create directory ‘/var/run/jetty-no-exist’: Permission denied
** ERROR: Unable to create directory: /var/run/jetty-no-exist
          Correct issues preventing use of $JETTY_RUN and try again.
```

**Don't have write/create access to JETTY_PID file path location**

Note: the `/var/run/` path exist in the following tests, but the Jetty user doesn't have permissions to write there.

``` shell
[jetty-base]$ export JETTY_PID=/var/run/jetty.pid
[jetty-base]$ ../jetty-home-10.0.17-SNAPSHOT/bin/jetty.sh start
Starting Jetty: touch: cannot touch ‘/var/run/jetty.pid’: Permission denied
** ERROR: Unable to touch file: /var/run/jetty.pid
          Correct issues preventing use of $JETTY_PID and try again.
```

**Don't have write/create access to JETTY_STATE file path location**

``` shell
[jetty-base]$ export JETTY_STATE=/var/run/jetty.state
[jetty-base]$ ../jetty-home-10.0.17-SNAPSHOT/bin/jetty.sh start
Starting Jetty: touch: cannot touch ‘/var/run/jetty.state’: Permission denied
** ERROR: Unable to touch file: /var/run/jetty.state
          Correct issues preventing use of $JETTY_STATE and try again.
```