### PR TITLE
Issue #10696 - Addressing start-stop-daemon behaviors in jetty.sh

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -525,7 +525,6 @@ then
     START_STOP_DAEMON_AVAILABLE=1
   else
     USE_START_STOP_DAEMON=0
-    JETTY_ARGS=(${JETTY_ARGS[*]} "--module=pid" "jetty.pid=$JETTY_PID")
   fi
 fi
 
@@ -582,13 +581,14 @@ case "$ACTION" in
         CH_USER="--chuid $JETTY_USER"
       fi
 
+      # use of --pidfile /dev/null disables internal pidfile
+      # management of the start-stop-daemon (see man page)
       echo ${RUN_ARGS[@]} | xargs start-stop-daemon \
        --start $CH_USER \
-       --pidfile "$JETTY_PID" \
+       --pidfile /dev/null \
        --chdir "$JETTY_BASE" \
        --background \
-       --output "${JETTY_RUN}/start-stop.log"
-       --make-pidfile \
+       --output "${JETTY_RUN}/start-stop.log" \
        --startas "$JAVA" \
        --
       (( DEBUG )) && echo "Starting: start-stop-daemon"

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -552,8 +552,8 @@ case "$ACTION" in
       exit
     fi
 
-    # If not changing users, test for file system permissions.
-    if [ -z "$JETTY_USER"]
+    # Do not test for file system permissions if user is root, or process will switch to JETTY_USER
+    if [ $UID -ne 0] && [ -z "$JETTY_USER"]
     then
       if ! touch "$JETTY_PID"
       then

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -225,16 +225,14 @@ testFileSystemPermissions()
   fi
 
   # Don't test if JETTY_USER is specified
-  # as the Jetty process will switch to a different
-  # user id on startup
-  if [ -z "$JETTY_USER"] ; then
+  # as the Jetty process will switch to a different user id on startup
+  if [ -n "$JETTY_USER"] ; then
     (( DEBUG )) && echo "Not testing file system permissions: JETTY_USER=$JETTY_USER"
     return 0
   fi
 
   # Don't test if setuid is specified
-  # as the Jetty process will switch to a different
-  # user id on startup
+  # as the Jetty process will switch to a different user id on startup
   if expr "${JETTY_ARGS[*]}" : '.*setuid.*' >/dev/null
   then
     (( DEBUG )) && echo "Not testing file system permissions: setuid in use"

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -553,7 +553,7 @@ case "$ACTION" in
     fi
 
     # Do not test for file system permissions if user is root, or process will switch to JETTY_USER
-    if [ $UID -ne 0] && [ -z "$JETTY_USER"]
+    if [ $UID -ne 0 ] && [ -z "$JETTY_USER" ]
     then
       if ! touch "$JETTY_PID"
       then

--- a/jetty-home/src/main/resources/etc/jetty.conf
+++ b/jetty-home/src/main/resources/etc/jetty.conf
@@ -8,4 +8,4 @@
 # Each line in this file becomes an argument to start.jar
 # in addition to those found in the start.ini file
 # =======================================================
---module=pid,state
+--module=state

--- a/jetty-home/src/main/resources/etc/jetty.conf
+++ b/jetty-home/src/main/resources/etc/jetty.conf
@@ -8,4 +8,4 @@
 # Each line in this file becomes an argument to start.jar
 # in addition to those found in the start.ini file
 # =======================================================
---module=state
+--module=pid,state


### PR DESCRIPTION
* moving the `touch <file>` tests to only execute if the `JETTY_USER` is unspecified. (ie: no user id change)
* disabling internal pid-file management on `start-stop-daemon`, allowing Jetty's `PidFile` and `jetty.sh` manage it.
* re-introducing the `USE_START_STOP_DAEMON=1` to the `jetty.sh` to allow disabling use of `start-stop-daemon` based on configuration.