### PR TITLE
Dependency Rollup - Jan 2024 - [`jetty-10.0.x`]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     # Associate with milestone 10.0.x
     milestone: 6
     ignore:
+      # Do not upgrade major versions of dependencies
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
       # Restrict updates in this branch to jetty in the 10.x.x space
       - dependency-name: "jakarta.servlet:*"
         versions: [ ">=5.0.0" ]
@@ -60,6 +63,9 @@ updates:
     # Associate with milestone 11.0.x
     milestone: 7
     ignore:
+      # Do not upgrade major versions of dependencies
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
       # Restrict updates in this branch to jetty in the 11.x.x space
       - dependency-name: "jakarta.activation:*"
         versions: [ ">=2.1.0" ]

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -17,7 +17,7 @@
     <maven.deploy.plugin.version>3.0.0-M2</maven.deploy.plugin.version>
     <maven.javadoc.plugin.version>3.4.0</maven.javadoc.plugin.version>
     <maven.remote-resources.plugin.version>3.1.0</maven.remote-resources.plugin.version>
-    <maven.surefire.plugin.version>3.2.2</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.2.3</maven.surefire.plugin.version>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>

--- a/jetty-gcloud/pom.xml
+++ b/jetty-gcloud/pom.xml
@@ -13,7 +13,7 @@
   <name>Jetty :: GCloud</name>
 
   <properties>
-    <gcloud.version>2.11.4</gcloud.version>
+    <gcloud.version>2.17.6</gcloud.version>
   </properties>
 
   <modules>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <osgi-version>3.18.500</osgi-version>
-    <osgi-services-version>3.11.100</osgi-services-version>
+    <osgi-services-version>3.11.200</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <osgi-version>3.18.500</osgi-version>
+    <osgi-version>3.18.600</osgi-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -17,7 +17,7 @@
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
     <osgi-service-component-version>1.5.0</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
-    <osgi-util-version>3.7.200</osgi-util-version>
+    <osgi-util-version>3.7.300</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>
     <osgi-util-promise-version>1.3.0</osgi-util-promise-version>
     <osgi-util-measurement-version>1.0.2</osgi-util-measurement-version>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -15,7 +15,7 @@
     <osgi-version>3.18.500</osgi-version>
     <osgi-services-version>3.11.100</osgi-services-version>
     <osgi-service-cm-version>1.6.1</osgi-service-cm-version>
-    <osgi-service-component-version>1.5.0</osgi-service-component-version>
+    <osgi-service-component-version>1.5.1</osgi-service-component-version>
     <osgi-service-event-version>1.4.1</osgi-service-event-version>
     <osgi-util-version>3.7.200</osgi-util-version>
     <osgi-util-function-version>1.2.0</osgi-util-function-version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <maven.invoker.plugin.version>3.6.0</maven.invoker.plugin.version>
     <groovy.version>4.0.6</groovy.version>
     <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.6.2</maven.javadoc.plugin.version>
+    <maven.javadoc.plugin.version>3.6.3</maven.javadoc.plugin.version>
     <maven.plugin-tools.version>3.10.2</maven.plugin-tools.version>
     <maven-plugin.plugin.version>3.10.2</maven-plugin.plugin.version>
     <maven.release.plugin.version>3.0.1</maven.release.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>
-    <org.osgi.util.promise.version>1.2.0</org.osgi.util.promise.version>
+    <org.osgi.util.promise.version>1.3.0</org.osgi.util.promise.version>
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>4.0.0</plexus-utils.version>
     <plexus-xml.version>4.0.2</plexus-xml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <spotbugs.maven.plugin.version>4.7.2.0</spotbugs.maven.plugin.version>
-    <versions.maven.plugin.version>2.12.0</versions.maven.plugin.version>
+    <versions.maven.plugin.version>2.16.2</versions.maven.plugin.version>
 
     <!-- testing -->
     <invoker.mergeUserSettings>false</invoker.mergeUserSettings>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <h2spec.maven.plugin.version>1.0.10</h2spec.maven.plugin.version>
     <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
-    <license.maven.plugin.version>4.1</license.maven.plugin.version>
+    <license.maven.plugin.version>4.3</license.maven.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>
     <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty.test.version>6.0</jetty.test.version>
     <jmh.version>1.37</jmh.version>
-    <jna.version>5.12.1</jna.version>
+    <jna.version>5.14.0</jna.version>
     <jnr-constants.version>0.10.4</jnr-constants.version>
     <jnr-enxio.version>0.32.13</jnr-enxio.version>
     <jnr-ffi.version>2.2.12</jnr-ffi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>
     <log4j2.version>2.22.0</log4j2.version>
     <logback.version>1.3.13</logback.version>
-    <mariadb.version>3.0.8</mariadb.version>
+    <mariadb.version>3.3.2</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.resolver.version>1.9.18</maven.resolver.version>
     <maven.version>3.9.0</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
     <maven.clean.plugin.version>3.3.2</maven.clean.plugin.version>
     <maven.checkstyle.plugin.version>3.3.1</maven.checkstyle.plugin.version>
-    <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
+    <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.6.1</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
     <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <jsp.impl.version>9.0.83.1</jsp.impl.version>
     <junit.version>5.9.1</junit.version>
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>
-    <log4j2.version>2.22.0</log4j2.version>
+    <log4j2.version>2.22.1</log4j2.version>
     <logback.version>1.3.13</logback.version>
     <mariadb.version>3.0.8</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <apache.avro.version>1.11.3</apache.avro.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
-    <asciidoctorj-diagram.version>2.2.13</asciidoctorj-diagram.version>
+    <asciidoctorj-diagram.version>2.2.14</asciidoctorj-diagram.version>
     <asciidoctorj.version>2.5.6</asciidoctorj.version>
     <mina.core.version>2.2.3</mina.core.version>
     <asm.version>9.6</asm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <jnr-ffi.version>2.2.12</jnr-ffi.version>
     <jnr-posix.version>3.1.15</jnr-posix.version>
     <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
-    <jolokia.version>1.7.1</jolokia.version>
+    <jolokia.version>1.7.2</jolokia.version>
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.5.0</json-smart.version>
     <jsp.impl.version>9.0.83.1</jsp.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <jmh.version>1.37</jmh.version>
     <jna.version>5.12.1</jna.version>
     <jnr-constants.version>0.10.4</jnr-constants.version>
-    <jnr-enxio.version>0.32.13</jnr-enxio.version>
+    <jnr-enxio.version>0.32.16</jnr-enxio.version>
     <jnr-ffi.version>2.2.12</jnr-ffi.version>
     <jnr-posix.version>3.1.15</jnr-posix.version>
     <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <jnr-enxio.version>0.32.13</jnr-enxio.version>
     <jnr-ffi.version>2.2.12</jnr-ffi.version>
     <jnr-posix.version>3.1.15</jnr-posix.version>
-    <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
+    <jnr-unixsocket.version>0.38.21</jnr-unixsocket.version>
     <jolokia.version>1.7.1</jolokia.version>
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.5.0</json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jakarta.websocket.api.version>1.1.2</jakarta.websocket.api.version>
     <jakarta.xml.bind.api.version>2.3.3</jakarta.xml.bind.api.version>
     <jakarta.xml.bind.impl.version>2.3.6</jakarta.xml.bind.impl.version>
-    <jakarta.xml.jaxws.impl.version>2.3.5</jakarta.xml.jaxws.impl.version>
+    <jakarta.xml.jaxws.impl.version>2.3.7</jakarta.xml.jaxws.impl.version>
     <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version>
     <jamon.version>2.82</jamon.version>
     <javax.activation.impl.version>1.1.0.v201105071233</javax.activation.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <google.errorprone.version>2.15.0</google.errorprone.version>
     <grpc.version>1.49.2</grpc.version>
     <gson.version>2.9.1</gson.version>
-    <guava.version>32.1.2-jre</guava.version>
+    <guava.version>33.0.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jakarta.xml.bind.api.version>2.3.3</jakarta.xml.bind.api.version>
     <jakarta.xml.bind.impl.version>2.3.6</jakarta.xml.bind.impl.version>
     <jakarta.xml.jaxws.impl.version>2.3.5</jakarta.xml.jaxws.impl.version>
-    <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version>
+    <jakarta.xml.ws.api.version>4.0.1</jakarta.xml.ws.api.version>
     <jamon.version>2.82</jamon.version>
     <javax.activation.impl.version>1.1.0.v201105071233</javax.activation.impl.version>
     <javax.cdi.api.version>2.0</javax.cdi.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <bndlib.version>6.3.1</bndlib.version>
     <build-support.version>1.5</build-support.version>
-    <checkstyle.version>10.3.4</checkstyle.version>
+    <checkstyle.version>10.12.7</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons.compress.version>1.25.0</commons.compress.version>
     <commons.io.version>2.15.1</commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <maven.remote-resources-plugin.version>3.1.0</maven.remote-resources-plugin.version>
     <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
     <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
-    <maven.surefire.plugin.version>3.2.2</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.2.3</maven.surefire.plugin.version>
     <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <spotbugs.maven.plugin.version>4.7.2.0</spotbugs.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <google.errorprone.version>2.15.0</google.errorprone.version>
-    <grpc.version>1.49.2</grpc.version>
+    <grpc.version>1.60.1</grpc.version>
     <gson.version>2.9.1</gson.version>
     <guava.version>32.1.2-jre</guava.version>
     <guice.version>5.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
     <jakarta.websocket.api.version>1.1.2</jakarta.websocket.api.version>
     <jakarta.xml.bind.api.version>2.3.3</jakarta.xml.bind.api.version>
-    <jakarta.xml.bind.impl.version>2.3.6</jakarta.xml.bind.impl.version>
+    <jakarta.xml.bind.impl.version>2.3.9</jakarta.xml.bind.impl.version>
     <jakarta.xml.jaxws.impl.version>2.3.5</jakarta.xml.jaxws.impl.version>
     <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version>
     <jamon.version>2.82</jamon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <junit.version>5.9.1</junit.version>
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>
     <log4j2.version>2.22.0</log4j2.version>
-    <logback.version>1.3.13</logback.version>
+    <logback.version>1.3.14</logback.version>
     <mariadb.version>3.0.8</mariadb.version>
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.resolver.version>1.9.18</maven.resolver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <hazelcast.version>5.2.1</hazelcast.version>
     <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.18.Final</infinispan.version>
-    <jackson.version>2.14.2</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
     <jakarta.annotation.api.version>1.3.5</jakarta.annotation.api.version>
     <jakarta.el-api.version>3.0.3</jakarta.el-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jakarta.xml.bind.api.version>2.3.3</jakarta.xml.bind.api.version>
     <jakarta.xml.bind.impl.version>2.3.9</jakarta.xml.bind.impl.version>
     <jakarta.xml.jaxws.impl.version>2.3.7</jakarta.xml.jaxws.impl.version>
-    <jakarta.xml.ws.api.version>4.0.1</jakarta.xml.ws.api.version>
+    <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version>
     <jamon.version>2.82</jamon.version>
     <javax.activation.impl.version>1.1.0.v201105071233</javax.activation.impl.version>
     <javax.cdi.api.version>2.0</javax.cdi.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <maven.resolver.version>1.9.18</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
-    <mongodb.version>3.12.11</mongodb.version>
+    <mongodb.version>3.12.14</mongodb.version>
     <openpojo.version>0.9.1</openpojo.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <asciidoctorj-diagram.version>2.2.13</asciidoctorj-diagram.version>
-    <asciidoctorj.version>2.5.6</asciidoctorj.version>
+    <asciidoctorj.version>2.5.11</asciidoctorj.version>
     <mina.core.version>2.2.3</mina.core.version>
     <asm.version>9.6</asm.version>
     <awaitility.version>4.2.0</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <jnr-constants.version>0.10.4</jnr-constants.version>
     <jnr-enxio.version>0.32.13</jnr-enxio.version>
     <jnr-ffi.version>2.2.12</jnr-ffi.version>
-    <jnr-posix.version>3.1.15</jnr-posix.version>
+    <jnr-posix.version>3.1.18</jnr-posix.version>
     <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
     <jolokia.version>1.7.1</jolokia.version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <google.errorprone.version>2.15.0</google.errorprone.version>
     <grpc.version>1.49.2</grpc.version>
-    <gson.version>2.9.1</gson.version>
+    <gson.version>2.10.1</gson.version>
     <guava.version>32.1.2-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <org.osgi.util.promise.version>1.2.0</org.osgi.util.promise.version>
     <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
     <plexus-utils.version>4.0.0</plexus-utils.version>
-    <plexus-xml.version>4.0.2</plexus-xml.version>
+    <plexus-xml.version>4.0.3</plexus-xml.version>
     <slf4j.version>2.0.5</slf4j.version>
     <springboot.version>2.1.1.RELEASE</springboot.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <guava.version>32.1.2-jre</guava.version>
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <hawtio.version>2.15.2</hawtio.version>
+    <hawtio.version>3.0.0</hawtio.version>
     <hazelcast.version>5.2.1</hazelcast.version>
     <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.18.Final</infinispan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
     <!-- some maven plugins versions -->
     <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
-    <build-helper.maven.plugin.version>3.3.0</build-helper.maven.plugin.version>
+    <build-helper.maven.plugin.version>3.5.0</build-helper.maven.plugin.version>
     <buildnumber.maven.plugin.version>3.2.0</buildnumber.maven.plugin.version>
     <depends.maven.plugin.version>1.5.0</depends.maven.plugin.version>
     <flatten.maven.plugin.version>1.3.0</flatten.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>
     <org.osgi.util.promise.version>1.2.0</org.osgi.util.promise.version>
-    <plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
+    <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>
     <plexus-utils.version>4.0.0</plexus-utils.version>
     <plexus-xml.version>4.0.2</plexus-xml.version>
     <slf4j.version>2.0.5</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <mina.core.version>2.2.3</mina.core.version>
     <asm.version>9.6</asm.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <bndlib.version>6.3.1</bndlib.version>
+    <bndlib.version>7.0.0</bndlib.version>
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>10.3.4</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <disruptor.version>3.4.2</disruptor.version>
     <felix.version>7.0.5</felix.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-    <google.errorprone.version>2.15.0</google.errorprone.version>
+    <google.errorprone.version>2.24.0</google.errorprone.version>
     <grpc.version>1.49.2</grpc.version>
     <gson.version>2.9.1</gson.version>
     <guava.version>32.1.2-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>
-    <hazelcast.version>5.2.1</hazelcast.version>
+    <hazelcast.version>5.3.6</hazelcast.version>
     <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.18.Final</infinispan.version>
     <jackson.version>2.14.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <depends.maven.plugin.version>1.5.0</depends.maven.plugin.version>
     <flatten.maven.plugin.version>1.3.0</flatten.maven.plugin.version>
     <h2spec.maven.plugin.version>1.0.10</h2spec.maven.plugin.version>
-    <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
+    <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <license.maven.plugin.version>4.1</license.maven.plugin.version>
     <maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <grpc.version>1.60.1</grpc.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>33.0.0-jre</guava.version>
-    <guice.version>7.0.0</guice.version>
+    <guice.version>5.1.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>3.0.0</hawtio.version>
     <hazelcast.version>5.3.6</hazelcast.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <build-helper.maven.plugin.version>3.3.0</build-helper.maven.plugin.version>
     <buildnumber.maven.plugin.version>3.2.0</buildnumber.maven.plugin.version>
     <depends.maven.plugin.version>1.5.0</depends.maven.plugin.version>
-    <flatten.maven.plugin.version>1.3.0</flatten.maven.plugin.version>
+    <flatten.maven.plugin.version>1.5.0</flatten.maven.plugin.version>
     <h2spec.maven.plugin.version>1.0.10</h2spec.maven.plugin.version>
     <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <maven.surefire.plugin.version>3.2.2</maven.surefire.plugin.version>
     <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
-    <spotbugs.maven.plugin.version>4.7.2.0</spotbugs.maven.plugin.version>
+    <spotbugs.maven.plugin.version>4.8.2.0</spotbugs.maven.plugin.version>
     <versions.maven.plugin.version>2.12.0</versions.maven.plugin.version>
 
     <!-- testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <jna.version>5.12.1</jna.version>
     <jnr-constants.version>0.10.4</jnr-constants.version>
     <jnr-enxio.version>0.32.13</jnr-enxio.version>
-    <jnr-ffi.version>2.2.12</jnr-ffi.version>
+    <jnr-ffi.version>2.2.15</jnr-ffi.version>
     <jnr-posix.version>3.1.15</jnr-posix.version>
     <jnr-unixsocket.version>0.38.17</jnr-unixsocket.version>
     <jolokia.version>1.7.1</jolokia.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <mina.core.version>2.2.3</mina.core.version>
     <asm.version>9.6</asm.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <bndlib.version>7.0.0</bndlib.version>
+    <bndlib.version>6.3.1</bndlib.version>
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>10.12.7</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jboss.logging.annotations.version>2.2.1.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.5.3.Final</jboss.logging.version>
-    <jboss-logmanager.version>3.0.2.Final</jboss-logmanager.version>
+    <jboss-logmanager.version>3.0.4.Final</jboss-logmanager.version>
     <jboss-threads.version>3.5.1.Final</jboss-threads.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <grpc.version>1.49.2</grpc.version>
     <gson.version>2.9.1</gson.version>
     <guava.version>32.1.2-jre</guava.version>
-    <guice.version>5.1.0</guice.version>
+    <guice.version>7.0.0</guice.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hawtio.version>2.15.2</hawtio.version>
     <hazelcast.version>5.2.1</hazelcast.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <json-simple.version>1.1.1</json-simple.version>
     <json-smart.version>2.5.0</json-smart.version>
     <jsp.impl.version>9.0.83.1</jsp.impl.version>
-    <junit.version>5.9.1</junit.version>
+    <junit.version>5.10.1</junit.version>
     <kerb-simplekdc.version>2.0.3</kerb-simplekdc.version>
     <log4j2.version>2.22.0</log4j2.version>
     <logback.version>1.3.13</logback.version>


### PR DESCRIPTION
Rollup of dependency updates for Jan 2024 in branch `jetty-10.0.x`