### PR TITLE
ensure callback is always completed in WebSocketCoreSession

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
@@ -351,11 +351,21 @@ public class WebSocketCoreSession implements CoreSession, Dumpable
 
         CloseStatus closeStatus = new CloseStatus(code, cause);
         if (CloseStatus.isTransmittableStatusCode(code))
+        {
             close(closeStatus, callback);
+        }
         else
         {
             if (sessionState.onClosed(closeStatus))
+            {
                 closeConnection(closeStatus, callback);
+            }
+            else
+            {
+                // We are already closed because of a previous failure.
+                // Succeed because failing might re-enter this branch if it's the Frame callback.
+                callback.succeeded();
+            }
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
@@ -317,11 +317,21 @@ public class WebSocketCoreSession implements CoreSession, Dumpable
 
         CloseStatus closeStatus = new CloseStatus(code, cause);
         if (CloseStatus.isTransmittableStatusCode(code))
+        {
             close(closeStatus, callback);
+        }
         else
         {
             if (sessionState.onClosed(closeStatus))
+            {
                 closeConnection(closeStatus, callback);
+            }
+            else
+            {
+                // We are already closed because of a previous failure.
+                // Succeed because failing might re-enter this branch if it's the Frame callback.
+                callback.succeeded();
+            }
         }
     }
 


### PR DESCRIPTION
If the session is already closed the callback for `WebSocketCoreSession.processHandlerError` and `WebSocketCoreSession.processConnectionError`.

Almost always when this method is called is with a `NOOP` callback.

There is one spot which uses the frame callback, which is why we don't want to fail the callback here because the frame callback on failure will call back `processHandlerError`.
