### PR TITLE
Fixes #11031 - HttpClient should expose Connection/EndPoint used by H…

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpChannel.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.client;
 
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -53,7 +54,7 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
     {
         boolean result = false;
         boolean abort = true;
-        try (AutoLock l = _lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             if (_exchange == null)
             {
@@ -64,12 +65,14 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
             }
         }
 
+        HttpRequest request = exchange.getRequest();
         if (abort)
         {
-            exchange.getRequest().abort(new UnsupportedOperationException("Pipelined requests not supported"));
+            request.abort(new UnsupportedOperationException("Pipelined requests not supported"));
         }
         else
         {
+            request.setConnection(getConnection());
             if (LOG.isDebugEnabled())
                 LOG.debug("{} associated {} to {}", exchange, result, this);
         }
@@ -80,7 +83,7 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
     public boolean disassociate(HttpExchange exchange)
     {
         boolean result = false;
-        try (AutoLock l = _lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             HttpExchange existing = _exchange;
             _exchange = null;
@@ -98,11 +101,13 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
 
     public HttpExchange getHttpExchange()
     {
-        try (AutoLock l = _lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             return _exchange;
         }
     }
+
+    protected abstract Connection getConnection();
 
     @Override
     public long getExpireNanoTime()

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -275,6 +276,18 @@ public class HttpProxy extends ProxyConfiguration.Proxy
             this.destination = destination;
             this.connection = connection;
             this.promise = promise;
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress()
+        {
+            return connection.getLocalSocketAddress();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress()
+        {
+            return connection.getRemoteSocketAddress();
         }
 
         @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -69,6 +70,7 @@ public class HttpRequest implements Request
     private final AtomicReference<Throwable> aborted = new AtomicReference<>();
     private final HttpClient client;
     private final HttpConversation conversation;
+    private Connection connection;
     private String scheme;
     private String host;
     private int port;
@@ -160,6 +162,17 @@ public class HttpRequest implements Request
     public HttpConversation getConversation()
     {
         return conversation;
+    }
+
+    @Override
+    public Connection getConnection()
+    {
+        return connection;
+    }
+
+    void setConnection(Connection connection)
+    {
+        this.connection = connection;
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Connection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Connection.java
@@ -51,10 +51,16 @@ public interface Connection extends Closeable
     /**
      * @return the local socket address associated with the connection
      */
-    SocketAddress getLocalSocketAddress();
+    default SocketAddress getLocalSocketAddress()
+    {
+        return null;
+    }
 
     /**
      * @return the remote socket address associated with the connection
      */
-    SocketAddress getRemoteSocketAddress();
+    default SocketAddress getRemoteSocketAddress()
+    {
+        return null;
+    }
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Connection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Connection.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.client.api;
 
 import java.io.Closeable;
+import java.net.SocketAddress;
 
 import org.eclipse.jetty.util.Promise;
 
@@ -46,4 +47,14 @@ public interface Connection extends Closeable
      * @see #close()
      */
     boolean isClosed();
+
+    /**
+     * @return the local socket address associated with the connection
+     */
+    SocketAddress getLocalSocketAddress();
+
+    /**
+     * @return the remote socket address associated with the connection
+     */
+    SocketAddress getRemoteSocketAddress();
 }

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/api/Request.java
@@ -51,6 +51,22 @@ import org.eclipse.jetty.util.Fields;
 public interface Request
 {
     /**
+     * <p>Returns the connection associated with this request.</p>
+     * <p>The connection is available only starting from the
+     * {@link #onRequestBegin(BeginListener) request begin} event,
+     * when a connection is associated with the request to be sent,
+     * otherwise {@code null} is returned.</p>
+     *
+     * @return the connection associated with this request,
+     * or {@code null} if there is no connection associated
+     * with this request
+     */
+    default Connection getConnection()
+    {
+        return null;
+    }
+
+    /**
      * @return the URI scheme of this request, such as "http" or "https"
      */
     String getScheme();

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpChannelOverHTTP.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.eclipse.jetty.client.HttpChannel;
 import org.eclipse.jetty.client.HttpExchange;
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http.HttpFields;
@@ -53,6 +54,12 @@ public class HttpChannelOverHTTP extends HttpChannel
     protected HttpReceiverOverHTTP newHttpReceiver()
     {
         return new HttpReceiverOverHTTP(this);
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return connection;
     }
 
     @Override

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/http/HttpConnectionOverHTTP.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.client.http;
 
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.Collections;
@@ -98,6 +99,18 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
     public HttpDestination getHttpDestination()
     {
         return delegate.getHttpDestination();
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress()
+    {
+        return delegate.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress()
+    {
+        return delegate.getRemoteSocketAddress();
     }
 
     @Override
@@ -283,6 +296,18 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
         protected Iterator<HttpChannel> getHttpChannels()
         {
             return Collections.<HttpChannel>singleton(channel).iterator();
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress()
+        {
+            return getEndPoint().getLocalSocketAddress();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress()
+        {
+            return getEndPoint().getRemoteSocketAddress();
         }
 
         @Override

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpChannelOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpChannelOverFCGI.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.client.HttpChannel;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpReceiver;
 import org.eclipse.jetty.client.HttpSender;
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.fcgi.generator.Flusher;
 import org.eclipse.jetty.fcgi.generator.Generator;
@@ -43,7 +44,7 @@ public class HttpChannelOverFCGI extends HttpChannel
     private int request;
     private HttpVersion version;
 
-    public HttpChannelOverFCGI(final HttpConnectionOverFCGI connection, Flusher flusher, long idleTimeout)
+    public HttpChannelOverFCGI(HttpConnectionOverFCGI connection, Flusher flusher, long idleTimeout)
     {
         super(connection.getHttpDestination());
         this.connection = connection;
@@ -61,6 +62,12 @@ public class HttpChannelOverFCGI extends HttpChannel
     void setRequest(int request)
     {
         this.request = request;
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return connection;
     }
 
     @Override

--- a/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
+++ b/jetty-fcgi/fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/http/HttpConnectionOverFCGI.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.fcgi.client.http;
 
 import java.io.EOFException;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.Collections;
@@ -85,6 +86,18 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     public HttpDestination getHttpDestination()
     {
         return destination;
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress()
+    {
+        return delegate.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress()
+    {
+        return delegate.getRemoteSocketAddress();
     }
 
     protected Flusher getFlusher()
@@ -319,7 +332,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
 
     private int acquireRequest()
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             int last = requests.getLast();
             int request = last + 1;
@@ -330,7 +343,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
 
     private void releaseRequest(int request)
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             requests.removeFirstOccurrence(request);
         }
@@ -371,6 +384,18 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         {
             HttpChannel channel = HttpConnectionOverFCGI.this.channel;
             return channel == null ? Collections.emptyIterator() : Collections.singleton(channel).iterator();
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress()
+        {
+            return getEndPoint().getLocalSocketAddress();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress()
+        {
+            return getEndPoint().getRemoteSocketAddress();
         }
 
         @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpReceiver;
 import org.eclipse.jetty.client.HttpSender;
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Channel;
@@ -65,6 +66,12 @@ public class HttpChannelOverHTTP2 extends HttpChannel
     public Stream.Listener getStreamListener()
     {
         return listener;
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return connection;
     }
 
     @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpConnectionOverHTTP2.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.http2.client.http;
 
+import java.net.SocketAddress;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.Iterator;
 import java.util.List;
@@ -66,6 +67,18 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     public Session getSession()
     {
         return session;
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress()
+    {
+        return session.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress()
+    {
+        return session.getRemoteSocketAddress();
     }
 
     public boolean isRecycleHttpChannels()

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpChannelOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpChannelOverHTTP3.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpReceiver;
 import org.eclipse.jetty.client.HttpSender;
+import org.eclipse.jetty.client.api.Connection;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.client.internal.HTTP3SessionClient;
@@ -48,6 +49,12 @@ public class HttpChannelOverHTTP3 extends HttpChannel
     public Stream.Client.Listener getStreamListener()
     {
         return receiver;
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return connection;
     }
 
     @Override

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpConnectionOverHTTP3.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.http3.client.http.internal;
 
+import java.net.SocketAddress;
 import java.nio.channels.AsynchronousCloseException;
 import java.util.Iterator;
 import java.util.Set;
@@ -48,6 +49,18 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     public HTTP3SessionClient getSession()
     {
         return session;
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress()
+    {
+        return session.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress()
+    {
+        return session.getRemoteSocketAddress();
     }
 
     @Override

--- a/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpClientTest.java
+++ b/tests/test-http-client-transport/src/test/java/org/eclipse/jetty/http/client/HttpClientTest.java
@@ -835,6 +835,25 @@ public class  HttpClientTest extends AbstractTest<TransportScenario>
         assertEquals(200, response.getStatus());
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(TransportProvider.class)
+    public void testRequestConnection(Transport transport) throws Exception
+    {
+        init(transport);
+
+        scenario.start(new EmptyServerHandler());
+
+        ContentResponse response = scenario.client.newRequest(scenario.newURI())
+            .onRequestBegin(r ->
+            {
+                if (r.getConnection() == null)
+                    r.abort(new IllegalStateException());
+            })
+            .send();
+
+        assertEquals(200, response.getStatus());
+    }
+
     private void sleep(long time) throws IOException
     {
         try


### PR DESCRIPTION
…TTP requests.

Introduced method Request.getConnection() to expose the Connection after at the request begin event.