### PR TITLE
Issue #11081 - fix race condition in WebSocket FrameHandlers

### DIFF
--- a/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-javax-common/src/main/java/org/eclipse/jetty/websocket/javax/common/JavaxWebSocketFrameHandler.java
@@ -596,9 +596,10 @@ public class JavaxWebSocketFrameHandler implements FrameHandler
         }
 
         // Accept the payload into the message sink
-        activeMessageSink.accept(frame, callback);
+        MessageSink messageSink = activeMessageSink;
         if (frame.isFin())
             activeMessageSink = null;
+        messageSink.accept(frame, callback);
     }
 
     public void onPing(Frame frame, Callback callback)

--- a/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-websocket/websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -345,9 +345,10 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         }
 
         // Accept the payload into the message sink
-        activeMessageSink.accept(frame, callback);
+        MessageSink messageSink = activeMessageSink;
         if (frame.isFin())
             activeMessageSink = null;
+        messageSink.accept(frame, callback);
     }
 
     private void onBinaryFrame(Frame frame, Callback callback)


### PR DESCRIPTION
The websocket `MessageSink` could demand which could cause another thread to start processing websocket frames and eventually end up trying to use the message sink before it has been nulled out by the original thread in `onMessage()`.

As far as I can tell this can only occur if the first thread was suspended with `Session.suspend()`, then another frame arrived, then `SuspendToken.resume()` was called from a different thread.

Wasn't able to write a good test for this but can reproduce manually by putting sleeps in the code.