### PR TITLE
H3: fix flusher

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
+++ b/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
@@ -401,8 +401,17 @@ public abstract class QuicSession extends ContainerLifeCycle
         if (LOG.isDebugEnabled())
             LOG.debug("outward closing 0x{}/{} on {}", Long.toHexString(error), reason, this);
         quicheConnection.close(error, reason);
-        // Flushing will eventually forward the outward close to the connection.
-        flush();
+        try
+        {
+            // Flushing will eventually forward the outward close to the connection.
+            flush();
+        }
+        catch (IllegalStateException ise)
+        {
+            // Flusher already is in CLOSED state, nothing else to do.
+            if (LOG.isDebugEnabled())
+                LOG.debug("IllegalStateException caught while flushing, flusher={} {}", flusher, this, ise);
+        }
     }
 
     private void finishOutwardClose(Throwable failure)

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -691,7 +691,12 @@ public class JnaQuicheConnection extends QuicheConnection
                 throw new IOException("connection was released");
             int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), buffer, new size_t(buffer.remaining()), last).intValue();
             if (written == quiche_error.QUICHE_ERR_DONE)
+            {
+                int rc = LibQuiche.INSTANCE.quiche_conn_stream_writable(quicheConn, new uint64_t(streamId), new size_t(buffer.remaining()));
+                if (rc < 0)
+                    throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(rc));
                 return 0;
+            }
             if (written < 0L)
                 throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(written));
             buffer.position(buffer.position() + written);


### PR DESCRIPTION
The H3 flusher suffers from 2 bugs:

 - When `feedClearBytesForStream` is called after the client sent a stop request, `quiche_conn_stream_send` does not differentiate between an empty flow control window and a closed stream. An extra check needs to be done to differentiate between the two cases.
 - When a session is flushed, that can race with the connection being closed making the flusher throw `IllegalStateException`. That case has to be intercepted to silence the error as it is harmless in the case of a connection close.

Fixes #10519