### PR TITLE
Accurate implementation of H2 `Request.beginNanoTime()`

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.http2.RateControl;
 import org.eclipse.jetty.http2.frames.FrameType;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.NanoTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,14 +86,13 @@ public class ServerParser extends Parser
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Parsing {}", buffer);
-
+            takeNanoTime();
             while (true)
             {
                 switch (state)
                 {
                     case PREFACE:
                     {
-                        beginNanoTime = NanoTime.now(); // TODO #9900 check beginNanoTime's accuracy
                         if (!prefaceParser.parse(buffer))
                             return;
                         if (notifyPreface)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
@@ -86,7 +86,6 @@ public class ServerParser extends Parser
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Parsing {}", buffer);
-            takeNanoTime();
             while (true)
             {
                 switch (state)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
@@ -21,6 +21,7 @@ import org.eclipse.jetty.http2.RateControl;
 import org.eclipse.jetty.http2.frames.FrameType;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +94,7 @@ public class ServerParser extends Parser
                 {
                     case PREFACE:
                     {
+                        beginNanoTime = NanoTime.now(); // TODO #9900 check beginNanoTime's accuracy
                         if (!prefaceParser.parse(buffer))
                             return;
                         if (notifyPreface)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
@@ -86,6 +86,7 @@ public class ServerParser extends Parser
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Parsing {}", buffer);
+
             while (true)
             {
                 switch (state)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/test/java/org/eclipse/jetty/http2/frames/ContinuationParseTest.java
@@ -162,6 +162,107 @@ public class ContinuationParseTest
     }
 
     @Test
+    public void testBeginNanoTime() throws Exception
+    {
+        ArrayByteBufferPool.Tracking bufferPool = new ArrayByteBufferPool.Tracking();
+        HeadersGenerator generator = new HeadersGenerator(new HeaderGenerator(bufferPool), new HpackEncoder());
+
+        final List<HeadersFrame> frames = new ArrayList<>();
+        Parser parser = new Parser(bufferPool, 8192);
+        parser.init(new Parser.Listener()
+        {
+            @Override
+            public void onHeaders(HeadersFrame frame)
+            {
+                frames.add(frame);
+            }
+
+            @Override
+            public void onConnectionFailure(int error, String reason)
+            {
+                frames.add(new HeadersFrame(null, null, false));
+            }
+        });
+
+        int streamId = 13;
+        HttpFields fields = HttpFields.build()
+            .put("Accept", "text/html")
+            .put("User-Agent", "Jetty");
+        MetaData.Request metaData = new MetaData.Request("GET", HttpScheme.HTTP.asString(), new HostPortHttpField("localhost:8080"), "/path", HttpVersion.HTTP_2, fields, -1);
+
+        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator();
+        generator.generateHeaders(accumulator, streamId, metaData, null, true);
+
+        List<ByteBuffer> byteBuffers = accumulator.getByteBuffers();
+        assertEquals(2, byteBuffers.size());
+
+        ByteBuffer headersBody = byteBuffers.remove(1);
+        int start = headersBody.position();
+        int length = headersBody.remaining();
+        int firstHalf = length / 2;
+        int lastHalf = length - firstHalf;
+
+        // Adjust the length of the HEADERS frame.
+        ByteBuffer headersHeader = byteBuffers.get(0);
+        headersHeader.put(0, (byte)((firstHalf >>> 16) & 0xFF));
+        headersHeader.put(1, (byte)((firstHalf >>> 8) & 0xFF));
+        headersHeader.put(2, (byte)(firstHalf & 0xFF));
+
+        // Remove the END_HEADERS flag from the HEADERS header.
+        headersHeader.put(4, (byte)(headersHeader.get(4) & ~Flags.END_HEADERS));
+
+        // New HEADERS body.
+        headersBody.position(start);
+        headersBody.limit(start + firstHalf);
+        byteBuffers.add(headersBody.slice());
+
+        // Split the rest of the HEADERS body into a CONTINUATION frame.
+        byte[] continuationHeader = new byte[9];
+        continuationHeader[0] = (byte)((lastHalf >>> 16) & 0xFF);
+        continuationHeader[1] = (byte)((lastHalf >>> 8) & 0xFF);
+        continuationHeader[2] = (byte)(lastHalf & 0xFF);
+        continuationHeader[3] = (byte)FrameType.CONTINUATION.getType();
+        continuationHeader[4] = Flags.END_HEADERS;
+        continuationHeader[5] = 0x00;
+        continuationHeader[6] = 0x00;
+        continuationHeader[7] = 0x00;
+        continuationHeader[8] = (byte)streamId;
+        byteBuffers.add(ByteBuffer.wrap(continuationHeader));
+        // CONTINUATION body.
+        headersBody.position(start + firstHalf);
+        headersBody.limit(start + length);
+        byteBuffers.add(headersBody.slice());
+
+        byteBuffers = accumulator.getByteBuffers();
+        assertEquals(4, byteBuffers.size());
+        parser.parse(byteBuffers.get(0));
+        long beginNanoTime = parser.getBeginNanoTime();
+        parser.parse(byteBuffers.get(1));
+        parser.parse(byteBuffers.get(2));
+        parser.parse(byteBuffers.get(3));
+
+        accumulator.release();
+
+        assertEquals(1, frames.size());
+        HeadersFrame frame = frames.get(0);
+        assertEquals(streamId, frame.getStreamId());
+        assertTrue(frame.isEndStream());
+        MetaData.Request request = (MetaData.Request)frame.getMetaData();
+        assertEquals(metaData.getMethod(), request.getMethod());
+        assertEquals(metaData.getHttpURI(), request.getHttpURI());
+        for (int j = 0; j < fields.size(); ++j)
+        {
+            HttpField field = fields.getField(j);
+            assertTrue(request.getHttpFields().contains(field));
+        }
+        PriorityFrame priority = frame.getPriority();
+        assertNull(priority);
+        assertEquals(beginNanoTime, request.getBeginNanoTime());
+
+        assertEquals(0, bufferPool.getLeaks().size(), bufferPool.dumpLeaks());
+    }
+
+    @Test
     public void testLargeHeadersBlock() throws Exception
     {
         // Use a ByteBufferPool with a small factor, so that the accumulation buffer is not too large.

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http2.hpack;
 
 import java.nio.ByteBuffer;
+import java.util.function.LongSupplier;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -43,14 +44,18 @@ public class HpackDecoder
     private final MetaDataBuilder _builder;
     private final HuffmanDecoder _huffmanDecoder;
     private final NBitIntegerDecoder _integerDecoder;
+    private final LongSupplier _beginNanoTimeSupplier;
     private int _maxTableCapacity;
 
     /**
      * @param maxHeaderSize The maximum allowed size of a decoded headers block,
      * expressed as total of all name and value bytes, plus 32 bytes per field
+     * @param beginNanoTimeSupplier The supplier of a nano timestamp taken at
+     * the time the first byte was read
      */
-    public HpackDecoder(int maxHeaderSize)
+    public HpackDecoder(int maxHeaderSize, LongSupplier beginNanoTimeSupplier)
     {
+        _beginNanoTimeSupplier = beginNanoTimeSupplier;
         _context = new HpackContext(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
         _builder = new MetaDataBuilder(maxHeaderSize);
         _huffmanDecoder = new HuffmanDecoder();
@@ -296,6 +301,7 @@ public class HpackDecoder
             }
         }
 
+        _builder.setBeginNanoTime(_beginNanoTimeSupplier.getAsLong());
         return _builder.build();
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -40,6 +40,7 @@ public class MetaDataBuilder
     private HpackException.StreamException _streamException;
     private boolean _request;
     private boolean _response;
+    private long _beginNanoTime = Long.MIN_VALUE;
 
     /**
      * @param maxHeadersSize The maximum size of the headers, expressed as total name and value characters.
@@ -61,6 +62,13 @@ public class MetaDataBuilder
     public void setMaxSize(int maxSize)
     {
         _maxSize = maxSize;
+    }
+
+    public void setBeginNanoTime(long beginNanoTime)
+    {
+        if (beginNanoTime == Long.MIN_VALUE)
+            beginNanoTime++;
+        _beginNanoTime = beginNanoTime;
     }
 
     /**
@@ -250,12 +258,14 @@ public class MetaDataBuilder
                     if (_path == null)
                         throw new HpackException.StreamException("No Path");
                 }
+                long nanoTime = _beginNanoTime == Long.MIN_VALUE ? NanoTime.now() : _beginNanoTime;
+                _beginNanoTime = Long.MIN_VALUE;
                 if (isConnect)
-                    return new MetaData.ConnectRequest(NanoTime.now(), _scheme, _authority, _path, fields, _protocol); // TODO #9900 make beginNanoTime accurate
+                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
                 else
                     return new MetaData.Request(
-                        NanoTime.now(), // TODO #9900 make beginNanoTime accurate
-                         _method,
+                        nanoTime,
+                        _method,
                         _scheme.asString(),
                         _authority,
                         _path,

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackDecoderTest.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http2.hpack.HpackException.CompressionException;
 import org.eclipse.jetty.http2.hpack.HpackException.SessionException;
 import org.eclipse.jetty.http2.hpack.HpackException.StreamException;
 import org.eclipse.jetty.http2.hpack.internal.MetaDataBuilder;
+import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.StringUtil;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ public class HpackDecoderTest
     @Test
     public void testDecodeD3() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         // First request
         String encoded = "828684410f7777772e6578616d706c652e636f6d";
@@ -106,7 +107,7 @@ public class HpackDecoderTest
     @Test
     public void testDecodeD4() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         // First request
         String encoded = "828684418cf1e3c2e5f23a6ba0ab90f4ff";
@@ -141,7 +142,7 @@ public class HpackDecoderTest
     {
         String value = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";
 
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         String encoded = "8682418cF1E3C2E5F23a6bA0Ab90F4Ff841f0822426173696320515778685a475270626a70766347567549484e6c633246745a513d3d";
         byte[] bytes = StringUtil.fromHexString(encoded);
         byte[] array = new byte[bytes.length + 1];
@@ -163,7 +164,7 @@ public class HpackDecoderTest
     @Test
     public void testDecodeHuffmanWithArrayOffset() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "8286418cf1e3c2e5f23a6ba0ab90f4ff84";
         byte[] bytes = StringUtil.fromHexString(encoded);
@@ -187,7 +188,7 @@ public class HpackDecoderTest
         String encoded = "886196C361Be940b6a65B6850400B8A00571972e080a62D1Bf5f87497cA589D34d1f9a0f0d0234327690Aa69D29aFcA954D3A5358980Ae112e0f7c880aE152A9A74a6bF3";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
 
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         MetaData.Response response = (MetaData.Response)decoder.decode(buffer);
 
         assertThat(response.getStatus(), is(200));
@@ -205,7 +206,7 @@ public class HpackDecoderTest
     {
         String encoded = "203f136687A0E41d139d090760881c6490B2Cd39Ba7f";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         MetaData metaData = decoder.decode(buffer);
         assertThat(metaData.getHttpFields().get(HttpHeader.HOST), is("localhost0"));
         assertThat(metaData.getHttpFields().get(HttpHeader.COOKIE), is("abcdefghij"));
@@ -227,7 +228,7 @@ public class HpackDecoderTest
 
         String encoded = "203f136687A0E41d139d090760881c6490B2Cd39Ba7f20";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         try
         {
             decoder.decode(buffer);
@@ -245,7 +246,7 @@ public class HpackDecoderTest
         String encoded = "3f610f17FfEc02Df3990A190A0D4Ee5b3d2940Ec98Aa4a62D127D29e273a0aA20dEcAa190a503b262d8a2671D4A2672a927aA874988a2471D05510750c951139EdA2452a3a548cAa1aA90bE4B228342864A9E0D450A5474a92992a1aA513395448E3A0Aa17B96cFe3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f14E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F3E7Cf9f3e7cF9F353F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F54f";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
 
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         decoder.setMaxTableCapacity(128);
         MetaData metaData = decoder.decode(buffer);
 
@@ -259,7 +260,7 @@ public class HpackDecoderTest
         String encoded = "BE";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
 
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         decoder.setMaxTableCapacity(128);
 
         try
@@ -445,7 +446,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedStandard() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "83" + "49509F";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -463,7 +464,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedExtraPadding()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "84" + "49509FFF";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -475,7 +476,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedZeroPadding()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "83" + "495090";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -488,7 +489,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedWithEOS()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "87" + "497FFFFFFF427F";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -500,7 +501,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedOneIncompleteOctet()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "81" + "FE";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -512,7 +513,7 @@ public class HpackDecoderTest
     @Test
     public void testHuffmanEncodedTwoIncompleteOctet()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "82868441" + "82" + "FFFE";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -524,7 +525,7 @@ public class HpackDecoderTest
     @Test
     public void testZeroLengthName()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "00000130";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -535,7 +536,7 @@ public class HpackDecoderTest
     @Test
     public void testZeroLengthValue() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "00016800";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -547,7 +548,7 @@ public class HpackDecoderTest
     @Test
     public void testUpperCaseName()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "0001480130";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));
@@ -558,7 +559,7 @@ public class HpackDecoderTest
     @Test
     public void testWhiteSpaceName()
     {
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
 
         String encoded = "0001200130";
         ByteBuffer buffer = ByteBuffer.wrap(StringUtil.fromHexString(encoded));

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.MetaData.Response;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +44,7 @@ public class HpackTest
     public void encodeDecodeResponseTest() throws Exception
     {
         HpackEncoder encoder = new HpackEncoder();
-        HpackDecoder decoder = new HpackDecoder(8192);
+        HpackDecoder decoder = new HpackDecoder(8192, NanoTime::now);
         ByteBuffer buffer = BufferUtil.allocateDirect(16 * 1024);
 
         long contentLength = 1024;
@@ -99,7 +100,7 @@ public class HpackTest
     public void encodeDecodeTooLargeTest() throws Exception
     {
         HpackEncoder encoder = new HpackEncoder();
-        HpackDecoder decoder = new HpackDecoder(164);
+        HpackDecoder decoder = new HpackDecoder(164, NanoTime::now);
         ByteBuffer buffer = BufferUtil.allocateDirect(16 * 1024);
 
         HttpFields fields0 = HttpFields.build()
@@ -159,7 +160,7 @@ public class HpackTest
     @Test
     public void evictReferencedFieldTest() throws Exception
     {
-        HpackDecoder decoder = new HpackDecoder(1024);
+        HpackDecoder decoder = new HpackDecoder(1024, NanoTime::now);
         decoder.setMaxTableCapacity(200);
         HpackEncoder encoder = new HpackEncoder();
         encoder.setMaxTableCapacity(decoder.getMaxTableCapacity());
@@ -206,7 +207,7 @@ public class HpackTest
     public void testHopHeadersAreRemoved() throws Exception
     {
         HpackEncoder encoder = new HpackEncoder();
-        HpackDecoder decoder = new HpackDecoder(16384);
+        HpackDecoder decoder = new HpackDecoder(16384, NanoTime::now);
 
         HttpFields input = HttpFields.build()
             .add(HttpHeader.ACCEPT, "*")
@@ -233,7 +234,7 @@ public class HpackTest
     public void testTETrailers() throws Exception
     {
         HpackEncoder encoder = new HpackEncoder();
-        HpackDecoder decoder = new HpackDecoder(16384);
+        HpackDecoder decoder = new HpackDecoder(16384, NanoTime::now);
 
         String teValue = "trailers";
         String trailerValue = "Custom";
@@ -258,7 +259,7 @@ public class HpackTest
     public void testColonHeaders() throws Exception
     {
         HpackEncoder encoder = new HpackEncoder();
-        HpackDecoder decoder = new HpackDecoder(16384);
+        HpackDecoder decoder = new HpackDecoder(16384, NanoTime::now);
 
         HttpFields input = HttpFields.build()
             .add(":status", "200")


### PR DESCRIPTION
The implementation is similar to H1 and FCGI: take a nano timestamp at the time the very first byte is parsed, then use that timestamp to create the `MetaData.Request`.

This is one of the implementations necessary to close https://github.com/jetty/jetty.project/issues/9900.