### PR TITLE
Fix Build on Windows

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -24,8 +24,8 @@
     <global>
       <glob>{*.java,*.xml,*.properties,*.mod,*.adoc}</glob>
       <excludes>
-        <exclude>*Jenkinsfile*</exclude>
-        <exclude>./idea/*</exclude>
+        <exclude glob="*Jenkinsfile*" />
+        <exclude glob="./idea/*" />
       </excludes>
     </global>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1985,7 +1985,7 @@
         </os>
       </activation>
       <properties>
-        <jetty.unixdomain.dir>${user.home}</jetty.unixdomain.dir>
+        <jetty.unixdomain.dir>${java.io.tmpdir}</jetty.unixdomain.dir>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
The `jetty-12.0.x` branch cannot build on Windows, as-is, due to a few fundamental configuration mistakes.

This PR introduces 2 fixes.

1. The build-cache exclusions are defined as proper globs, not relying on discovery mechanism that fails on windows.  (The `*Jenkinfile*` is attempted as a java Path, but the `*` symbol is not allowed in a Path object, so the build fails with an IllegalStateException).
2. The `jetty.unixdomain.dir` property is set to `java.io.tmpdir` to avoid having clean / install / build-cache / etc (a whole host of plugins) from seeing the entire user `%HOME%` directory as being involved in the build. (this would result in OutOfMemoryError due to the sheer number of files in a users home directory).

These 2 changes allow the build to proceed.
There are still test failures, but those are not unexpected at this point in time.
You can build with skipping tests only if these 2 changes are applied.