### PR TITLE
Updates to jetty.sh and testing to reduce failures 

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -635,18 +635,17 @@ case "$ACTION" in
         chown "$JETTY_USER" "$JETTY_PID"
         su - "$JETTY_USER" $SU_SHELL -c "
           cd \"$JETTY_BASE\"
-          echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
+          echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
           PID=\$!
           disown \$PID"
         (( DEBUG )) && echo "Starting: su shell (w/user $JETTY_USER) on PID $PID"
       else
         # Startup if not switching users
-        echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} > /dev/null &
+        echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
         PID=$!
         disown $PID
         (( DEBUG )) && echo "Starting: java command on PID $PID"
       fi
-
     fi
 
     if expr "${JETTY_ARGS[*]}" : '.*jetty\.state=.*' >/dev/null

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto17.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto17.java
@@ -16,18 +16,18 @@ package org.eclipse.jetty.tests.distribution.jettysh;
 /**
  * An OS Image of linux specific for running on Amazon AWS.
  * This is based on Amazon Linux 2 (which is based on Alpine 3).
- * Amazon Corretto JDK 11 is installed.
+ * Amazon Corretto JDK 17 is installed.
  * This image does NOT come with start-stop-daemon installed.
  * Instead of apt, it uses yum (the redhat package manager)
  */
-public class ImageOSAmazonCorretto11 extends ImageOS
+public class ImageOSAmazonCorretto17 extends ImageOS
 {
-    public ImageOSAmazonCorretto11()
+    public ImageOSAmazonCorretto17()
     {
-        super("amazoncorretto-jdk11",
+        super("amazoncorretto-jdk17-jetty12",
             builder ->
                 builder
-                    .from("amazoncorretto:11.0.20")
+                    .from("amazoncorretto:17")
                     .run("yum update -y ; " +
                         "yum install -y curl tar gzip vim shadow-utils net-tools")
                     .env("TEST_DIR", "/var/test")

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSUbuntuJammyJDK17.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSUbuntuJammyJDK17.java
@@ -22,7 +22,7 @@ public class ImageOSUbuntuJammyJDK17 extends ImageOS
 {
     public ImageOSUbuntuJammyJDK17()
     {
-        super("ubuntu-22.04-jdk17",
+        super("ubuntu-22.04-jdk17-jetty12",
             builder ->
                 builder
                     .from("ubuntu:22.04")

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageUserChange.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageUserChange.java
@@ -31,7 +31,7 @@ public class ImageUserChange extends ImageFromDSL
                     "useradd --home-dir=${JETTY_BASE} --shell=/bin/bash jetty ; " +
                     "chown jetty:jetty ${JETTY_BASE} ; " +
                     "chmod a+w ${JETTY_BASE} ; " +
-                    "echo \"JETTY_USER=jetty\" > /etc/default/jetty") // user change
+                    "echo \"JETTY_USER=jetty\" >> /etc/default/jetty") // user change
                 .user("jetty")
                 // Configure Jetty Base
                 .workDir("${JETTY_BASE}")

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
@@ -61,7 +61,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
         List<ImageFromDSL> images = new ArrayList<>();
 
         // Loop through all OS images
-        for (ImageOS osImage : List.of(new ImageOSUbuntuJammyJDK17(), new ImageOSAmazonCorretto11()))
+        for (ImageOS osImage : List.of(new ImageOSUbuntuJammyJDK17(), new ImageOSAmazonCorretto17()))
         {
             // Establish user Images based on OS Image
             List<ImageFromDSL> userImages = new ArrayList<>();


### PR DESCRIPTION
+ Updating AmazonCorretto to JDK 17
+ Making sure /etc/default/jetty is populated correctly in the user_change mode
+ Removing warnings from jetty startup about --start-log-file=... being unrecognized
+ Adding unique jetty12 identifier to docker image names (helps to keep different jetty versions apart when manually testing)