### PR TITLE
Improved Eviction in ArrayByteBufferPool for #11371

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -578,7 +578,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 if (!_entry.release())
                     _entry.remove();
                 else if (updateAndCheckMemory(byteBuffer.capacity(), byteBuffer.isDirect()))
-                    releaseExcessMemory(byteBuffer.isDirect());;
+                    releaseExcessMemory(byteBuffer.isDirect());
             }
             return released;
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -397,7 +397,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 for (RetainedBucket bucket : buckets)
                 {
                     long idle = (long)bucket.getPool().getIdleCount() * bucket._capacity;
-                    if (idle > mostIdleSize)
+                    if (idle >= mostIdleSize)
                     {
                         mostIdleBucket = bucket;
                         mostIdleSize = idle;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -588,6 +588,48 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     }
 
     /**
+     * A variant of the {@link ArrayByteBufferPool} that
+     * uses buckets of buffers that increase linearly in size by a fixed factor
+     * (eg 2k, 4k, 6k, 8k, etc.).
+     */
+    public static class Linear extends ArrayByteBufferPool
+    {
+        public Linear()
+        {
+            this(0, -1, Integer.MAX_VALUE);
+        }
+
+        public Linear(int minCapacity, int maxCapacity, int maxBucketSize)
+        {
+            this(minCapacity, maxCapacity, maxBucketSize, -1L, -1L);
+        }
+
+        public Linear(int minCapacity, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory)
+        {
+            this(minCapacity,
+                DEFAULT_FACTOR,
+                maxCapacity,
+                maxBucketSize,
+                maxHeapMemory,
+                maxDirectMemory);
+        }
+
+        private Linear(int minCapacity, int factor, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory)
+        {
+            super(minCapacity,
+                factor,
+                maxCapacity,
+                maxBucketSize,
+                maxHeapMemory,
+                maxDirectMemory,
+
+                c -> (c - 1) / factor,
+                i -> (i + 1) * factor
+            );
+        }
+    }
+
+    /**
      * <p>A variant of {@link ArrayByteBufferPool} that tracks buffer
      * acquires/releases, useful to identify buffer leaks.</p>
      * <p>Use {@link #getLeaks()} when the system is idle to get

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -457,7 +457,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         private void evict()
         {
-            while (true)
+            for (int i = _pool.size(); i-- > 0;)
             {
                 Pool.Entry<RetainableByteBuffer> entry = _pool instanceof BucketCompoundPool bcp ? bcp.acquireSecondaryFirst() : _pool.acquire();
                 if (entry == null)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -235,7 +235,9 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             return;
         }
 
-        Buffer pooledBuffer = new Buffer(nonPooledBuffer.getByteBuffer(), b ->
+        ByteBuffer byteBuffer = nonPooledBuffer.getByteBuffer();
+        BufferUtil.reset(byteBuffer);
+        Buffer pooledBuffer = new Buffer(byteBuffer, b ->
         {
             BufferUtil.reset(b.getByteBuffer());
             if (!reservedEntry.release())

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -496,10 +496,11 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                     inUse++;
             }
 
-            return String.format("%s{capacity=%d,inuse=%d(%d%%)}",
+            return String.format("%s{capacity=%d,inuse=%d/%d(%d%%)}",
                 super.toString(),
                 _capacity,
                 inUse,
+                entries,
                 entries > 0 ? (inUse * 100) / entries : 0);
         }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -71,6 +71,36 @@ public class CompoundPool<P> implements Pool<P>
     }
 
     @Override
+    public int getIdleCount()
+    {
+        return primaryPool.getIdleCount() + secondaryPool.getIdleCount();
+    }
+
+    @Override
+    public boolean hasIdle()
+    {
+        return secondaryPool.hasIdle() || primaryPool.hasIdle();
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        return primaryPool.getInUseCount() + secondaryPool.getInUseCount();
+    }
+
+    @Override
+    public int getReservedCount()
+    {
+        return primaryPool.getReservedCount() + secondaryPool.getReservedCount();
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        return primaryPool.getTerminatedCount() + secondaryPool.getTerminatedCount();
+    }
+
+    @Override
     public int getMaxSize()
     {
         return primaryPool.getMaxSize() + secondaryPool.getMaxSize();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -26,8 +26,8 @@ import org.eclipse.jetty.util.Pool;
  */
 public class CompoundPool<P> implements Pool<P>
 {
-    private final Pool<P> primaryPool;
-    private final Pool<P> secondaryPool;
+    protected final Pool<P> primaryPool;
+    protected final Pool<P> secondaryPool;
 
     public CompoundPool(Pool<P> primaryPool, Pool<P> secondaryPool)
     {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -171,6 +171,36 @@ public class QueuedPool<P> implements Pool<P>
         return queue.stream();
     }
 
+    @Override
+    public int getReservedCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getIdleCount()
+    {
+        return size();
+    }
+
+    @Override
+    public boolean hasIdle()
+    {
+        return !queue.isEmpty();
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        return 0;
+    }
+
     private static class QueuedEntry<P> implements Entry<P>
     {
         private final QueuedPool<P> pool;

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -287,6 +287,7 @@ public class ArrayByteBufferPoolTest
         for (int i = 0; i < 3; i++)
         {
             RetainableByteBuffer buf1 = pool.acquire(10, true);
+            System.err.println(buf1);
             assertThat(buf1, is(notNullValue()));
             assertThat(buf1.capacity(), is(ArrayByteBufferPool.DEFAULT_FACTOR));
             RetainableByteBuffer buf2 = pool.acquire(10, true);

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -340,7 +340,6 @@ public class ArrayByteBufferPoolTest
         for (int i = 0; i < 3; i++)
         {
             RetainableByteBuffer buf1 = pool.acquire(10, true);
-            System.err.println(buf1);
             assertThat(buf1, is(notNullValue()));
             assertThat(buf1.capacity(), is(ArrayByteBufferPool.DEFAULT_FACTOR));
             RetainableByteBuffer buf2 = pool.acquire(10, true);

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -202,6 +202,8 @@ public class ArrayByteBufferPoolTest
     public void testBufferReleaseRepools()
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool(0, 10, 20, 1);
+        pool.acquire(1, true).release();
+        pool.acquire(11, true).release();
 
         List<RetainableByteBuffer> all = new ArrayList<>();
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -107,8 +107,11 @@ public class ArrayByteBufferPoolTest
         ArrayByteBufferPool pool = new ArrayByteBufferPool(10, 10, 20, Integer.MAX_VALUE);
 
         RetainableByteBuffer buf1 = pool.acquire(10, true);
-
+        assertThat(pool.getDirectMemory(), is(0L));
+        buf1.release();
         assertThat(pool.getDirectMemory(), is(10L));
+
+        buf1 = pool.acquire(10, true);
         assertThat(pool.getAvailableDirectMemory(), is(0L));
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(pool.getDirectByteBufferCount(), is(1L));
@@ -127,7 +130,9 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(pool.getDirectByteBufferCount(), is(1L));
 
+        assertThat(pool.getDirectMemory(), is(10L));
         assertThat(buf1.release(), is(true));
+        assertThat(pool.getDirectMemory(), is(10L));
         assertThat(buf1.isRetained(), is(false));
 
         assertThat(pool.getDirectMemory(), is(10L));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -147,6 +147,10 @@ public class ArrayByteBufferPoolTest
         ArrayByteBufferPool pool = new ArrayByteBufferPool(10, 10, 20, Integer.MAX_VALUE);
 
         RetainableByteBuffer buf1 = pool.acquire(10, true);
+        assertThat(pool.getDirectMemory(), is(0L));
+        buf1.release();
+        assertThat(pool.getDirectMemory(), is(10L));
+        buf1 = pool.acquire(10, true);
 
         assertThat(pool.getDirectMemory(), is(10L));
         assertThat(pool.getAvailableDirectMemory(), is(0L));
@@ -224,6 +228,9 @@ public class ArrayByteBufferPoolTest
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool(10, 10, 20, Integer.MAX_VALUE);
 
+        pool.acquire(10, true).release();
+        pool.acquire(20, true).release();
+
         pool.acquire(1, true);  // not pooled, < minCapacity
         pool.acquire(10, true); // pooled
         pool.acquire(20, true); // pooled
@@ -240,7 +247,11 @@ public class ArrayByteBufferPoolTest
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool();
 
+        RetainableByteBuffer b1 = pool.acquire(10, true);
+        RetainableByteBuffer b2 = pool.acquire(10, true);
+        b1.release();
         pool.acquire(10, true);
+        b2.release();
         pool.acquire(10, true);
 
         assertThat(pool.getDirectByteBufferCount(), is(2L));
@@ -261,6 +272,9 @@ public class ArrayByteBufferPoolTest
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool();
         RetainableByteBuffer buf1 = pool.acquire(10, true);
+        buf1.release();
+        buf1 = pool.acquire(10, true);
+
         assertThat(pool.getDirectByteBufferCount(), is(1L));
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(buf1.release(), is(true));
@@ -273,7 +287,7 @@ public class ArrayByteBufferPoolTest
         RetainableByteBuffer buf2 = pool.acquire(10, true);
         assertThat(pool.getDirectByteBufferCount(), is(1L));
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
-        assertThat(buf2 == buf1, is(true)); // make sure it's not a new instance
+        assertThat(buf2, sameInstance(buf1)); // make sure it's not a new instance
         assertThat(buf1.release(), is(true));
         assertThat(pool.getDirectByteBufferCount(), is(1L));
         assertThat(pool.getAvailableDirectByteBufferCount(), is(1L));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/ServerConnectorSslServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/ServerConnectorSslServerTest.java
@@ -32,7 +32,6 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.AbstractConnectionFactory;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.HttpServerTestBase;
 import org.eclipse.jetty.server.Request;
@@ -65,7 +64,6 @@ public class ServerConnectorSslServerTest extends HttpServerTestBase
 {
     private SSLContext _sslContext;
     private ArrayByteBufferPool.Tracking _trackingBufferPool;
-    private HttpConfiguration _httpConfiguration;
 
     public ServerConnectorSslServerTest()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -143,11 +143,16 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         return maxMultiplex.applyAsInt(pooled);
     }
 
+    protected void leaked()
+    {
+    }
+
     private void leaked(Holder<P> holder)
     {
         leaked.increment();
         if (LOG.isDebugEnabled())
             LOG.debug("Leaked " + holder);
+        leaked();
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -126,6 +126,70 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         this.maxMultiplex = Objects.requireNonNull(maxMultiplex);
     }
 
+    @Override
+    public int getReservedCount()
+    {
+        int count = 0;
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && entry.isReserved())
+                count++;
+        }
+        return count;
+    }
+
+    @Override
+    public int getIdleCount()
+    {
+        int count = 0;
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && entry.isIdle())
+                count++;
+        }
+        return count;
+    }
+
+    @Override
+    public boolean hasIdle()
+    {
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && entry.isIdle())
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        int count = 0;
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && entry.isInUse())
+                count++;
+        }
+        return count;
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        int count = 0;
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && entry.isTerminated())
+                count++;
+        }
+        return count;
+    }
+
     @ManagedAttribute("number of entries leaked (not released nor referenced)")
     public long getLeaked()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Pool.java
@@ -143,6 +143,14 @@ public interface Pool<P>
     }
 
     /**
+     * @return true if there are idle entries
+     */
+    default boolean hasIdle()
+    {
+        return stream().anyMatch(Entry::isIdle);
+    }
+
+    /**
      * @return the number of in-use entries
      */
     @ManagedAttribute("The number of in-use entries")


### PR DESCRIPTION
Experimental fix for #11371

If a pooled buffer is not available during acquire, a temporary buffer is returned.   

Only when that buffer is released do we try to put that into the pool.   If that succeeds, then one and only one thread will check the size and evict entries from the bucket with the most idle memory.

It is currently failing lots of tests, but some of the tests are probably incorrect as they check the pool size after the acquire rather than after the release.


Also this PR fixes the handling of memory counts when buffers are leaked.

