### PR TITLE
Do not throw from HttpChannelState.read() method

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -867,7 +867,6 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public Content.Chunk read()
         {
-            Content.Chunk chunk;
             try
             {
                 HttpStream stream;
@@ -882,7 +881,7 @@ public class HttpChannelState implements HttpChannel, Components
 
                     stream = httpChannel._stream;
                 }
-                chunk = stream.read();
+                Content.Chunk chunk = stream.read();
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("read {}", chunk);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -883,22 +883,22 @@ public class HttpChannelState implements HttpChannel, Components
                     stream = httpChannel._stream;
                 }
                 chunk = stream.read();
+
+                if (LOG.isDebugEnabled())
+                    LOG.debug("read {}", chunk);
+
+                if (chunk != null && chunk.hasRemaining())
+                    _contentBytesRead.add(chunk.getByteBuffer().remaining());
+
+                if (chunk instanceof Trailers trailers)
+                    _trailers = trailers.getTrailers();
+
+                return chunk;
             }
             catch (Throwable t)
             {
                 return Content.Chunk.from(t, true);
             }
-
-            if (LOG.isDebugEnabled())
-                LOG.debug("read {}", chunk);
-
-            if (chunk != null && chunk.hasRemaining())
-                _contentBytesRead.add(chunk.getByteBuffer().remaining());
-
-            if (chunk instanceof Trailers trailers)
-                _trailers = trailers.getTrailers();
-
-            return chunk;
         }
 
         @Override


### PR DESCRIPTION
Fixes #11363 by ensuring that read never throws, but instead returns an Error chunk.