### PR TITLE
H3: fix flusher

### DIFF
--- a/jetty-quic/quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
+++ b/jetty-quic/quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
@@ -401,8 +401,17 @@ public abstract class QuicSession extends ContainerLifeCycle
         if (LOG.isDebugEnabled())
             LOG.debug("outward closing 0x{}/{} on {}", Long.toHexString(error), reason, this);
         quicheConnection.close(error, reason);
-        // Flushing will eventually forward the outward close to the connection.
-        flush();
+        try
+        {
+            // Flushing will eventually forward the outward close to the connection.
+            flush();
+        }
+        catch (IllegalStateException ise)
+        {
+            // Flusher already is in CLOSED state, nothing else to do.
+            if (LOG.isDebugEnabled())
+                LOG.debug("IllegalStateException caught while flushing, flusher={} {}", flusher, this, ise);
+        }
     }
 
     private void finishOutwardClose(Throwable failure)

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/ForeignIncubatorQuicheConnection.java
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/ForeignIncubatorQuicheConnection.java
@@ -29,8 +29,8 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import org.eclipse.jetty.quic.quiche.Quiche;
-import org.eclipse.jetty.quic.quiche.Quiche.quiche_error;
 import org.eclipse.jetty.quic.quiche.Quiche.quic_error;
+import org.eclipse.jetty.quic.quiche.Quiche.quiche_error;
 import org.eclipse.jetty.quic.quiche.QuicheConfig;
 import org.eclipse.jetty.quic.quiche.QuicheConnection;
 import org.eclipse.jetty.util.BufferUtil;
@@ -865,7 +865,12 @@ public class ForeignIncubatorQuicheConnection extends QuicheConnection
             }
 
             if (written == quiche_error.QUICHE_ERR_DONE)
+            {
+                int rc = quiche_h.quiche_conn_stream_writable(quicheConn, streamId, buffer.remaining());
+                if (rc < 0)
+                    throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(rc));
                 return 0;
+            }
             if (written < 0L)
                 throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(written));
             buffer.position((int)(buffer.position() + written));

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
@@ -310,6 +310,12 @@ public class quiche_h
         FunctionDescriptor.of(C_LONG, C_POINTER, C_LONG, C_POINTER, C_LONG, C_CHAR)
     );
 
+    private static final MethodHandle quiche_conn_stream_writable$MH = downcallHandle(
+        "quiche_conn_stream_writable",
+        "(Ljdk/incubator/foreign/MemoryAddress;JJ)I",
+        FunctionDescriptor.of(C_INT, C_POINTER, C_LONG, C_LONG)
+    );
+
     private static final MethodHandle quiche_conn_stream_recv$MH = downcallHandle(
         "quiche_conn_stream_recv",
         "(Ljdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;)J",
@@ -663,6 +669,18 @@ public class quiche_h
         try
         {
             return (long) quiche_conn_stream_send$MH.invokeExact(conn, stream_id, buf, buf_len, fin);
+        }
+        catch (Throwable ex)
+        {
+            throw new AssertionError("should not reach here", ex);
+        }
+    }
+
+    public static int quiche_conn_stream_writable(MemoryAddress conn, long stream_id, long buf_len)
+    {
+        try
+        {
+            return (int) quiche_conn_stream_writable$MH.invokeExact(conn, stream_id, buf_len);
         }
         catch (Throwable ex)
         {

--- a/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -692,7 +692,12 @@ public class JnaQuicheConnection extends QuicheConnection
                 throw new IOException("connection was released");
             int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), buffer, new size_t(buffer.remaining()), last).intValue();
             if (written == quiche_error.QUICHE_ERR_DONE)
+            {
+                int rc = LibQuiche.INSTANCE.quiche_conn_stream_writable(quicheConn, new uint64_t(streamId), new size_t(buffer.remaining()));
+                if (rc < 0)
+                    throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(rc));
                 return 0;
+            }
             if (written < 0L)
                 throw new IOException("failed to write to stream " + streamId + "; quiche_err=" + quiche_error.errToString(written));
             buffer.position(buffer.position() + written);


### PR DESCRIPTION
The H3 flusher suffers from 2 bugs:

 - When feedClearBytesForStream is called after the client sends a stop request, quiche_conn_stream_send does not differentiate between an empty flow control window and a closed stream. An extra check needs to be done to differentiate between the two cases.
 - When a session is flushed, that can race with the connection being closed, making the flusher throw IllegalStateException. That case has to be intercepted to silence the error, as it is harmless in the case of a connection close.

Fixes https://github.com/jetty/jetty.project/issues/10519