### PR TITLE
Fixes #11372 - Scheduler queue in the HTTP client grows infinitely when a server times out

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
@@ -119,7 +119,7 @@ public abstract class CyclicTimeouts<T extends CyclicTimeouts.Expirable> impleme
                     continue;
                 }
                 long newExpiresAt = expirable.getExpireNanoTime();
-                if (newExpiresAt == expiresAt)
+                if (newExpiresAt == Long.MAX_VALUE || newExpiresAt == expiresAt)
                     continue;
                 expiresAt = newExpiresAt;
             }


### PR DESCRIPTION
Fixed regression introduced with #9897.
After onExpire() returns false, the entity is asked again the expirationNanoTime, but there was no check whether it was Long.MAX_VALUE, indicating that the entity should not be rescheduled.

This was causing scheduling of timeouts far in the future (about Long.MAX_VALUE nanos away), but each at a slightly different time, causing the leak.