### PR TITLE
Don't track mounts for `newResource()` that doesn't exist

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -129,7 +129,7 @@ public class FileSystemPool implements Dumpable
             }
             // use root FS URI so that pool key/release/sweep is sane
             URI rootURI = fileSystem.getPath("/").toUri();
-            Mount mount = new Mount(rootURI, new MountedPathResource(uri));
+            Mount mount = new Mount(rootURI, new MountedPathResource(jarURIRoot));
             retain(rootURI, fileSystem, mount);
             return mount;
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -108,23 +108,24 @@ public class FileSystemPool implements Dumpable
             throw new IllegalArgumentException("not an supported scheme: " + uri);
 
         FileSystem fileSystem = null;
+        URI jarURIRoot = toJarURIRoot(uri);
         try (AutoLock ignore = poolLock.lock())
         {
             try
             {
-                fileSystem = FileSystems.newFileSystem(uri, ENV_MULTIRELEASE_RUNTIME);
+                fileSystem = FileSystems.newFileSystem(jarURIRoot, ENV_MULTIRELEASE_RUNTIME);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Mounted new FS {}", uri);
+                    LOG.debug("Mounted new FS {}", jarURIRoot);
             }
             catch (FileSystemAlreadyExistsException fsaee)
             {
-                fileSystem = Paths.get(uri).getFileSystem();
+                fileSystem = Paths.get(jarURIRoot).getFileSystem();
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Using existing FS {}", uri);
+                    LOG.debug("Using existing FS {}", jarURIRoot);
             }
             catch (ProviderNotFoundException pnfe)
             {
-                throw new IllegalArgumentException("Unable to mount FileSystem from unsupported URI: " + uri, pnfe);
+                throw new IllegalArgumentException("Unable to mount FileSystem from unsupported URI: " + jarURIRoot, pnfe);
             }
             // use root FS URI so that pool key/release/sweep is sane
             URI rootURI = fileSystem.getPath("/").toUri();
@@ -137,6 +138,13 @@ public class FileSystemPool implements Dumpable
             IO.close(fileSystem);
             throw e;
         }
+    }
+
+    private URI toJarURIRoot(URI uri)
+    {
+        String rawURI = uri.toASCIIString();
+        int idx = rawURI.indexOf("!/");
+        return URI.create(rawURI.substring(0, idx + 2));
     }
 
     private void unmount(URI fsUri)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -244,7 +244,7 @@ class ResourceFactoryInternals
          *
          * @param uri The URI to mount that may require a FileSystem (e.g. "jar:file://tmp/some.jar!/directory/file.txt")
          * @return A reference counted {@link FileSystemPool.Mount} for that file system or null. Callers should call
-         * {@link FileSystemPool.Mount#close()} once they no longer require any resources from a mounted resource.
+         * {@link FileSystemPool.Mount#close()} once they no longer require this specific Mount.
          * @throws IllegalArgumentException If the uri could not be mounted.
          */
         private FileSystemPool.Mount mountIfNeeded(URI uri)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -397,7 +397,7 @@ public class MountedPathResourceTest
 
             assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
             int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-            assertThat(mountCount, is(4));
+            assertThat(mountCount, is(1));
         }
 
         assertThat(FileSystemPool.INSTANCE.mounts().size(), is(0));
@@ -433,13 +433,10 @@ public class MountedPathResourceTest
 
             assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
             int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-            assertThat(mountCount, is(4));
+            assertThat(mountCount, is(1));
             String dump = resourceFactory.dump();
-            assertThat(dump, containsString("newResourceReferences size=4"));
+            assertThat(dump, containsString("newResourceReferences size=1"));
             assertThat(dump, containsString(uriRoot.toASCIIString()));
-            assertThat(dump, containsString(uriRez.toASCIIString()));
-            assertThat(dump, containsString(uriDeep.toASCIIString()));
-            assertThat(dump, containsString(uriZzz.toASCIIString()));
         }
         finally
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -257,10 +258,9 @@ public class PathResourceTest
             Resource resBadFile = resourceFactory.newResource(jarUri.toASCIIString() + "bad/file.txt");
             assertNull(resBadFile);
 
-            if (resourceFactory instanceof ResourceFactoryInternals.Mountable mountable)
+            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
-                List<FileSystemPool.Mount> mounts = mountable.getMounts();
-                assertThat(mounts.size(), is(1));
+                assertThat(tracking.getTrackingCount(), is(1));
             }
         }
     }
@@ -292,11 +292,78 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            if (resourceFactory instanceof ResourceFactoryInternals.Mountable mountable)
+            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
-                List<FileSystemPool.Mount> mounts = mountable.getMounts();
-                assertThat(mounts.size(), is(1));
+                assertThat(tracking.getTrackingCount(), is(1));
             }
+        }
+    }
+
+    @Test
+    public void testMountsForSameJarDifferentResourceFactories(WorkDir workDir) throws IOException
+    {
+        Path tmpPath = workDir.getEmptyPathDir();
+        Path testJar = tmpPath.resolve("test.jar");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+
+        URI jarUri = URIUtil.uriJarPrefix(testJar.toUri(), "!/");
+        try (FileSystem zipfs = FileSystems.newFileSystem(jarUri, env))
+        {
+            Path root = zipfs.getPath("/");
+            Files.writeString(root.resolve("one.txt"), "Contents of one.txt", StandardCharsets.UTF_8);
+
+            Path dir = root.resolve("datainf");
+            Files.createDirectory(dir);
+            Files.writeString(dir.resolve("two.txt"), "Contents of two.txt", StandardCharsets.UTF_8);
+        }
+
+        assertThat(FileSystemPool.INSTANCE.mounts(), is(empty()));
+
+        try (ResourceFactory.Closeable resourceFactory1 = ResourceFactory.closeable();
+             ResourceFactory.Closeable resourceFactory2 = ResourceFactory.closeable())
+        {
+            Resource oneTxt = resourceFactory1.newResource(jarUri.toASCIIString() + "one.txt");
+            assertTrue(Resources.isReadableFile(oneTxt));
+
+            Resource oneTxt2 = resourceFactory1.newResource(jarUri.toASCIIString() + "one.txt");
+            assertTrue(Resources.isReadableFile(oneTxt));
+
+            Resource twoTxt = resourceFactory2.newResource(jarUri.toASCIIString() + "datainf/two.txt");
+            assertTrue(Resources.isReadableFile(twoTxt));
+
+            assertThat("Should see only 1 FS Mount", FileSystemPool.INSTANCE.mounts().size(), is(1));
+
+            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
+            {
+                assertThat(tracking.getTrackingCount(), is(1));
+            }
+
+            if (resourceFactory2 instanceof ResourceFactoryInternals.Tracking tracking)
+            {
+                assertThat(tracking.getTrackingCount(), is(1));
+            }
+
+            // Close Resource Factory 1
+            resourceFactory1.close();
+
+            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
+            {
+                assertThat(tracking.getTrackingCount(), is(0));
+            }
+
+            // should not be able to use closed ResourceFactory.Closable
+            assertThrows(IllegalStateException.class, () -> resourceFactory1.newResource(jarUri.toASCIIString() + "one.txt"));
+
+            assertThat("Should see only 1 FS Mount", FileSystemPool.INSTANCE.mounts().size(), is(1));
+
+            Resource oneAlt = resourceFactory2.newResource(jarUri.toASCIIString() + "one.txt");
+            assertTrue(Resources.isReadableFile(oneAlt));
+        }
+        finally
+        {
+            assertThat(FileSystemPool.INSTANCE.mounts(), is(empty()));
         }
     }
 


### PR DESCRIPTION
Don't hold / track mounts from `newResource()` that would result in a no-op.