### PR TITLE
Align Core, ee9 and ee10 `AbstractTest` and fix ee9 H3 tests

### DIFF
--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -274,7 +274,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -60,6 +60,8 @@ import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
 import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -71,13 +73,17 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(WorkDirExtension.class)
 public class AbstractTest
 {
+    public WorkDir workDir;
+
     @RegisterExtension
     public final BeforeTestExecutionCallback printMethodName = context ->
         System.err.printf("Running %s.%s() %s%n", context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), context.getDisplayName());
@@ -268,7 +274,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);
@@ -334,7 +340,7 @@ public class AbstractTest
                 yield new ServerConnector(server, 1, 1, newServerConnectionFactory(transport));
             case H3:
                 HTTP3ServerConnector h3Connector = new HTTP3ServerConnector(server, sslContextFactoryServer, newServerConnectionFactory(transport));
-                h3Connector.getQuicConfiguration().setPemWorkDirectory(Path.of(System.getProperty("java.io.tmpdir")));
+                h3Connector.getQuicConfiguration().setPemWorkDirectory(workDir.getEmptyPathDir());
                 yield h3Connector;
             case UNIX_DOMAIN:
                 UnixDomainServerConnector unixConnector = new UnixDomainServerConnector(server, 1, 1, newServerConnectionFactory(transport));

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
@@ -124,7 +124,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
@@ -124,7 +124,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
@@ -133,7 +133,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
@@ -13,9 +13,15 @@
 
 package org.eclipse.jetty.ee9.test.client.transport;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -52,17 +58,23 @@ import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
 import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class AbstractTest
 {
+    public WorkDir workDir;
+
     protected final HttpConfiguration httpConfig = new HttpConfiguration();
     protected SslContextFactory.Server sslContextFactoryServer;
     protected Server server;
@@ -121,7 +133,7 @@ public class AbstractTest
     {
         if (transport == Transport.UNIX_DOMAIN)
         {
-            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", System.getProperty("java.io.tmpdir"));
+            String unixDomainDir = System.getProperty("jetty.unixdomain.dir", workDir.getEmptyPathDir().toString());
             unixDomainPath = Files.createTempFile(Path.of(unixDomainDir), "unix_", ".sock");
             assertTrue(unixDomainPath.toAbsolutePath().toString().length() < UnixDomainServerConnector.MAX_UNIX_DOMAIN_PATH_LENGTH, "Unix-Domain path too long");
             Files.delete(unixDomainPath);
@@ -151,14 +163,25 @@ public class AbstractTest
         return new Server(serverThreads);
     }
 
-    protected SslContextFactory.Server newSslContextFactoryServer()
+    protected SslContextFactory.Server newSslContextFactoryServer() throws Exception
     {
         SslContextFactory.Server ssl = new SslContextFactory.Server();
-        ssl.setKeyStorePath("src/test/resources/keystore.p12");
-        ssl.setKeyStorePassword("storepwd");
-        ssl.setUseCipherSuitesOrder(true);
-        ssl.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        configureSslContextFactory(ssl);
         return ssl;
+    }
+
+    private static void configureSslContextFactory(SslContextFactory sslContextFactory) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException
+    {
+        KeyStore keystore = KeyStore.getInstance("PKCS12");
+        try (InputStream is = Files.newInputStream(Path.of("src/test/resources/keystore.p12")))
+        {
+            keystore.load(is, "storepwd".toCharArray());
+        }
+        sslContextFactory.setTrustStore(keystore);
+        sslContextFactory.setKeyStore(keystore);
+        sslContextFactory.setKeyStorePassword("storepwd");
+        sslContextFactory.setUseCipherSuitesOrder(true);
+        sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
     }
 
     protected void startClient(Transport transport) throws Exception
@@ -178,7 +201,11 @@ public class AbstractTest
             case HTTP, HTTPS, H2C, H2, FCGI ->
                 new ServerConnector(server, 1, 1, newServerConnectionFactory(transport));
             case H3 ->
-                new HTTP3ServerConnector(server, sslContextFactoryServer, newServerConnectionFactory(transport));
+            {
+                HTTP3ServerConnector http3ServerConnector = new HTTP3ServerConnector(server, sslContextFactoryServer, newServerConnectionFactory(transport));
+                http3ServerConnector.getQuicConfiguration().setPemWorkDirectory(workDir.getEmptyPathDir());
+                yield http3ServerConnector;
+            }
             case UNIX_DOMAIN ->
             {
                 UnixDomainServerConnector connector = new UnixDomainServerConnector(server, 1, 1, newServerConnectionFactory(transport));
@@ -225,16 +252,15 @@ public class AbstractTest
         return list.toArray(ConnectionFactory[]::new);
     }
 
-    protected SslContextFactory.Client newSslContextFactoryClient()
+    protected SslContextFactory.Client newSslContextFactoryClient() throws Exception
     {
         SslContextFactory.Client ssl = new SslContextFactory.Client();
-        ssl.setKeyStorePath("src/test/resources/keystore.p12");
-        ssl.setKeyStorePassword("storepwd");
+        configureSslContextFactory(ssl);
         ssl.setEndpointIdentificationAlgorithm(null);
         return ssl;
     }
 
-    protected HttpClientTransport newHttpClientTransport(Transport transport)
+    protected HttpClientTransport newHttpClientTransport(Transport transport) throws Exception
     {
         return switch (transport)
         {


### PR DESCRIPTION
The client test suite relies on a `AbstractTest` in Core, ee9 and ee10 which are pretty similar but slightly diverged over time. Re-aligning these classes to avoid surprises because of slightly different configs.

This has a side-effect of fixing the ee9 H3 tests which were broken because the client's trust store was not correctly configured.

Closes #10386.