### PR TITLE
add deployment exception for non Jakarta WebSocket endpoints used in ServerEndpointConfig

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
@@ -65,7 +65,11 @@ public class CreatorNegotiator extends WebSocketNegotiator.AbstractNegotiator
 
         if (websocketPojo == null)
             return null;
-        return factory.newFrameHandler(websocketPojo, request, response);
+
+        FrameHandler frameHandler = factory.newFrameHandler(websocketPojo, request, response);
+        if (frameHandler == null)
+            callback.failed(new IllegalStateException("No WebSocket FrameHandler was created"));
+        return frameHandler;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -178,9 +178,9 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             throw new DeploymentException("Unable to deploy null endpoint class from ServerEndpointConfig: " + config.getClass().getName());
         }
 
-        if (!(jakarta.websocket.Endpoint.class.isAssignableFrom(endpointClass))
-            && endpointClass.getAnnotation(ServerEndpoint.class) == null
-            && endpointClass.getAnnotation(ClientEndpoint.class) == null)
+        if (!(jakarta.websocket.Endpoint.class.isAssignableFrom(endpointClass)) &&
+            endpointClass.getAnnotation(ServerEndpoint.class) == null &&
+            endpointClass.getAnnotation(ClientEndpoint.class) == null)
         {
             throw new DeploymentException("Unable to deploy unknown endpoint class: " + endpointClass.getName());
         }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.DeploymentException;
 import jakarta.websocket.server.ServerEndpoint;
 import jakarta.websocket.server.ServerEndpointConfig;
@@ -175,6 +176,13 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
         if (endpointClass == null)
         {
             throw new DeploymentException("Unable to deploy null endpoint class from ServerEndpointConfig: " + config.getClass().getName());
+        }
+
+        if (!(jakarta.websocket.Endpoint.class.isAssignableFrom(endpointClass))
+            && endpointClass.getAnnotation(ServerEndpoint.class) == null
+            && endpointClass.getAnnotation(ClientEndpoint.class) == null)
+        {
+            throw new DeploymentException("Unable to deploy unknown endpoint class: " + endpointClass.getName());
         }
 
         if (!Modifier.isPublic(endpointClass.getModifiers()))

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
@@ -22,6 +22,7 @@ import jakarta.websocket.server.ServerContainer;
 import jakarta.websocket.server.ServerEndpoint;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets.BadEndpoint;
 import org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets.InvalidCloseIntSocket;
 import org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets.InvalidErrorErrorSocket;
 import org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets.InvalidErrorIntSocket;
@@ -33,6 +34,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.websocket.core.exception.InvalidSignatureException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -100,6 +102,28 @@ public class DeploymentExceptionTest
             ServerContainer serverContainer = (ServerContainer)context.getServletContext().getAttribute(ServerContainer.class.getName());
             Exception e = assertThrows(DeploymentException.class, () -> serverContainer.addEndpoint(pojo));
             assertThat(e.getCause(), instanceOf(InvalidSignatureException.class));
+        }
+        finally
+        {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testDeploymentException() throws Exception
+    {
+        ServletContextHandler context = new ServletContextHandler();
+        context.setServer(server);
+        JakartaWebSocketServletContainerInitializer.configure(context, null);
+
+        contexts.addHandler(context);
+        try
+        {
+            context.start();
+            ServerContainer serverContainer = (ServerContainer)context.getServletContext().getAttribute(ServerContainer.class.getName());
+
+            // We cannot deploy this because it does not extend Endpoint and has no @ServerEndpoint/@ClientEndpoint annotation.
+            assertThrows(DeploymentException.class, () -> serverContainer.addEndpoint(BadEndpoint.class));
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/DeploymentExceptionTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import jakarta.websocket.DeploymentException;
 import jakarta.websocket.server.ServerContainer;
 import jakarta.websocket.server.ServerEndpoint;
+import jakarta.websocket.server.ServerEndpointConfig;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
 import org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets.BadEndpoint;
@@ -123,7 +124,10 @@ public class DeploymentExceptionTest
             ServerContainer serverContainer = (ServerContainer)context.getServletContext().getAttribute(ServerContainer.class.getName());
 
             // We cannot deploy this because it does not extend Endpoint and has no @ServerEndpoint/@ClientEndpoint annotation.
-            assertThrows(DeploymentException.class, () -> serverContainer.addEndpoint(BadEndpoint.class));
+            assertThrows(DeploymentException.class, () ->
+                serverContainer.addEndpoint(BadEndpoint.class));
+            assertThrows(DeploymentException.class, () ->
+                serverContainer.addEndpoint(ServerEndpointConfig.Builder.create(BadEndpoint.class, "/ws").build()));
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/sockets/BadEndpoint.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/sockets/BadEndpoint.java
@@ -1,0 +1,34 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets;
+
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.MessageHandler;
+
+public class BadEndpoint
+    {
+        public void onOpen(jakarta.websocket.Session session, EndpointConfig config)
+        {
+            try
+            {
+                session.addMessageHandler((MessageHandler.Whole<Object>)System.out::println);
+                System.out.println("server open");
+                session.getBasicRemote().sendText("connected");
+            }
+            catch (Throwable t)
+            {
+                t.printStackTrace(System.err);
+            }
+        }
+    }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.DeploymentException;
 import jakarta.websocket.server.ServerEndpoint;
 import jakarta.websocket.server.ServerEndpointConfig;
@@ -176,6 +177,13 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
         if (endpointClass == null)
         {
             throw new DeploymentException("Unable to deploy null endpoint class from ServerEndpointConfig: " + config.getClass().getName());
+        }
+
+        if (!(jakarta.websocket.Endpoint.class.isAssignableFrom(endpointClass)) &&
+            endpointClass.getAnnotation(ServerEndpoint.class) == null &&
+            endpointClass.getAnnotation(ClientEndpoint.class) == null)
+        {
+            throw new DeploymentException("Unable to deploy unknown endpoint class: " + endpointClass.getName());
         }
 
         if (!Modifier.isPublic(endpointClass.getModifiers()))

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/BadEndpoint.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/BadEndpoint.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee10.websocket.jakarta.tests.server.sockets;
+package org.eclipse.jetty.ee9.websocket.jakarta.tests.server;
 
 import jakarta.websocket.EndpointConfig;
 import jakarta.websocket.MessageHandler;


### PR DESCRIPTION
## Issue #11009

If a jakarta WebSocket endpoint does not extend `jakarta.websocket.Endpoint` and does not have a `@ClientEndpoint` or `@ServerEndpoint` annotation then it should throw `DeploymentException`.

And if for some reason the `FrameHandlerFactory` failed to create a `FrameHandler` from the websocket pojo then the `CreatorNegotiator` should be responsible to send an error like specified in the javadoc.