### PR TITLE
Fix `ContentSourceInputStream` mis-behaving in the presence of empty chunks

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourceInputStream.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourceInputStream.java
@@ -31,8 +31,8 @@ import org.eclipse.jetty.util.IO;
 public class ContentSourceInputStream extends InputStream
 {
     private final Blocker.Shared blocking = new Blocker.Shared();
-    private final byte[] oneByte = new byte[1];
     private final Content.Source content;
+    private byte[] oneByte;
     private Content.Chunk chunk;
 
     public ContentSourceInputStream(Content.Source content)
@@ -43,6 +43,8 @@ public class ContentSourceInputStream extends InputStream
     @Override
     public int read() throws IOException
     {
+        if (oneByte == null)
+            oneByte = new byte[1];
         int read = read(oneByte, 0, 1);
         return read < 0 ? -1 : oneByte[0] & 0xFF;
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourceInputStream.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourceInputStream.java
@@ -75,7 +75,13 @@ public class ContentSourceInputStream extends InputStream
                 return l;
             }
 
-            chunk = content.read();
+            // Skip empty chunks.
+            while (true)
+            {
+                chunk = content.read();
+                if (chunk == null || chunk.hasRemaining() || chunk.isLast() || Content.Chunk.isFailure(chunk))
+                    break;
+            }
 
             if (chunk == null)
             {

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentSourceInputStreamTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ContentSourceInputStreamTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
@@ -20,13 +21,114 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.jetty.io.content.ContentSourceInputStream;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ContentSourceInputStreamTest
 {
+    @Test
+    public void testSingleByteReadInPresenceOfEmptyChunks() throws Exception
+    {
+        TestSource originalSource = new TestSource(
+            null,
+            Content.Chunk.EMPTY,
+            Content.Chunk.from(ByteBuffer.wrap("123".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("456".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("789".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null
+        );
+
+        ContentSourceInputStream contentSourceInputStream = new ContentSourceInputStream(originalSource);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        while (true)
+        {
+            int read = contentSourceInputStream.read();
+            if (read == -1)
+                break;
+            baos.write(read);
+        }
+        assertThat(baos.toString(US_ASCII), is("123456789"));
+    }
+
+    @Test
+    public void testByteArrayReadInPresenceOfEmptyChunks() throws Exception
+    {
+        TestSource originalSource = new TestSource(
+            null,
+            Content.Chunk.EMPTY,
+            Content.Chunk.from(ByteBuffer.wrap("123".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("456".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("789".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null
+        );
+
+        ContentSourceInputStream contentSourceInputStream = new ContentSourceInputStream(originalSource);
+        byte[] buffer = new byte[2];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        while (true)
+        {
+            int read = contentSourceInputStream.read(buffer);
+            if (read == -1)
+                break;
+            if (read == 0)
+                fail("blocking read() cannot return with 0 byte read");
+            baos.write(buffer, 0, read);
+        }
+        assertThat(baos.toString(US_ASCII), is("123456789"));
+    }
+
+    @Test
+    public void testEmptyByteArrayReadInPresenceOfEmptyChunks() throws Exception
+    {
+        TestSource originalSource = new TestSource(
+            null,
+            Content.Chunk.EMPTY,
+            Content.Chunk.from(ByteBuffer.wrap("123".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("456".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null,
+            Content.Chunk.from(ByteBuffer.wrap("789".getBytes(US_ASCII)), false),
+            Content.Chunk.EMPTY,
+            null
+        );
+
+        ContentSourceInputStream contentSourceInputStream = new ContentSourceInputStream(originalSource);
+        byte[] emptyBuffer = new byte[0];
+        byte[] buffer = new byte[2];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        while (true)
+        {
+            int read = contentSourceInputStream.read(emptyBuffer);
+            assertThat(read, anyOf(is(0), is(-1)));
+            read = contentSourceInputStream.read(emptyBuffer);
+            assertThat(read, anyOf(is(0), is(-1)));
+
+            read = contentSourceInputStream.read(buffer);
+            if (read == -1)
+                break;
+            if (read == 0)
+                fail("blocking read() cannot return with 0 byte read");
+            baos.write(buffer, 0, read);
+        }
+        assertThat(baos.toString(US_ASCII), is("123456789"));
+    }
+
     @Test
     public void testTransientErrorsAreRethrownOnRead() throws Exception
     {


### PR DESCRIPTION
`ContentSourceInputStream.read()` returns whatever data is in the one byte internal array when the content source returns the `EMPTY` chunk.

`ContentSourceInputStream.read(byte[])` mistakenly returns zero when the content source returns the `EMPTY` chunk.

This PR fixes both bugs.