### PR TITLE
Fixes #11098 - Sporadic NPE in ArrayByteBufferPool.evict().

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -207,23 +207,23 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                     if (!reservedEntry.release())
                         reservedEntry.remove();
                 });
-                reservedEntry.enable(buffer, true);
-                if (direct)
-                    _currentDirectMemory.addAndGet(buffer.capacity());
-                else
-                    _currentHeapMemory.addAndGet(buffer.capacity());
-                releaseExcessMemory(direct);
+
+                // A reserved entry may become old and be evicted before it is enabled.
+                if (reservedEntry.enable(buffer, true))
+                {
+                    if (direct)
+                        _currentDirectMemory.addAndGet(buffer.capacity());
+                    else
+                        _currentHeapMemory.addAndGet(buffer.capacity());
+                    releaseExcessMemory(direct);
+                    return buffer;
+                }
             }
-            else
-            {
-                buffer = newRetainableByteBuffer(size, direct, this::removed);
-            }
+            return newRetainableByteBuffer(size, direct, this::removed);
         }
-        else
-        {
-            buffer = entry.getPooled();
-            ((Buffer)buffer).acquire();
-        }
+
+        buffer = entry.getPooled();
+        ((Buffer)buffer).acquire();
         return buffer;
     }
 
@@ -409,8 +409,10 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 if (oldestEntry == null)
                     continue;
 
-                // A concurrent thread evicted the same entry.
                 // Get the pooled buffer now in case we can evict below.
+                // The buffer may be null if the entry has been reserved but
+                // not yet enabled, or the entry has been removed by a concurrent
+                // thread, that may also have nulled-out the pooled buffer.
                 RetainableByteBuffer buffer = oldestEntry.getPooled();
                 if (buffer == null)
                     continue;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -282,7 +282,7 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         // No need to lock, no race with reserve()
         // and the race with terminate() is harmless.
         Holder<P> holder = ((ConcurrentEntry<P>)entry).getHolder();
-        boolean evicted = holder != null && entries.remove(holder);
+        boolean evicted = entries.remove(holder);
         if (LOG.isDebugEnabled())
             LOG.debug("evicted {} {} for {}", evicted, entry, this);
 
@@ -418,16 +418,16 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         //    1+ -> multiplex count
         private final AtomicBiInteger state = new AtomicBiInteger(0, -1);
         private final ConcurrentPool<E> pool;
+        private final Holder<E> holder;
         // The pooled object. This is not volatile as it is set once and then never changed.
         // Other threads accessing must check the state field above first, so a good before/after
         // relationship exists to make a memory barrier.
         private E pooled;
-        private final Holder<E> holder;
 
         public ConcurrentEntry(ConcurrentPool<E> pool)
         {
             this.pool = pool;
-            holder = new Holder<>(this);
+            this.holder = new Holder<>(this);
         }
 
         private Holder<E> getHolder()


### PR DESCRIPTION
Reorganized ArrayByteBufferPool.evict() code to avoid NPE. 
Small change to ConcurrentPool: no need to null check the final ConcurrentEntry.holder field.