### PR TITLE
Fixes #11066 - URIUtilTest.testFileUriGetUriLastPathSegment on macOS

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -810,12 +810,24 @@ public class URIUtilTest
             FS.touch(base);
         }
         URI uri = base.toUri();
-        if (OS.MAC.isCurrentOs())
+
+        try
         {
-            // Normalize Unicode to NFD form that OSX Path/FileSystem produces
-            expectedName = Normalizer.normalize(expectedName, Normalizer.Form.NFD);
+            assertThat(URIUtil.getUriLastPathSegment(uri), is(expectedName));
         }
-        assertThat(URIUtil.getUriLastPathSegment(uri), is(expectedName));
+        catch (AssertionError e)
+        {
+            if (OS.MAC.isCurrentOs())
+            {
+                // Normalize Unicode to NFD form that OSX Path/FileSystem produces
+                expectedName = Normalizer.normalize(expectedName, Normalizer.Form.NFD);
+                assertThat(URIUtil.getUriLastPathSegment(uri), is(expectedName));
+            }
+            else
+            {
+                throw e;
+            }
+        }
     }
 
     public static Stream<Arguments> uriLastSegmentSource() throws IOException


### PR DESCRIPTION
We special-cased this test on macOS to support NFD form normalization.

That may no longer be necessary, and therefore the test currently fails.

Run the default expectations, and, in case of failure on macOS, test against the old workaround.