### PR TITLE
Fixes #10771 - EE10 ServletApi.isSecure() bug with ForwardedRequestCustomizer

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1156,7 +1156,7 @@ public class ServletApiRequest implements HttpServletRequest
     @Override
     public boolean isSecure()
     {
-        return getRequest().getConnectionMetaData().isSecure();
+        return getRequest().isSecure();
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
@@ -89,6 +89,33 @@ public class RequestTest
     }
 
     @Test
+    public void testIsSecure() throws Exception
+    {
+        final AtomicReference<Boolean> resultIsSecure = new AtomicReference<>();
+
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse resp)
+            {
+                resultIsSecure.set(request.isSecure());
+            }
+        });
+
+        String rawResponse = _connector.getResponse(
+            """
+                GET / HTTP/1.1
+                Host: local
+                Connection: close
+                X-Forwarded-Proto: https
+                
+                """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat("request.isSecure", resultIsSecure.get(), is(true));
+    }
+
+    @Test
     public void testConnectRequestURLSameAsHost() throws Exception
     {
         final AtomicReference<String> resultRequestURL = new AtomicReference<>();


### PR DESCRIPTION
Introduce testcase + fix.

Fixes: #10771