### PR TITLE
Update to cdi-api 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
     <jakarta.authentication.api.version>2.0.0</jakarta.authentication.api.version>
     <jakarta.el.api.version>4.0.0</jakarta.el.api.version>
-    <jakarta.enterprise.cdi.api.version>3.0.0</jakarta.enterprise.cdi.api.version>
+    <jakarta.enterprise.cdi.api.version>3.0.1</jakarta.enterprise.cdi.api.version>
     <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>
-    <jakarta.interceptor.api.version>2.0.0</jakarta.interceptor.api.version>
+    <jakarta.interceptor.api.version>2.0.1</jakarta.interceptor.api.version>
     <jakarta.mail.api.version>2.0.1</jakarta.mail.api.version>
     <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
     <jakarta.servlet.jsp.api.version>3.0.0</jakarta.servlet.jsp.api.version>


### PR DESCRIPTION
Dependabot auto update to cdi-api 3.0.1 failed due to dependency on interceptor-api 2.0.1, see #10289. This PR replaces that.