### PR TITLE
Issue #11312 - fix deprecated init-param detection in DefaultServlet

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -330,13 +330,13 @@ public class DefaultServlet extends HttpServlet
 
     private String getInitParameter(String name, String... deprecated)
     {
-        String value = super.getInitParameter(name);
+        String value = getInitParameter(name);
         if (value != null)
             return value;
 
         for (String d : deprecated)
         {
-            value = super.getInitParameter(d);
+            value = getInitParameter(d);
             if (value != null)
             {
                 LOG.warn("Deprecated {} used instead of {}", d, name);

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -317,13 +317,13 @@ public class DefaultServlet extends HttpServlet implements ResourceFactory, Welc
 
     private String getInitParameter(String name, String... deprecated)
     {
-        String value = super.getInitParameter(name);
+        String value = getInitParameter(name);
         if (value != null)
             return value;
 
         for (String d : deprecated)
         {
-            value = super.getInitParameter(d);
+            value = getInitParameter(d);
             if (value != null)
             {
                 LOG.warn("Deprecated {} used instead of {}", d, name);


### PR DESCRIPTION
Addressing calls to `getInitParameter()` in DefaultServlet on ee10/ee9/ee8 to properly find deprecated init param names.

Fixes #11312