### PR TITLE
Issue #10346 - fix bug in NetworkFuzzer to de-flake JsrEchoTest

### DIFF
--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/NetworkFuzzer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/NetworkFuzzer.java
@@ -220,7 +220,6 @@ public class NetworkFuzzer extends Fuzzer.Adapter implements Fuzzer, AutoCloseab
         private CoreSession coreSession;
         private final AutoLock lock = new AutoLock();
 
-
         public void setEndPoint(EndPoint endpoint)
         {
             this.endPoint = endpoint;

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/NetworkFuzzer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/NetworkFuzzer.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FutureCallback;
+import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.CoreSession;
@@ -214,9 +215,11 @@ public class NetworkFuzzer extends Fuzzer.Adapter implements Fuzzer, AutoCloseab
     public static class FrameCapture implements FrameHandler
     {
         private final BlockingQueue<Frame> receivedFrames = new LinkedBlockingQueue<>();
+        private final CountDownLatch openLatch = new CountDownLatch(1);
         private EndPoint endPoint;
-        private CountDownLatch openLatch = new CountDownLatch(1);
         private CoreSession coreSession;
+        private final AutoLock lock = new AutoLock();
+
 
         public void setEndPoint(EndPoint endpoint)
         {
@@ -235,8 +238,11 @@ public class NetworkFuzzer extends Fuzzer.Adapter implements Fuzzer, AutoCloseab
         @Override
         public void onFrame(Frame frame, Callback callback)
         {
-            receivedFrames.offer(Frame.copy(frame));
-            callback.succeeded();
+            try (AutoLock ignored = lock.lock())
+            {
+                receivedFrames.add(Frame.copy(frame));
+                callback.succeeded();
+            }
             coreSession.demand();
         }
 
@@ -263,7 +269,7 @@ public class NetworkFuzzer extends Fuzzer.Adapter implements Fuzzer, AutoCloseab
                 throw new IOException(e);
             }
 
-            synchronized (this)
+            try (AutoLock ignored = lock.lock())
             {
                 FutureCallback callback = new FutureCallback();
                 endPoint.write(callback, buffer);


### PR DESCRIPTION
Fixing bug in `NetworkFuzzer`.

closes #10346 

>The NetworkFuzzer is sending frames by writing directly through the Endpoint, and at the same time the client received a close frame, then the implementation automatically tries to send a close response when the callback is succeeded.
>
> So we have two concurrent writes to the endpoint and get the WritePendingException, with the NetworkFuzzer bypassing the IteratingCallback in the FrameFlusher.


By adding the lock around `callback.succeeded()` inside `onFrame()`, we can make sure that the close frame won't be processed until the initial write is done. 

But ideally we'd just want to remove usage of the `NetworkFuzzer` all together.