### PR TITLE
Backport to 10.0.x : accurate implementation of H3 `Request.beginNanoTime()`

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
@@ -151,6 +151,13 @@ public class MetaData implements Iterable<HttpField>
                 version, fields, contentLength);
         }
 
+        public Request(long beginNanoTime, String method, String scheme, HostPortHttpField authority, String uri, HttpVersion version, HttpFields fields, long contentLength)
+        {
+            this(beginNanoTime, method,
+                HttpURI.build().scheme(scheme).host(authority == null ? null : authority.getHost()).port(authority == null ? -1 : authority.getPort()).pathQuery(uri),
+                version, fields, contentLength);
+        }
+
         public Request(String method, HttpURI uri, HttpVersion version, HttpFields fields, long contentLength, Supplier<HttpFields> trailers)
         {
             this(NanoTime.now(), method, uri, version, fields, contentLength, trailers);
@@ -222,9 +229,19 @@ public class MetaData implements Iterable<HttpField>
             this(scheme == null ? null : scheme.asString(), authority, path, fields, protocol);
         }
 
+        public ConnectRequest(long beginNanoTime, HttpScheme scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        {
+            this(beginNanoTime, scheme == null ? null : scheme.asString(), authority, path, fields, protocol);
+        }
+
         public ConnectRequest(String scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
         {
-            super(HttpMethod.CONNECT.asString(),
+            this(NanoTime.now(), scheme, authority, path, fields, protocol);
+        }
+
+        public ConnectRequest(long beginNanoTime, String scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        {
+            super(beginNanoTime, HttpMethod.CONNECT.asString(),
                 HttpURI.build().scheme(scheme).host(authority == null ? null : authority.getHost()).port(authority == null ? -1 : authority.getPort()).pathQuery(path),
                 HttpVersion.HTTP_2, fields, Long.MIN_VALUE, null);
             _protocol = protocol;

--- a/jetty-http3/http3-common/src/test/java/org/eclipse/jetty/http3/internal/DataGenerateParseTest.java
+++ b/jetty-http3/http3-common/src/test/java/org/eclipse/jetty/http3/internal/DataGenerateParseTest.java
@@ -23,9 +23,11 @@ import org.eclipse.jetty.http3.frames.DataFrame;
 import org.eclipse.jetty.http3.internal.generator.MessageGenerator;
 import org.eclipse.jetty.http3.internal.parser.MessageParser;
 import org.eclipse.jetty.http3.internal.parser.ParserListener;
+import org.eclipse.jetty.http3.qpack.QpackDecoder;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.NullByteBufferPool;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -58,6 +60,8 @@ public class DataGenerateParseTest
         new MessageGenerator(null, true).generate(lease, 0, input, null);
 
         List<DataFrame> frames = new ArrayList<>();
+        QpackDecoder decoder = new QpackDecoder(instructions -> {});
+        decoder.setBeginNanoTimeSupplier(NanoTime::now);
         MessageParser parser = new MessageParser(new ParserListener()
         {
             @Override
@@ -65,7 +69,7 @@ public class DataGenerateParseTest
             {
                 frames.add(frame);
             }
-        }, null, 13, () -> true);
+        }, decoder, 13, () -> true);
         parser.init(UnaryOperator.identity());
         for (ByteBuffer buffer : lease.getByteBuffers())
         {

--- a/jetty-http3/http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
+++ b/jetty-http3/http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http3.qpack.QpackDecoder;
 import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.NullByteBufferPool;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +55,7 @@ public class HeadersGenerateParseTest
 
         QpackDecoder decoder = new QpackDecoder(instructions -> {});
         decoder.setMaxHeadersSize(4 * 1024);
+        decoder.setBeginNanoTimeSupplier(NanoTime::now);
         List<HeadersFrame> frames = new ArrayList<>();
         MessageParser parser = new MessageParser(new ParserListener()
         {

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.MetaData;
@@ -59,6 +60,7 @@ public class QpackDecoder implements Dumpable
     private int _maxHeadersSize;
     private int _maxBlockedStreams;
     private int _maxTableCapacity;
+    private LongSupplier _beginNanoTimeSupplier;
 
     private static class MetaDataNotification
     {
@@ -101,6 +103,11 @@ public class QpackDecoder implements Dumpable
     public int getMaxHeadersSize()
     {
         return _maxHeadersSize;
+    }
+
+    public void setBeginNanoTimeSupplier(LongSupplier beginNanoTimeSupplier)
+    {
+        _beginNanoTimeSupplier = beginNanoTimeSupplier;
     }
 
     /**
@@ -180,7 +187,7 @@ public class QpackDecoder implements Dumpable
         {
             // Parse the buffer into an Encoded Field Section.
             int base = signBit ? requiredInsertCount - deltaBase - 1 : requiredInsertCount + deltaBase;
-            EncodedFieldSection encodedFieldSection = new EncodedFieldSection(streamId, handler, requiredInsertCount, base, buffer);
+            EncodedFieldSection encodedFieldSection = new EncodedFieldSection(streamId, handler, requiredInsertCount, base, buffer, _beginNanoTimeSupplier.getAsLong());
 
             // Decode it straight away if we can, otherwise add it to the list of EncodedFieldSections.
             if (requiredInsertCount <= insertCount)

--- a/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncodedFieldSection.java
+++ b/jetty-http3/http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncodedFieldSection.java
@@ -44,13 +44,15 @@ public class EncodedFieldSection
     private final int _requiredInsertCount;
     private final int _base;
     private final QpackDecoder.Handler _handler;
+    private final long _beginNanoTime;
 
-    public EncodedFieldSection(long streamId, QpackDecoder.Handler handler, int requiredInsertCount, int base, ByteBuffer content) throws QpackException
+    public EncodedFieldSection(long streamId, QpackDecoder.Handler handler, int requiredInsertCount, int base, ByteBuffer content, long beginNanoTime) throws QpackException
     {
         _streamId = streamId;
         _requiredInsertCount = requiredInsertCount;
         _base = base;
         _handler = handler;
+        _beginNanoTime = beginNanoTime;
 
         try
         {
@@ -104,6 +106,7 @@ public class EncodedFieldSection
             HttpField decodedField = encodedField.decode(context);
             metaDataBuilder.emit(decodedField);
         }
+        metaDataBuilder.setBeginNanoTime(_beginNanoTime);
         return metaDataBuilder.build();
     }
 

--- a/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/BlockedStreamsTest.java
+++ b/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/BlockedStreamsTest.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http3.qpack.internal.instruction.LiteralNameEntryInstru
 import org.eclipse.jetty.http3.qpack.internal.instruction.SectionAcknowledgmentInstruction;
 import org.eclipse.jetty.http3.qpack.internal.instruction.SetCapacityInstruction;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +57,7 @@ public class BlockedStreamsTest
         _decoderHandler = new TestDecoderHandler();
         _encoder = new QpackEncoder(_encoderHandler, MAX_BLOCKED_STREAMS);
         _decoder = new QpackDecoder(_decoderHandler, MAX_HEADER_SIZE);
+        _decoder.setBeginNanoTimeSupplier(NanoTime::now);
     }
 
     @Test

--- a/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncodeDecodeTest.java
+++ b/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncodeDecodeTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http3.qpack.internal.instruction.SetCapacityInstruction
 import org.eclipse.jetty.http3.qpack.internal.parser.DecoderInstructionParser;
 import org.eclipse.jetty.http3.qpack.internal.parser.EncoderInstructionParser;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,7 @@ public class EncodeDecodeTest
             }
         };
         _decoder = new QpackDecoder(_decoderHandler, MAX_HEADER_SIZE);
+        _decoder.setBeginNanoTimeSupplier(NanoTime::now);
 
         _encoderInstructionParser = new EncoderInstructionParser(new EncoderParserDebugHandler(_encoder));
         _decoderInstructionParser = new DecoderInstructionParser(new DecoderParserDebugHandler(_decoder));

--- a/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EvictionTest.java
+++ b/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EvictionTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,7 @@ public class EvictionTest
         _decoder = new QpackDecoder(_decoderHandler);
         _decoder.setMaxHeadersSize(1024);
         _decoder.setMaxTableCapacity(4 * 1024);
+        _decoder.setBeginNanoTimeSupplier(NanoTime::now);
 
         _encoder = new QpackEncoder(_encoderHandler)
         {

--- a/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/SectionAcknowledgmentTest.java
+++ b/jetty-http3/http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/SectionAcknowledgmentTest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http3.qpack.QpackException.SessionException;
 import org.eclipse.jetty.http3.qpack.internal.instruction.SectionAcknowledgmentInstruction;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,7 @@ public class SectionAcknowledgmentTest
         _decoderHandler = new TestDecoderHandler();
         _encoder = new QpackEncoder(_encoderHandler, MAX_BLOCKED_STREAMS);
         _decoder = new QpackDecoder(_decoderHandler, MAX_HEADER_SIZE);
+        _decoder.setBeginNanoTimeSupplier(NanoTime::now);
     }
 
     @Test


### PR DESCRIPTION
Backport the 12.0.x implementation of H3 Request.beginNanoTime() to 10.0.x.

This will allow for an accurate comparison of 10.0.x vs 12.0.x performance of H3.

See: https://github.com/jetty/jetty.project/issues/9900.