### PR TITLE
Fixes #10679 - Review HTTP/2 rate control (CVE-2023-44487)

### DIFF
--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
@@ -80,16 +80,28 @@ public class ContinuationBodyParser extends BodyParser
                     int remaining = buffer.remaining();
                     if (remaining < length)
                     {
-                        headerBlockFragments.storeFragment(buffer, remaining, false);
+                        ContinuationFrame frame = new ContinuationFrame(getStreamId(), false);
+                        if (!rateControlOnEvent(frame))
+                            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_continuation_frame_rate");
+
+                        if (!headerBlockFragments.storeFragment(buffer, remaining, false))
+                            return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_continuation_stream");
+
                         length -= remaining;
                         break;
                     }
                     else
                     {
-                        boolean last = hasFlag(Flags.END_HEADERS);
-                        headerBlockFragments.storeFragment(buffer, length, last);
+                        boolean endHeaders = hasFlag(Flags.END_HEADERS);
+                        ContinuationFrame frame = new ContinuationFrame(getStreamId(), endHeaders);
+                        if (!rateControlOnEvent(frame))
+                            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_continuation_frame_rate");
+
+                        if (!headerBlockFragments.storeFragment(buffer, length, endHeaders))
+                            return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_continuation_stream");
+
                         reset();
-                        if (last)
+                        if (endHeaders)
                             return onHeaders(buffer);
                         return true;
                     }
@@ -107,17 +119,21 @@ public class ContinuationBodyParser extends BodyParser
     {
         ByteBuffer headerBlock = headerBlockFragments.complete();
         MetaData metaData = headerBlockParser.parse(headerBlock, headerBlock.remaining());
-        if (metaData == null)
-            return true;
+        HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, headerBlockFragments.getPriorityFrame(), headerBlockFragments.isEndStream());
+        headerBlockFragments.reset();
+
         if (metaData == HeaderBlockParser.SESSION_FAILURE)
             return false;
-        HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, headerBlockFragments.getPriorityFrame(), headerBlockFragments.isEndStream());
-        if (metaData == HeaderBlockParser.STREAM_FAILURE)
+
+        if (metaData != HeaderBlockParser.STREAM_FAILURE)
+        {
+            notifyHeaders(frame);
+        }
+        else
         {
             if (!rateControlOnEvent(frame))
-                return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_continuation_frame_rate");
+                return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
         }
-        notifyHeaders(frame);
         return true;
     }
 

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
@@ -76,8 +76,15 @@ public class HeadersBodyParser extends BodyParser
         }
         else
         {
-            headerBlockFragments.setStreamId(getStreamId());
-            headerBlockFragments.setEndStream(isEndStream());
+            if (headerBlockFragments.getStreamId() != 0)
+            {
+                connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
+            }
+            else
+            {
+                headerBlockFragments.setStreamId(getStreamId());
+                headerBlockFragments.setEndStream(isEndStream());
+            }
         }
     }
 
@@ -173,6 +180,18 @@ public class HeadersBodyParser extends BodyParser
                 }
                 case HEADERS:
                 {
+                    if (!hasFlag(Flags.END_HEADERS))
+                    {
+                        headerBlockFragments.setStreamId(getStreamId());
+                        headerBlockFragments.setEndStream(isEndStream());
+                        if (hasFlag(Flags.PRIORITY))
+                            headerBlockFragments.setPriorityFrame(new PriorityFrame(getStreamId(), parentStreamId, weight, exclusive));
+                    }
+                    state = State.HEADER_BLOCK;
+                    break;
+                }
+                case HEADER_BLOCK:
+                {
                     if (hasFlag(Flags.END_HEADERS))
                     {
                         int maxLength = headerBlockParser.getMaxHeaderListSize();
@@ -196,7 +215,7 @@ public class HeadersBodyParser extends BodyParser
                             {
                                 HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
                                 if (!rateControlOnEvent(frame))
-                                    connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
+                                    return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
                             }
                         }
                     }
@@ -205,16 +224,14 @@ public class HeadersBodyParser extends BodyParser
                         int remaining = buffer.remaining();
                         if (remaining < length)
                         {
-                            headerBlockFragments.storeFragment(buffer, remaining, false);
+                            if (!headerBlockFragments.storeFragment(buffer, remaining, false))
+                                return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
                             length -= remaining;
                         }
                         else
                         {
-                            headerBlockFragments.setStreamId(getStreamId());
-                            headerBlockFragments.setEndStream(isEndStream());
-                            if (hasFlag(Flags.PRIORITY))
-                                headerBlockFragments.setPriorityFrame(new PriorityFrame(getStreamId(), parentStreamId, weight, exclusive));
-                            headerBlockFragments.storeFragment(buffer, length, false);
+                            if (!headerBlockFragments.storeFragment(buffer, length, false))
+                                return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
                             state = State.PADDING;
                             loop = paddingLength == 0;
                         }
@@ -258,6 +275,6 @@ public class HeadersBodyParser extends BodyParser
 
     private enum State
     {
-        PREPARE, PADDING_LENGTH, EXCLUSIVE, PARENT_STREAM_ID, PARENT_STREAM_ID_BYTES, WEIGHT, HEADERS, PADDING
+        PREPARE, PADDING_LENGTH, EXCLUSIVE, PARENT_STREAM_ID, PARENT_STREAM_ID_BYTES, WEIGHT, HEADERS, HEADER_BLOCK, PADDING
     }
 }

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
@@ -92,7 +92,7 @@ public class Parser
         this.listener = listener;
         unknownBodyParser = new UnknownBodyParser(headerParser, listener);
         HeaderBlockParser headerBlockParser = new HeaderBlockParser(headerParser, byteBufferPool, hpackDecoder, unknownBodyParser);
-        HeaderBlockFragments headerBlockFragments = new HeaderBlockFragments();
+        HeaderBlockFragments headerBlockFragments = new HeaderBlockFragments(hpackDecoder.getMaxHeaderListSize());
         bodyParsers[FrameType.DATA.getType()] = new DataBodyParser(headerParser, listener);
         bodyParsers[FrameType.HEADERS.getType()] = new HeadersBodyParser(headerParser, listener, headerBlockParser, headerBlockFragments);
         bodyParsers[FrameType.PRIORITY.getType()] = new PriorityBodyParser(headerParser, listener);

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/ResetBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/ResetBodyParser.java
@@ -63,7 +63,7 @@ public class ResetBodyParser extends BodyParser
                 {
                     if (buffer.remaining() >= 4)
                     {
-                        return onReset(buffer.getInt());
+                        return onReset(buffer, buffer.getInt());
                     }
                     else
                     {
@@ -78,7 +78,7 @@ public class ResetBodyParser extends BodyParser
                     --cursor;
                     error += currByte << (8 * cursor);
                     if (cursor == 0)
-                        return onReset(error);
+                        return onReset(buffer, error);
                     break;
                 }
                 default:
@@ -90,9 +90,11 @@ public class ResetBodyParser extends BodyParser
         return false;
     }
 
-    private boolean onReset(int error)
+    private boolean onReset(ByteBuffer buffer, int error)
     {
         ResetFrame frame = new ResetFrame(getStreamId(), error);
+        if (!rateControlOnEvent(frame))
+            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_rst_stream_frame_rate");
         reset();
         notifyReset(frame);
         return true;

--- a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/UnknownBodyParser.java
+++ b/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/parser/UnknownBodyParser.java
@@ -40,7 +40,6 @@ public class UnknownBodyParser extends BodyParser
         boolean parsed = cursor == 0;
         if (parsed && !rateControlOnEvent(new UnknownFrame(getFrameType())))
             return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_unknown_frame_rate");
-
         return parsed;
     }
 

--- a/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
+++ b/jetty-http2/http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
@@ -94,9 +94,17 @@ public class FrameFloodTest
     }
 
     @Test
-    public void testSettingsFrameFlood()
+    public void testEmptySettingsFrameFlood()
     {
         byte[] payload = new byte[0];
+        testFrameFlood(null, frameFrom(payload.length, FrameType.SETTINGS.getType(), 0, 0, payload));
+    }
+
+    @Test
+    public void testSettingsFrameFlood()
+    {
+        // | Key0 | Key1 | Value0 | Value1 | Value2 | Value3 |
+        byte[] payload = new byte[]{0, 8, 0, 0, 0, 1};
         testFrameFlood(null, frameFrom(payload.length, FrameType.SETTINGS.getType(), 0, 0, payload));
     }
 
@@ -106,15 +114,32 @@ public class FrameFloodTest
         byte[] payload = {0, 0, 0, 0, 0, 0, 0, 0};
         testFrameFlood(null, frameFrom(payload.length, FrameType.PING.getType(), 0, 0, payload));
     }
-    
+
     @Test
-    public void testContinuationFrameFlood()
+    public void testEmptyContinuationFrameFlood()
     {
         int streamId = 13;
         byte[] headersPayload = new byte[0];
         byte[] headersBytes = frameFrom(headersPayload.length, FrameType.HEADERS.getType(), 0, streamId, headersPayload);
         byte[] continuationPayload = new byte[0];
         testFrameFlood(headersBytes, frameFrom(continuationPayload.length, FrameType.CONTINUATION.getType(), 0, streamId, continuationPayload));
+    }
+
+    @Test
+    public void testContinuationFrameFlood()
+    {
+        int streamId = 13;
+        byte[] headersPayload = new byte[0];
+        byte[] headersBytes = frameFrom(headersPayload.length, FrameType.HEADERS.getType(), 0, streamId, headersPayload);
+        byte[] continuationPayload = new byte[1];
+        testFrameFlood(headersBytes, frameFrom(continuationPayload.length, FrameType.CONTINUATION.getType(), 0, streamId, continuationPayload));
+    }
+
+    @Test
+    public void testResetStreamFrameFlood()
+    {
+        byte[] payload = {0, 0, 0, 0};
+        testFrameFlood(null, frameFrom(payload.length, FrameType.RST_STREAM.getType(), 0, 13, payload));
     }
 
     @Test
@@ -127,7 +152,7 @@ public class FrameFloodTest
     private void testFrameFlood(byte[] preamble, byte[] bytes)
     {
         AtomicBoolean failed = new AtomicBoolean();
-        Parser parser = new Parser(byteBufferPool, 4096, new WindowRateControl(8, Duration.ofSeconds(1)));
+        Parser parser = new Parser(byteBufferPool, 8192, new WindowRateControl(8, Duration.ofSeconds(1)));
         parser.init(new Parser.Listener.Adapter()
         {
             @Override

--- a/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -62,7 +62,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
     private int maxHeaderBlockFragment = 0;
     private int maxFrameSize = Frame.DEFAULT_MAX_LENGTH;
     private int maxSettingsKeys = SettingsFrame.DEFAULT_MAX_KEYS;
-    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(50);
+    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(128);
     private FlowControlStrategy.Factory flowControlStrategyFactory = () -> new BufferingFlowControlStrategy(0.5F);
     private long streamIdleTimeout;
 


### PR DESCRIPTION
Addresses CVE-2023-44487 - (in case https://github.com/github/advisory-database/issues/2869 isn't fixed, use top level link https://nvd.nist.gov/vuln/detail/CVE-2023-44487)

* Bumped the rate control rate from 50 events/s to 128.
* Added rate control for all CONTINUATION frames.
* Added rate control for invalid PUSH_PROMISE frames.
* Added rate control for RST_STREAM frames.
* Added rate control for all SETTINGS frames.
* Fixed growth of header block accumulation buffer.