### PR TITLE
Fixed issue 10305 Embedded Jetty server fails to start when requests path contains not existed directory

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java
@@ -233,9 +233,19 @@ public class RolloverFileOutputStream extends OutputStream
             File file = new File(_filename);
             _filename = file.getCanonicalPath();
             file = new File(_filename);
-            File dir = new File(file.getParent());
-            if (!dir.isDirectory() || !dir.canWrite())
+            File dir = file.getParentFile();
+            if (!dir.exists())
+            {
+                throw new IOException("Log directory does not exist. Path=" + dir);
+            }
+            else if (!dir.isDirectory())
+            {
+                throw new IOException("Path for Log directory is not a directory. Path=" + dir);
+            }
+            else if (!dir.canWrite())
+            {
                 throw new IOException("Cannot write log directory " + dir);
+            }
 
             // Is this a rollover file?
             String filename = file.getName();

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -182,6 +182,47 @@ public class RolloverFileOutputStreamTest
     }
 
     @Test
+    public void testMissingDirectory()
+    {
+
+        ZoneId zone = toZoneId("Australia/Sydney");
+        ZonedDateTime now = toDateTime("2016.04.10-08:30:12.3 AM AEDT", zone);
+        String templateString = "missingDir/test-rofos-yyyy_mm_dd.log";
+        String excMessageExpected = "Log directory does not exist.";
+
+        try (RolloverFileOutputStream rofos =
+                 new RolloverFileOutputStream(templateString, false, 3, TimeZone.getTimeZone(zone), null, null, now))
+        {
+            rofos.write("TICK".getBytes());
+            rofos.flush();
+        }
+        catch (Exception ex)
+        {
+            boolean exClassOK = false;
+            if (ex instanceof java.io.IOException)
+            {
+                exClassOK = true;
+            }
+            assertThat("Exception Type", exClassOK, is(true));
+
+            String excMessageActual = ex.getMessage();
+            boolean messageOK = false;
+            if (excMessageActual != null)
+            {
+                excMessageActual = excMessageActual.trim();
+                if (!excMessageActual.isEmpty())
+                {
+                    if (excMessageActual.contains(excMessageExpected))
+                    {
+                        messageOK = true;
+                    }
+                }
+            }
+            assertThat("Exception Message", messageOK, is(true));
+        }
+    }        
+
+    @Test
     public void testFileHandling() throws Exception
     {
         Path testPath = testingDir.getEmptyPathDir();

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -36,7 +36,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(WorkDirExtension.class)
 public class RolloverFileOutputStreamTest
@@ -185,41 +188,21 @@ public class RolloverFileOutputStreamTest
     public void testMissingDirectory()
     {
 
-        ZoneId zone = toZoneId("Australia/Sydney");
-        ZonedDateTime now = toDateTime("2016.04.10-08:30:12.3 AM AEDT", zone);
         String templateString = "missingDir/test-rofos-yyyy_mm_dd.log";
-        String excMessageExpected = "Log directory does not exist.";
-
-        try (RolloverFileOutputStream rofos =
-                 new RolloverFileOutputStream(templateString, false, 3, TimeZone.getTimeZone(zone), null, null, now))
+        String excMessageActual = null;
+        Throwable error = null;
+        try (RolloverFileOutputStream rofos = new RolloverFileOutputStream(templateString))
         {
-            rofos.write("TICK".getBytes());
-            rofos.flush();
+            throw new IllegalStateException();
         }
-        catch (Exception ex)
+        catch (Throwable  t)
         {
-            boolean exClassOK = false;
-            if (ex instanceof java.io.IOException)
-            {
-                exClassOK = true;
-            }
-            assertThat("Exception Type", exClassOK, is(true));
-
-            String excMessageActual = ex.getMessage();
-            boolean messageOK = false;
-            if (excMessageActual != null)
-            {
-                excMessageActual = excMessageActual.trim();
-                if (!excMessageActual.isEmpty())
-                {
-                    if (excMessageActual.contains(excMessageExpected))
-                    {
-                        messageOK = true;
-                    }
-                }
-            }
-            assertThat("Exception Message", messageOK, is(true));
+            error = t;
+            excMessageActual = t.getMessage();
         }
+        assertNotNull(error);
+        assertThat(error, instanceOf(IOException.class));
+        assertThat(excMessageActual, containsString("Log directory does not exist."));
     }        
 
     @Test

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -189,8 +189,7 @@ public class RolloverFileOutputStreamTest
     {
 
         String templateString = "missingDir/test-rofos-yyyy_mm_dd.log";
-        String excMessageActual = null;
-        Throwable error = null;
+        Throwable error;
         try (RolloverFileOutputStream rofos = new RolloverFileOutputStream(templateString))
         {
             throw new IllegalStateException();
@@ -198,11 +197,11 @@ public class RolloverFileOutputStreamTest
         catch (Throwable  t)
         {
             error = t;
-            excMessageActual = t.getMessage();
         }
         assertNotNull(error);
         assertThat(error, instanceOf(IOException.class));
-        assertThat(excMessageActual, containsString("Log directory does not exist."));
+        error.getMessage();
+        assertThat(error.getMessage(), containsString("Log directory does not exist."));
     }        
 
     @Test


### PR DESCRIPTION
Changed error message when requests log path in RequestLogWriter contains not existed directory.