### PR TITLE
Replace non serializable properties with null values

### DIFF
--- a/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
@@ -10,6 +10,9 @@
       <New id="sessionDataStoreFactory" class="org.eclipse.jetty.server.session.JDBCSessionDataStoreFactory">
         <Set name="gracePeriodSec" property="jetty.session.gracePeriod.seconds"/>
         <Set name="savePeriodSec" property="jetty.session.savePeriod.seconds"/>
+        <Set name="serializationSkipNonSerializable" property="jetty.session.serialization.skipNonSerializable"/>
+        <Set name="serializationLogNonSerializable" property="jetty.session.serialization.logNonSerializable"/>
+        <Set name="serializationСompressData" property="jetty.session.serialization.compressData"/>
         <Set name="databaseAdaptor">
           <Ref refid="databaseAdaptor" />
         </Set>

--- a/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
@@ -12,7 +12,7 @@
         <Set name="savePeriodSec" property="jetty.session.savePeriod.seconds"/>
         <Set name="serializationSkipNonSerializable" property="jetty.session.serialization.skipNonSerializable"/>
         <Set name="serializationLogNonSerializable" property="jetty.session.serialization.logNonSerializable"/>
-        <Set name="serializationСompressData" property="jetty.session.serialization.compressData"/>
+        <Set name="serializationCompressData" property="jetty.session.serialization.compressData"/>
         <Set name="databaseAdaptor">
           <Ref refid="databaseAdaptor" />
         </Set>

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -28,6 +28,10 @@ db-connection-type?=datasource
 #jetty.session.gracePeriod.seconds=3600
 #jetty.session.savePeriod.seconds=0
 
+#jetty.session.serialization.skipNonSerializable=false
+#jetty.session.serialization.logNonSerializable=false
+#jetty.session.serialization.compressData=false
+
 #jetty.session.jdbc.blobType=
 #jetty.session.jdbc.longType=
 #jetty.session.jdbc.stringType=

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/ExtendedObjectOutputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/ExtendedObjectOutputStream.java
@@ -1,0 +1,72 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.session;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExtendedObjectOutputStream extends java.io.ObjectOutputStream
+{
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExtendedObjectOutputStream.class);
+
+    private NullOutputStream nos = new NullOutputStream();
+    private ObjectOutputStream oos = new ObjectOutputStream(nos);
+
+    private boolean _serializationLogSkipped;
+
+    public ExtendedObjectOutputStream(OutputStream out, boolean serializationLogSkipped) throws IOException
+    {
+        super(out);
+        enableReplaceObject(true);
+        this._serializationLogSkipped = serializationLogSkipped;
+    }
+
+    @Override
+    protected Object replaceObject(Object obj) throws IOException
+    {
+        try
+        {
+            oos.writeObject(obj);
+
+            return obj;
+        }
+        catch (Throwable ex)
+        {
+            if (obj instanceof Serializable)
+            {
+                return obj;
+            }
+
+            if (_serializationLogSkipped)
+            {
+                LOG.warn("Skipping object <{}> serialization, class <{}>  ", obj, obj.getClass());
+            }
+        }
+
+        return null;
+    }
+
+    public class NullOutputStream extends OutputStream
+    {
+        @Override
+        public void write(int b) throws IOException {}
+    }
+
+}

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java
@@ -762,11 +762,8 @@ public class JDBCSessionDataStore extends AbstractSessionDataStore
 
                     try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes))
                     {
-                        statement.setBinaryStream(13, bais, bytes.length); //attribute map as blob
+                        statement.setBinaryStream(12, bais, bytes.length); //attribute map as blob
                     }
-                    
-                    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-                    statement.setBinaryStream(12, bais, bytes.length); //attribute map as blob
                 }
 
                 statement.executeUpdate();

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStoreFactory.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStoreFactory.java
@@ -29,6 +29,10 @@ public class JDBCSessionDataStoreFactory extends AbstractSessionDataStoreFactory
      */
     JDBCSessionDataStore.SessionTableSchema _schema;
 
+    boolean _serializationSkipNonSerializable = false;
+    boolean _serializationLogNonSerializable = false;
+    boolean _serializationCompressData = false;
+
     @Override
     public SessionDataStore getSessionDataStore(SessionHandler handler)
     {
@@ -37,6 +41,11 @@ public class JDBCSessionDataStoreFactory extends AbstractSessionDataStoreFactory
         ds.setSessionTableSchema(_schema);
         ds.setGracePeriodSec(getGracePeriodSec());
         ds.setSavePeriodSec(getSavePeriodSec());
+
+        ds.setSerializationSkipNonSerializable(_serializationSkipNonSerializable);
+        ds.setSerializationLogNonSerializable(_serializationLogNonSerializable);
+        ds.setSerializationCompressData(_serializationCompressData);
+
         return ds;
     }
 
@@ -54,5 +63,20 @@ public class JDBCSessionDataStoreFactory extends AbstractSessionDataStoreFactory
     public void setSessionTableSchema(JDBCSessionDataStore.SessionTableSchema schema)
     {
         _schema = schema;
+    }
+
+    public void setSerializationSkipNonSerializable(boolean serializationSkipNonSerializable)
+    {
+        _serializationSkipNonSerializable = serializationSkipNonSerializable;
+    }
+
+    public void setSerializationLogNonSerializable(boolean serializationLogNonSerializable)
+    {
+        _serializationLogNonSerializable = serializationLogNonSerializable;
+    }
+
+    public void setSerializationCompressData(boolean serializationCompressData)
+    {
+        _serializationCompressData = serializationCompressData;
     }
 }


### PR DESCRIPTION
This update add next options support to jetty server module `session-store-jdbc`:
1. `jetty.session.serialization.skipNonSerializable` -- this option allows to replace non serializable objects with null to allow serialize partially serializable objects. Code is in [jetty-server/src/main/java/org/eclipse/jetty/server/session/ExtendedObjectOutputStream.java](https://github.com/jetty/jetty.project/compare/jetty-10.0.x...yurem:jetty.project:jetty-10.0.x#diff-64f99a059ff506f0599a8b0afb371e328c31c60c4f4d600e1d2c9fef5c52e433)
2. `jetty.session.serialization.logNonSerializable` -- this additional option for previous one to log warn messages about skipped objects
3. `jetty.session.serialization.compressData` -- this option allow to compress session data before storing in DB.

The idea of these options come up when we worked on making Shibboleth IDP sessions serializable. More info is on [this ](https://github.com/GluuFederation/oxShibboleth/wiki/Shibboth-clustering) wiki page. This option significantly reduced count of changes which we need to apply to Shibboleth IDP code.


Mainly it eliminates serialization problems like these in session Beans:
```
public class IdPUIInfo implements java.io.Serializable {
    
... 
    /** Warning check against a non localized keyword. */
    private final Predicate<Keywords> nullLanguageKeyword = new java.util.function.Predicate<>() {
        public boolean test(final Keywords u) {
        ...
        }
    };
...
```

or
```
public final class RelyingPartyUIContext extends BaseContext {

...
    @Nullable private NonnullSupplier<HttpServletRequest> requestSupplier;
    // Where NonnullSupplier<T> extends java.util.function.Supplier<T> 
...

```