### PR TITLE
Improve Resource use in MetaInfConfiguration

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -378,64 +378,70 @@ public class MetaInfConfiguration extends AbstractConfiguration
         // Resource target does not exist
         if (Resources.missing(target))
             return;
-        ResourceFactory resourceFactory = ResourceFactory.of(context);
 
-        Resource resourcesDir;
-        if (cache != null && cache.containsKey(target))
-        {
-            resourcesDir = cache.get(target);
-            if (isEmptyResource(resourcesDir))
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} cached as containing no META-INF/resources", target);
-                return;
-            }
-            else if (LOG.isDebugEnabled())
-                LOG.debug("{} META-INF/resources found in cache ", target);
-        }
-        else
-        {
-            //not using caches or not in the cache so check for the resources dir
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} META-INF/resources checked", target);
-            if (target.isDirectory())
-            {
-                //TODO think  how to handle an unpacked jar file (eg for osgi)
-                resourcesDir = target.resolve("/META-INF/resources");
-            }
-            else
-            {
-                // Resource represents a packed jar
-                Resource jarFileResource = resourceFactory.newJarFileResource(target.getURI());
-                resourcesDir = jarFileResource.resolve("META-INF/resources");
-            }
+       try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
+       {
+           Resource resourcesDir;
+           if (cache != null && cache.containsKey(target))
+           {
+               resourcesDir = cache.get(target);
+               if (isEmptyResource(resourcesDir))
+               {
+                   if (LOG.isDebugEnabled())
+                       LOG.debug("{} cached as containing no META-INF/resources", target);
+                   return;
+               }
+               else if (LOG.isDebugEnabled())
+                   LOG.debug("{} META-INF/resources found in cache ", target);
+           }
+           else
+           {
+               //not using caches or not in the cache so check for the resources dir
+               if (LOG.isDebugEnabled())
+                   LOG.debug("{} META-INF/resources checked", target);
+               if (target.isDirectory())
+               {
+                   //TODO think  how to handle an unpacked jar file (eg for osgi)
+                   resourcesDir = target.resolve("/META-INF/resources");
+               }
+               else
+               {
+                   // Resource represents a packed jar
+                   Resource jarFileResource = closeable.newJarFileResource(target.getURI());
+                   resourcesDir = jarFileResource.resolve("META-INF/resources");
+               }
 
-            if (isEmptyResource(resourcesDir))
-            {
-                return;
-            }
+               if (isEmptyResource(resourcesDir))
+               {
+                   return;
+               }
 
-            if (cache != null)
-            {
-                Resource old = cache.putIfAbsent(target, resourcesDir);
-                if (old != null)
-                    resourcesDir = old;
-                else if (LOG.isDebugEnabled())
-                    LOG.debug("{} META-INF/resources cache updated", target);
-            }
-        }
+               //convert our Resource reference to something associated with the context
+               //because it's lifecycle is the same as the context
+               resourcesDir = context.getResourceFactory().newResource(resourcesDir.getURI());
 
-        //add it to the meta inf resources for this context
-        Set<Resource> dirs = (Set<Resource>)context.getAttribute(METAINF_RESOURCES);
-        if (dirs == null)
-        {
-            dirs = new HashSet<>();
-            context.setAttribute(METAINF_RESOURCES, dirs);
-        }
-        if (LOG.isDebugEnabled())
-            LOG.debug("{} added to context", resourcesDir);
+               if (cache != null)
+               {
+                   Resource old = cache.putIfAbsent(target, resourcesDir);
+                   if (old != null)
+                       resourcesDir = old;
+                   else if (LOG.isDebugEnabled())
+                       LOG.debug("{} META-INF/resources cache updated", target);
+               }
+           }
 
-        dirs.add(resourcesDir);
+           //add it to the meta inf resources for this context
+           Set<Resource> dirs = (Set<Resource>)context.getAttribute(METAINF_RESOURCES);
+           if (dirs == null)
+           {
+               dirs = new HashSet<>();
+               context.setAttribute(METAINF_RESOURCES, dirs);
+           }
+           if (LOG.isDebugEnabled())
+               LOG.debug("{} added to context", resourcesDir);
+
+           dirs.add(resourcesDir);
+       }
     }
 
     private static boolean isEmptyResource(Resource resourcesDir)
@@ -452,58 +458,64 @@ public class MetaInfConfiguration extends AbstractConfiguration
      */
     public void scanForFragment(WebAppContext context, Resource jar, ConcurrentHashMap<Resource, Resource> cache)
     {
-        ResourceFactory resourceFactory = ResourceFactory.of(context);
-
-        Resource webFrag;
-        if (cache != null && cache.containsKey(jar))
+        try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
         {
-            webFrag = cache.get(jar);
-            if (isEmptyFragment(webFrag))
+            Resource webFrag;
+            if (cache != null && cache.containsKey(jar))
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} cached as containing no META-INF/web-fragment.xml", jar);
-                return;
-            }
-            else if (LOG.isDebugEnabled())
-                LOG.debug("{} META-INF/web-fragment.xml found in cache ", jar);
-        }
-        else
-        {
-            //not using caches or not in the cache so check for the web-fragment.xml
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} META-INF/web-fragment.xml checked", jar);
-            if (jar.isDirectory())
-            {
-                webFrag = jar.resolve("META-INF/web-fragment.xml");
+                webFrag = cache.get(jar);
+                if (isEmptyFragment(webFrag))
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("{} cached as containing no META-INF/web-fragment.xml", jar);
+                    return;
+                }
+                else if (LOG.isDebugEnabled())
+                    LOG.debug("{} META-INF/web-fragment.xml found in cache ", jar);
             }
             else
             {
-               webFrag = resourceFactory.newJarFileResource(jar.getURI()).resolve("META-INF/web-fragment.xml");
+                //not using caches or not in the cache so check for the web-fragment.xml
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} META-INF/web-fragment.xml checked", jar);
+
+                Resource tmp;
+                if (jar.isDirectory())
+                {
+                    tmp = jar.resolve("META-INF/web-fragment.xml");
+                }
+                else
+                {
+                    tmp = closeable.newJarFileResource(jar.getURI()).resolve("META-INF/web-fragment.xml");
+                }
+
+                if (isEmptyFragment(tmp))
+                    return;
+
+                //convert the ephemeral Resource reference for the fragment into a Resource
+                //associated with the context lifecycle
+                webFrag = context.getResourceFactory().newResource(tmp.getURI());
+                if (cache != null)
+                {
+                    //web-fragment.xml doesn't exist: put token in cache to signal we've seen the jar
+                    Resource old = cache.putIfAbsent(jar, webFrag);
+                    if (old != null)
+                        webFrag = old;
+                    else if (LOG.isDebugEnabled())
+                        LOG.debug("{} META-INF/web-fragment.xml cache updated", jar);
+                }
             }
 
-            if (isEmptyFragment(webFrag))
-                return;
-
-            if (cache != null)
+            Map<Resource, Resource> fragments = (Map<Resource, Resource>)context.getAttribute(METAINF_FRAGMENTS);
+            if (fragments == null)
             {
-                //web-fragment.xml doesn't exist: put token in cache to signal we've seen the jar
-                Resource old = cache.putIfAbsent(jar, webFrag);
-                if (old != null)
-                    webFrag = old;
-                else if (LOG.isDebugEnabled())
-                    LOG.debug("{} META-INF/web-fragment.xml cache updated", jar);
+                fragments = new HashMap<>();
+                context.setAttribute(METAINF_FRAGMENTS, fragments);
             }
+            fragments.put(jar, webFrag);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} added to context", webFrag);
         }
-
-        Map<Resource, Resource> fragments = (Map<Resource, Resource>)context.getAttribute(METAINF_FRAGMENTS);
-        if (fragments == null)
-        {
-            fragments = new HashMap<>();
-            context.setAttribute(METAINF_FRAGMENTS, fragments);
-        }
-        fragments.put(jar, webFrag);
-        if (LOG.isDebugEnabled())
-            LOG.debug("{} added to context", webFrag);
     }
 
     private static boolean isEmptyFragment(Resource webFrag)
@@ -544,15 +556,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             //not using caches or not in the cache so find all tlds
             tlds = new HashSet<>();
-            if (jar.isDirectory())
-            {
-                tlds.addAll(getTlds(jar.getPath()));
-            }
-            else
-            {
-                URI uri = jar.getURI();
-                tlds.addAll(getTlds(context, uri));
-            }
+            tlds.addAll(getTlds(context, jar));
 
             if (cache != null)
             {
@@ -589,47 +593,32 @@ public class MetaInfConfiguration extends AbstractConfiguration
     }
 
     /**
-     * Find all .tld files in all subdirs of the given dir.
-     *
-     * @param dir the directory to scan
-     * @return the list of tlds found
-     * @throws IOException if unable to scan the directory
-     */
-    private Collection<URL> getTlds(Path dir) throws IOException
-    {
-        if (dir == null || !Files.isDirectory(dir))
-            return Collections.emptySet();
-
-        Set<URL> tlds = new HashSet<>();
-
-        try (Stream<Path> entries = Files.walk(dir)
-            .filter(Files::isRegularFile)
-            .filter(FileID::isTld))
-        {
-            Iterator<Path> iter = entries.iterator();
-            while (iter.hasNext())
-            {
-                Path entry = iter.next();
-                tlds.add(entry.toUri().toURL());
-            }
-        }
-        return tlds;
-    }
-
-    /**
      * Find all .tld files in the given jar.
      *
-     * @param uri the uri to jar file
+     * @param resource the jar file
      * @return the collection of tlds as url references
      * @throws IOException if unable to scan the jar file
      */
-    private Collection<URL> getTlds(WebAppContext context, URI uri) throws IOException
+    private Collection<URL> getTlds(WebAppContext context, Resource resource) throws IOException
     {
         HashSet<URL> tlds = new HashSet<>();
+        Resource resourceDir;
+
         try (ResourceFactory.Closeable closeableResourceFactory = ResourceFactory.closeable())
         {
-            Resource closeableResource = closeableResourceFactory.newJarFileResource(uri);
-            try (Stream<Path> stream = Files.walk(closeableResource.getPath()))
+            if (!resource.isDirectory())
+            {
+                //turn it into a jar:file
+                resourceDir = closeableResourceFactory.newJarFileResource(resource.getURI());
+            }
+            else
+                resourceDir = resource;
+
+            Resource metaInf = resourceDir.resolve("META-INF");
+            if (!metaInf.isDirectory())
+                return tlds; //no tlds
+
+            try (Stream<Path> stream = Files.walk(metaInf.getPath()))
             {
                 Iterator<Path> it = stream
                     .filter(Files::isRegularFile)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -354,7 +354,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         //Scan jars for META-INF information
         if (jars != null)
         {
-            try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
+            try (ResourceFactory.Closeable scanResourceFactory = ResourceFactory.closeable())
             {
                 for (Resource r : jars)
                 {

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -362,8 +362,9 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
                     try
                     {
+                        //If not already a directory, convert by mounting as jar file
                         if (!dir.isDirectory())
-                            dir = closeable.newJarFileResource(dir.getURI());
+                            dir = scanResourceFactory.newJarFileResource(dir.getURI());
                     }
                     catch (Exception e)
                     {
@@ -423,7 +424,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             if (isEmptyResource(resourcesDir))
                 return;
 
-            //convert to a Resource tied to the Context lifecycle
+            //convert from an ephemeral Resource to one that is associated with the context's lifecycle
             resourcesDir = context.getResourceFactory().newResource(resourcesDir.getURI());
 
             if (cache != null)
@@ -491,7 +492,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             if (isEmptyFragment(webFrag))
                 return;
 
-            //convert webFragment Resource to one tied to the Context lifecycle
+            //convert ephemeral Resource to one associated with the context's lifecycle ResourceFactory
             webFrag = context.getResourceFactory().newResource(webFrag.getURI());
 
             if (cache != null)
@@ -513,7 +514,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
         if (dir instanceof MountedPathResource)
         {
-            //ensure we get the original .jar rather than jar:file:
+            //ensure we link from the original .jar rather than jar:file:
             dir = context.getResourceFactory().newResource(((MountedPathResource)dir).getContainerPath());
         }
         

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -356,10 +356,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             try (ResourceFactory.Closeable scanResourceFactory = ResourceFactory.closeable())
             {
-                for (Resource r : jars)
+                for (Resource dir : jars)
                 {
-                    Resource dir = r;
-
                     try
                     {
                         //If not already a directory, convert by mounting as jar file

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -360,7 +360,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         //Scan jars for META-INF information
         if (jars != null)
         {
-            try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
+            try (ResourceFactory.Closeable scanResourceFactory = ResourceFactory.closeable())
             {
                 for (Resource r : jars)
                 {
@@ -368,8 +368,9 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
                     try
                     {
+                        //if not already a directory, convert it by mounting as jar file
                         if (!dir.isDirectory())
-                            dir = closeable.newJarFileResource(dir.getURI());
+                            dir = scanResourceFactory.newJarFileResource(dir.getURI());
                     }
                     catch (Exception e)
                     {
@@ -429,7 +430,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             if (isEmptyResource(resourcesDir))
                 return;
 
-            //convert to a Resource tied to the Context lifecycle
+            //convert from an ephemeral Resource to one that is associated with the context's lifecycle
             resourcesDir = context.getResourceFactory().newResource(resourcesDir.getURI());
 
             if (cache != null)
@@ -493,7 +494,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             if (isEmptyFragment(webFrag))
                 return;
 
-            //convert webFragment Resource to one tied to the Context lifecycle
+            //convert ephemeral Resource to one associated with the context's lifecycle ResourceFactory
             webFrag = context.getResourceFactory().newResource(webFrag.getURI());
 
             if (cache != null)
@@ -515,7 +516,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
 
         if (dir instanceof MountedPathResource)
         {
-            //ensure we get the original .jar rather than jar:file:
+            //ensure we link from the original .jar rather than jar:file:
             dir = context.getResourceFactory().newResource(((MountedPathResource)dir).getContainerPath());
         }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -618,7 +618,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
                 resourceDir = resource;
 
             Resource metaInf = resourceDir.resolve("META-INF");
-            if (!metaInf.isDirectory())
+            if (isEmptyResource(metaInf))
                 return tlds; //no tlds
 
             try (Stream<Path> stream = Files.walk(metaInf.getPath()))

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -362,10 +362,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             try (ResourceFactory.Closeable scanResourceFactory = ResourceFactory.closeable())
             {
-                for (Resource r : jars)
+                for (Resource dir : jars)
                 {
-                    Resource dir = r;
-
                     try
                     {
                         //if not already a directory, convert it by mounting as jar file

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -24,7 +24,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,10 +36,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.FileID;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UriPatternPredicate;
+import org.eclipse.jetty.util.resource.MountedPathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollators;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -180,18 +179,18 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (modulePath != null)
         {
             List<Path> matchingBasePaths =
-            Stream.of(modulePath.split(File.pathSeparator))
-                .map(URIUtil::toURI)
-                .filter(uriPatternPredicate)
-                .map(Paths::get)
-                .toList();
-            for (Path path: matchingBasePaths)
+                Stream.of(modulePath.split(File.pathSeparator))
+                    .map(URIUtil::toURI)
+                    .filter(uriPatternPredicate)
+                    .map(Paths::get)
+                    .toList();
+            for (Path path : matchingBasePaths)
             {
                 if (Files.isDirectory(path))
                 {
                     try (Stream<Path> listing = Files.list(path))
                     {
-                        for (Path listEntry: listing.toList())
+                        for (Path listEntry : listing.toList())
                         {
                             Resource resource = resourceFactory.newResource(listEntry);
                             context.getMetaData().addContainerResource(resource);
@@ -361,93 +360,99 @@ public class MetaInfConfiguration extends AbstractConfiguration
         //Scan jars for META-INF information
         if (jars != null)
         {
-            for (Resource r : jars)
+            try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
             {
-                if (scanTypes.contains(METAINF_RESOURCES))
-                    scanForResources(context, r, metaInfResourceCache);
-                if (scanTypes.contains(METAINF_FRAGMENTS))
-                    scanForFragment(context, r, metaInfFragmentCache);
-                if (scanTypes.contains(METAINF_TLDS))
-                    scanForTlds(context, r, metaInfTldCache);
+                for (Resource r : jars)
+                {
+                    Resource dir = r;
+
+                    try
+                    {
+                        if (!dir.isDirectory())
+                            dir = closeable.newJarFileResource(dir.getURI());
+                    }
+                    catch (Exception e)
+                    {
+                        //not an appropriate uri, skip it
+                        continue;
+                    }
+
+                    if (isEmptyResource(dir))
+                        continue;
+
+                    if (scanTypes.contains(METAINF_RESOURCES))
+                        scanForResources(context, dir, metaInfResourceCache);
+                    if (scanTypes.contains(METAINF_FRAGMENTS))
+                        scanForFragment(context, dir, metaInfFragmentCache);
+                    if (scanTypes.contains(METAINF_TLDS))
+                        scanForTlds(context, dir, metaInfTldCache);
+                }
             }
         }
     }
 
     /**
-     * Scan for META-INF/resources dir in the given jar.
+     * Scan for META-INF/resources dir in the given directory.
      *
      * @param context the context for the scan
-     * @param target the target resource to scan for
+     * @param dir the target directory to scan
      * @param cache the resource cache
      */
-    public void scanForResources(WebAppContext context, Resource target, ConcurrentHashMap<Resource, Resource> cache)
+    public void scanForResources(WebAppContext context, Resource dir, ConcurrentHashMap<Resource, Resource> cache)
     {
         // Resource target does not exist
-        if (target == null)
+        if (isEmptyResource(dir))
             return;
 
-       try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
-       {
-           Resource resourcesDir = null;
+        Resource resourcesDir = null;
 
-           if (cache != null && cache.containsKey(target))
-           {
-               resourcesDir = cache.get(target);
-               if (isEmptyResource(resourcesDir))
-               {
-                   if (LOG.isDebugEnabled())
-                       LOG.debug("{} cached as containing no META-INF/resources", target);
-                   return;
-               }
-               else if (LOG.isDebugEnabled())
-                   LOG.debug("{} META-INF/resources found in cache ", target);
-           }
-           else
-           {
-               //not using caches or not in the cache so check for the resources dir
-               if (LOG.isDebugEnabled())
-                   LOG.debug("{} META-INF/resources checked", target);
-               if (target.isDirectory())
-               {
-                   //TODO think  how to handle an unpacked jar file (eg for osgi)
-                   resourcesDir = target.resolve("/META-INF/resources");
-               }
-               else
-               {
-                   // Resource represents a packed jar
-                   resourcesDir = closeable.newJarFileResource(target.getURI()).resolve("META-INF/resources");
-               }
+        if (cache != null && cache.containsKey(dir))
+        {
+            resourcesDir = cache.get(dir);
+            if (isEmptyResource(resourcesDir))
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} cached as containing no META-INF/resources", dir);
+                return;
+            }
+            else if (LOG.isDebugEnabled())
+                LOG.debug("{} META-INF/resources found in cache ", dir);
+        }
+        else
+        {
+            //not using caches or not in the cache so check for the resources dir
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} META-INF/resources checked", dir);
 
-               if (isEmptyResource(resourcesDir))
-               {
-                   return;
-               }
+            resourcesDir = dir.resolve("/META-INF/resources");
 
-               //convert to a Resource tied to the Context lifecycle
-               resourcesDir = context.getResourceFactory().newResource(resourcesDir.getURI());
+            if (isEmptyResource(resourcesDir))
+                return;
 
-               if (cache != null)
-               {
-                   Resource old = cache.putIfAbsent(target, resourcesDir);
-                   if (old != null)
-                       resourcesDir = old;
-                   else if (LOG.isDebugEnabled())
-                       LOG.debug("{} META-INF/resources cache updated", target);
-               }
-           }
+            //convert to a Resource tied to the Context lifecycle
+            resourcesDir = context.getResourceFactory().newResource(resourcesDir.getURI());
 
-           //add it to the meta inf resources for this context
-           Set<Resource> dirs = (Set<Resource>)context.getAttribute(METAINF_RESOURCES);
-           if (dirs == null)
-           {
-               dirs = new HashSet<Resource>();
-               context.setAttribute(METAINF_RESOURCES, dirs);
-           }
-           if (LOG.isDebugEnabled())
-               LOG.debug("{} added to context", resourcesDir);
+            if (cache != null)
+            {
+                Resource old = cache.putIfAbsent(dir, resourcesDir);
+                if (old != null)
+                    resourcesDir = old;
+                else if (LOG.isDebugEnabled())
+                    LOG.debug("{} META-INF/resources cache updated", dir);
+            }
+        }
 
-           dirs.add(resourcesDir);
-       }
+        //add it to the meta inf resources for this context
+        Set<Resource> dirs = (Set<Resource>)context.getAttribute(METAINF_RESOURCES);
+        if (dirs == null)
+        {
+            dirs = new HashSet<Resource>();
+            context.setAttribute(METAINF_RESOURCES, dirs);
+        }
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} added to context", resourcesDir);
+
+        dirs.add(resourcesDir);
     }
 
     private static boolean isEmptyResource(Resource resourcesDir)
@@ -459,66 +464,64 @@ public class MetaInfConfiguration extends AbstractConfiguration
      * Scan for META-INF/web-fragment.xml file in the given jar.
      *
      * @param context the context for the scan
-     * @param jar the jar resource to scan for fragements in
+     * @param dir the directory to scan for fragments
      * @param cache the resource cache
      */
-    public void scanForFragment(WebAppContext context, Resource jar, ConcurrentHashMap<Resource, Resource> cache)
+    public void scanForFragment(WebAppContext context, Resource dir, ConcurrentHashMap<Resource, Resource> cache)
     {
         Resource webFrag = null;
-        try (ResourceFactory.Closeable closeable = ResourceFactory.closeable())
+        if (cache != null && cache.containsKey(dir))
         {
-            if (cache != null && cache.containsKey(jar))
+            webFrag = cache.get(dir);
+            if (isEmptyFragment(webFrag))
             {
-                webFrag = cache.get(jar);
-                if (isEmptyFragment(webFrag))
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("{} cached as containing no META-INF/web-fragment.xml", jar);
-                    return;
-                }
-                else if (LOG.isDebugEnabled())
-                    LOG.debug("{} META-INF/web-fragment.xml found in cache ", jar);
-            }
-            else
-            {
-                //not using caches or not in the cache so check for the web-fragment.xml
                 if (LOG.isDebugEnabled())
-                    LOG.debug("{} META-INF/web-fragment.xml checked", jar);
-                if (jar.isDirectory())
-                {
-                    webFrag = jar.resolve("META-INF/web-fragment.xml");
-                }
-                else
-                {
-                    webFrag = closeable.newJarFileResource(jar.getURI()).resolve("META-INF/web-fragment.xml");
-                }
-
-                if (isEmptyFragment(webFrag))
-                    return;
-
-                //convert webFragment Resource to one tied to the Context lifecycle
-                webFrag = context.getResourceFactory().newResource(webFrag.getURI());
-
-                if (cache != null)
-                {
-                    Resource old = cache.putIfAbsent(jar, webFrag);
-                    if (old != null)
-                        webFrag = old;
-                    else if (LOG.isDebugEnabled())
-                        LOG.debug("{} META-INF/web-fragment.xml cache updated", jar);
-                }
+                    LOG.debug("{} cached as containing no META-INF/web-fragment.xml", dir);
+                return;
             }
-
-            Map<Resource, Resource> fragments = (Map<Resource, Resource>)context.getAttribute(METAINF_FRAGMENTS);
-            if (fragments == null)
-            {
-                fragments = new HashMap<Resource, Resource>();
-                context.setAttribute(METAINF_FRAGMENTS, fragments);
-            }
-            fragments.put(jar, webFrag);
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} added to context", webFrag);
+            else if (LOG.isDebugEnabled())
+                LOG.debug("{} META-INF/web-fragment.xml found in cache ", dir);
         }
+        else
+        {
+            //not using caches or not in the cache so check for the web-fragment.xml
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} META-INF/web-fragment.xml checked", dir);
+
+            webFrag = dir.resolve("META-INF/web-fragment.xml");
+
+            if (isEmptyFragment(webFrag))
+                return;
+
+            //convert webFragment Resource to one tied to the Context lifecycle
+            webFrag = context.getResourceFactory().newResource(webFrag.getURI());
+
+            if (cache != null)
+            {
+                Resource old = cache.putIfAbsent(dir, webFrag);
+                if (old != null)
+                    webFrag = old;
+                else if (LOG.isDebugEnabled())
+                    LOG.debug("{} META-INF/web-fragment.xml cache updated", dir);
+            }
+        }
+
+        Map<Resource, Resource> fragments = (Map<Resource, Resource>)context.getAttribute(METAINF_FRAGMENTS);
+        if (fragments == null)
+        {
+            fragments = new HashMap<Resource, Resource>();
+            context.setAttribute(METAINF_FRAGMENTS, fragments);
+        }
+
+        if (dir instanceof MountedPathResource)
+        {
+            //ensure we get the original .jar rather than jar:file:
+            dir = context.getResourceFactory().newResource(((MountedPathResource)dir).getContainerPath());
+        }
+
+        fragments.put(dir, webFrag);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} added to context", webFrag);
     }
 
     private static boolean isEmptyFragment(Resource webFrag)
@@ -530,42 +533,45 @@ public class MetaInfConfiguration extends AbstractConfiguration
      * Discover META-INF/*.tld files in the given jar
      *
      * @param context the context for the scan
-     * @param jar the jar resources to scan tlds for
+     * @param dir the directory to scan for .tlds
      * @param cache the resource cache
-     * @throws Exception if unable to scan for tlds
+     * @throws Exception if unable to scan for .tlds
      */
-    public void scanForTlds(WebAppContext context, Resource jar, ConcurrentHashMap<Resource, Collection<URL>> cache)
+    public void scanForTlds(WebAppContext context, Resource dir, ConcurrentHashMap<Resource, Collection<URL>> cache)
         throws Exception
     {
         Collection<URL> tlds;
 
-        if (cache != null && cache.containsKey(jar))
+        if (isEmptyResource(dir))
+            return;
+
+        if (cache != null && cache.containsKey(dir))
         {
-            Collection<URL> tmp = cache.get(jar);
+            Collection<URL> tmp = cache.get(dir);
             if (tmp.isEmpty())
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("{} cached as containing no tlds", jar);
+                    LOG.debug("{} cached as containing no tlds", dir);
                 return;
             }
             else
             {
                 tlds = tmp;
                 if (LOG.isDebugEnabled())
-                    LOG.debug("{} tlds found in cache ", jar);
+                    LOG.debug("{} tlds found in cache ", dir);
             }
         }
         else
         {
             //not using caches or not in the cache so find all tlds
             tlds = new HashSet<>();
-            tlds.addAll(getTlds(context, jar));
+            tlds.addAll(getTlds(context, dir));
 
             if (cache != null)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("{} tld cache updated", jar);
-                Collection<URL> old = cache.putIfAbsent(jar, tlds);
+                    LOG.debug("{} tld cache updated", dir);
+                Collection<URL> old = cache.putIfAbsent(dir, tlds);
                 if (old != null)
                     tlds = old;
             }
@@ -598,43 +604,31 @@ public class MetaInfConfiguration extends AbstractConfiguration
     /**
      * Find all .tld files in the given jar.
      *
-     * @param resource the jar file
+     * @param dir the dir to check for .tlds
      * @return the collection of tlds as url references
      * @throws IOException if unable to scan the jar file
      */
-    private Collection<URL> getTlds(WebAppContext context, Resource resource) throws IOException
+    private Collection<URL> getTlds(WebAppContext context, Resource dir) throws IOException
     {
         HashSet<URL> tlds = new HashSet<>();
-        Resource resourceDir;
 
-        try (ResourceFactory.Closeable closeableResourceFactory = ResourceFactory.closeable())
+        Resource metaInf = dir.resolve("META-INF");
+        if (isEmptyResource(metaInf))
+            return tlds; //no tlds
+
+        try (Stream<Path> stream = Files.walk(metaInf.getPath()))
         {
-            if (!resource.isDirectory())
+            Iterator<Path> it = stream
+                .filter(Files::isRegularFile)
+                .filter(FileID::isTld)
+                .iterator();
+            while (it.hasNext())
             {
-                //turn it into a jar:file
-                resourceDir = closeableResourceFactory.newJarFileResource(resource.getURI());
+                Path entry = it.next();
+                tlds.add(entry.toUri().toURL());
             }
-            else
-                resourceDir = resource;
-
-            Resource metaInf = resourceDir.resolve("META-INF");
-            if (isEmptyResource(metaInf))
-                return tlds; //no tlds
-
-            try (Stream<Path> stream = Files.walk(metaInf.getPath()))
-            {
-                Iterator<Path> it = stream
-                    .filter(Files::isRegularFile)
-                    .filter(FileID::isTld)
-                    .iterator();
-                while (it.hasNext())
-                {
-                    Path entry = it.next();
-                    tlds.add(entry.toUri().toURL());
-                }
-            }
-            return tlds;
         }
+        return tlds;
     }
 
     protected List<Resource> findClassDirs(WebAppContext context)


### PR DESCRIPTION
* Reduce mounts of jar:file references in MetaInfConfiguration.
* Only align `META-INF/resources` and `META-INF/web-fragment.xml` Resources with the lifecycle of the `WebAppContext`
* Make scan of .tlds more efficient.