### PR TITLE
Stabilize `secondary_super_cache` in server code

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
@@ -19,7 +19,6 @@ import java.nio.channels.ReadPendingException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Invocable.InvocationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +115,8 @@ public abstract class FillInterest
     public InvocationType getCallbackInvocationType()
     {
         Callback callback = _interested.get();
-        return Invocable.getInvocationType(callback);
+        // Identical to Invocable.getInvocationType(callback) except that the cast is costly here.
+        return callback == null ? InvocationType.BLOCKING : callback.getInvocationType();
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -718,11 +718,19 @@ public interface Request extends Attributes, Content.Source
      */
     class Wrapper implements Request, Attributes
     {
-        private final Request wrapped;
+        /**
+         * Implementation note: Request.Wrapper does not extend from Attributes.Wrapper
+         * as getWrapped() would either need to be implemented as {@code return (Request)getWrapped()}
+         * which would requiring a cast from one interface type to another, spoiling the
+         * secondary_super_cache, or by storing the same {@code _wrapped} object in two fields
+         * (one in Attributes.Wrapper as type Attributes and one in Request.Wrapper as type Request)
+         * to save the costly cast.
+         */
+        private final Request _wrapped;
 
         public Wrapper(Request wrapped)
         {
-            this.wrapped = Objects.requireNonNull(wrapped);
+            _wrapped = Objects.requireNonNull(wrapped);
         }
 
         @Override
@@ -895,7 +903,7 @@ public interface Request extends Attributes, Content.Source
 
         public Request getWrapped()
         {
-            return wrapped;
+            return _wrapped;
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -719,12 +719,12 @@ public interface Request extends Attributes, Content.Source
     class Wrapper implements Request, Attributes
     {
         /**
-         * Implementation note: Request.Wrapper does not extend from Attributes.Wrapper
-         * as getWrapped() would either need to be implemented as {@code return (Request)getWrapped()}
-         * which would requiring a cast from one interface type to another, spoiling the
-         * secondary_super_cache, or by storing the same {@code _wrapped} object in two fields
-         * (one in Attributes.Wrapper as type Attributes and one in Request.Wrapper as type Request)
-         * to save the costly cast.
+         * Implementation note: {@link Request.Wrapper} does not extend from {@link Attributes.Wrapper}
+         * as {@link #getWrapped()} would either need to be implemented as {@code return (Request)getWrapped()}
+         * which would require a cast from one interface type to another, spoiling the JVM's
+         * {@code secondary_super_cache}, or by storing the same {@code _wrapped} object in two fields
+         * (one in {@link Attributes.Wrapper} as type {@link Attributes} and one in {@link Request.Wrapper} as
+         * type {@link Request}) to save the costly cast from interface type to another.
          */
         private final Request _wrapped;
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -25,7 +25,9 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -714,14 +716,13 @@ public interface Request extends Attributes, Content.Source
     /**
      * <p>A wrapper for {@code Request} instances.</p>
      */
-    class Wrapper extends Attributes.Wrapper implements Request
+    class Wrapper implements Request, Attributes
     {
-        private final Request request;
+        private final Request wrapped;
 
         public Wrapper(Request wrapped)
         {
-            super(wrapped);
-            this.request = wrapped;
+            this.wrapped = Objects.requireNonNull(wrapped);
         }
 
         @Override
@@ -857,10 +858,44 @@ public interface Request extends Attributes, Content.Source
         }
 
         @Override
+        public Object removeAttribute(String name)
+        {
+            return getWrapped().removeAttribute(name);
+        }
+
+        @Override
+        public Object setAttribute(String name, Object attribute)
+        {
+            return getWrapped().setAttribute(name, attribute);
+        }
+
+        @Override
+        public Object getAttribute(String name)
+        {
+            return getWrapped().getAttribute(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNameSet()
+        {
+            return getWrapped().getAttributeNameSet();
+        }
+
+        @Override
+        public Map<String, Object> asAttributeMap()
+        {
+            return getWrapped().asAttributeMap();
+        }
+
+        @Override
+        public void clearAttributes()
+        {
+            getWrapped().clearAttributes();
+        }
+
         public Request getWrapped()
         {
-            // Identical to (Request)super.getWrapped() except that the cast is costly here.
-            return request;
+            return wrapped;
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -716,9 +716,12 @@ public interface Request extends Attributes, Content.Source
      */
     class Wrapper extends Attributes.Wrapper implements Request
     {
+        private final Request request;
+
         public Wrapper(Request wrapped)
         {
             super(wrapped);
+            this.request = wrapped;
         }
 
         @Override
@@ -856,7 +859,8 @@ public interface Request extends Attributes, Content.Source
         @Override
         public Request getWrapped()
         {
-            return (Request)super.getWrapped();
+            // Identical to (Request)super.getWrapped() except that the cast is costly here.
+            return request;
         }
     }
 


### PR DESCRIPTION
Fix the type pollution of the top two contenders on the server reported in #10781.

Removing the cast-to-interface in these two places boosts perf by a couple of %.