### PR TITLE
Fixes #10384 - ServletChannel now using proper state changes for calls to ErrorHandler to avoid IllegalStateExceptions

### DIFF
--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
@@ -640,12 +640,10 @@ public abstract class AbstractProxyServlet extends HttpServlet
     {
         proxyRequest.abort(failure).whenComplete((aborted, x) ->
         {
-            // The variable 'aborted' could be null.
-            if (aborted == Boolean.FALSE)
-            {
-                int status = clientRequestStatus(failure);
-                sendProxyResponseError(clientRequest, proxyResponse, status);
-            }
+            if (aborted)
+                return;
+            int status = clientRequestStatus(failure);
+            sendProxyResponseError(clientRequest, proxyResponse, status);
         });
     }
 

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -81,7 +81,6 @@ import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1109,7 +1108,6 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    @Disabled("idle timeouts do not work yet")
     public void testAfterContentTransformerClosingFilesOnClientRequestException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
@@ -108,23 +108,27 @@ public class ErrorHandler implements Request.Handler
         {
             try
             {
-                contextHandler.requestInitialized(servletContextRequest, httpServletRequest);
-                errorDispatcher.error(httpServletRequest, httpServletResponse);
+                try
+                {
+                    contextHandler.requestInitialized(servletContextRequest, httpServletRequest);
+                    errorDispatcher.error(httpServletRequest, httpServletResponse);
+                }
+                finally
+                {
+                    contextHandler.requestDestroyed(servletContextRequest, httpServletRequest);
+                }
                 callback.succeeded();
                 return true;
             }
             catch (ServletException e)
             {
-                LOG.debug("Unable to call error dispatcher", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to call error dispatcher", e);
                 if (response.isCommitted())
                 {
                     callback.failed(e);
                     return true;
                 }
-            }
-            finally
-            {
-                contextHandler.requestDestroyed(servletContextRequest, httpServletRequest);
             }
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.servlet.RequestDispatcher;
@@ -199,7 +198,9 @@ public class ServletChannel
         return _state.isSendError();
     }
 
-    /** Format the address or host returned from Request methods
+    /**
+     * Format the address or host returned from Request methods
+     *
      * @param addr The address or host
      * @return Default implementation returns {@link HostPort#normalizeHost(String)}
      */
@@ -508,22 +509,11 @@ public class ServletChannel
                             }
                             else
                             {
-                                AtomicBoolean asyncCompletion = new AtomicBoolean(false);
-                                Callback errorCallback = Callback.from(() ->
-                                {
-                                    if (!asyncCompletion.compareAndSet(false, true))
-                                        _state.scheduleDispatch();
-                                });
-
                                 // We do not notify ServletRequestListener on this dispatch because it might not
                                 // be dispatched to an error page, so we delegate this responsibility to the ErrorHandler.
                                 reopen();
-                                errorHandler.handle(getServletContextRequest(), getServletContextResponse(), errorCallback);
-
-                                // If the callback has already been completed we should continue in handle loop.
-                                // Otherwise, the callback will schedule a dispatch to handle().
-                                if (asyncCompletion.compareAndSet(false, true))
-                                    return;
+                                _state.completing();
+                                errorHandler.handle(getServletContextRequest(), getServletContextResponse(), Callback.from(NON_BLOCKING, () -> _state.completed(null), _state::completed));
                             }
                         }
                         catch (Throwable x)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -512,8 +512,8 @@ public class ServletChannel
                                 // We do not notify ServletRequestListener on this dispatch because it might not
                                 // be dispatched to an error page, so we delegate this responsibility to the ErrorHandler.
                                 reopen();
-                                _state.completing();
-                                errorHandler.handle(getServletContextRequest(), getServletContextResponse(), Callback.from(NON_BLOCKING, () -> _state.completed(null), _state::completed));
+                                _state.errorHandling();
+                                errorHandler.handle(getServletContextRequest(), getServletContextResponse(), Callback.from(_state::errorHandlingComplete));
                             }
                         }
                         catch (Throwable x)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -1190,7 +1190,7 @@ public class ServletChannelState
         try (AutoLock ignored = lock())
         {
             if (_state == State.HANDLING)
-                return _requestState != RequestState.BLOCKING;
+                return _requestState != RequestState.BLOCKING && _requestState != RequestState.ERRORING;
             return _requestState == RequestState.ASYNC || _requestState == RequestState.EXPIRING;
         }
     }
@@ -1199,7 +1199,7 @@ public class ServletChannelState
     {
         try (AutoLock ignored = lock())
         {
-            return !_initial || _requestState != RequestState.BLOCKING;
+            return !_initial || (_requestState != RequestState.BLOCKING && _requestState != RequestState.ERRORING);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -33,6 +33,7 @@ import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.UnavailableException;
@@ -1618,6 +1619,115 @@ public class ErrorPageTest
             String responseBody = response.getContent();
             assertThat(responseBody, Matchers.containsString("<h1>This is the 500 HTML</h1>"));
         }
+    }
+
+    @Test
+    public void testErrorHandlerCallsStartAsync() throws Exception
+    {
+        ServletContextHandler context = new ServletContextHandler("/");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(598, "/error/598");
+        context.setErrorHandler(errorPageErrorHandler);
+
+        HttpServlet appServlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.sendError(598);
+            }
+        };
+        context.addServlet(appServlet, "/async/*");
+        HttpServlet error598Servlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                AsyncContext asyncContext = req.startAsync();
+                asyncContext.start(() ->
+                {
+                    try
+                    {
+                        int originalStatus = resp.getStatus();
+                        resp.setStatus(599);
+                        ServletOutputStream output = resp.getOutputStream();
+                        output.print("ORIGINAL STATUS CODE: " + originalStatus);
+                        asyncContext.complete();
+                    }
+                    catch (Throwable x)
+                    {
+                        asyncContext.complete();
+                    }
+                });
+            }
+        };
+        context.addServlet(error598Servlet, "/error/598");
+
+        startServer(context);
+
+        String request = """
+            GET /async/ HTTP/1.1
+            Host: localhost
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+
+        assertThat(response.getStatus(), is(599));
+        String responseBody = response.getContent();
+        assertThat(responseBody, containsString("ORIGINAL STATUS CODE: 598"));
+    }
+
+    @Test
+    public void testErrorHandlerCallsSendError() throws Exception
+    {
+        ServletContextHandler context = new ServletContextHandler("/");
+
+        ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
+        errorPageErrorHandler.addErrorPage(597, "/error/597");
+        errorPageErrorHandler.addErrorPage(598, "/error/598");
+        context.setErrorHandler(errorPageErrorHandler);
+
+        HttpServlet appServlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.sendError(597);
+            }
+        };
+        context.addServlet(appServlet, "/async/*");
+        HttpServlet error597Servlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.sendError(598);
+            }
+        };
+        context.addServlet(error597Servlet, "/error/597");
+        // Cannot land on an error page from another
+        // error page, so this Servlet is never called.
+        HttpServlet error598Servlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(599);
+            }
+        };
+        context.addServlet(error598Servlet, "/error/598");
+
+        startServer(context);
+
+        String request = """
+            GET /async/ HTTP/1.1
+            Host: localhost
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+
+        assertThat(response.getStatus(), is(598));
     }
 
     public static class ErrorDumpServlet extends HttpServlet

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -82,7 +82,6 @@ import org.eclipse.jetty.util.ajax.JSON;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1115,7 +1114,6 @@ public class AsyncMiddleManServletTest
     }
 
     @Test
-    @Disabled("idle timeouts do not work yet")
     public void testAfterContentTransformerClosingFilesOnClientRequestException(WorkDir workDir) throws Exception
     {
         Path targetTestsDir = workDir.getEmptyPathDir();


### PR DESCRIPTION
Reworked the ServletChannel.handle() SEND_ERROR case. Now using the proper state changes to call ErrorHandler.handle(), which is asynchronous, so that IllegalStateExceptions are avoided.

Restored idle timeout tests in ee9/ee10 AsyncMiddleManServletTest.