### PR TITLE
Proposal for Early Connector Start

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -88,7 +88,7 @@ public class Server extends HandlerWrapper implements Attributes
     private final AutoLock _dateLock = new AutoLock();
     private volatile DateField _dateField;
     private long _stopTimeout;
-    private boolean _startConnectorsEarly = true;
+    private boolean _startConnectorsEarly = false;
 
     public Server()
     {

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandlerList.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HandlerList.java
@@ -44,7 +44,7 @@ public class HandlerList extends HandlerCollection
     {
         Handler[] handlers = getHandlers();
 
-        if (handlers != null && isStarted())
+        if (handlers != null)
         {
             for (int i = 0; i < handlers.length; i++)
             {


### PR DESCRIPTION
This is proposal for offering a way to start connectors early for those deployments that want to have inter-context / inter-handler communications (via http requests) during the Server startup.

Such as having webappA deploy before webappB.
Then webappB having a load-on-start servlet init that makes an HTTP request to webappA to access something from it.