### PR TITLE
Issue#11353 - Default virtual thread executor should created named threads

### DIFF
--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
@@ -13,10 +13,6 @@
 
 package org.eclipse.jetty.test.client.transport;
 
-import java.util.Arrays;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.ContentResponse;
@@ -45,7 +41,6 @@ public class VirtualThreadsTest extends AbstractTest
         // No virtual thread support in FCGI server-side.
         Assumptions.assumeTrue(transport != Transport.FCGI);
 
-        String virtualThreadsName = "green-";
         prepareServer(transport, new Handler.Abstract()
         {
             @Override
@@ -53,7 +48,7 @@ public class VirtualThreadsTest extends AbstractTest
             {
                 if (!VirtualThreads.isVirtualThread())
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
-                if (!Thread.currentThread().getName().startsWith(virtualThreadsName))
+                if (!Thread.currentThread().getName().startsWith("jetty-vt-"))
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
                 callback.succeeded();
                 return true;
@@ -62,13 +57,7 @@ public class VirtualThreadsTest extends AbstractTest
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
-            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
+            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         }
         server.start();
         startClient(transport);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -42,8 +42,8 @@ public class VirtualThreads
             Class<?> builderClass = Class.forName("java.lang.Thread$Builder");
             Object threadBuilder = Thread.class.getMethod("ofVirtual").invoke(null);
             threadBuilder = builderClass.getMethod("name", String.class, long.class).invoke(threadBuilder, "jetty-vt-", 0L);
-            ThreadFactory factory = (ThreadFactory) builderClass.getMethod("factory").invoke(threadBuilder);
-            return (Executor) Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(threadBuilder);
+            return (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -13,13 +13,13 @@
 
 package org.eclipse.jetty.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>Utility class to use to query the runtime for virtual thread support,

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
@@ -14,11 +14,7 @@
 package org.eclipse.jetty.ee10.test.client.transport;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,7 +51,6 @@ public class VirtualThreadsTest extends AbstractTest
         // No virtual thread support in FCGI server-side.
         Assumptions.assumeTrue(transport != Transport.FCGI);
 
-        String virtualThreadsName = "green-";
         prepareServer(transport, new HttpServlet()
         {
             @Override
@@ -63,20 +58,14 @@ public class VirtualThreadsTest extends AbstractTest
             {
                 if (!VirtualThreads.isVirtualThread())
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
-                if (!Thread.currentThread().getName().startsWith(virtualThreadsName))
+                if (!Thread.currentThread().getName().startsWith("jetty-vt-"))
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
             }
         });
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
-            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
+            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         }
         server.start();
         startClient(transport);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
@@ -14,11 +14,7 @@
 package org.eclipse.jetty.ee9.test.client.transport;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,7 +51,6 @@ public class VirtualThreadsTest extends AbstractTest
         // No virtual thread support in FCGI server-side.
         Assumptions.assumeTrue(transport != Transport.FCGI);
 
-        String virtualThreadsName = "green-";
         prepareServer(transport, new HttpServlet()
         {
             @Override
@@ -63,20 +58,14 @@ public class VirtualThreadsTest extends AbstractTest
             {
                 if (!VirtualThreads.isVirtualThread())
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
-                if (!Thread.currentThread().getName().startsWith(virtualThreadsName))
+                if (!Thread.currentThread().getName().startsWith("jetty-vt-"))
                     response.setStatus(HttpStatus.NOT_IMPLEMENTED_501);
             }
         });
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
-            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
+            ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         }
         server.start();
         startClient(transport);


### PR DESCRIPTION
Specify a `ThreadFactory` when setting up the default virtual thread executor so it creates named threads.

(issue #11353)

Tested the reflective logic in `probeVirtualThreadExecutor` against different JDK versions for compatibility reasons:
- 19 (preview) ✅ 
- 20 (preview) ✅ 
- 21 ✅ 

Likewise, it does not work on the previous versions (JDK 18 and below) as virtual threads were only introduced in JDK 19 (preview). 
For older JDKs, the behavior remains the same as before:
- `VirtualThreads#getDefaultVirtualThreadsExecutor` reutrns `null`
- `VirtualThreads#areSupported` returns `false`