### PR TITLE
fix failing fast profile

### DIFF
--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -251,6 +251,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
+          <skipAssembly>${asciidoctor.skip}</skipAssembly>
           <descriptors>
             <descriptor>src/main/assembly/html.xml</descriptor>
           </descriptors>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -251,6 +251,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
+          <!-- if asciidoc generation has been skipped this will generate a assembly plugin error
+          so in this case just skip documentation assembly as well -->
           <skipAssembly>${asciidoctor.skip}</skipAssembly>
           <descriptors>
             <descriptor>src/main/assembly/html.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     you will get thanks from Eclipse IDE users -->
     <!-- but hey we have no more strange people?? :P -->
     <infinispan.docker.image.version>11.0.14.Final</infinispan.docker.image.version>
-
+    <asciidoctor.skip>false</asciidoctor.skip>
     <project.build.outputTimestamp>2023-06-05T23:12:49Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
with this change, we skip ascidoc generation and assembly of the doc (which was  failing because of empty content)
but at least we check circular dependencies etc...

some details  here https://github.com/eclipse/jetty.project/pull/10549#discussion_r1340347277