### PR TITLE
force file and directory mode

### DIFF
--- a/jetty-ee10/jetty-ee10-home/src/main/assembly/jetty-assembly.xml
+++ b/jetty-ee10/jetty-ee10-home/src/main/assembly/jetty-assembly.xml
@@ -15,6 +15,8 @@
       <excludes>
         <exclude>**/META-INF/**</exclude>
       </excludes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-ee10/jetty-ee10-home/src/main/assembly/jetty-source-assembly.xml
+++ b/jetty-ee10/jetty-ee10-home/src/main/assembly/jetty-source-assembly.xml
@@ -12,6 +12,8 @@
       <includes>
         <include>**</include>
       </includes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-ee8/jetty-ee8-home/src/main/assembly/jetty-assembly.xml
+++ b/jetty-ee8/jetty-ee8-home/src/main/assembly/jetty-assembly.xml
@@ -15,6 +15,8 @@
       <excludes>
         <exclude>**/META-INF/**</exclude>
       </excludes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-ee8/jetty-ee8-home/src/main/assembly/jetty-source-assembly.xml
+++ b/jetty-ee8/jetty-ee8-home/src/main/assembly/jetty-source-assembly.xml
@@ -12,6 +12,8 @@
       <includes>
         <include>**</include>
       </includes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-ee9/jetty-ee9-home/src/main/assembly/jetty-assembly.xml
+++ b/jetty-ee9/jetty-ee9-home/src/main/assembly/jetty-assembly.xml
@@ -15,6 +15,8 @@
       <excludes>
         <exclude>**/META-INF/**</exclude>
       </excludes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>

--- a/jetty-ee9/jetty-ee9-home/src/main/assembly/jetty-source-assembly.xml
+++ b/jetty-ee9/jetty-ee9-home/src/main/assembly/jetty-source-assembly.xml
@@ -12,6 +12,8 @@
       <includes>
         <include>**</include>
       </includes>
+      <fileMode>644</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
this will avoid stupid reproducible builds issues based on strange local repository permissions: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/eclipse/jetty/jetty-project/jetty-project-12.0.2.diffoscope