### PR TITLE
Fix incorrect call to super in BufferedResponseHandler

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -173,7 +173,8 @@ public class Server extends Handler.Wrapper implements Attributes
     public boolean handle(Request request, Response response, Callback callback) throws Exception
     {
         // Handle either with normal handler or default handler
-        return super.handle(request, response, callback) || _defaultHandler != null && _defaultHandler.handle(request, response, callback);
+        Handler next = getHandler();
+        return next != null && next.handle(request, response, callback) || _defaultHandler != null && _defaultHandler.handle(request, response, callback);
     }
 
     public String getServerInfo()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -150,8 +150,8 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
                 if (LOG.isDebugEnabled())
                     LOG.debug("{} excluded by path suffix mime type {}", this, request);
 
-                // handle normally
-                return super.handle(request, response, callback);
+                // handle without buffering
+                return next.handle(request, response, callback);
             }
         }
 


### PR DESCRIPTION
Whilst looking at inlining some needless wrapper super calls, I spotted this bug in BufferedResponseHandler