### PR TITLE
Issue #11317 - Low hanging fix for LOG.debug in addBean.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -416,7 +416,7 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
         }
 
         if (LOG.isDebugEnabled())
-            LOG.debug("{} added {}", this, newBean);
+            LOG.debug("{} added {}", String.format("%s@%x", this.getClass().getSimpleName(), hashCode()), newBean);
 
         return true;
     }


### PR DESCRIPTION
Possibly small fix for #11317 and `this` handling.