### PR TITLE
Rollback JDK21 requirements during Compile + Jar creation in Jetty 10+

### DIFF
--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -23,8 +23,8 @@
           <fail>false</fail>
           <rules>
             <requireJavaVersion>
-              <version>[21,)</version>
-              <message>[ERROR] OLD JDK [${java.version}] in use. Jetty documentation ${project.version} MUST use JDK 21 or newer</message>
+              <version>[17,)</version>
+              <message>[ERROR] OLD JDK [${java.version}] in use. Jetty documentation ${project.version} MUST use JDK 17 or newer</message>
             </requireJavaVersion>
           </rules>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2216,8 +2216,8 @@
                 <configuration>
                   <rules>
                     <requireJavaVersion>
-                      <version>[21,)</version>
-                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 21 or newer</message>
+                      <version>[17,)</version>
+                      <message>[ERROR] OLD JDK [${java.version}] in use. Jetty Release ${project.version} MUST use JDK 17 or newer</message>
                     </requireJavaVersion>
                   </rules>
                 </configuration>

--- a/scripts/release-jetty.sh
+++ b/scripts/release-jetty.sh
@@ -163,6 +163,11 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
     # This is equivalent to 'mvn release:perform'
     if proceedyn "Build/Deploy from tag $TAG_NAME? (Y/n)" y; then
         mvn clean deploy -Peclipse-release $DEPLOY_OPTS
+        echo "IMPORTANT NOTICE: You will need to build+deploy jetty-documentation on JDK21 to make the documentation sane!"
+        echo "Switch to a new window, make sure you are using JDK21, and run the following command:"
+        echo "$ mvn clean deploy -Peclipse-release $DEPLOY_OPTS -pl :jetty-documentation"
+        if proceedyn "Did you build and deploy jetty-documentation in JDK21? (y/N)" n; then
+        fi
     fi
     if proceedyn "Update working directory for $VER_NEXT? (Y/n)" y; then
         echo "Update VERSION.txt for $VER_NEXT"


### PR DESCRIPTION
Since there are reports that the JDK 21 built jars (built to Bytecode 55, aka Java 11) of Jetty 10.0.16 are causing problems in other build tools (graalvm, bazel, crac, etc) we have to rollback this JDK21 requirement on the build until JDK21 gets more stable.

This PR makes the release only have a JDK17 requirement.
Making the only JDK21 requirement left for jetty-documentation (to produce sane docs), now an extra step in the release script.