### PR TITLE
disable duplicate finder for javadoc as it is plenty of unzipped sources

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <checkstyle.skip>true</checkstyle.skip>
+    <duplicate-finder.skip>true</duplicate-finder.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
     <pmd.skip>true</pmd.skip>
     <sonar.skip>true</sonar.skip>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
