### PR TITLE
Issue #10936 - write MultiPart files to disk by default

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java
@@ -172,7 +172,7 @@ public class MultiPartFormInputStream
             if (MultiPartFormInputStream.this._config.getMaxFileSize() > 0 && _size + 1 > MultiPartFormInputStream.this._config.getMaxFileSize())
                 throw new IllegalStateException("Multipart Mime part " + _name + " exceeds max filesize");
 
-            if (MultiPartFormInputStream.this._config.getFileSizeThreshold() > 0 &&
+            if (MultiPartFormInputStream.this._config.getFileSizeThreshold() >= 0 &&
                 _size + 1 > MultiPartFormInputStream.this._config.getFileSizeThreshold() && _file == null)
                 createFile();
 
@@ -185,7 +185,7 @@ public class MultiPartFormInputStream
             if (MultiPartFormInputStream.this._config.getMaxFileSize() > 0 && _size + length > MultiPartFormInputStream.this._config.getMaxFileSize())
                 throw new IllegalStateException("Multipart Mime part " + _name + " exceeds max filesize");
 
-            if (MultiPartFormInputStream.this._config.getFileSizeThreshold() > 0 &&
+            if (MultiPartFormInputStream.this._config.getFileSizeThreshold() >= 0 &&
                 _size + length > MultiPartFormInputStream.this._config.getFileSizeThreshold() && _file == null)
                 createFile();
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartFormInputStreamTest.java
@@ -549,6 +549,26 @@ public class MultiPartFormInputStreamTest
     }
 
     @Test
+    public void testPartTmpFileCreationWithDefaultConfig() throws Exception
+    {
+        MultipartConfigElement config = new MultipartConfigElement(_dirname);
+        MultiPartFormInputStream mpis = new MultiPartFormInputStream(new ByteArrayInputStream(createMultipartRequestString("tptfcwdc").getBytes()),
+                _contentType,
+                config,
+                _tmpDir);
+        mpis.setDeleteOnExit(true);
+        mpis.getParts();
+
+        MultiPart part = (MultiPart)mpis.getPart("stuff");
+        File stuff = part.getFile();
+        assertThat(stuff, notNullValue()); // should write to disk by default
+        assertThat(stuff.exists(), is(true));
+        part.cleanUp();
+        assertThat(stuff.exists(), is(false));  //tmp file was removed after cleanup
+        stuff.deleteOnExit(); //clean up test
+    }
+
+    @Test
     public void testPartTmpFileDeletion() throws Exception
     {
         MultipartConfigElement config = new MultipartConfigElement(_dirname, 1024, 3072, 50);
@@ -878,8 +898,8 @@ public class MultiPartFormInputStreamTest
         assertThat(f, notNullValue()); // longer than 100 bytes, should already be a tmp file
 
         Part stuff = mpis.getPart("stuff");
-        f = ((MultiPartFormInputStream.MultiPart)stuff).getFile(); //should only be in memory, no filename
-        assertThat(f, nullValue());
+        f = ((MultiPartFormInputStream.MultiPart)stuff).getFile(); //should be written to a file by default
+        assertThat(f, notNullValue());
     }
 
     private void testMulti(String filename) throws IOException


### PR DESCRIPTION
fixes #10936 

## Motivation

MultiPart files should be written to disk by default according to Jakarta EE 10 which is not the case.

## Modifications:

* Create a file also when `fileSizeThreshold` is `0`
* Add a unit test ensuring that a file is created when using the default configuration