### PR TITLE
Issue #11260 - Allow `QuickStartConfiguration` to be used in mixed contexts environment where some do not have a WEB-INF/quickstart-web.xml

### DIFF
--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
@@ -109,24 +109,29 @@ public class QuickStartConfiguration extends AbstractConfiguration
             return;
         }
 
-        if (LOG.isDebugEnabled())
-            LOG.debug("quickStartWebXml={} exists={}", quickStartWebXml, quickStartWebXml.exists());
-
         // Get the mode
         Mode mode = getModeForContext(context);
 
         if (LOG.isDebugEnabled())
-            LOG.debug("QuickStart.Mode={} on {}", mode, context);
+            LOG.debug("mode={} quickStartWebXml={} exists={} for {}",
+                mode,
+                quickStartWebXml,
+                quickStartWebXml.exists(),
+                context);
 
         switch (mode)
         {
             case GENERATE:
             {
                 if (quickStartWebXml.exists())
-                    LOG.info("Regenerating {}", quickStartWebXml);
+                    LOG.info("Regenerating {} for {}", quickStartWebXml, context);
                 else
-                    LOG.info("Generating {}", quickStartWebXml);
-                generateQuickStart(context);
+                    LOG.info("Generating {} for {}", quickStartWebXml, context);
+
+                // generate the quickstart file then abort
+                QuickStartGeneratorConfiguration generator = new QuickStartGeneratorConfiguration(true);
+                configure(generator, context);
+                context.addConfiguration(generator);
                 break;
             }
             case AUTO:
@@ -158,14 +163,6 @@ public class QuickStartConfiguration extends AbstractConfiguration
             default:
                 throw new IllegalStateException("Unhandled QuickStart.Mode: " + mode);
         }
-    }
-
-    private void generateQuickStart(WebAppContext context) throws IOException
-    {
-        // generate the quickstart file then abort
-        QuickStartGeneratorConfiguration generator = new QuickStartGeneratorConfiguration(true);
-        configure(generator, context);
-        context.addConfiguration(generator);
     }
 
     protected void configure(QuickStartGeneratorConfiguration generator, WebAppContext context) throws IOException

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
@@ -115,6 +115,9 @@ public class QuickStartConfiguration extends AbstractConfiguration
         // Get the mode
         Mode mode = getModeForContext(context);
 
+        if (LOG.isDebugEnabled())
+            LOG.debug("QuickStart.Mode={} on {}", mode, context);
+
         switch (mode)
         {
             case GENERATE:
@@ -128,11 +131,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
             }
             case AUTO:
             {
-                if (!quickStartWebXml.exists())
-                {
-                    LOG.info("Generating {}", quickStartWebXml);
-                    generateQuickStart(context);
-                }
+                // TODO: why doesn't AUTO generate a WEB-INF/quickstart-web.xml if not present?
                 if (quickStartWebXml.exists())
                 {
                     quickStart(context);
@@ -145,16 +144,17 @@ public class QuickStartConfiguration extends AbstractConfiguration
                 break;
             }
             case QUICKSTART:
+            {
                 if (quickStartWebXml.exists())
                 {
                     quickStart(context);
                 }
                 else
                 {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("No quickstart xml file, starting webapp {} normally", context);
+                    throw new IllegalStateException("No WEB-INF/quickstart-web.xml file for " + context);
                 }
                 break;
+            }
             default:
                 throw new IllegalStateException("Unhandled QuickStart.Mode: " + mode);
         }

--- a/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
+++ b/jetty-quickstart/src/main/java/org/eclipse/jetty/quickstart/QuickStartConfiguration.java
@@ -139,6 +139,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("No quickstart-web.xml found, starting webapp {} normally", context);
+                    super.preConfigure(context);
                 }
                 break;
             }

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/PreconfigureSpecWar.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/PreconfigureSpecWar.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.quickstart;
 
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -52,10 +51,12 @@ public class PreconfigureSpecWar
 
         LOG.info("Preconfigured in {}ms", NanoTime.millisSince(__start));
 
+        /*
         Path quickStartXml = target.resolve("WEB-INF/quickstart-web.xml");
         try (InputStream in = Files.newInputStream(quickStartXml))
         {
             IO.copy(in, System.out);
         }
+         */
     }
 }

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
@@ -36,6 +36,8 @@ import org.eclipse.jetty.xml.XmlConfiguration;
 import org.eclipse.jetty.xml.XmlParser.Node;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,8 +49,9 @@ public class QuickStartTest
      * Test of an exploded webapp directory, no WEB-INF/quickstart-web.xml,
      * with QuickStartConfiguration enabled.
      */
-    @Test
-    public void testExplodedWebAppDirNoWebXml() throws Exception
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testExplodedWebAppDirNoWebXml(boolean defaultMode) throws Exception
     {
         Path jettyHome = MavenPaths.targetDir();
         Path webappDir = MavenPaths.targetTestDir("no-web-xml");
@@ -65,7 +68,9 @@ public class QuickStartTest
             new EnvConfiguration(),
             new PlusConfiguration(),
             new AnnotationConfiguration());
-        webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.QUICKSTART);
+        // Default mode should allow this style of exploded webapp dir.
+        if (!defaultMode)
+            webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.AUTO);
         webapp.setWarResource(new PathResource(webappDir));
         webapp.setContextPath("/");
         server.setHandler(webapp);

--- a/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
+++ b/tests/test-quickstart/src/test/java/org/eclipse/jetty/quickstart/QuickStartTest.java
@@ -24,6 +24,8 @@ import org.eclipse.jetty.plus.webapp.EnvConfiguration;
 import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.PathResource;
@@ -41,6 +43,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuickStartTest
 {
+    /**
+     * Test of an exploded webapp directory, no WEB-INF/quickstart-web.xml,
+     * with QuickStartConfiguration enabled.
+     */
+    @Test
+    public void testExplodedWebAppDirNoWebXml() throws Exception
+    {
+        Path jettyHome = MavenPaths.targetDir();
+        Path webappDir = MavenPaths.targetTestDir("no-web-xml");
+        Path src = MavenPaths.projectBase().resolve("src/test/webapps/no-web-xml");
+        FS.ensureEmpty(webappDir);
+        org.eclipse.jetty.toolchain.test.IO.copyDir(src, webappDir);
+
+        System.setProperty("jetty.home", jettyHome.toString());
+
+        Server server = new Server(0);
+
+        WebAppContext webapp = new WebAppContext();
+        webapp.addConfiguration(new QuickStartConfiguration(),
+            new EnvConfiguration(),
+            new PlusConfiguration(),
+            new AnnotationConfiguration());
+        webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.QUICKSTART);
+        webapp.setWarResource(new PathResource(webappDir));
+        webapp.setContextPath("/");
+        server.setHandler(webapp);
+        server.start();
+
+        URL url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/index.html");
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        assertEquals(200, connection.getResponseCode());
+        assertThat(IO.toString((InputStream)connection.getContent()), Matchers.containsString("<p>Contents of no-web-xml</p>"));
+
+        server.stop();
+    }
 
     @Test
     public void testStandardTestWar() throws Exception

--- a/tests/test-quickstart/src/test/webapps/no-web-xml/index.html
+++ b/tests/test-quickstart/src/test/webapps/no-web-xml/index.html
@@ -1,0 +1,1 @@
+<p>Contents of no-web-xml</p>


### PR DESCRIPTION
+ Converted IllegalStateException to just a warn level logging statement.
+ Improved tracking of _is quickstart enabled_ within WebAppContext itself, not the QuickStartConfiguration
+ Added unit test of an exploded webapp directory that has no WEB-INF or web.xml