### PR TITLE
deprecate PushCacheFilter (9.4)

### DIFF
--- a/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushCacheFilter.java
+++ b/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushCacheFilter.java
@@ -73,7 +73,9 @@ import org.eclipse.jetty.util.log.Logger;
  * cache.</p>
  * <p>If the init param useQueryInKey is set, then the query string is used as
  * as part of the key to identify a resource</p>
+ * @deprecated no replacement for this deprecated http feature
  */
+@Deprecated
 @ManagedObject("Push cache based on the HTTP 'Referer' header")
 public class PushCacheFilter implements Filter
 {
@@ -86,6 +88,11 @@ public class PushCacheFilter implements Filter
     private int _maxAssociations = 16;
     private long _renew = System.nanoTime();
     private boolean _useQueryInKey;
+
+    public PushCacheFilter()
+    {
+        LOG.warn(PushCacheFilter.class.getSimpleName() + " is an example class not suitable for production.");
+    }
 
     @Override
     public void init(FilterConfig config) throws ServletException


### PR DESCRIPTION
Following the deprecation of the `PushSessionCacheFilter` in PR #9715 we should also deprecate the `PushCacheFilter`.