### PR TITLE
Changed default implementation of Session.Listener.onNewStream() and …

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -853,28 +853,14 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     private void notifyDataAvailable(Stream stream)
     {
-        Listener listener = this.listener;
-        if (listener != null)
+        Listener listener = Objects.requireNonNullElse(this.listener, Listener.AUTO_DISCARD);
+        try
         {
-            try
-            {
-                listener.onDataAvailable(stream);
-            }
-            catch (Throwable x)
-            {
-                LOG.info("Failure while notifying listener {}", listener, x);
-            }
+            listener.onDataAvailable(stream);
         }
-        else
+        catch (Throwable x)
         {
-            Data data = readData();
-            if (data != null)
-            {
-                data.release();
-                if (data.frame().isEndStream())
-                    return;
-            }
-            stream.demand();
+            LOG.info("Failure while notifying listener {}", listener, x);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java
@@ -228,9 +228,14 @@ public interface Session
          * <p>Applications can detect whether request DATA frames will be arriving
          * by testing {@link HeadersFrame#isEndStream()}. If the application is
          * interested in processing the DATA frames, it must demand for DATA
-         * frames using {@link Stream#demand()} and return a
+         * frames using {@link Stream#demand()} and then return either a
          * {@link Stream.Listener} implementation that overrides
-         * {@link Stream.Listener#onDataAvailable(Stream)}.</p>
+         * {@link Stream.Listener#onDataAvailable(Stream)} where applications can
+         * read from the {@link Stream} via {@link Stream#readData()}, or
+         * {@link Stream.Listener#AUTO_DISCARD} that automatically reads and
+         * discards DATA frames.
+         * Returning {@code null} is possible but discouraged, and has the
+         * same effect of demanding and discarding the DATA frames.</p>
          *
          * @param stream the newly created stream
          * @param frame the HEADERS frame received
@@ -238,7 +243,9 @@ public interface Session
          */
         public default Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
         {
-            return null;
+            if (!frame.isEndStream())
+                stream.demand();
+            return Stream.Listener.AUTO_DISCARD;
         }
 
         /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -265,6 +265,14 @@ public interface Stream
     public interface Listener
     {
         /**
+         * <p>A convenient constant for a {@link Listener} implementation that
+         * demands and discards DATA frames, typically to be returned from
+         * {@link Session.Listener#onNewStream(Stream, HeadersFrame)}
+         * and {@link Listener#onPush(Stream, PushPromiseFrame)}.</p>
+         */
+        public static Listener AUTO_DISCARD = new Listener() {};
+
+        /**
          * <p>Callback method invoked when a stream is created locally by
          * {@link Session#newStream(HeadersFrame, Promise, Listener)}.</p>
          *
@@ -282,11 +290,22 @@ public interface Stream
          */
         public default void onHeaders(Stream stream, HeadersFrame frame)
         {
-            stream.demand();
+            if (!frame.isEndStream())
+                stream.demand();
         }
 
         /**
          * <p>Callback method invoked when a PUSH_PROMISE frame has been received.</p>
+         * <p>Applications that override this method are typically interested in
+         * processing the pushed stream DATA frames, and must demand for pushed
+         * DATA frames via {@link Stream#demand()} and then return either a
+         * {@link Listener} implementation that overrides
+         * {@link #onDataAvailable(Stream)} where applications can
+         * read from the {@link Stream} via {@link Stream#readData()}, or
+         * {@link #AUTO_DISCARD} that automatically reads and
+         * discards DATA frames.
+         * Returning {@code null} is possible but discouraged, and has the
+         * same effect of demanding and discarding the pushed DATA frames.</p>
          *
          * @param stream the pushed stream
          * @param frame the PUSH_PROMISE frame received
@@ -294,7 +313,8 @@ public interface Stream
          */
         public default Listener onPush(Stream stream, PushPromiseFrame frame)
         {
-            return null;
+            stream.demand();
+            return AUTO_DISCARD;
         }
 
         /**
@@ -352,6 +372,18 @@ public interface Stream
          */
         public default void onDataAvailable(Stream stream)
         {
+            while (true)
+            {
+                Data data = stream.readData();
+                if (data == null)
+                {
+                    stream.demand();
+                    return;
+                }
+                data.release();
+                if (data.frame().isEndStream())
+                    return;
+            }
         }
 
         /**

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -507,7 +507,7 @@ public class GoAwayTest extends AbstractTest
                         // the server and be able to complete this stream.
                         clientStream1.data(new DataFrame(clientStream1.getId(), ByteBuffer.allocate(flowControlWindow / 2), true), Callback.NOOP);
                     }
-                }, new Stream.Listener() {});
+                }, AUTO_DISCARD);
             }
         });
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/SettingsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/SettingsTest.java
@@ -261,7 +261,7 @@ public class SettingsTest extends AbstractTest
                         MetaData.Request push = newRequest("GET", "/push", HttpFields.EMPTY);
                         try
                         {
-                            s.push(new PushPromiseFrame(s.getId(), push), new Stream.Listener() {});
+                            s.push(new PushPromiseFrame(s.getId(), push), Stream.Listener.AUTO_DISCARD);
                         }
                         catch (IllegalStateException x)
                         {
@@ -359,7 +359,7 @@ public class SettingsTest extends AbstractTest
 
         MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
         HeadersFrame frame = new HeadersFrame(request, null, true);
-        clientSession.newStream(frame, new Stream.Listener() {});
+        clientSession.newStream(frame, Stream.Listener.AUTO_DISCARD);
 
         Assertions.assertTrue(clientFailureLatch.await(5, TimeUnit.SECONDS));
     }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/resources/jetty-logging.properties
@@ -1,4 +1,5 @@
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.client.LEVEL=DEBUG
 #org.eclipse.jetty.http2.LEVEL=DEBUG
+#org.eclipse.jetty.http2.tests.LEVEL=DEBUG
 org.eclipse.jetty.http2.hpack.LEVEL=INFO

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -51,7 +51,7 @@ public class ByteBufferAggregator
         if (startSize <= 0)
             throw new IllegalArgumentException("startSize must be > 0, was: " + startSize);
         if (startSize > maxSize)
-            throw new IllegalArgumentException("maxSize (" + maxSize + ") must be > startSize (" + startSize + ")");
+            throw new IllegalArgumentException("maxSize (" + maxSize + ") must be >= startSize (" + startSize + ")");
         _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
         _direct = direct;
         _maxSize = maxSize;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -51,7 +51,7 @@ public class ByteBufferAggregator
         if (startSize <= 0)
             throw new IllegalArgumentException("startSize must be > 0, was: " + startSize);
         if (startSize > maxSize)
-            throw new IllegalArgumentException("maxSize (" + maxSize + ") must be >= startSize (" + startSize + ")");
+            throw new IllegalArgumentException("maxSize (" + maxSize + ") must be > startSize (" + startSize + ")");
         _bufferPool = (bufferPool == null) ? new ByteBufferPool.NonPooling() : bufferPool;
         _direct = direct;
         _maxSize = maxSize;


### PR DESCRIPTION
…Stream.Listener.onDataAvailable() to auto-discard DATA frames.

For normal cases, these methods are overridden and the application is in full control. For test cases, these methods may not be overridden and the default implementation conveniently avoids buffer leaks.

Fixed flaky test RawHTTP2ProxyTest.testRawHTTP2Proxy() due to the bad assumption that the first DATA frame ends the stream (so an aggregator is needed), and a copy/paste error in ServerToProxyToClient while processing DATA frames.