### PR TITLE
drop buildnumber:create already executed by jetty-util

### DIFF
--- a/jetty-core/jetty-start/pom.xml
+++ b/jetty-core/jetty-start/pom.xml
@@ -44,6 +44,29 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
+            <id>build.properties</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>jetty-util</artifactId>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                  <includes>**/build.properties</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"></fileMapper>
+                  </fileMappers>
+                  <outputDirectory>${project.build.outputDirectory}/org/eclipse/jetty/start/</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+          <execution>
             <id>unpack</id>
             <goals>
               <goal>unpack</goal>

--- a/jetty-core/jetty-start/pom.xml
+++ b/jetty-core/jetty-start/pom.xml
@@ -109,23 +109,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>create-buildnumber</id>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <doCheck>false</doCheck>
-              <doUpdate>false</doUpdate>
-              <revisionOnScmFailure>${nonCanonicalRevision}</revisionOnScmFailure>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/build.properties
+++ b/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/build.properties
@@ -1,4 +1,0 @@
-buildNumber=${buildNumber}
-timestamp=${timestamp}
-version=${project.version}
-scmUrl=${project.scm.connection}


### PR DESCRIPTION
re-running buildnumber-maven-plugin a second time creates a new timestamp property value, which breaks Reproducible Builds https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/eclipse/jetty/jetty-project/README.md

AFAIK, the second run is not really necessary, just some cleanup forgotten that until now was not identified as causing any harm