### PR TITLE
Upgrade to Maven build cache extension 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <mariadb.version>3.2.0</mariadb.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
-    <maven-build-cache.version>1.0.1</maven-build-cache.version>
+    <maven-build-cache.version>1.1.0-SNAPSHOT</maven-build-cache.version>
     <maven-plugin.plugin.version>3.10.1</maven-plugin.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <mariadb.version>3.2.0</mariadb.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
-    <maven-build-cache.version>1.1.0-SNAPSHOT</maven-build-cache.version>
+    <maven-build-cache.version>1.1.0</maven-build-cache.version>
     <maven-plugin.plugin.version>3.10.1</maven-plugin.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>


### PR DESCRIPTION
- test build cache extension 1.1.0-SNAPSHOT
- use Maven build cache extension 1.1.0
