### PR TITLE
Fix #10656 return value for HttpServletRequest.getProtocolRequestId() in ee10

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -187,6 +187,8 @@ public class ServletApiRequest implements HttpServletRequest
     @Override
     public String getProtocolRequestId()
     {
+        if (getRequest().getConnectionMetaData().getHttpVersion().getVersion() <= HttpVersion.HTTP_1_0.getVersion())
+            return null;
         return getRequest().getId();
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -187,9 +187,11 @@ public class ServletApiRequest implements HttpServletRequest
     @Override
     public String getProtocolRequestId()
     {
-        if (getRequest().getConnectionMetaData().getHttpVersion().getVersion() <= HttpVersion.HTTP_1_0.getVersion())
-            return null;
-        return getRequest().getId();
+        return switch (getRequest().getConnectionMetaData().getHttpVersion())
+        {
+            case HTTP_2, HTTP_3 -> getRequest().getId();
+            default -> "";
+        };
     }
 
     @Override


### PR DESCRIPTION
Return null for HTTP/1.0 and previous

Fixes: #10656