### PR TITLE
Fixes #11282 - Deadlocks with DEBUG logging enabled in jetty-server testing.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteArrayEndPoint.java
@@ -492,13 +492,14 @@ public class ByteArrayEndPoint extends AbstractEndPoint
     public String toString()
     {
         int q;
-        ByteBuffer b;
+        Object b;
         String o;
-        try (AutoLock lock = _lock.lock())
+        try (AutoLock lock = _lock.tryLock())
         {
-            q = _inQ.size();
-            b = _inQ.peek();
-            o = BufferUtil.toDetailString(_out);
+            boolean held = lock.isHeldByCurrentThread();
+            q = held ? _inQ.size() : -1;
+            b = held ? _inQ.peek() : "?";
+            o = held ? BufferUtil.toDetailString(_out) : "?";
         }
         return String.format("%s[q=%d,q[0]=%s,o=%s]", super.toString(), q, b, o);
     }


### PR DESCRIPTION
Introduced AutoLock.tryLock() to use it in the toString() implementations that lock in order to retrieve a consistent state to produce the string.