### PR TITLE
Add more instrumentation to `ArrayByteBufferPool` and improve its eviction algorithm

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -224,6 +224,15 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                     }
                     return buffer;
                 }
+                else
+                {
+                    // Cannot enable, keep the allocated ByteBuffer, wrap it in another RBB with
+                    // a different releaser and remove the reserved entry from the pool.
+                    Buffer retainableByteBuffer = new Buffer(buffer.getByteBuffer(), this::removed);
+                    retainableByteBuffer.acquire();
+                    reservedEntry.remove();
+                    return retainableByteBuffer;
+                }
             }
             return newRetainableByteBuffer(size, direct, this::removed);
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -19,6 +19,7 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -518,8 +519,10 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             int entries = 0;
             int inUse = 0;
-            for (Pool.Entry<RetainableByteBuffer> entry : getPool().stream().toList())
+            Iterator<Pool.Entry<RetainableByteBuffer>> it = getPool().stream().iterator();
+            while (it.hasNext())
             {
+                Pool.Entry<RetainableByteBuffer> entry = it.next();
                 entries++;
                 if (entry.isInUse())
                     inUse++;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -79,6 +79,9 @@ public class CompoundPool<P> implements Pool<P>
     @Override
     public Stream<Entry<P>> stream()
     {
-        return Stream.concat(primaryPool.stream(), secondaryPool.stream());
+        // Stream the secondary pool first as the 1st idle object returned by the stream
+        // is used as an eviction candidate, and it is preferable to prioritize evicting
+        // from the secondary pool.
+        return Stream.concat(secondaryPool.stream(), primaryPool.stream());
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -363,6 +363,28 @@ public class ArrayByteBufferPoolTest
     }
 
     @Test
+    public void testStatisticalPool()
+    {
+        ArrayByteBufferPool pool = new ArrayByteBufferPool.Statistical();
+
+        pool.acquire(1, true).release();
+        pool.acquire(100, true).release();
+        pool.acquire(1_000, true).release();
+        pool.acquire(10_000, true).release();
+        pool.acquire(10_000, true).release();
+        pool.acquire(10_000, true).release();
+        pool.acquire(100_000, true).release();
+
+        String dump = pool.dump();
+        assertThat(dump, containsString("requested buffer sizes size=5"));
+        assertThat(dump, containsString("1=1"));
+        assertThat(dump, containsString("100=1"));
+        assertThat(dump, containsString("1000=1"));
+        assertThat(dump, containsString("10000=3"));
+        assertThat(dump, containsString("100000=1"));
+    }
+
+    @Test
     public void testEndiannessResetOnRelease()
     {
         ArrayByteBufferPool bufferPool = new ArrayByteBufferPool();

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -359,7 +359,7 @@ public class ArrayByteBufferPoolTest
 
         b3.release();
         b4.getByteBuffer().limit(b4.getByteBuffer().capacity() - 2);
-        assertThat(pool.dump(), containsString("{capacity=4,inuse=3(75%)"));
+        assertThat(pool.dump(), containsString("{capacity=4,entries=4,inuse=3(75%)"));
     }
 
     @Test

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io;
 
+import java.lang.ref.Reference;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,7 @@ public class ArrayByteBufferPoolTest
 
         RetainableByteBuffer rbb = pool.acquire(100, true);
         assertThat(pool.getDirectMemory(), is(4096L));
+        Reference.reachabilityFence(rbb);
         rbb = null;
 
         await().atMost(5, TimeUnit.SECONDS).until(() ->

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -376,12 +376,15 @@ public class ArrayByteBufferPoolTest
         pool.acquire(100_000, true).release();
 
         String dump = pool.dump();
+        System.out.println(dump);
+
         assertThat(dump, containsString("requested buffer sizes size=5"));
         assertThat(dump, containsString("1=1"));
         assertThat(dump, containsString("100=1"));
         assertThat(dump, containsString("1000=1"));
         assertThat(dump, containsString("10000=3"));
         assertThat(dump, containsString("100000=1"));
+        assertThat(dump, containsString("direct=16384/")); // total in pool: one 4K buffer + one 12K buffer
     }
 
     @Test

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -201,7 +201,7 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         }
     }
 
-    void sweep()
+    public void sweep()
     {
         for (int i = 0; i < entries.size(); i++)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -201,8 +201,13 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         }
     }
 
-    public void sweep()
+    /**
+     * Sweep the pool, removing any leaked entry.
+     * @return the leaked entries count.
+     */
+    public int sweep()
     {
+        int leakedCount = 0;
         for (int i = 0; i < entries.size(); i++)
         {
             Holder<P> holder = entries.get(i);
@@ -210,8 +215,10 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
             {
                 leaked(holder);
                 entries.remove(i--);
+                leakedCount++;
             }
         }
+        return leakedCount;
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -256,7 +256,7 @@ public interface Dumpable
     {
         for (Iterator<? extends Map.Entry<?, ?>> i = map.entrySet().iterator(); i.hasNext(); )
         {
-            Map.Entry entry = i.next();
+            Map.Entry<?, ?> entry = i.next();
             String nextIndent = indent + ((i.hasNext() || !last) ? "|  " : "   ");
             out.append(indent).append("+@ ").append(String.valueOf(entry.getKey())).append(" = ");
             Object item = entry.getValue();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
@@ -1,0 +1,52 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.component;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class DumpableMap implements Dumpable
+{
+    private final String _name;
+    private final Map<?, ?> _map;
+
+    public DumpableMap(String name, Map<?, ?> map)
+    {
+        _name = name;
+        _map = map;
+    }
+
+    public static DumpableMap from(String name, Map<?, ?> items)
+    {
+        return from(name, items, false);
+    }
+
+    public static DumpableMap from(String name, Map<?, ?> items, boolean ordered)
+    {
+        items = items == null ? Collections.emptyMap() : items;
+        if (ordered && !(items instanceof SortedMap<?,?>))
+            items = new TreeMap<>(items);
+        return new DumpableMap(name, items);
+    }
+
+    @Override
+    public void dump(Appendable out, String indent) throws IOException
+    {
+        Dumpable.dumpObjects(out, indent, _name + " size=" + (_map == null ? 0 : _map.size()), _map);
+    }
+}
+

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
@@ -46,7 +46,8 @@ public class DumpableMap implements Dumpable
     @Override
     public void dump(Appendable out, String indent) throws IOException
     {
-        Dumpable.dumpObjects(out, indent, _name + " size=" + (_map == null ? 0 : _map.size()), _map);
+        Object[] array = _map == null ? null : _map.entrySet().toArray();
+        Dumpable.dumpObjects(out, indent, _name + " size=" + (array == null ? 0 : array.length), array);
     }
 }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
@@ -38,7 +38,7 @@ public class DumpableMap implements Dumpable
     public static DumpableMap from(String name, Map<?, ?> items, boolean ordered)
     {
         items = items == null ? Collections.emptyMap() : items;
-        if (ordered && !(items instanceof SortedMap<?,?>))
+        if (ordered && !(items instanceof SortedMap<?, ?>))
             items = new TreeMap<>(items);
         return new DumpableMap(name, items);
     }


### PR DESCRIPTION
The current info reported in `ArrayByteBufferPool`'s dump is too limited, this is an attempt at improving that.
This could help with issues like #11326 as we may better understand the state of the pool when it reaches a problematic point.

Also, the eviction algorithm was reworked to fix its most glaring problems.