### PR TITLE
Fixes #11223 - WebSocketClient.connect with URI including query parameters don't work for HTTP2 connector

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
@@ -224,26 +224,35 @@ public class MetaData implements Iterable<HttpField>
     {
         private final String _protocol;
 
-        public ConnectRequest(HttpScheme scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        public ConnectRequest(HttpScheme scheme, HostPortHttpField authority, String pathQuery, HttpFields fields, String protocol)
         {
-            this(scheme == null ? null : scheme.asString(), authority, path, fields, protocol);
+            this(scheme == null ? null : scheme.asString(), authority, pathQuery, fields, protocol);
         }
 
-        public ConnectRequest(long beginNanoTime, HttpScheme scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        public ConnectRequest(long beginNanoTime, HttpScheme scheme, HostPortHttpField authority, String pathQuery, HttpFields fields, String protocol)
         {
-            this(beginNanoTime, scheme == null ? null : scheme.asString(), authority, path, fields, protocol);
+            this(beginNanoTime, scheme == null ? null : scheme.asString(), authority, pathQuery, fields, protocol);
         }
 
-        public ConnectRequest(String scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        public ConnectRequest(String scheme, HostPortHttpField authority, String pathQuery, HttpFields fields, String protocol)
         {
-            this(NanoTime.now(), scheme, authority, path, fields, protocol);
+            this(NanoTime.now(), scheme, authority, pathQuery, fields, protocol);
         }
 
-        public ConnectRequest(long beginNanoTime, String scheme, HostPortHttpField authority, String path, HttpFields fields, String protocol)
+        public ConnectRequest(long beginNanoTime, String scheme, HostPortHttpField authority, String pathQuery, HttpFields fields, String protocol)
         {
-            super(beginNanoTime, HttpMethod.CONNECT.asString(),
-                HttpURI.build().scheme(scheme).host(authority == null ? null : authority.getHost()).port(authority == null ? -1 : authority.getPort()).pathQuery(path),
-                HttpVersion.HTTP_2, fields, Long.MIN_VALUE, null);
+            super(beginNanoTime,
+                HttpMethod.CONNECT.asString(),
+                HttpURI.build()
+                    .scheme(scheme)
+                    .host(authority == null ? null : authority.getHost())
+                    .port(authority == null ? -1 : authority.getPort())
+                    .pathQuery(pathQuery),
+                HttpVersion.HTTP_2,
+                fields,
+                Long.MIN_VALUE,
+                null
+            );
             _protocol = protocol;
         }
 

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpSenderOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpSenderOverHTTP2.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.URIUtil;
 
 public class HttpSenderOverHTTP2 extends HttpSender
 {
@@ -63,7 +64,8 @@ public class HttpSenderOverHTTP2 extends HttpSender
             else
             {
                 HostPortHttpField authority = new HostPortHttpField(request.getHost(), request.getPort());
-                metaData = new MetaData.ConnectRequest(request.getScheme(), authority, request.getPath(), request.getHeaders(), upgradeProtocol);
+                String pathQuery = URIUtil.addPathQuery(request.getPath(), request.getQuery());
+                metaData = new MetaData.ConnectRequest(request.getScheme(), authority, pathQuery, request.getHeaders(), upgradeProtocol);
             }
         }
         else

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpSenderOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpSenderOverHTTP3.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.internal.HTTP3Stream;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.URIUtil;
 
 public class HttpSenderOverHTTP3 extends HttpSender
 {
@@ -63,7 +64,8 @@ public class HttpSenderOverHTTP3 extends HttpSender
             else
             {
                 HostPortHttpField authority = new HostPortHttpField(request.getHost(), request.getPort());
-                metaData = new MetaData.ConnectRequest(request.getScheme(), authority, request.getPath(), request.getHeaders(), upgradeProtocol);
+                String pathQuery = URIUtil.addPathQuery(request.getPath(), request.getQuery());
+                metaData = new MetaData.ConnectRequest(request.getScheme(), authority, pathQuery, request.getHeaders(), upgradeProtocol);
             }
         }
         else

--- a/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-websocket/websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
@@ -162,7 +162,7 @@ public class WebSocketOverHTTP2Test
         startClient(protocolFn);
 
         EventSocket wsEndPoint = new EventSocket();
-        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/ws/echo");
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/ws/echo/query?param=value");
         Session session = wsClient.connect(wsEndPoint, uri).get(5, TimeUnit.SECONDS);
 
         String text = "websocket";
@@ -382,6 +382,11 @@ public class WebSocketOverHTTP2Test
         protected void configure(JettyWebSocketServletFactory factory)
         {
             factory.addMapping("/ws/echo", (request, response) -> new EchoSocket());
+            factory.addMapping("/ws/echo/query", (request, response) ->
+            {
+                assertNotNull(request.getQueryString());
+                return new EchoSocket();
+            });
             factory.addMapping("/ws/null", (request, response) -> null);
             factory.addMapping("/ws/throw", (request, response) ->
             {


### PR DESCRIPTION
Fixed concatenation of path and query for HTTP/2 and HTTP/3 when creating `MetaData.ConnectRequest` to "tunnel" the WebSocket upgrade.