### PR TITLE
Fixes #11081 - Dropped WebSocket messages due to race condition in WebSocket frame handling.

### DIFF
--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
@@ -38,9 +38,7 @@ public class ByteArrayMessageSink extends AbstractMessageSink
         // The javax layer instead uses decoders for whole byte array messages instead of this message sink.
         MethodType onMessageType = MethodType.methodType(Void.TYPE, byte[].class, int.class, int.class);
         if (methodHandle.type().changeReturnType(void.class) != onMessageType.changeReturnType(void.class))
-        {
             throw InvalidSignatureException.build(onMessageType, methodHandle.type());
-        }
     }
 
     @Override
@@ -56,8 +54,9 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                     String.format("Binary message too large: (actual) %,d > (configured max binary message size) %,d", size, maxBinaryMessageSize));
             }
 
-            // If we are fin and no OutputStream has been created we don't need to aggregate.
-            if (frame.isFin() && (out == null))
+            // If the frame is fin and no accumulator has
+            // been created, then we don't need to aggregate.
+            if (frame.isFin() && out == null)
             {
                 if (frame.hasPayload())
                 {
@@ -65,7 +64,11 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                     methodHandle.invoke(buf, 0, buf.length);
                 }
                 else
+                {
                     methodHandle.invoke(EMPTY_BUFFER, 0, 0);
+                }
+
+                reset();
 
                 callback.succeeded();
                 session.demand(1);
@@ -79,31 +82,25 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                 if (out == null)
                     out = new ByteBufferCallbackAccumulator();
                 out.addEntry(payload, callback);
+                // The callback is now stored in the accumulator, so if
+                // the methodHandle throws, don't fail the callback twice.
+                callback = Callback.NOOP;
             }
 
-            // If the methodHandle throws we don't want to fail callback twice.
-            callback = Callback.NOOP;
             if (frame.isFin())
             {
                 byte[] buf = out.takeByteArray();
                 methodHandle.invoke(buf, 0, buf.length);
+                reset();
             }
 
+            callback.succeeded();
             session.demand(1);
         }
         catch (Throwable t)
         {
-            if (out != null)
-                out.fail(t);
+            fail(t);
             callback.failed(t);
-        }
-        finally
-        {
-            if (frame.isFin())
-            {
-                // reset
-                out = null;
-            }
         }
     }
 
@@ -112,5 +109,11 @@ public class ByteArrayMessageSink extends AbstractMessageSink
     {
         if (out != null)
             out.fail(failure);
+        reset();
+    }
+
+    private void reset()
+    {
+        out = null;
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
@@ -33,7 +33,6 @@ public class ByteArrayMessageSink extends AbstractMessageSink
     public ByteArrayMessageSink(CoreSession session, MethodHandle methodHandle)
     {
         super(session, methodHandle);
-
         // This uses the offset length byte array signature not supported by javax websocket.
         // The javax layer instead uses decoders for whole byte array messages instead of this message sink.
         MethodType onMessageType = MethodType.methodType(Void.TYPE, byte[].class, int.class, int.class);
@@ -56,7 +55,7 @@ public class ByteArrayMessageSink extends AbstractMessageSink
 
             // If the frame is fin and no accumulator has
             // been created, then we don't need to aggregate.
-            if (frame.isFin() && out == null)
+            if (frame.isFin() && (out == null || out.getLength() == 0))
             {
                 if (frame.hasPayload())
                 {
@@ -67,8 +66,6 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                 {
                     methodHandle.invoke(EMPTY_BUFFER, 0, 0);
                 }
-
-                reset();
 
                 callback.succeeded();
                 session.demand(1);
@@ -91,7 +88,6 @@ public class ByteArrayMessageSink extends AbstractMessageSink
             {
                 byte[] buf = out.takeByteArray();
                 methodHandle.invoke(buf, 0, buf.length);
-                reset();
             }
 
             callback.succeeded();
@@ -109,11 +105,5 @@ public class ByteArrayMessageSink extends AbstractMessageSink
     {
         if (out != null)
             out.fail(failure);
-        reset();
-    }
-
-    private void reset()
-    {
-        out = null;
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteArrayMessageSink.java
@@ -53,8 +53,8 @@ public class ByteArrayMessageSink extends AbstractMessageSink
                     String.format("Binary message too large: (actual) %,d > (configured max binary message size) %,d", size, maxBinaryMessageSize));
             }
 
-            // If the frame is fin and no accumulator has
-            // been created, then we don't need to aggregate.
+            // If the frame is fin and no accumulator has been
+            // created or used, then we don't need to aggregate.
             if (frame.isFin() && (out == null || out.getLength() == 0))
             {
                 if (frame.hasPayload())

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteBufferMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/ByteBufferMessageSink.java
@@ -52,8 +52,8 @@ public class ByteBufferMessageSink extends AbstractMessageSink
                     size, maxBinaryMessageSize));
             }
 
-            // If the frame is fin and no accumulator has
-            // been created, then we don't need to aggregate.
+            // If the frame is fin and no accumulator has been
+            // created or used, then we don't need to aggregate.
             if (frame.isFin() && (out == null || out.getLength() == 0))
             {
                 if (frame.hasPayload())

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
@@ -23,13 +23,12 @@ import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
 
 public class StringMessageSink extends AbstractMessageSink
 {
-    private final Utf8StringBuilder out;
+    private Utf8StringBuilder out;
     private int size;
 
     public StringMessageSink(CoreSession session, MethodHandle methodHandle)
     {
         super(session, methodHandle);
-        this.out = new Utf8StringBuilder(session.getInputBufferSize());
         this.size = 0;
     }
 
@@ -46,6 +45,8 @@ public class StringMessageSink extends AbstractMessageSink
                     size, maxTextMessageSize));
             }
 
+            if (out == null)
+                out = new Utf8StringBuilder(session.getInputBufferSize());
             out.append(frame.getPayload());
 
             if (frame.isFin())
@@ -72,7 +73,7 @@ public class StringMessageSink extends AbstractMessageSink
 
     private void reset()
     {
+        out = null;
         size = 0;
-        out.reset();
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
@@ -23,12 +23,13 @@ import org.eclipse.jetty.websocket.core.exception.MessageTooLargeException;
 
 public class StringMessageSink extends AbstractMessageSink
 {
-    private Utf8StringBuilder out;
+    private final Utf8StringBuilder out;
     private int size;
 
     public StringMessageSink(CoreSession session, MethodHandle methodHandle)
     {
         super(session, methodHandle);
+        this.out = new Utf8StringBuilder(session.getInputBufferSize());
         this.size = 0;
     }
 
@@ -45,8 +46,6 @@ public class StringMessageSink extends AbstractMessageSink
                     size, maxTextMessageSize));
             }
 
-            if (out == null)
-                out = new Utf8StringBuilder(session.getInputBufferSize());
             out.append(frame.getPayload());
 
             if (frame.isFin())
@@ -74,6 +73,6 @@ public class StringMessageSink extends AbstractMessageSink
     private void reset()
     {
         size = 0;
-        out = null;
+        out.reset();
     }
 }

--- a/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
+++ b/jetty-websocket/websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java
@@ -47,33 +47,33 @@ public class StringMessageSink extends AbstractMessageSink
 
             if (out == null)
                 out = new Utf8StringBuilder(session.getInputBufferSize());
-
             out.append(frame.getPayload());
+
             if (frame.isFin())
+            {
                 methodHandle.invoke(out.toString());
+                reset();
+            }
 
             callback.succeeded();
             session.demand(1);
         }
         catch (Throwable t)
         {
+            reset();
             callback.failed(t);
-        }
-        finally
-        {
-            if (frame.isFin())
-            {
-                // reset
-                size = 0;
-                out = null;
-            }
         }
     }
 
     @Override
     public void fail(Throwable failure)
     {
-        if (out != null)
-            out.reset();
+        reset();
+    }
+
+    private void reset()
+    {
+        size = 0;
+        out = null;
     }
 }


### PR DESCRIPTION
Now the reset of the MessageSink internal accumulators happens before the demand.

This avoids the race, since as soon as there is demand another thread could enter the MessageSink, but the accumulator has already been reset.