### PR TITLE
Merge 11 to 12 Issue #10731 wrong context attribute name javax.servlet instead of jakarta.servlet (#10735) and Address build/test failure against bad entities. (#10742)

### DIFF
--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlParserTest.java
@@ -20,6 +20,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
@@ -35,7 +36,16 @@ public class XmlParserTest
     {
         // we want to parse a simple XML, no dtds, no xsds.
         // just do it, without validation
-        XmlParser parser = new XmlParser(false);
+        XmlParser parser = new XmlParser(false)
+        {
+            @Override
+            protected InputSource resolveEntity(String pid, String sid)
+            {
+                InputSource inputSource = super.resolveEntity(pid, sid);
+                assertNotNull(inputSource, "You are using entities in your XML that don't match your redirectEntity mappings: pid=" + pid + ", sid=" + sid);
+                return inputSource;
+            }
+        };
         URL url = XmlParserTest.class.getResource("configureSimple.xml");
         assertNotNull(url);
         XmlParser.Node testDoc = parser.parse(url.toString());

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/test/java/org/eclipse/jetty/ee10/jstl/JspConfig.java
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/test/java/org/eclipse/jetty/ee10/jstl/JspConfig.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 
+import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 
 /**
@@ -27,7 +28,7 @@ public class JspConfig
 {
     public static void init(WebAppContext context, URI baseUri, File scratchDir)
     {
-        context.setAttribute("jakarta.servlet.context.tempdir", scratchDir);
+        context.setAttribute(ServletContext.TEMPDIR, scratchDir);
         context.setAttribute("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern",
             ".*/jetty-jakarta-servlet-api-[^/]*\\.jar$|.*jakarta.servlet.jsp.jstl-[^/]*\\.jar|.*taglibs-standard.*\\.jar");
         context.setWar(baseUri.toASCIIString());

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -111,7 +111,7 @@ public class WebInfConfiguration extends AbstractConfiguration
      * exit depends on value of persistTempDirectory.
      * </li>
      * <li>
-     * Iff jakarta.servlet.context.tempdir context attribute is set for
+     * If {@value jakarta.servlet.ServletContext#TEMPDIR} context attribute is set for
      * this webapp &amp;&amp; exists &amp;&amp; writeable, then use it. Set delete on exit depends on
      * value of persistTempDirectory.
      * </li>

--- a/jetty-ee9/jetty-ee9-glassfish-jstl/src/test/java/org/eclipse/jetty/ee9/jstl/JspConfig.java
+++ b/jetty-ee9/jetty-ee9-glassfish-jstl/src/test/java/org/eclipse/jetty/ee9/jstl/JspConfig.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.ee9.jstl;
 import java.io.File;
 import java.net.URI;
 
+import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 
 /**
@@ -26,7 +27,7 @@ public class JspConfig
 {
     public static void init(WebAppContext context, URI baseUri, File scratchDir)
     {
-        context.setAttribute("jakarta.servlet.context.tempdir", scratchDir);
+        context.setAttribute(ServletContext.TEMPDIR, scratchDir);
         context.setAttribute("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern",
             System.getProperty("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern"));
         context.setWar(baseUri.toASCIIString());

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
@@ -386,7 +386,7 @@ public class MultiPartFormInputStream
      * @param in Request input stream
      * @param contentType Content-Type header
      * @param config MultipartConfigElement
-     * @param contextTmpDir javax.servlet.context.tempdir
+     * @param contextTmpDir {@value jakarta.servlet.ServletContext#TEMPDIR}
      */
     public MultiPartFormInputStream(InputStream in, String contentType, MultipartConfigElement config, File contextTmpDir)
     {
@@ -397,7 +397,8 @@ public class MultiPartFormInputStream
      * @param in Request input stream
      * @param contentType Content-Type header
      * @param config MultipartConfigElement
-     * @param contextTmpDir javax.servlet.context.tempdir
+     * @param contextTmpDir {@value jakarta.servlet.ServletContext#TEMPDIR}
+     * @param maxParts the maximum number of parts that can be parsed from the multipart content (0 for no parts allowed, -1 for unlimited parts).
      */
     public MultiPartFormInputStream(InputStream in, String contentType, MultipartConfigElement config, File contextTmpDir, int maxParts)
     {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1997,7 +1997,7 @@ public class Request implements HttpServletRequest
     private MultiPartFormInputStream newMultiParts(MultipartConfigElement config, int maxParts) throws IOException
     {
         return new MultiPartFormInputStream(getInputStream(), getContentType(), config,
-            (_context != null ? (File)_context.getAttribute("jakarta.servlet.context.tempdir") : null), maxParts);
+            (_context != null ? (File)_context.getAttribute(ServletContext.TEMPDIR) : null), maxParts);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1157,7 +1157,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     /**
      * Set temporary directory for context.
-     * The jakarta.servlet.context.tempdir attribute is also set.
+     * The {@value jakarta.servlet.ServletContext#TEMPDIR} attribute is also set.
      *
      * @param dir Writable temporary directory.
      */

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -113,7 +113,7 @@ public class WebInfConfiguration extends AbstractConfiguration
      * exit depends on value of persistTempDirectory.
      * </li>
      * <li>
-     * Iff jakarta.servlet.context.tempdir context attribute is set for
+     * Iff {@value jakarta.servlet.ServletContext#TEMPDIR} context attribute is set for
      * this webapp &amp;&amp; exists &amp;&amp; writeable, then use it. Set delete on exit depends on
      * value of persistTempDirectory.
      * </li>


### PR DESCRIPTION
* Issue #10731 wrong context attribute name javax.servlet instead of jakarta.servlet

Signed-off-by: Olivier Lamy <olamy@apache.org>

* Update jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java

Co-authored-by: Simone Bordet <simone.bordet@gmail.com>

* Update jetty-server/src/main/java/org/eclipse/jetty/server/Request.java

Co-authored-by: Simone Bordet <simone.bordet@gmail.com>

* fix javadoc

Signed-off-by: Olivier Lamy <olamy@apache.org>

* more usage of constant

Signed-off-by: Olivier Lamy <olamy@apache.org>

---------

Signed-off-by: Olivier Lamy <olamy@apache.org>
Co-authored-by: Simone Bordet <simone.bordet@gmail.com>