### PR TITLE
Issue #10334 - Cleanup Module + XML properties usage

### DIFF
--- a/jetty-core/jetty-server/src/main/config/modules/bytebufferpool-quadratic.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/bytebufferpool-quadratic.mod
@@ -29,9 +29,3 @@ etc/jetty-bytebufferpool-quadratic.xml
 
 ## Maximum direct memory held idle by the pool (0 for heuristic, -1 for unlimited).
 #jetty.byteBufferPool.maxDirectMemory=0
-
-## Maximum heap memory retained whilst in use by the pool (0 for heuristic, -1 for unlimited, -2 for no retained).
-#jetty.byteBufferPool.retainedHeapMemory=0
-
-## Maximum direct memory retained whilst in use by the pool (0 for heuristic, -1 for unlimited, -2 for no retained).
-#jetty.byteBufferPool.retainedDirectMemory=0

--- a/jetty-core/jetty-server/src/main/config/modules/bytebufferpool.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/bytebufferpool.mod
@@ -31,9 +31,3 @@ etc/jetty-bytebufferpool.xml
 
 ## Maximum direct memory held idle by the pool (0 for heuristic, -1 for unlimited).
 #jetty.byteBufferPool.maxDirectMemory=0
-
-## Maximum heap memory retained whilst in use by the pool (0 for heuristic, -1 for unlimited, -2 for no retained).
-#jetty.byteBufferPool.retainedHeapMemory=0
-
-## Maximum direct memory retained whilst in use by the pool (0 for heuristic, -1 for unlimited, -2 for no retained).
-#jetty.byteBufferPool.retainedDirectMemory=0

--- a/jetty-core/jetty-server/src/main/config/modules/graceful.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/graceful.mod
@@ -11,8 +11,3 @@ server
 
 [xml]
 etc/jetty-graceful.xml
-
-[ini-template]
-
-## If the Graceful shutdown should wait for async requests as well as the currently dispatched ones.
-# jetty.statistics.gracefulShutdownWaitsForRequests=true

--- a/jetty-core/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/gzip.mod
@@ -39,9 +39,6 @@ etc/jetty-gzip.xml
 ## Set the {@link Deflater} flush mode to use.
 # jetty.gzip.syncFlush=false
 
-## The set of DispatcherType that this filter will operate on
-# jetty.gzip.dispatcherTypes=REQUEST
-
 ## Comma separated list of included HTTP methods
 # jetty.gzip.includedMethodList=GET,POST
 

--- a/jetty-core/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -55,14 +55,16 @@ db-connection-type=datasource
 #jetty.session.jdbc.schema.maxIntervalColumn=maxInterval
 #jetty.session.jdbc.schema.mapColumn=map
 #jetty.session.jdbc.schema.table=JettySessions
-# Optional name of the schema used to identify where the session table is defined in the database: 
+
+# Optional name of the schema used to identify where the session table is defined in the database:
 #  "" - empty string, no schema name 
 #  "INFERRED" - special string meaning infer from the current db connection
 #  name - a string defined by the user
-#jetty.session.jdbc.schema.schemaName
+# jetty.session.jdbc.schema.schemaName=
+
 # Optional name of the catalog used to identify where the session table is defined in the database: 
 #  "" - empty string, no catalog name
 #  "INFERRED" - special string meaning infer from the current db connection
 #  name - a string defined by the user
-#jetty.session.jdbc.schema.catalogName
+# jetty.session.jdbc.schema.catalogName=
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-deploy.xml
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-deploy.xml
@@ -37,7 +37,7 @@
               <Name>jetty.deploy.defaultsDescriptorPath</Name>
               <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
               <Default>
-                <Property name="jetty.base" default="." />/etc/webdefault-ee10.xml
+                <Property name="jetty.home" default="." />/etc/webdefault-ee10.xml
               </Default>
             </Property>
           </Set>

--- a/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-deploy.xml
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-deploy.xml
@@ -35,13 +35,13 @@
           <Set name="defaultsDescriptor">
             <Property>
               <Name>jetty.deploy.defaultsDescriptorPath</Name>
+              <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
               <Default>
-                <Property name="jetty.home" default="." />/etc/webdefault-ee10.xml
+                <Property name="jetty.base" default="." />/etc/webdefault-ee10.xml
               </Default>
             </Property>
           </Set>
           <Set name="scanInterval" property="jetty.deploy.scanInterval"/>
-          <Set name="defaultsDescriptor" property="jetty.deploy.defaultsDescriptor"/>
           <Set name="extractWars" property="jetty.deploy.extractWars" />
           <Set name="parentLoaderPriority" property="jetty.deploy.parentLoaderPriority" />
           <Set name="configurationClasses" property="jetty.deploy.configurationClasses" />

--- a/jetty-ee10/jetty-ee10-webapp/src/main/config/modules/ee10-deploy.mod
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/config/modules/ee10-deploy.mod
@@ -19,7 +19,7 @@ etc/jetty-ee10-deploy.xml
 # jetty.deploy.monitoredDir=webapps
 
 ## Defaults Descriptor for all deployed webapps
-# jetty.deploy.defaultsDescriptor=${jetty.base}/etc/webdefault-ee10.xml
+# jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault-ee10.xml
 
 ## Monitored directory scan period (seconds)
 # jetty.deploy.scanInterval=1

--- a/jetty-ee8/jetty-ee8-openid/src/main/config/etc/jetty-ee8-openid.xml
+++ b/jetty-ee8/jetty-ee8-openid/src/main/config/etc/jetty-ee8-openid.xml
@@ -33,7 +33,7 @@
         <Arg name="tokenEndpoint"><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
         <Arg name="clientId"><Property name="jetty.openid.clientId"/></Arg>
         <Arg name="clientSecret"><Property name="jetty.openid.clientSecret"/></Arg>
-        <Arg name="authMethod"><Property name="jetty.openid.authMethod" default="client_secret_post"/></Arg>
+        <Arg name="authMethod"><Property name="jetty.openid.authenticationMethod" deprecated="jetty.openid.authMethod" default="client_secret_post"/></Arg>
         <Arg name="httpClient"><Ref refid="HttpClient"/></Arg>
         <Set name="authenticateNewUsers">
           <Property name="jetty.openid.authenticateNewUsers" default="false"/>

--- a/jetty-ee8/jetty-ee8-openid/src/main/config/modules/ee8-openid.mod
+++ b/jetty-ee8/jetty-ee8-openid/src/main/config/modules/ee8-openid.mod
@@ -45,4 +45,4 @@ etc/jetty-ee8-openid.xml
 # jetty.openid.sslContextFactory.trustAll=false
 
 ## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
-# jetty.openid.authMethod=client_secret_post
+# jetty.openid.authenticationMethod=client_secret_post

--- a/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-deploy.xml
+++ b/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-deploy.xml
@@ -37,7 +37,7 @@
               <Name>jetty.deploy.defaultsDescriptorPath</Name>
               <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
               <Default>
-                <Property name="jetty.base" default="." />/etc/webdefault-ee8.xml
+                <Property name="jetty.home" default="." />/etc/webdefault-ee8.xml
               </Default>
             </Property>
           </Set>

--- a/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-deploy.xml
+++ b/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-deploy.xml
@@ -32,8 +32,16 @@
               </Arg>
             </Call>
           </Set>
+          <Set name="defaultsDescriptor">
+            <Property>
+              <Name>jetty.deploy.defaultsDescriptorPath</Name>
+              <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
+              <Default>
+                <Property name="jetty.base" default="." />/etc/webdefault-ee8.xml
+              </Default>
+            </Property>
+          </Set>
           <Set name="scanInterval" property="jetty.deploy.scanInterval"/>
-          <Set name="defaultsDescriptor" property="jetty.deploy.defaultsDescriptor"/>
           <Set name="extractWars" property="jetty.deploy.extractWars" />
           <Set name="parentLoaderPriority" property="jetty.deploy.parentLoaderPriority" />
           <Set name="configurationClasses" property="jetty.deploy.configurationClasses" />

--- a/jetty-ee8/jetty-ee8-webapp/src/main/config/modules/ee8-deploy.mod
+++ b/jetty-ee8/jetty-ee8-webapp/src/main/config/modules/ee8-deploy.mod
@@ -19,7 +19,7 @@ etc/jetty-ee8-deploy.xml
 # jetty.deploy.monitoredDir=webapps
 
 ## Defaults Descriptor for all deployed webapps
-# jetty.deploy.defaultsDescriptor=${jetty.base}/etc/webdefault-ee8.xml
+# jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault-ee8.xml
 
 ## Monitored directory scan period (seconds)
 # jetty.deploy.scanInterval=1

--- a/jetty-ee9/jetty-ee9-openid/src/main/config/etc/jetty-ee9-openid.xml
+++ b/jetty-ee9/jetty-ee9-openid/src/main/config/etc/jetty-ee9-openid.xml
@@ -33,7 +33,7 @@
         <Arg name="tokenEndpoint"><Property name="jetty.openid.provider.tokenEndpoint"/></Arg>
         <Arg name="clientId"><Property name="jetty.openid.clientId"/></Arg>
         <Arg name="clientSecret"><Property name="jetty.openid.clientSecret"/></Arg>
-        <Arg name="authMethod"><Property name="jetty.openid.authMethod" default="client_secret_post"/></Arg>
+        <Arg name="authMethod"><Property name="jetty.openid.authenticationMethod" deprecated="jetty.openid.authMethod" default="client_secret_post"/></Arg>
         <Arg name="httpClient"><Ref refid="HttpClient"/></Arg>
         <Set name="authenticateNewUsers">
           <Property name="jetty.openid.authenticateNewUsers" default="false"/>

--- a/jetty-ee9/jetty-ee9-openid/src/main/config/modules/ee9-openid.mod
+++ b/jetty-ee9/jetty-ee9-openid/src/main/config/modules/ee9-openid.mod
@@ -48,7 +48,7 @@ etc/jetty-ee9-openid.xml
 # jetty.openid.sslContextFactory.trustAll=false
 
 ## What authentication method to use with the Token Endpoint (client_secret_post, client_secret_basic).
-# jetty.openid.authMethod=client_secret_post
+# jetty.openid.authenticationMethod=client_secret_post
 
 ## Whether the user should be logged out after the idToken expires.
 # jetty.openid.logoutWhenIdTokenIsExpired=false

--- a/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-deploy.xml
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-deploy.xml
@@ -37,7 +37,7 @@
               <Name>jetty.deploy.defaultsDescriptorPath</Name>
               <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
               <Default>
-                <Property name="jetty.base" default="." />/etc/webdefault-ee9.xml
+                <Property name="jetty.home" default="." />/etc/webdefault-ee9.xml
               </Default>
             </Property>
           </Set>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-deploy.xml
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-deploy.xml
@@ -32,8 +32,16 @@
               </Arg>
             </Call>
           </Set>
+          <Set name="defaultsDescriptor">
+            <Property>
+              <Name>jetty.deploy.defaultsDescriptorPath</Name>
+              <Deprecated>jetty.deploy.defaultsDescriptor</Deprecated>
+              <Default>
+                <Property name="jetty.base" default="." />/etc/webdefault-ee9.xml
+              </Default>
+            </Property>
+          </Set>
           <Set name="scanInterval" property="jetty.deploy.scanInterval"/>
-          <Set name="defaultsDescriptor" property="jetty.deploy.defaultsDescriptor"/>
           <Set name="extractWars" property="jetty.deploy.extractWars" />
           <Set name="parentLoaderPriority" property="jetty.deploy.parentLoaderPriority" />
           <Set name="configurationClasses" property="jetty.deploy.configurationClasses" />

--- a/jetty-ee9/jetty-ee9-webapp/src/main/config/modules/ee9-deploy.mod
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/config/modules/ee9-deploy.mod
@@ -19,7 +19,7 @@ etc/jetty-ee9-deploy.xml
 # jetty.deploy.monitoredDir=webapps
 
 ## Defaults Descriptor for all deployed webapps
-# jetty.deploy.defaultsDescriptor=${jetty.base}/etc/webdefault-ee9.xml
+# jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault-ee9.xml
 
 ## Monitored directory scan period (seconds)
 # jetty.deploy.scanInterval=1


### PR DESCRIPTION
There are a few bad property declarations floating around the codebase that are cleaned up in this PR.

Things addressed:

* Properties declared in MOD that are not used in any XML
* Properties declared in XML that are not also declared in any MOD
* Deprecated properties are consistently deprecated and replacement names are used instead.
* Duplicate `<Set>` calls to same name + property pair are reduced to 1 instance in XML.

Fixes #10334 