### PR TITLE
Fixes #10679 - Review HTTP/2 rate control (CVE-2023-44487)

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
@@ -75,8 +75,15 @@ public class HeadersBodyParser extends BodyParser
         }
         else
         {
-            headerBlockFragments.setStreamId(getStreamId());
-            headerBlockFragments.setEndStream(isEndStream());
+            if (headerBlockFragments.getStreamId() != 0)
+            {
+                connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
+            }
+            else
+            {
+                headerBlockFragments.setStreamId(getStreamId());
+                headerBlockFragments.setEndStream(isEndStream());
+            }
         }
     }
 
@@ -172,6 +179,18 @@ public class HeadersBodyParser extends BodyParser
                 }
                 case HEADERS:
                 {
+                    if (!hasFlag(Flags.END_HEADERS))
+                    {
+                        headerBlockFragments.setStreamId(getStreamId());
+                        headerBlockFragments.setEndStream(isEndStream());
+                        if (hasFlag(Flags.PRIORITY))
+                            headerBlockFragments.setPriorityFrame(new PriorityFrame(getStreamId(), parentStreamId, weight, exclusive));
+                    }
+                    state = State.HEADER_BLOCK;
+                    break;
+                }
+                case HEADER_BLOCK:
+                {
                     if (hasFlag(Flags.END_HEADERS))
                     {
                         int maxLength = headerBlockParser.getMaxHeaderListSize();
@@ -195,7 +214,7 @@ public class HeadersBodyParser extends BodyParser
                             {
                                 HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
                                 if (!rateControlOnEvent(frame))
-                                    connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
+                                    return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
                             }
                         }
                     }
@@ -204,16 +223,14 @@ public class HeadersBodyParser extends BodyParser
                         int remaining = buffer.remaining();
                         if (remaining < length)
                         {
-                            headerBlockFragments.storeFragment(buffer, remaining, false);
+                            if (!headerBlockFragments.storeFragment(buffer, remaining, false))
+                                return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
                             length -= remaining;
                         }
                         else
                         {
-                            headerBlockFragments.setStreamId(getStreamId());
-                            headerBlockFragments.setEndStream(isEndStream());
-                            if (hasFlag(Flags.PRIORITY))
-                                headerBlockFragments.setPriorityFrame(new PriorityFrame(getStreamId(), parentStreamId, weight, exclusive));
-                            headerBlockFragments.storeFragment(buffer, length, false);
+                            if (!headerBlockFragments.storeFragment(buffer, length, false))
+                                return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_headers_frame");
                             state = State.PADDING;
                             loop = paddingLength == 0;
                         }
@@ -257,6 +274,6 @@ public class HeadersBodyParser extends BodyParser
 
     private enum State
     {
-        PREPARE, PADDING_LENGTH, EXCLUSIVE, PARENT_STREAM_ID, PARENT_STREAM_ID_BYTES, WEIGHT, HEADERS, PADDING
+        PREPARE, PADDING_LENGTH, EXCLUSIVE, PARENT_STREAM_ID, PARENT_STREAM_ID_BYTES, WEIGHT, HEADERS, HEADER_BLOCK, PADDING
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
@@ -74,7 +74,7 @@ public class Parser
         this.listener = listener;
         unknownBodyParser = new UnknownBodyParser(headerParser, listener);
         HeaderBlockParser headerBlockParser = new HeaderBlockParser(headerParser, bufferPool, hpackDecoder, unknownBodyParser);
-        HeaderBlockFragments headerBlockFragments = new HeaderBlockFragments(bufferPool);
+        HeaderBlockFragments headerBlockFragments = new HeaderBlockFragments(bufferPool, hpackDecoder.getMaxHeaderListSize());
         bodyParsers[FrameType.DATA.getType()] = new DataBodyParser(headerParser, listener);
         bodyParsers[FrameType.HEADERS.getType()] = new HeadersBodyParser(headerParser, listener, headerBlockParser, headerBlockFragments);
         bodyParsers[FrameType.PRIORITY.getType()] = new PriorityBodyParser(headerParser, listener);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.Flags;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 
 public class PushPromiseBodyParser extends BodyParser
@@ -65,13 +66,9 @@ public class PushPromiseBodyParser extends BodyParser
                     length = getBodyLength();
 
                     if (isPadding())
-                    {
                         state = State.PADDING_LENGTH;
-                    }
                     else
-                    {
                         state = State.STREAM_ID;
-                    }
                     break;
                 }
                 case PADDING_LENGTH:
@@ -131,7 +128,15 @@ public class PushPromiseBodyParser extends BodyParser
                         state = State.PADDING;
                         loop = paddingLength == 0;
                         if (metaData != HeaderBlockParser.STREAM_FAILURE)
+                        {
                             onPushPromise(streamId, metaData);
+                        }
+                        else
+                        {
+                            HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
+                            if (!rateControlOnEvent(frame))
+                                return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
+                        }
                     }
                     break;
                 }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ResetBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ResetBodyParser.java
@@ -58,7 +58,7 @@ public class ResetBodyParser extends BodyParser
                 {
                     if (buffer.remaining() >= 4)
                     {
-                        return onReset(buffer.getInt());
+                        return onReset(buffer, buffer.getInt());
                     }
                     else
                     {
@@ -73,7 +73,7 @@ public class ResetBodyParser extends BodyParser
                     --cursor;
                     error += currByte << (8 * cursor);
                     if (cursor == 0)
-                        return onReset(error);
+                        return onReset(buffer, error);
                     break;
                 }
                 default:
@@ -85,9 +85,11 @@ public class ResetBodyParser extends BodyParser
         return false;
     }
 
-    private boolean onReset(int error)
+    private boolean onReset(ByteBuffer buffer, int error)
     {
         ResetFrame frame = new ResetFrame(getStreamId(), error);
+        if (!rateControlOnEvent(frame))
+            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_rst_stream_frame_rate");
         reset();
         notifyReset(frame);
         return true;

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
@@ -73,10 +73,7 @@ public class SettingsBodyParser extends BodyParser
             return;
         boolean isReply = hasFlag(Flags.ACK);
         SettingsFrame frame = new SettingsFrame(Collections.emptyMap(), isReply);
-        if (!isReply && !rateControlOnEvent(frame))
-            connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_settings_frame_rate");
-        else
-            onSettings(frame);
+        onSettings(buffer, frame);
     }
 
     private boolean validateFrame(ByteBuffer buffer, int streamId, int bodyLength)
@@ -219,11 +216,13 @@ public class SettingsBodyParser extends BodyParser
             return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_settings_max_frame_size");
 
         SettingsFrame frame = new SettingsFrame(settings, hasFlag(Flags.ACK));
-        return onSettings(frame);
+        return onSettings(buffer, frame);
     }
 
-    private boolean onSettings(SettingsFrame frame)
+    private boolean onSettings(ByteBuffer buffer, SettingsFrame frame)
     {
+        if (!rateControlOnEvent(frame))
+            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_settings_frame_rate");
         reset();
         notifySettings(frame);
         return true;

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/UnknownBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/UnknownBodyParser.java
@@ -35,7 +35,6 @@ public class UnknownBodyParser extends BodyParser
         boolean parsed = cursor == 0;
         if (parsed && !rateControlOnEvent(new UnknownFrame(getFrameType())))
             return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_unknown_frame_rate");
-
         return parsed;
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/FrameFloodTest.java
@@ -96,9 +96,17 @@ public class FrameFloodTest
     }
 
     @Test
-    public void testSettingsFrameFlood()
+    public void testEmptySettingsFrameFlood()
     {
         byte[] payload = new byte[0];
+        testFrameFlood(null, frameFrom(payload.length, FrameType.SETTINGS.getType(), 0, 0, payload));
+    }
+
+    @Test
+    public void testSettingsFrameFlood()
+    {
+        // | Key0 | Key1 | Value0 | Value1 | Value2 | Value3 |
+        byte[] payload = new byte[]{0, 8, 0, 0, 0, 1};
         testFrameFlood(null, frameFrom(payload.length, FrameType.SETTINGS.getType(), 0, 0, payload));
     }
 
@@ -108,15 +116,32 @@ public class FrameFloodTest
         byte[] payload = {0, 0, 0, 0, 0, 0, 0, 0};
         testFrameFlood(null, frameFrom(payload.length, FrameType.PING.getType(), 0, 0, payload));
     }
-    
+
     @Test
-    public void testContinuationFrameFlood()
+    public void testEmptyContinuationFrameFlood()
     {
         int streamId = 13;
         byte[] headersPayload = new byte[0];
         byte[] headersBytes = frameFrom(headersPayload.length, FrameType.HEADERS.getType(), 0, streamId, headersPayload);
         byte[] continuationPayload = new byte[0];
         testFrameFlood(headersBytes, frameFrom(continuationPayload.length, FrameType.CONTINUATION.getType(), 0, streamId, continuationPayload));
+    }
+
+    @Test
+    public void testContinuationFrameFlood()
+    {
+        int streamId = 13;
+        byte[] headersPayload = new byte[0];
+        byte[] headersBytes = frameFrom(headersPayload.length, FrameType.HEADERS.getType(), 0, streamId, headersPayload);
+        byte[] continuationPayload = new byte[1];
+        testFrameFlood(headersBytes, frameFrom(continuationPayload.length, FrameType.CONTINUATION.getType(), 0, streamId, continuationPayload));
+    }
+
+    @Test
+    public void testResetStreamFrameFlood()
+    {
+        byte[] payload = {0, 0, 0, 0};
+        testFrameFlood(null, frameFrom(payload.length, FrameType.RST_STREAM.getType(), 0, 13, payload));
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -73,7 +73,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
     private int maxFrameSize = Frame.DEFAULT_MAX_SIZE;
     private int maxSettingsKeys = SettingsFrame.DEFAULT_MAX_KEYS;
     private boolean connectProtocolEnabled = true;
-    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(50);
+    private RateControl.Factory rateControlFactory = new WindowRateControl.Factory(128);
     private FlowControlStrategy.Factory flowControlStrategyFactory = () -> new BufferingFlowControlStrategy(0.5F);
     private long streamIdleTimeout;
     private boolean useInputDirectByteBuffers;


### PR DESCRIPTION
Addresses CVE-2023-44487 - (in case https://github.com/github/advisory-database/issues/2869 isn't fixed, use top level link https://nvd.nist.gov/vuln/detail/CVE-2023-44487)

* Bumped the rate control rate from 50 events/s to 128.
* Added rate control for all CONTINUATION frames.
* Added rate control for invalid PUSH_PROMISE frames.
* Added rate control for RST_STREAM frames.
* Added rate control for all SETTINGS frames.
* Fixed growth of header block accumulation buffer.