### PR TITLE
Issue #11292 - Missing Date Response Header.

### DIFF
--- a/jetty-core/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty.xml
@@ -57,7 +57,7 @@
       <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
       <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
       <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false"/></Set>
       <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
       <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
       <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
@@ -66,7 +66,7 @@
       <Set name="uriCompliance"><Call class="org.eclipse.jetty.http.UriCompliance" name="from"><Arg><Property name="jetty.httpConfig.uriCompliance" default="DEFAULT"/></Arg></Call></Set>
       <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="from"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
       <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="from"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="relativeRedirectAllowed" property="jetty.httpConfig.relativeRedirectAllowed"/>
+      <Set name="relativeRedirectAllowed"><Property name="jetty.httpConfig.relativeRedirectAllowed" default="false"/></Set>
       <Set name="useInputDirectByteBuffers" property="jetty.httpConfig.useInputDirectByteBuffers"/>
       <Set name="useOutputDirectByteBuffers" property="jetty.httpConfig.useOutputDirectByteBuffers"/>
     </New>

--- a/jetty-core/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty.xml
@@ -57,7 +57,7 @@
       <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
       <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
       <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false"/></Set>
+      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
       <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
       <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
       <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
@@ -66,7 +66,7 @@
       <Set name="uriCompliance"><Call class="org.eclipse.jetty.http.UriCompliance" name="from"><Arg><Property name="jetty.httpConfig.uriCompliance" default="DEFAULT"/></Arg></Call></Set>
       <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="from"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
       <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="from"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="relativeRedirectAllowed"><Property name="jetty.httpConfig.relativeRedirectAllowed" default="false"/></Set>
+      <Set name="relativeRedirectAllowed" property="jetty.httpConfig.relativeRedirectAllowed"/>
       <Set name="useInputDirectByteBuffers" property="jetty.httpConfig.useInputDirectByteBuffers"/>
       <Set name="useOutputDirectByteBuffers" property="jetty.httpConfig.useOutputDirectByteBuffers"/>
     </New>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1749,7 +1749,10 @@ public class DistributionTests extends AbstractJettyHomeTest
             assertEquals(0, run1.getExitValue());
 
             int httpPort = distribution.freePort();
-            List<String> args = List.of("jetty.http.port=" + httpPort);
+            List<String> args = List.of(
+                "jetty.http.port=" + httpPort,
+                "jetty.httpConfig.sendDateHeader=true"
+            );
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
                 assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));


### PR DESCRIPTION
* Revert changes to boolean values in HttpConfiguration from commit 103e1d95fda3539eb5356d74daa52459bd516c3f
* Add Unit Tests for Date Response header in ee10 and DistributionTests

Fixes: #11292