### PR TITLE
Updates to jetty.sh and testing to reduce failures

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -635,13 +635,13 @@ case "$ACTION" in
         chown "$JETTY_USER" "$JETTY_PID"
         su - "$JETTY_USER" $SU_SHELL -c "
           cd \"$JETTY_BASE\"
-          echo ${RUN_ARGS[*]} --start-log-file=\"$JETTY_START_LOG\" | xargs ${JAVA} > /dev/null &
+          echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
           PID=\$!
           disown \$PID"
         (( DEBUG )) && echo "Starting: su shell (w/user $JETTY_USER) on PID $PID"
       else
         # Startup if not switching users
-        echo ${RUN_ARGS[*]} --start-log-file="${JETTY_START_LOG}" | xargs ${JAVA} > /dev/null &
+        echo ${RUN_ARGS[*]} | xargs ${JAVA} > /dev/null &
         PID=$!
         disown $PID
         (( DEBUG )) && echo "Starting: java command on PID $PID"

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto11.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto11.java
@@ -24,7 +24,7 @@ public class ImageOSAmazonCorretto11 extends ImageOS
 {
     public ImageOSAmazonCorretto11()
     {
-        super("amazoncorretto-jdk11",
+        super("amazoncorretto-jdk11-jetty10",
             builder ->
                 builder
                     .from("amazoncorretto:11.0.20")

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSUbuntuJammyJDK17.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSUbuntuJammyJDK17.java
@@ -22,7 +22,7 @@ public class ImageOSUbuntuJammyJDK17 extends ImageOS
 {
     public ImageOSUbuntuJammyJDK17()
     {
-        super("ubuntu-22.04-jdk17",
+        super("ubuntu-22.04-jdk17-jetty10",
             builder ->
                 builder
                     .from("ubuntu:22.04")

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageUserChange.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageUserChange.java
@@ -31,7 +31,7 @@ public class ImageUserChange extends ImageFromDSL
                     "useradd --home-dir=${JETTY_BASE} --shell=/bin/bash jetty ; " +
                     "chown jetty:jetty ${JETTY_BASE} ; " +
                     "chmod a+w ${JETTY_BASE} ; " +
-                    "echo \"JETTY_USER=jetty\" > /etc/default/jetty") // user change
+                    "echo \"JETTY_USER=jetty\" >> /etc/default/jetty") // user change
                 .user("jetty")
                 // Configure Jetty Base
                 .workDir("${JETTY_BASE}")


### PR DESCRIPTION
Backport of #10790 to Jetty 10.

+ Making sure /etc/default/jetty is populated correctly in the user_change mode
+ Removing warnings from jetty startup about --start-log-file=... being unrecognized
+ Adding unique jetty10 identifier to docker image names (helps to keep different jetty versions apart when manually testing)