### PR TITLE
Fix flaky EE10 `ServletRequestListenerTest`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestListenerTest.java
@@ -213,8 +213,8 @@ public class ServletRequestListenerTest
             contextHandler.setErrorHandler((request, response, callback) ->
             {
                 response.setStatus(500);
-                response.write(true, BufferUtil.toBuffer("error handled"), callback);
                 _events.add("errorHandler");
+                response.write(true, BufferUtil.toBuffer("error handled"), callback);
                 return true;
             });
 


### PR DESCRIPTION
Fix a small race in the test itself.

The list of asserted events must be modified before the response is written, otherwise, the asserting thread might get the response before the error event item is added to the list.

See: https://jenkins.webtide.net/blue/organizations/jenkins/jetty.project/detail/PR-10880/4/tests