### PR TITLE
The replaceCookie method renamed to putCookie and refined #10797

### DIFF
--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CookiePatternRule.java
@@ -95,7 +95,7 @@ public class CookiePatternRule extends PatternRule
             @Override
             protected boolean handle(Response response, Callback callback) throws Exception
             {
-                Response.addCookie(response, HttpCookie.from(_name, _value));
+                Response.putCookie(response, HttpCookie.from(_name, _value));
                 return super.handle(response, callback);
             }
         };

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -323,7 +323,9 @@ public interface Response extends Content.Sink
     }
 
     /**
-     * <p>Adds an HTTP cookie to the response.</p>
+     * <p>Adds an HTTP {@link HttpHeader#SET_COOKIE} header to the response.</p>
+     * <p>If a matching {@link HttpHeader#SET_COOKIE} already exists for matching name, path, domain etc.
+     * then it will be replaced.</p>
      *
      * @param response the HTTP response
      * @param cookie the HTTP cookie to add
@@ -334,51 +336,63 @@ public interface Response extends Content.Sink
             throw new IllegalArgumentException("Cookie.name cannot be blank/null");
 
         Request request = response.getRequest();
-        response.getHeaders().add(new HttpCookieUtils.SetCookieHttpField(HttpCookieUtils.checkSameSite(cookie, request.getContext()),
-            request.getConnectionMetaData().getHttpConfiguration().getResponseCookieCompliance()));
-
-        // Expire responses with set-cookie headers so they do not get cached.
-        response.getHeaders().put(HttpFields.EXPIRES_01JAN1970);
-    }
-
-    /**
-     * <p>Replaces (if already exists, otherwise adds) an HTTP cookie to the response.</p>
-     *
-     * @param response the HTTP response
-     * @param cookie the HTTP cookie to replace or add
-     */
-    static void replaceCookie(Response response, HttpCookie cookie)
-    {
-        if (StringUtil.isBlank(cookie.getName()))
-            throw new IllegalArgumentException("Cookie.name cannot be blank/null");
-
-        Request request = response.getRequest();
         HttpConfiguration httpConfiguration = request.getConnectionMetaData().getHttpConfiguration();
+        CookieCompliance compliance = httpConfiguration.getResponseCookieCompliance();
+        HttpField setCookie = new HttpCookieUtils.SetCookieHttpField(HttpCookieUtils.checkSameSite(cookie, request.getContext()), compliance);
+
+        boolean expires = false;
 
         for (ListIterator<HttpField> i = response.getHeaders().listIterator(); i.hasNext(); )
         {
             HttpField field = i.next();
+            HttpHeader header = field.getHeader();
+            if (header == null)
+                continue;
 
-            if (field.getHeader() == HttpHeader.SET_COOKIE)
+            switch (header)
             {
-                CookieCompliance compliance = httpConfiguration.getResponseCookieCompliance();
-                if (field instanceof HttpCookieUtils.SetCookieHttpField)
+                case SET_COOKIE ->
                 {
-                    if (!HttpCookieUtils.match(((HttpCookieUtils.SetCookieHttpField)field).getHttpCookie(), cookie.getName(), cookie.getDomain(), cookie.getPath()))
-                        continue;
-                }
-                else
-                {
-                    if (!HttpCookieUtils.match(field.getValue(), cookie.getName(), cookie.getDomain(), cookie.getPath()))
-                        continue;
+                    if (field instanceof HttpCookieUtils.SetCookieHttpField setCookieHttpField)
+                    {
+                        if (!HttpCookieUtils.match(setCookieHttpField.getHttpCookie(), cookie.getName(), cookie.getDomain(), cookie.getPath()))
+                            continue;
+                    }
+                    else
+                    {
+                        if (!HttpCookieUtils.match(field.getValue(), cookie.getName(), cookie.getDomain(), cookie.getPath()))
+                            continue;
+                    }
+
+                    if (setCookie == null)
+                    {
+                        i.remove();
+                    }
+                    else
+                    {
+                        i.set(setCookie);
+                        setCookie = null;
+                    }
                 }
 
-                i.set(new HttpCookieUtils.SetCookieHttpField(HttpCookieUtils.checkSameSite(cookie, request.getContext()), compliance));
-                return;
+                case EXPIRES -> expires = true;
             }
         }
 
-        // Not replaced, so add normally
+        if (setCookie != null)
+            response.getHeaders().add(setCookie);
+
+        // Expire responses with set-cookie headers, so they do not get cached.
+        if (!expires)
+            response.getHeaders().put(HttpFields.EXPIRES_01JAN1970);
+    }
+
+    /**
+     * @deprecated use {@link #addCookie(Response, HttpCookie)}
+     */
+    @Deprecated
+    static void replaceCookie(Response response, HttpCookie cookie)
+    {
         addCookie(response, cookie);
     }
 

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/ManagedSession.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/ManagedSession.java
@@ -610,7 +610,7 @@ public class ManagedSession implements Session
         }
 
         if (response != null && isSetCookieNeeded())
-            Response.addCookie(response, getSessionManager().getSessionCookie(this, request.isSecure()));
+            Response.putCookie(response, getSessionManager().getSessionCookie(this, request.isSecure()));
         if (LOG.isDebugEnabled())
             LOG.debug("renew {}->{}", oldId, newId);
     }

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/ManagedSession.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/ManagedSession.java
@@ -610,7 +610,7 @@ public class ManagedSession implements Session
         }
 
         if (response != null && isSetCookieNeeded())
-            Response.replaceCookie(response, getSessionManager().getSessionCookie(this, request.isSecure()));
+            Response.addCookie(response, getSessionManager().getSessionCookie(this, request.isSecure()));
         if (LOG.isDebugEnabled())
             LOG.debug("renew {}->{}", oldId, newId);
     }

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/SessionHandler.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/SessionHandler.java
@@ -117,7 +117,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
                 session = _session.get();
                 HttpCookie cookie = getSessionCookie(session, getConnectionMetaData().isSecure());
                 if (cookie != null)
-                    Response.replaceCookie(_response, cookie);
+                    Response.addCookie(_response, cookie);
             }
 
             return session == null || !session.isValid() ? null : session;
@@ -136,7 +136,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
                 _session.set(session);
                 HttpCookie cookie = access(session, getConnectionMetaData().isSecure());
                 if (cookie != null)
-                    Response.replaceCookie(_response, cookie);
+                    Response.addCookie(_response, cookie);
             }
 
             return handler.handle(this, _response, callback);

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/SessionHandler.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/SessionHandler.java
@@ -117,7 +117,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
                 session = _session.get();
                 HttpCookie cookie = getSessionCookie(session, getConnectionMetaData().isSecure());
                 if (cookie != null)
-                    Response.addCookie(_response, cookie);
+                    Response.putCookie(_response, cookie);
             }
 
             return session == null || !session.isValid() ? null : session;
@@ -136,7 +136,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
                 _session.set(session);
                 HttpCookie cookie = access(session, getConnectionMetaData().isSecure());
                 if (cookie != null)
-                    Response.addCookie(_response, cookie);
+                    Response.putCookie(_response, cookie);
             }
 
             return handler.handle(this, _response, callback);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -483,7 +483,7 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
 
         HttpCookie cookie = _sessionManager.getSessionCookie(_managedSession, isSecure());
         if (cookie != null)
-            Response.replaceCookie(_response, cookie);
+            Response.addCookie(_response, cookie);
 
         return _managedSession;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -483,7 +483,7 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
 
         HttpCookie cookie = _sessionManager.getSessionCookie(_managedSession, isSecure());
         if (cookie != null)
-            Response.addCookie(_response, cookie);
+            Response.putCookie(_response, cookie);
 
         return _managedSession;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -338,7 +338,7 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
                 {
                     HttpCookie c = sh.getSessionCookie(managedSession, getRequest().isSecure());
                     if (c != null)
-                        Response.addCookie(getWrapped(), c);
+                        Response.putCookie(getWrapped(), c);
                 }
                 else
                 {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -686,7 +686,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
         if (cookie != null)
         {
             ServletContextResponse servletContextResponse = servletContextRequest.getServletContextResponse();
-            Response.addCookie(servletContextResponse, cookie);
+            Response.putCookie(servletContextResponse, cookie);
         }
 
         return next.handle(request, response, callback);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -38,7 +38,6 @@ import jakarta.servlet.http.HttpSessionIdListener;
 import jakarta.servlet.http.HttpSessionListener;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpCookie.SameSite;
-import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -687,7 +686,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
         if (cookie != null)
         {
             ServletContextResponse servletContextResponse = servletContextRequest.getServletContextResponse();
-            Response.replaceCookie(servletContextResponse, cookie);
+            Response.addCookie(servletContextResponse, cookie);
         }
 
         return next.handle(request, response, callback);


### PR DESCRIPTION
Fix #10797 by make addCookie always replace existing SetCookie fields. Deprecated replaceCookie method.