### PR TITLE
Fixes #11259 - HTTP/2 connection not closed after idle timeout when TCP congested.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -1935,7 +1935,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                         goAwayFrame = goAwaySent;
                         closed = CloseState.CLOSING;
                         zeroStreamsAction = null;
-                        failure = cause = new TimeoutException("Session idle timeout expired");
+                        failure = cause = newTimeoutException();
                     }
                     case REMOTELY_CLOSED ->
                     {
@@ -1944,7 +1944,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                         goAwayFrame = goAwaySent;
                         closed = CloseState.CLOSING;
                         zeroStreamsAction = null;
-                        failure = cause = new TimeoutException("Session idle timeout expired");
+                        failure = cause = newTimeoutException();
                     }
                     default -> terminate = true;
                 }
@@ -1955,7 +1955,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 if (LOG.isDebugEnabled())
                     LOG.debug("Already closed, ignored idle timeout for {}", HTTP2Session.this);
                 // Writes may be TCP congested, so termination never happened.
-                flusher.abort(new TimeoutException());
+                flusher.abort(newTimeoutException());
                 return false;
             }
 
@@ -1975,6 +1975,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             notifyFailure(HTTP2Session.this, cause, Callback.NOOP);
             terminate(goAwayFrame);
             return false;
+        }
+
+        private TimeoutException newTimeoutException()
+        {
+            return new TimeoutException("Session idle timeout expired");
         }
 
         private void onSessionFailure(int error, String reason, Callback callback)

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
@@ -628,13 +628,9 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
         failStreams(stream -> true, error, reason, true, new IOException(reason));
 
         if (goAwayFrame != null)
-        {
             writeControlFrame(goAwayFrame, Callback.from(() -> terminateAndDisconnect(error, reason)));
-        }
         else
-        {
             terminateAndDisconnect(error, reason);
-        }
     }
 
     private void terminateAndDisconnect(long error, String reason)

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/IdleTimeoutTest.java
@@ -1,0 +1,148 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http3.tests;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http3.api.Session;
+import org.eclipse.jetty.http3.api.Stream;
+import org.eclipse.jetty.http3.client.HTTP3Client;
+import org.eclipse.jetty.http3.frames.HeadersFrame;
+import org.eclipse.jetty.http3.server.HTTP3ServerConnector;
+import org.eclipse.jetty.http3.server.RawHTTP3ServerConnectionFactory;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.quic.quiche.QuicheConnection;
+import org.eclipse.jetty.quic.server.ServerQuicConnection;
+import org.eclipse.jetty.quic.server.ServerQuicSession;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(WorkDirExtension.class)
+public class IdleTimeoutTest
+{
+    private Server server;
+    private HTTP3Client http3Client;
+
+    @BeforeEach
+    public void prepare()
+    {
+        QueuedThreadPool serverExecutor = new QueuedThreadPool();
+        serverExecutor.setName("server");
+        server = new Server();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(http3Client);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testIdleTimeoutWhenCongested(WorkDir workDir) throws Exception
+    {
+        long idleTimeout = 1000;
+        AtomicBoolean established = new AtomicBoolean();
+        CountDownLatch disconnectLatch = new CountDownLatch(1);
+        RawHTTP3ServerConnectionFactory h3 = new RawHTTP3ServerConnectionFactory(new HttpConfiguration(), new Session.Server.Listener()
+        {
+            @Override
+            public void onAccept(Session session)
+            {
+                established.set(true);
+            }
+
+            @Override
+            public void onDisconnect(Session session, long error, String reason)
+            {
+                disconnectLatch.countDown();
+            }
+        });
+
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath("src/test/resources/keystore.p12");
+        sslContextFactory.setKeyStorePassword("storepwd");
+        HTTP3ServerConnector connector = new HTTP3ServerConnector(server, sslContextFactory, h3)
+        {
+            @Override
+            protected ServerQuicConnection newConnection(EndPoint endpoint)
+            {
+                return new ServerQuicConnection(this, endpoint)
+                {
+                    @Override
+                    protected ServerQuicSession newQuicSession(SocketAddress remoteAddress, QuicheConnection quicheConnection)
+                    {
+                        return new ServerQuicSession(getExecutor(), getScheduler(), getByteBufferPool(), quicheConnection, this, remoteAddress, getQuicServerConnector())
+                        {
+                            @Override
+                            public int flush(long streamId, ByteBuffer buffer, boolean last) throws IOException
+                            {
+                                if (established.get())
+                                    return 0;
+                                return super.flush(streamId, buffer, last);
+                            }
+
+                            @Override
+                            public void outwardClose(long error, String reason)
+                            {
+                                closeLatch.countDown();
+                                super.outwardClose(error, reason);
+                            }
+                        };
+                    }
+                };
+            }
+        };
+        connector.getQuicConfiguration().setPemWorkDirectory(workDir.getEmptyPathDir());
+        connector.setIdleTimeout(idleTimeout);
+        server.addConnector(connector);
+        server.start();
+
+        http3Client = new HTTP3Client();
+        http3Client.getClientConnector().setSslContextFactory(new SslContextFactory.Client(true));
+        http3Client.start();
+
+        Session.Client session = http3Client.connect(new InetSocketAddress("localhost", connector.getLocalPort()), new Session.Client.Listener() {})
+            .get(5, TimeUnit.SECONDS);
+
+        MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost:" + connector.getLocalPort() + "/path"), HttpVersion.HTTP_3, HttpFields.EMPTY);
+        // The request will complete exceptionally.
+        session.newRequest(new HeadersFrame(request, true), new Stream.Client.Listener() {});
+
+        assertTrue(closeLatch.await(5 * idleTimeout, TimeUnit.MILLISECONDS));
+        assertTrue(disconnectLatch.await(5 * idleTimeout, TimeUnit.MILLISECONDS));
+    }
+}

--- a/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
+++ b/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/QuicSession.java
@@ -398,11 +398,15 @@ public abstract class QuicSession extends ContainerLifeCycle
 
     public void outwardClose(long error, String reason)
     {
+        boolean closed = quicheConnection.close(error, reason);
         if (LOG.isDebugEnabled())
-            LOG.debug("outward closing 0x{}/{} on {}", Long.toHexString(error), reason, this);
-        quicheConnection.close(error, reason);
-        // Flushing will eventually forward the outward close to the connection.
-        flush();
+            LOG.debug("outward closing ({}) 0x{}/{} on {}", closed, Long.toHexString(error), reason, this);
+        if (closed)
+        {
+            // Flushing will eventually forward
+            // the outward close to the connection.
+            flush();
+        }
     }
 
     private void finishOutwardClose(Throwable failure)

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/QuicServerConnector.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/QuicServerConnector.java
@@ -305,6 +305,16 @@ public class QuicServerConnector extends AbstractNetworkConnector
         throw new UnsupportedOperationException(getClass().getSimpleName() + " has no accept mechanism");
     }
 
+    protected EndPoint newEndPoint(DatagramChannel channel, ManagedSelector selector, SelectionKey selectionKey)
+    {
+        return new DatagramChannelEndPoint(channel, selector, selectionKey, getScheduler());
+    }
+
+    protected ServerQuicConnection newConnection(EndPoint endpoint)
+    {
+        return new ServerQuicConnection(QuicServerConnector.this, endpoint);
+    }
+
     private class ServerDatagramSelectorManager extends SelectorManager
     {
         protected ServerDatagramSelectorManager(Executor executor, Scheduler scheduler, int selectors)
@@ -315,7 +325,7 @@ public class QuicServerConnector extends AbstractNetworkConnector
         @Override
         protected EndPoint newEndPoint(SelectableChannel channel, ManagedSelector selector, SelectionKey selectionKey)
         {
-            EndPoint endPoint = new DatagramChannelEndPoint((DatagramChannel)channel, selector, selectionKey, getScheduler());
+            EndPoint endPoint = QuicServerConnector.this.newEndPoint((DatagramChannel)channel, selector, selectionKey);
             endPoint.setIdleTimeout(getIdleTimeout());
             return endPoint;
         }
@@ -323,7 +333,7 @@ public class QuicServerConnector extends AbstractNetworkConnector
         @Override
         public Connection newConnection(SelectableChannel channel, EndPoint endpoint, Object attachment)
         {
-            ServerQuicConnection connection = new ServerQuicConnection(QuicServerConnector.this, endpoint);
+            ServerQuicConnection connection = QuicServerConnector.this.newConnection(endpoint);
             connection.addEventListener(container);
             connection.setInputBufferSize(getInputBufferSize());
             connection.setOutputBufferSize(getOutputBufferSize());

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicConnection.java
@@ -45,11 +45,16 @@ public class ServerQuicConnection extends QuicConnection
     private final QuicServerConnector connector;
     private final SessionTimeouts sessionTimeouts;
 
-    protected ServerQuicConnection(QuicServerConnector connector, EndPoint endPoint)
+    public ServerQuicConnection(QuicServerConnector connector, EndPoint endPoint)
     {
         super(connector.getExecutor(), connector.getScheduler(), connector.getByteBufferPool(), endPoint);
         this.connector = connector;
         this.sessionTimeouts = new SessionTimeouts(connector.getScheduler());
+    }
+
+    public QuicServerConnector getQuicServerConnector()
+    {
+        return connector;
     }
 
     @Override
@@ -87,11 +92,16 @@ public class ServerQuicConnection extends QuicConnection
         }
         else
         {
-            QuicSession session = new ServerQuicSession(getExecutor(), getScheduler(), bufferPool, quicheConnection, this, remoteAddress, connector);
+            ServerQuicSession session = newQuicSession(remoteAddress, quicheConnection);
             // Send the response packet(s) that tryAccept() generated.
             session.flush();
             return session;
         }
+    }
+
+    protected ServerQuicSession newQuicSession(SocketAddress remoteAddress, QuicheConnection quicheConnection)
+    {
+        return new ServerQuicSession(getExecutor(), getScheduler(), getByteBufferPool(), quicheConnection, this, remoteAddress, getQuicServerConnector());
     }
 
     public void schedule(ServerQuicSession session)

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
@@ -46,7 +46,7 @@ public class ServerQuicSession extends QuicSession implements CyclicTimeouts.Exp
     private final Connector connector;
     private long expireNanoTime = Long.MAX_VALUE;
 
-    protected ServerQuicSession(Executor executor, Scheduler scheduler, ByteBufferPool bufferPool, QuicheConnection quicheConnection, QuicConnection connection, SocketAddress remoteAddress, Connector connector)
+    public ServerQuicSession(Executor executor, Scheduler scheduler, ByteBufferPool bufferPool, QuicheConnection quicheConnection, QuicConnection connection, SocketAddress remoteAddress, Connector connector)
     {
         super(executor, scheduler, bufferPool, quicheConnection, connection, remoteAddress);
         this.connector = connector;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/IdleTimeoutTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/IdleTimeoutTest.java
@@ -1,0 +1,103 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.ManagedSelector;
+import org.eclipse.jetty.io.SocketChannelEndPoint;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+public class IdleTimeoutTest
+{
+    private Server server;
+    private ServerConnector connector;
+
+    @BeforeEach
+    public void prepare()
+    {
+        QueuedThreadPool serverExecutor = new QueuedThreadPool();
+        serverExecutor.setName("server");
+        server = new Server();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testIdleTimeoutWhenCongested() throws Exception
+    {
+        long idleTimeout = 1000;
+        HttpConnectionFactory h1 = new HttpConnectionFactory(new HttpConfiguration());
+        connector = new ServerConnector(server, 1, 1, h1)
+        {
+            @Override
+            protected SocketChannelEndPoint newEndPoint(SocketChannel channel, ManagedSelector selectSet, SelectionKey key)
+            {
+                SocketChannelEndPoint endpoint = new SocketChannelEndPoint(channel, selectSet, key, getScheduler())
+                {
+                    @Override
+                    public boolean flush(ByteBuffer... buffers)
+                    {
+                        // Fake TCP congestion.
+                        return false;
+                    }
+
+                    @Override
+                    protected void onIncompleteFlush()
+                    {
+                        // Do nothing here to avoid spin loop,
+                        // since the network is actually writable,
+                        // as we are only faking TCP congestion.
+                    }
+                };
+                endpoint.setIdleTimeout(getIdleTimeout());
+                return endpoint;
+            }
+        };
+        connector.setIdleTimeout(idleTimeout);
+        server.addConnector(connector);
+        server.start();
+
+        try (SocketChannel client = SocketChannel.open())
+        {
+            client.connect(new InetSocketAddress("localhost", connector.getLocalPort()));
+
+            HttpTester.Request request = HttpTester.newRequest();
+            client.write(request.generate());
+
+            // The server never writes back anything, but should close the connection.
+            client.configureBlocking(false);
+            ByteBuffer inputBuffer = ByteBuffer.allocate(1024);
+            await().atMost(Duration.ofSeconds(5)).until(() -> client.read(inputBuffer), is(-1));
+            await().atMost(5, TimeUnit.SECONDS).until(() -> connector.getConnectedEndPoints().size(), is(0));
+        }
+    }
+}


### PR DESCRIPTION
Now upon the second idle timeout, the connection is forcibly closed. 
Fixed also similar problem in HTTP/3.