### PR TITLE
Fix HTTP/3 Client handling of MAX_FIELD_SECTION_SIZE setting

### DIFF
--- a/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/ClientHTTP3Session.java
+++ b/jetty-http3/http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/ClientHTTP3Session.java
@@ -184,7 +184,7 @@ public class ClientHTTP3Session extends ClientProtocolSession
             else if (key == SettingsFrame.MAX_FIELD_SECTION_SIZE)
             {
                 // Must cap the maxHeaderSize to avoid large allocations.
-                int maxHeadersSize = (int)Math.min(value, configuration.getMaxResponseHeadersSize());
+                int maxHeadersSize = (int)Math.min(value, configuration.getMaxRequestHeadersSize());
                 encoder.setMaxHeadersSize(maxHeadersSize);
             }
             else if (key == SettingsFrame.MAX_BLOCKED_STREAMS)

--- a/jetty-http3/http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
+++ b/jetty-http3/http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
@@ -373,13 +373,22 @@ public class ClientServerTest extends AbstractClientServerTest
             }
         });
 
-        int maxRequestHeadersSize = 128;
+        int maxRequestHeadersSize = 256;
         HTTP3Configuration http3Configuration = http3Client.getHTTP3Configuration();
         http3Configuration.setMaxRequestHeadersSize(maxRequestHeadersSize);
         // Disable the dynamic table, otherwise the large header
-        // is sent as string literal on the encoder stream.
+        // is sent as string literal on the encoder stream, rather than the message stream.
         http3Configuration.setMaxEncoderTableCapacity(0);
-        Session.Client clientSession = newSession(new Session.Client.Listener() {});
+        CountDownLatch settingsLatch = new CountDownLatch(1);
+        Session.Client clientSession = newSession(new Session.Client.Listener()
+        {
+            @Override
+            public void onSettings(Session session, SettingsFrame frame)
+            {
+                settingsLatch.countDown();
+            }
+        });
+        assertTrue(settingsLatch.await(5, TimeUnit.SECONDS));
 
         CountDownLatch requestFailureLatch = new CountDownLatch(1);
         HttpFields largeHeaders = HttpFields.build().put("too-large", "x".repeat(2 * maxRequestHeadersSize));
@@ -413,7 +422,7 @@ public class ClientServerTest extends AbstractClientServerTest
     @Test
     public void testResponseHeadersTooLarge() throws Exception
     {
-        int maxResponseHeadersSize = 128;
+        int maxResponseHeadersSize = 256;
         CountDownLatch settingsLatch = new CountDownLatch(2);
         AtomicReference<Session> serverSessionRef = new AtomicReference<>();
         CountDownLatch responseFailureLatch = new CountDownLatch(1);
@@ -458,7 +467,7 @@ public class ClientServerTest extends AbstractClientServerTest
         assertNotNull(h3);
         HTTP3Configuration http3Configuration = h3.getHTTP3Configuration();
         // Disable the dynamic table, otherwise the large header
-        // is sent as string literal on the encoder stream.
+        // is sent as string literal on the encoder stream, rather than the message stream.
         http3Configuration.setMaxEncoderTableCapacity(0);
         http3Configuration.setMaxResponseHeadersSize(maxResponseHeadersSize);
 


### PR DESCRIPTION
Upon receiving a SETTINGS frame from the server, the MAX_FIELD_SECTION_SIZE setting was mistakenly checked on the client against the response headers size instead of the request headers size.

Fixes #10759