### PR TITLE
Fix racy assertion in `HttpClientTLSTest.testHostNameVerificationFailure`

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
@@ -88,6 +88,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -600,16 +601,17 @@ public class HttpClientTLSTest
         startClient(clientTLSFactory);
 
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         client.newRequest("localhost", connector.getLocalPort())
             .scheme(HttpScheme.HTTPS.asString())
             .send(result ->
             {
-                Throwable failure = result.getFailure();
-                if (failure instanceof SSLPeerUnverifiedException)
-                    latch.countDown();
+                throwableRef.set(result.getRequestFailure());
+                latch.countDown();
             });
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertInstanceOf(SSLPeerUnverifiedException.class, throwableRef.get());
     }
 
     @Test


### PR DESCRIPTION
`testHostNameVerificationFailure` checks that a request fails with `SSLPeerUnverifiedException` by checking `Result.getFailure()`.

Unfortunately, depending on which of the client's reader or writer thread finishes first, `Result.getFailure()` will return either the request's `SSLPeerUnverifiedException` or the response' `EOFException`.

Asserting on `Result.getRequestFailure()` instead does solve the racy assertion.

Fixes #10698