### PR TITLE
Issue #10794 - Make sure 301 Moved Permanently produces query with `?` (instead of `;`)

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -828,11 +828,12 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
     protected void handleMovedPermanently(Request request, Response response, Callback callback)
     {
+        // TODO: should this be a fully qualified URI? (with scheme and host?)
         String location = _contextPath + "/";
         if (request.getHttpURI().getParam() != null)
             location += ";" + request.getHttpURI().getParam();
         if (request.getHttpURI().getQuery() != null)
-            location += ";" + request.getHttpURI().getQuery();
+            location += "?" + request.getHttpURI().getQuery();
 
         response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
         response.getHeaders().add(new HttpField(HttpHeader.LOCATION, location));

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
@@ -745,6 +745,16 @@ public class DefaultServletTest
         assertThat(response.toString(), response.getStatus(), is(HttpStatus.MOVED_TEMPORARILY_302));
         assertThat(response, containsHeaderValue("Location", "http://0.0.0.0/context/other/"));
 
+        rawResponse = connector.getResponse("GET /context/other?a=b HTTP/1.0\r\n\r\n");
+        response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.MOVED_TEMPORARILY_302));
+        assertThat(response, containsHeaderValue("Location", "http://0.0.0.0/context/other/?a=b"));
+
+        rawResponse = connector.getResponse("GET /context?a=b HTTP/1.0\r\n\r\n");
+        response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.MOVED_PERMANENTLY_301));
+        assertThat(response, containsHeaderValue("Location", "/context/?a=b"));
+
         // Test alt default
         rawResponse = connector.getResponse("GET /context/alt/dir/ HTTP/1.0\r\n\r\n");
         response = HttpTester.parseResponse(rawResponse);


### PR DESCRIPTION
Fixes #10794