### PR TITLE
Fixes #10806 - cache local and remote socket address in EndPoint for benefit of RequestLog

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
@@ -103,7 +103,7 @@ public class ByteArrayEndPoint extends AbstractEndPoint
 
     public ByteArrayEndPoint(Scheduler timer, long idleTimeoutMs, ByteBuffer input, ByteBuffer output)
     {
-        super(timer);
+        super(timer, NO_SOCKET_ADDRESS, NO_SOCKET_ADDRESS);
         if (BufferUtil.hasContent(input))
             addInput(input);
         _outputSize = (output == null) ? 1024 : output.capacity();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/DatagramChannelEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/DatagramChannelEndPoint.java
@@ -37,7 +37,7 @@ public class DatagramChannelEndPoint extends SelectableChannelEndPoint
 
     public DatagramChannelEndPoint(DatagramChannel channel, ManagedSelector selector, SelectionKey key, Scheduler scheduler)
     {
-        super(scheduler, channel, selector, key);
+        super(scheduler, channel, channel::getLocalAddress, channel::getRemoteAddress, selector, key);
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.io;
 
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -33,33 +32,13 @@ public class SocketChannelEndPoint extends SelectableChannelEndPoint
 
     public SocketChannelEndPoint(SocketChannel channel, ManagedSelector selector, SelectionKey key, Scheduler scheduler)
     {
-        super(scheduler, channel, selector, key);
+        super(scheduler, channel, channel::getLocalAddress, channel::getRemoteAddress, selector, key);
     }
 
     @Override
     public SocketChannel getChannel()
     {
         return (SocketChannel)super.getChannel();
-    }
-
-    @Override
-    public SocketAddress getRemoteSocketAddress()
-    {
-        SocketAddress socketAddress = super.getRemoteSocketAddress();
-
-        if (socketAddress != null)
-            return socketAddress;
-
-        try
-        {
-            return getChannel().getRemoteAddress();
-        }
-        catch (Throwable x)
-        {
-            if (LOG.isTraceEnabled())
-                LOG.trace("Could not retrieve remote socket address", x);
-            return null;
-        }
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.io;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 
@@ -48,6 +49,14 @@ public class SocketChannelEndPoint extends SelectableChannelEndPoint
         try
         {
             return getChannel().getRemoteAddress();
+        }
+        catch (ClosedChannelException e)
+        {
+            if (_remoteSocketAddress != null)
+                return _remoteSocketAddress;
+            if (LOG.isTraceEnabled())
+                LOG.trace("Could not retrieve remote socket address on closed channel", e);
+            return null;
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SocketChannelEndPoint.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.io;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 
@@ -46,17 +45,14 @@ public class SocketChannelEndPoint extends SelectableChannelEndPoint
     @Override
     public SocketAddress getRemoteSocketAddress()
     {
+        SocketAddress socketAddress = super.getRemoteSocketAddress();
+
+        if (socketAddress != null)
+            return socketAddress;
+
         try
         {
             return getChannel().getRemoteAddress();
-        }
-        catch (ClosedChannelException e)
-        {
-            if (_remoteSocketAddress != null)
-                return _remoteSocketAddress;
-            if (LOG.isTraceEnabled())
-                LOG.trace("Could not retrieve remote socket address on closed channel", e);
-            return null;
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.io.ssl;
 
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -491,7 +490,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         public SslEndPoint()
         {
             // Disable idle timeout checking: no scheduler and -1 timeout for this instance.
-            super(null);
+            super(null, SslConnection.this.getEndPoint()::getLocalSocketAddress, SslConnection.this.getEndPoint()::getRemoteSocketAddress);
             super.setIdleTimeout(-1);
         }
 
@@ -517,18 +516,6 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         public boolean isOpen()
         {
             return getEndPoint().isOpen();
-        }
-
-        @Override
-        public SocketAddress getLocalSocketAddress()
-        {
-            return getEndPoint().getLocalSocketAddress();
-        }
-
-        @Override
-        public SocketAddress getRemoteSocketAddress()
-        {
-            return getEndPoint().getRemoteSocketAddress();
         }
 
         @Override

--- a/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicStreamEndPoint.java
+++ b/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicStreamEndPoint.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.quic.common;
 
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -45,7 +44,7 @@ public class QuicStreamEndPoint extends AbstractEndPoint
 
     public QuicStreamEndPoint(Scheduler scheduler, QuicSession session, long streamId)
     {
-        super(scheduler);
+        super(scheduler, session.getLocalAddress(), session.getRemoteAddress());
         this.session = session;
         this.streamId = streamId;
     }
@@ -76,18 +75,6 @@ public class QuicStreamEndPoint extends AbstractEndPoint
     public long getStreamId()
     {
         return streamId;
-    }
-
-    @Override
-    public SocketAddress getLocalSocketAddress()
-    {
-        return session.getLocalAddress();
-    }
-
-    @Override
-    public SocketAddress getRemoteSocketAddress()
-    {
-        return session.getRemoteAddress();
     }
 
     public boolean isStreamFinished()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
@@ -415,7 +415,7 @@ public class RequestLogTest
                         EndPoint endPoint = request.getConnectionMetaData().getConnection().getEndPoint();
                         // Close connection
                         endPoint.close();
-                        // Wait for a bit
+                        // Wait for endpoint to be closed
                         Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> !endPoint.isOpen());
                     });
                     Content.Sink.write(response, true, msg, testCallback);


### PR DESCRIPTION
The EndPoint local-address and remote-address are inaccessible once the EndPoint is closed due to "ensureOpen" checks by the Java implementation itself.

This PR merely caches the local-address and remote-address in the EndPoint classes to be accessed if unable to get the attempt to get the SocketAddress from the Channel fails due to a `ClosedChannelException`.

Fixes: #10806 