### PR TITLE
Issue #10812 - Correct awaitility dependency scope

### DIFF
--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -62,6 +62,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Fixes #10812 by addressing an unintended side effect of #10667.

Needs forward-port to `11.x` but `12.x` is unaffected as https://github.com/jetty/jetty.project/pull/10765 fixed it (unfortunately not back-ported).