### PR TITLE
downgrade surefire due to jpms issue due to https://github.com/apache/maven-surefire/pull/668

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,8 @@
     <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
     <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
-    <maven.surefire.plugin.version>3.2.1</maven.surefire.plugin.version>
+    <!-- do not upgrade as jpms issue with ee10 annotations -->
+    <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
     <maven.version>3.9.0</maven.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <mina.core.version>2.2.3</mina.core.version>


### PR DESCRIPTION
[ERROR] java.lang.module.FindException: Module jakarta.interceptor not found, required by jakarta.transaction

Signed-off-by: Olivier Lamy <olamy@apache.org>
