### PR TITLE
Fixes #10390 - jetty http3 client and nghttpx.

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/ClientHTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/ClientHTTP3Session.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.jetty.http3.ControlFlusher;
 import org.eclipse.jetty.http3.DecoderStreamConnection;
 import org.eclipse.jetty.http3.EncoderStreamConnection;
+import org.eclipse.jetty.http3.Grease;
 import org.eclipse.jetty.http3.HTTP3Configuration;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.InstructionFlusher;
@@ -63,7 +64,7 @@ public class ClientHTTP3Session extends ClientProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("initializing HTTP/3 streams");
 
-        long encoderStreamId = getQuicSession().newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
+        long encoderStreamId = newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
         QuicStreamEndPoint encoderEndPoint = openInstructionEndPoint(encoderStreamId);
         InstructionFlusher encoderInstructionFlusher = new InstructionFlusher(quicSession, encoderEndPoint, EncoderStreamConnection.STREAM_TYPE);
         encoder = new QpackEncoder(new InstructionHandler(encoderInstructionFlusher));
@@ -72,7 +73,7 @@ public class ClientHTTP3Session extends ClientProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("created encoder stream #{} on {}", encoderStreamId, encoderEndPoint);
 
-        long decoderStreamId = getQuicSession().newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
+        long decoderStreamId = newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
         QuicStreamEndPoint decoderEndPoint = openInstructionEndPoint(decoderStreamId);
         InstructionFlusher decoderInstructionFlusher = new InstructionFlusher(quicSession, decoderEndPoint, DecoderStreamConnection.STREAM_TYPE);
         decoder = new QpackDecoder(new InstructionHandler(decoderInstructionFlusher));
@@ -80,7 +81,7 @@ public class ClientHTTP3Session extends ClientProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("created decoder stream #{} on {}", decoderStreamId, decoderEndPoint);
 
-        long controlStreamId = getQuicSession().newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
+        long controlStreamId = newStreamId(StreamType.CLIENT_UNIDIRECTIONAL);
         QuicStreamEndPoint controlEndPoint = openControlEndPoint(controlStreamId);
         controlFlusher = new ControlFlusher(quicSession, controlEndPoint, true);
         addBean(controlFlusher);
@@ -104,6 +105,11 @@ public class ClientHTTP3Session extends ClientProtocolSession
     public HTTP3SessionClient getSessionClient()
     {
         return session;
+    }
+
+    public long newStreamId(StreamType streamType)
+    {
+        return getQuicSession().newStreamId(streamType);
     }
 
     @Override
@@ -171,20 +177,26 @@ public class ClientHTTP3Session extends ClientProtocolSession
         {
             if (key == SettingsFrame.MAX_TABLE_CAPACITY)
             {
-                int maxTableCapacity = value.intValue();
+                int maxTableCapacity = (int)Math.min(value, Integer.MAX_VALUE);
                 encoder.setMaxTableCapacity(maxTableCapacity);
                 encoder.setTableCapacity(Math.min(maxTableCapacity, configuration.getMaxEncoderTableCapacity()));
             }
             else if (key == SettingsFrame.MAX_FIELD_SECTION_SIZE)
             {
                 // Must cap the maxHeaderSize to avoid large allocations.
-                int maxHeadersSize = Math.min(value.intValue(), configuration.getMaxRequestHeadersSize());
+                int maxHeadersSize = (int)Math.min(value, configuration.getMaxResponseHeadersSize());
                 encoder.setMaxHeadersSize(maxHeadersSize);
             }
             else if (key == SettingsFrame.MAX_BLOCKED_STREAMS)
             {
-                int maxBlockedStreams = value.intValue();
+                int maxBlockedStreams = (int)Math.min(value, Integer.MAX_VALUE);
                 encoder.setMaxBlockedStreams(maxBlockedStreams);
+            }
+            else
+            {
+                // SPEC: grease and unknown settings are ignored.
+                if (LOG.isDebugEnabled())
+                    LOG.debug("ignored {} setting {}={}", Grease.isGreaseValue(key) ? "grease" : "unknown", key, value);
             }
         });
     }

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
@@ -93,7 +93,7 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
     @Override
     public CompletableFuture<Stream> newRequest(HeadersFrame frame, Stream.Client.Listener listener)
     {
-        long streamId = getProtocolSession().getQuicSession().newStreamId(StreamType.CLIENT_BIDIRECTIONAL);
+        long streamId = getProtocolSession().newStreamId(StreamType.CLIENT_BIDIRECTIONAL);
         return newRequest(streamId, frame, listener);
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/Grease.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/Grease.java
@@ -1,0 +1,48 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http3;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * <p>A class to support GREASE (<a href="https://www.rfc-editor.org/rfc/rfc8701.txt">RFC 8701</a>) in HTTP/3.</p>
+ * <p>HTTP/3 GREASE values have the form {@code 0x1F * N + 0x21} with non negative values of {@code N}.</p>
+ */
+public class Grease
+{
+    /**
+     * @param value the value to test
+     * @return whether the value is a GREASE value as defined by HTTP/3
+     */
+    public static boolean isGreaseValue(long value)
+    {
+        if (value < 0)
+            return false;
+        return (value - 0x21) % 0x1F == 0;
+    }
+
+    /**
+     * @return a random grease value as defined by HTTP/3
+     */
+    public static long generateGreaseValue()
+    {
+        // This constant avoids to overflow VarLenInt.
+        long n = ThreadLocalRandom.current().nextLong(0x210842108421084L);
+        return 0x1F * n + 0x21;
+    }
+
+    private Grease()
+    {
+    }
+}

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3ErrorCode.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3ErrorCode.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.jetty.http3;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 public enum HTTP3ErrorCode
 {
     NO_ERROR(0x100),
@@ -45,9 +43,7 @@ public enum HTTP3ErrorCode
     public static long randomReservedCode()
     {
         // SPEC: reserved errors have the form 0x1F * n + 0x21.
-        // This constant avoids to overflow VarLenInt, which is how an error code is encoded.
-        long n = ThreadLocalRandom.current().nextLong(0x210842108421084L);
-        return 0x1F * n + 0x21;
+        return Grease.generateGreaseValue();
     }
 
     public long code()

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/ControlParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/ControlParser.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http3.parser;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.http3.Grease;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.frames.FrameType;
 import org.slf4j.Logger;
@@ -91,8 +92,9 @@ public class ControlParser
                                 return;
                             }
 
+                            // SPEC: grease and unknown frame types are ignored.
                             if (LOG.isDebugEnabled())
-                                LOG.debug("ignoring unknown frame type {}", Long.toHexString(frameType));
+                                LOG.debug("ignoring {} frame type {}", Grease.isGreaseValue(frameType) ? "grease" : "unknown", Long.toHexString(frameType));
 
                             BodyParser.Result result = unknownBodyParser.parse(buffer);
                             if (result == BodyParser.Result.NO_FRAME)

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/MessageParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/MessageParser.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.function.BooleanSupplier;
 import java.util.function.UnaryOperator;
 
+import org.eclipse.jetty.http3.Grease;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.frames.FrameType;
 import org.eclipse.jetty.http3.qpack.QpackDecoder;
@@ -138,8 +139,9 @@ public class MessageParser
                                 return Result.NO_FRAME;
                             }
 
+                            // SPEC: grease and unknown frame types are ignored.
                             if (LOG.isDebugEnabled())
-                                LOG.debug("ignoring unknown frame type {}", Long.toHexString(frameType));
+                                LOG.debug("ignoring {} frame type {}", Grease.isGreaseValue(frameType) ? "grease" : "unknown", Long.toHexString(frameType));
 
                             BodyParser.Result result = unknownBodyParser.parse(buffer);
                             if (result == BodyParser.Result.NO_FRAME)

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3Session.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.jetty.http3.ControlFlusher;
 import org.eclipse.jetty.http3.DecoderStreamConnection;
 import org.eclipse.jetty.http3.EncoderStreamConnection;
+import org.eclipse.jetty.http3.Grease;
 import org.eclipse.jetty.http3.HTTP3Configuration;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.InstructionFlusher;
@@ -62,7 +63,7 @@ public class ServerHTTP3Session extends ServerProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("initializing HTTP/3 streams");
 
-        long encoderStreamId = getQuicSession().newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
+        long encoderStreamId = newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
         QuicStreamEndPoint encoderEndPoint = openInstructionEndPoint(encoderStreamId);
         InstructionFlusher encoderInstructionFlusher = new InstructionFlusher(quicSession, encoderEndPoint, EncoderStreamConnection.STREAM_TYPE);
         encoder = new QpackEncoder(new InstructionHandler(encoderInstructionFlusher));
@@ -71,7 +72,7 @@ public class ServerHTTP3Session extends ServerProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("created encoder stream #{} on {}", encoderStreamId, encoderEndPoint);
 
-        long decoderStreamId = getQuicSession().newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
+        long decoderStreamId = newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
         QuicStreamEndPoint decoderEndPoint = openInstructionEndPoint(decoderStreamId);
         InstructionFlusher decoderInstructionFlusher = new InstructionFlusher(quicSession, decoderEndPoint, DecoderStreamConnection.STREAM_TYPE);
         decoder = new QpackDecoder(new InstructionHandler(decoderInstructionFlusher));
@@ -79,7 +80,7 @@ public class ServerHTTP3Session extends ServerProtocolSession
         if (LOG.isDebugEnabled())
             LOG.debug("created decoder stream #{} on {}", decoderStreamId, decoderEndPoint);
 
-        long controlStreamId = getQuicSession().newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
+        long controlStreamId = newStreamId(StreamType.SERVER_UNIDIRECTIONAL);
         QuicStreamEndPoint controlEndPoint = openControlEndPoint(controlStreamId);
         controlFlusher = new ControlFlusher(quicSession, controlEndPoint, configuration.isUseOutputDirectByteBuffers());
         addBean(controlFlusher);
@@ -103,6 +104,11 @@ public class ServerHTTP3Session extends ServerProtocolSession
     public HTTP3SessionServer getSessionServer()
     {
         return session;
+    }
+
+    public long newStreamId(StreamType streamType)
+    {
+        return getQuicSession().newStreamId(streamType);
     }
 
     @Override
@@ -170,20 +176,26 @@ public class ServerHTTP3Session extends ServerProtocolSession
         {
             if (key == SettingsFrame.MAX_TABLE_CAPACITY)
             {
-                int maxTableCapacity = value.intValue();
+                int maxTableCapacity = (int)Math.min(value, Integer.MAX_VALUE);
                 encoder.setMaxTableCapacity(maxTableCapacity);
                 encoder.setTableCapacity(Math.min(maxTableCapacity, configuration.getMaxEncoderTableCapacity()));
             }
             else if (key == SettingsFrame.MAX_FIELD_SECTION_SIZE)
             {
                 // Must cap the maxHeaderSize to avoid large allocations.
-                int maxHeadersSize = Math.min(value.intValue(), configuration.getMaxResponseHeadersSize());
+                int maxHeadersSize = (int)Math.min(value, configuration.getMaxResponseHeadersSize());
                 encoder.setMaxHeadersSize(maxHeadersSize);
             }
             else if (key == SettingsFrame.MAX_BLOCKED_STREAMS)
             {
-                int maxBlockedStreams = value.intValue();
+                int maxBlockedStreams = (int)Math.min(value, Integer.MAX_VALUE);
                 encoder.setMaxBlockedStreams(maxBlockedStreams);
+            }
+            else
+            {
+                // SPEC: grease and unknown settings are ignored.
+                if (LOG.isDebugEnabled())
+                    LOG.debug("ignored {} setting {}={}", Grease.isGreaseValue(key) ? "grease" : "unknown", key, value);
             }
         });
     }


### PR DESCRIPTION
Fixed handling of long settings values, so that they do not overflow. Added logging for GREASE cases.