### PR TITLE
Add configuration to allow deferring the initial Deployment until after Server is started

### DIFF
--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -59,5 +59,9 @@
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -53,7 +53,7 @@
                   </Default>
                 </Property>
               </Set>
-              <Set name="deployOnStartup"><Property name="jetty.deploy.deployOnStartup" default="true"/></Set>
+              <Set name="deferInitialScan"><Property name="jetty.deploy.deferInitialScan" default="false"/></Set>
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="1"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
               <Set name="configurationManager">

--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -53,6 +53,7 @@
                   </Default>
                 </Property>
               </Set>
+              <Set name="deployOnStartup"><Property name="jetty.deploy.deployOnStartup" default="true"/></Set>
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="1"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
               <Set name="configurationManager">

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -20,8 +20,14 @@ etc/jetty-deploy.xml
 # Defaults Descriptor for all deployed webapps
 # jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault.xml
 
+# Deploy On Startup
+# true (default) will deploy on start, allowing failed deployments to fail server start.
+# false will deploy after server has started, failed deployments will not stop server.
+# jetty.deploy.deployOnStartup=true
+
 # Monitored directory scan period (seconds)
 # jetty.deploy.scanInterval=1
 
 # Whether to extract *.war files
 # jetty.deploy.extractWars=true
+

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -20,10 +20,11 @@ etc/jetty-deploy.xml
 # Defaults Descriptor for all deployed webapps
 # jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault.xml
 
-# Deploy On Startup
-# true (default) will deploy on start, allowing failed deployments to fail server start.
-# false will deploy after server has started, failed deployments will not stop server.
-# jetty.deploy.deployOnStartup=true
+# Defer Initial Scan
+# true to have the initial scan deferred until the Server component is started.
+#      Note: deploy failures do not fail server startup in a deferred initial scan mode.
+# false (default) to have initial scan occur as normal.
+# jetty.deploy.deferInitialScan=false
 
 # Monitored directory scan period (seconds)
 # jetty.deploy.scanInterval=1

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -27,11 +27,13 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppProvider;
 import org.eclipse.jetty.deploy.DeploymentManager;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     private int _scanInterval = 10;
     private Scanner _scanner;
     private boolean _useRealPaths;
+    private boolean _delayScanning = false;
 
     private final Scanner.DiscreteListener _scannerListener = new Scanner.DiscreteListener()
     {
@@ -153,7 +156,28 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         _scanner.setScanDepth(1); //consider direct dir children of monitored dir
         _scanner.addListener(_scannerListener);
 
-        addBean(_scanner);
+        if (_delayScanning)
+        {
+            Server server = getDeploymentManager().getServer();
+
+            LifeCycle.Listener delayScanningTrigger = new LifeCycle.Listener()
+            {
+                @Override
+                public void lifeCycleStarted(LifeCycle event)
+                {
+                    if (event == server)
+                    {
+                        ScanningAppProvider.this.addBean(_scanner);
+                        _scanner.nudge();
+                    }
+                }
+            };
+            getDeploymentManager().getServer().addEventListener(delayScanningTrigger);
+        }
+        else
+        {
+            addBean(_scanner);
+        }
 
         super.doStart();
     }

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -336,7 +336,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
      *
      * <ul>
      *     <li>{@code true} - to have initial scan deferred until the {@link Server} component
-     *     has reached it's STARTED state.<br/>
+     *     has reached it's STARTED state.<br>
      *     Note: any failures in a deploy will not fail the Server startup in this mode.</li>
      *     <li>{@code false} - (default value) to have initial scan occur as normal on
      *     ScanningAppProvider startup.</li>

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppProvider;
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -157,10 +156,11 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         _scanner.setScanDepth(1); //consider direct dir children of monitored dir
         _scanner.addListener(_scannerListener);
         _scanner.setReportExistingFilesOnStartup(true);
-        _scanner.setScanInStart(_deployOnStartup);
+        boolean deferInitialScan = !_deployOnStartup;
+        _scanner.setDeferInitialScan(deferInitialScan);
         addBean(_scanner);
 
-        if (!_deployOnStartup)
+        if (deferInitialScan)
         {
             // Setup listener to wait for Server in STARTED state, which
             // triggers the first scan of the monitored directories
@@ -174,7 +174,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
                         {
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Triggering Delayed Scan of {}", _monitored);
-                            _scanner.scan(Callback.NOOP);
+                            _scanner.startup();
                         }
                     }
                 });

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -51,7 +51,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     private int _scanInterval = 10;
     private Scanner _scanner;
     private boolean _useRealPaths;
-    private boolean _deployOnStartup = true;
+    private boolean _deferInitialScan = false;
 
     private final Scanner.DiscreteListener _scannerListener = new Scanner.DiscreteListener()
     {
@@ -156,11 +156,10 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         _scanner.setScanDepth(1); //consider direct dir children of monitored dir
         _scanner.addListener(_scannerListener);
         _scanner.setReportExistingFilesOnStartup(true);
-        boolean deferInitialScan = !_deployOnStartup;
-        _scanner.setDeferInitialScan(deferInitialScan);
+        _scanner.setDeferInitialScan(_deferInitialScan);
         addBean(_scanner);
 
-        if (deferInitialScan)
+        if (_deferInitialScan)
         {
             // Setup listener to wait for Server in STARTED state, which
             // triggers the first scan of the monitored directories
@@ -321,14 +320,34 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         }
     }
 
-    public boolean isDeployOnStartup()
+    /**
+     * Test if initial scan should be deferred.
+     *
+     * @return true if initial scan is deferred, false to have initial scan occur on startup of ScanningAppProvider.
+     * @see Scanner#isDeferInitialScan()
+     */
+    public boolean isDeferInitialScan()
     {
-        return _deployOnStartup;
+        return _deferInitialScan;
     }
 
-    public void setDeployOnStartup(boolean deployOnStartup)
+    /**
+     * Flag to control initial scan behavior.
+     *
+     * <ul>
+     *     <li>{@code true} - to have initial scan deferred until the {@link Server} component
+     *     has reached it's STARTED state.<br/>
+     *     Note: any failures in a deploy will not fail the Server startup in this mode.</li>
+     *     <li>{@code false} - (default value) to have initial scan occur as normal on
+     *     ScanningAppProvider startup.</li>
+     * </ul>
+     *
+     * @param defer true to defer initial scan, false to have initial scan occur on startup of ScanningAppProvider.
+     * @see Scanner#setDeferInitialScan(boolean)
+     */
+    public void setDeferInitialScan(boolean defer)
     {
-        _deployOnStartup = deployOnStartup;
+        _deferInitialScan = defer;
     }
 
     public void setScanInterval(int scanInterval)

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -165,14 +165,14 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
                 @Override
                 public void lifeCycleStarted(LifeCycle event)
                 {
-                    if (event == server)
+                    if (event instanceof Server)
                     {
                         ScanningAppProvider.this.addBean(_scanner);
                         _scanner.nudge();
                     }
                 }
             };
-            getDeploymentManager().getServer().addEventListener(delayScanningTrigger);
+            server.addEventListener(delayScanningTrigger);
         }
         else
         {
@@ -318,6 +318,16 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    public boolean isDelayScanning()
+    {
+        return _delayScanning;
+    }
+
+    public void setDelayScanning(boolean delayScanning)
+    {
+        _delayScanning = delayScanning;
     }
 
     public void setScanInterval(int scanInterval)

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -159,7 +159,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         _scanner.setAutoStartScanning(!_deferInitialScan);
         addBean(_scanner);
 
-        if (_deferInitialScan)
+        if (isDeferInitialScan())
         {
             // Setup listener to wait for Server in STARTED state, which
             // triggers the first scan of the monitored directories

--- a/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -156,7 +156,7 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
         _scanner.setScanDepth(1); //consider direct dir children of monitored dir
         _scanner.addListener(_scannerListener);
         _scanner.setReportExistingFilesOnStartup(true);
-        _scanner.setDeferInitialScan(_deferInitialScan);
+        _scanner.setAutoStartScanning(!_deferInitialScan);
         addBean(_scanner);
 
         if (_deferInitialScan)
@@ -172,8 +172,8 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
                         if (event instanceof Server)
                         {
                             if (LOG.isDebugEnabled())
-                                LOG.debug("Triggering Delayed Scan of {}", _monitored);
-                            _scanner.startup();
+                                LOG.debug("Triggering Deferred Scan of {}", _monitored);
+                            _scanner.startScanning();
                         }
                     }
                 });
@@ -324,7 +324,6 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
      * Test if initial scan should be deferred.
      *
      * @return true if initial scan is deferred, false to have initial scan occur on startup of ScanningAppProvider.
-     * @see Scanner#isDeferInitialScan()
      */
     public boolean isDeferInitialScan()
     {
@@ -343,7 +342,6 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
      * </ul>
      *
      * @param defer true to defer initial scan, false to have initial scan occur on startup of ScanningAppProvider.
-     * @see Scanner#setDeferInitialScan(boolean)
      */
     public void setDeferInitialScan(boolean defer)
     {

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/providers/WebAppProviderTest.java
@@ -248,7 +248,7 @@ public class WebAppProviderTest
 
         Map<String, String> properties = new HashMap<>();
         properties.put("jetty.home", jettyHome.toString());
-        properties.put("jetty.deploy.onstartup", "false");
+        properties.put("jetty.deploy.deferInitialScan", "true");
         //Start jetty, but this time running from the symlinked base
         System.setProperty("jetty.home", properties.get("jetty.home"));
 
@@ -265,7 +265,7 @@ public class WebAppProviderTest
                 if (appProvider instanceof ScanningAppProvider)
                 {
                     ScanningAppProvider scanningAppProvider = (ScanningAppProvider)appProvider;
-                    assertFalse(scanningAppProvider.isDeployOnStartup(), "The DeployOnStartup configuration should be false");
+                    assertTrue(scanningAppProvider.isDeferInitialScan(), "The DeferInitialScan configuration should be true");
                 }
             }
 

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -69,46 +70,41 @@ public class XmlConfiguredJetty
     public static Server loadConfigurations(List<Resource> configurations, Map<String, String> properties)
         throws Exception
     {
-        XmlConfiguration last = null;
-        Object[] obj = new Object[configurations.size()];
+        Map<String, Object> idMap = configure(configurations, properties);
 
-        // Configure everything
-        for (int i = 0; i < configurations.size(); i++)
-        {
-            Resource config = configurations.get(i);
-            XmlConfiguration configuration = new XmlConfiguration(config);
-            if (last != null)
-                configuration.getIdMap().putAll(last.getIdMap());
-            configuration.getProperties().putAll(properties);
-            obj[i] = configuration.configure();
-            last = configuration;
-        }
+        Server server = (Server)idMap.get("Server");
 
-        // Test for Server Instance.
-        Server foundServer = null;
-        int serverCount = 0;
-        for (int i = 0; i < configurations.size(); i++)
-        {
-            if (obj[i] instanceof Server)
-            {
-                if (obj[i].equals(foundServer))
-                {
-                    // Identical server instance found
-                    break;
-                }
-                foundServer = (Server)obj[i];
-                serverCount++;
-            }
-        }
-
-        if (serverCount <= 0)
+        if (server == null)
         {
             throw new Exception("Load failed to configure a " + Server.class.getName());
         }
 
-        assertEquals(1, serverCount, "Server load count");
+        return server;
+    }
 
-        return foundServer;
+    /**
+     * Configure for the list of XML Resources and Properties.
+     *
+     * @param xmls the xml resources (in order of execution)
+     * @param properties the properties to use with the XML
+     * @return the ID Map of configured objects (key is the id name in the XML, and the value is configured object)
+     * @throws Exception if unable to create objects or read XML
+     */
+    public static Map<String, Object> configure(List<Resource> xmls, Map<String, String> properties) throws Exception
+    {
+        Map<String, Object> idMap = new HashMap<>();
+
+        // Configure everything
+        for (Resource xmlResource : xmls)
+        {
+            XmlConfiguration configuration = new XmlConfiguration(xmlResource);
+            configuration.getIdMap().putAll(idMap);
+            configuration.getProperties().putAll(properties);
+            configuration.configure();
+            idMap.putAll(configuration.getIdMap());
+        }
+
+        return idMap;
     }
 
     public XmlConfiguredJetty(Path testdir) throws IOException
@@ -424,6 +420,6 @@ public class XmlConfiguredJetty
 
     public void stop() throws Exception
     {
-        _server.stop();
+        LifeCycle.stop(_server);
     }
 }

--- a/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
@@ -19,7 +19,7 @@
               <Set name="scanInterval">1</Set>
               <Set name="tempDir"><Property name="jetty.home" default="target" />/workish</Set>
               <Set name="useRealPaths">false</Set>
-              <Set name="deployOnStartup"><Property name="jetty.deploy.onstartup" default="true"/></Set>
+              <Set name="deferInitialScan"><Property name="jetty.deploy.deferInitialScan" default="false"/></Set>
              </New>
             </Item>
           </Array>

--- a/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
@@ -19,6 +19,7 @@
               <Set name="scanInterval">1</Set>
               <Set name="tempDir"><Property name="jetty.home" default="target" />/workish</Set>
               <Set name="useRealPaths">false</Set>
+              <Set name="deployOnStartup"><Property name="jetty.deploy.onstartup" default="true"/></Set>
              </New>
             </Item>
           </Array>

--- a/jetty-deploy/src/test/resources/jetty-logging.properties
+++ b/jetty-deploy/src/test/resources/jetty-logging.properties
@@ -2,4 +2,4 @@
 #org.eclipse.jetty.deploy.DeploymentTempDirTest.LEVEL=DEBUG
 #org.eclipse.jetty.deploy.LEVEL=DEBUG
 #org.eclipse.jetty.webapp.LEVEL=DEBUG
-#org.eclipse.jetty.util.Scanner=DEBUG
+org.eclipse.jetty.util.Scanner.LEVEL=DEBUG

--- a/jetty-deploy/src/test/resources/jetty-logging.properties
+++ b/jetty-deploy/src/test/resources/jetty-logging.properties
@@ -2,4 +2,4 @@
 #org.eclipse.jetty.deploy.DeploymentTempDirTest.LEVEL=DEBUG
 #org.eclipse.jetty.deploy.LEVEL=DEBUG
 #org.eclipse.jetty.webapp.LEVEL=DEBUG
-org.eclipse.jetty.util.Scanner.LEVEL=DEBUG
+#org.eclipse.jetty.util.Scanner.LEVEL=DEBUG

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -70,6 +70,7 @@ public class Scanner extends ContainerLifeCycle
     private Map<Path, MetaData> _prevScan;
     private FilenameFilter _filter;
     private final Map<Path, IncludeExcludeSet<PathMatcher, Path>> _scannables = new ConcurrentHashMap<>();
+    private boolean _scanInStart = true;
     private boolean _reportExisting = true;
     private boolean _reportDirs = true;
     private Scheduler.Task _task;
@@ -521,6 +522,25 @@ public class Scanner extends ContainerLifeCycle
     }
 
     /**
+     * Test if scan in start is set
+     * @return true if begins during start of Scanner
+     */
+    public boolean isScanInStart()
+    {
+        return _scanInStart;
+    }
+
+    /**
+     * Set if Scanner should perform an initial scan during start of its lifecycle.
+     *
+     * @param scan true to scan during start of Scanner, false to not scan during start of Scanner.
+     */
+    public void setScanInStart(boolean scan)
+    {
+        this._scanInStart = scan;
+    }
+
+    /**
      * Whether or not an initial scan will report all files as being
      * added.
      *
@@ -587,19 +607,22 @@ public class Scanner extends ContainerLifeCycle
     public void doStart() throws Exception
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Scanner start: rprtExists={}, depth={}, rprtDirs={}, interval={}, filter={}, scannables={}",
-                      _reportExisting, _scanDepth, _reportDirs, _scanInterval, _filter, _scannables);
+            LOG.debug("Scanner start: scanInStart={}, reportExists={}, depth={}, rprtDirs={}, interval={}, filter={}, scannables={}",
+                      _scanInStart, _reportExisting, _scanDepth, _reportDirs, _scanInterval, _filter, _scannables);
 
-        if (_reportExisting)
+        if (_scanInStart)
         {
-            // if files exist at startup, report them
-            scan();
-            scan(); // scan twice so files reported as stable
-        }
-        else
-        {
-            //just register the list of existing files and only report changes
-            _prevScan = scanFiles();
+            if (_reportExisting)
+            {
+                // if files exist at startup, report them
+                scan();
+                scan(); // scan twice so files reported as stable
+            }
+            else
+            {
+                //just register the list of existing files and only report changes
+                _prevScan = scanFiles();
+            }
         }
 
         super.doStart();

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -632,7 +632,7 @@ public class Scanner extends ContainerLifeCycle
     }
 
     /**
-     * Perform the initial scan of the directories {@link #setScanDirs(List),
+     * Perform the initial scan of the directories {@link #setScanDirs(List)},
      * and start the scan interval schedule.
      */
     public void startup()

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -523,7 +523,7 @@ public class Scanner extends ContainerLifeCycle
     }
 
     /**
-     * Test if scanning should start automatically with Scanner.{@link #start()}
+     * Test if scanning should start automatically with {@code Scanner}.{@link #start()}
      *
      * @return true if scanning should start automatically, false to have scanning is deferred to a later manual call to {@link #startScanning()}
      */
@@ -545,7 +545,7 @@ public class Scanner extends ContainerLifeCycle
      *     is required to initiate this Scanner so that it can begin report files in the {@link #setScanDirs(List)}
      * </p>
      *
-     * @param autostart true if scanning should start automatically, false to have scanning is deferred to a later manual call to {@link #startScanning()}
+     * @param autostart true if scanning should start automatically, false to defer start of scanning to a later call to {@link #startScanning()}
      */
     public void setAutoStartScanning(boolean autostart)
     {
@@ -632,9 +632,9 @@ public class Scanner extends ContainerLifeCycle
     }
 
     /**
-     * Start the scanning process.
+     * Start scanning.
      * <p>
-     *     This will perform the scan of the directories {@link #setScanDirs(List)}
+     *     This will perform the initial scan of the directories {@link #setScanDirs(List)}
      *     and schedule future scans, following all of the configuration
      *     of the scan (eg: {@link #setReportExistingFilesOnStartup(boolean)})
      * </p>

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -622,16 +622,13 @@ public class Scanner extends ContainerLifeCycle
             LOG.debug("Scanner start: autoStartScanning={}, reportExists={}, depth={}, rprtDirs={}, interval={}, filter={}, scannables={}",
                 isAutoStartScanning(), _reportExisting, _scanDepth, _reportDirs, _scanInterval, _filter, _scannables);
 
-        if (isAutoStartScanning())
-        {
-            // need to manually start _scheduler here
-            if (!_scheduler.isRunning())
-                _scheduler.start();
-            startScanning();
-        }
-
         // Start the scanner and managed beans (eg: the scheduler)
         super.doStart();
+
+        if (isAutoStartScanning())
+        {
+            startScanning();
+        }
     }
 
     /**
@@ -646,8 +643,6 @@ public class Scanner extends ContainerLifeCycle
     {
         if (!isRunning())
             throw new IllegalStateException("Scanner not started");
-        // the scheduling of tasks cannot work until _scheduler is running
-        assert _scheduler.isRunning();
 
         if (_scanningStarted)
             return;


### PR DESCRIPTION
Introduce a `WebAppProvider` (and `ScanningAppProvider`) configuration `.setDeferInitialScan(boolean)` (defaults to false), which controls the initial deployment of webapps.

* `true` = to have initial scan deferred until the `Server` component has reached it's STARTED state.
* `false` = (default) to have initial scan occur as normal on `ScanningAppProvider` startup.

Notes:
Having `true` set will not fail the `Server` startup.  
Having `false` be default allows for failed deployments to also fail the server start.

Fixes #10669