### PR TITLE
Making FormFields get defaults from Context, not Request

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -40,6 +40,9 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
 {
     public static final String MAX_FIELDS_ATTRIBUTE = "org.eclipse.jetty.server.Request.maxFormKeys";
     public static final String MAX_LENGTH_ATTRIBUTE = "org.eclipse.jetty.server.Request.maxFormContentSize";
+    public static final int MAX_FIELDS_DEFAULT = 1000;
+    public static final int MAX_LENGTH_DEFAULT = 200000;
+
     private static final CompletableFuture<Fields> EMPTY = CompletableFuture.completedFuture(Fields.EMPTY);
 
     public static Charset getFormEncodedCharset(Request request)
@@ -108,8 +111,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static CompletableFuture<Fields> from(Request request)
     {
-        int maxFields = getRequestAttribute(request, FormFields.MAX_FIELDS_ATTRIBUTE);
-        int maxLength = getRequestAttribute(request, FormFields.MAX_LENGTH_ATTRIBUTE);
+        int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
+        int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         return from(request, maxFields, maxLength);
     }
 
@@ -124,8 +127,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static CompletableFuture<Fields> from(Request request, Charset charset)
     {
-        int maxFields = getRequestAttribute(request, FormFields.MAX_FIELDS_ATTRIBUTE);
-        int maxLength = getRequestAttribute(request, FormFields.MAX_LENGTH_ATTRIBUTE);
+        int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
+        int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
         return from(request, charset, maxFields, maxLength);
     }
 
@@ -188,18 +191,18 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         return futureFormFields;
     }
 
-    private static int getRequestAttribute(Request request, String attribute)
+    private static int getContextAttribute(Context context, String attribute, int defValue)
     {
-        Object value = request.getAttribute(attribute);
+        Object value = context.getAttribute(attribute);
         if (value == null)
-            return -1;
+            return defValue;
         try
         {
             return Integer.parseInt(value.toString());
         }
         catch (NumberFormatException x)
         {
-            return -1;
+            return defValue;
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -77,6 +77,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.FormFields;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -143,10 +144,10 @@ public class ServletContextHandler extends ContextHandler
 
     public static final int DEFAULT_LISTENER_TYPE_INDEX = 1;
     public static final int EXTENDED_LISTENER_TYPE_INDEX = 0;
-    public static final String MAX_FORM_KEYS_KEY = "org.eclipse.jetty.server.Request.maxFormKeys";
-    public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
-    public static final int DEFAULT_MAX_FORM_KEYS = 1000;
-    public static final int DEFAULT_MAX_FORM_CONTENT_SIZE = 200000;
+    public static final String MAX_FORM_KEYS_KEY = FormFields.MAX_FIELDS_ATTRIBUTE;
+    public static final String MAX_FORM_CONTENT_SIZE_KEY = FormFields.MAX_LENGTH_ATTRIBUTE;
+    public static final int DEFAULT_MAX_FORM_KEYS = FormFields.MAX_FIELDS_DEFAULT;
+    public static final int DEFAULT_MAX_FORM_CONTENT_SIZE = FormFields.MAX_LENGTH_DEFAULT;
 
     public static final int SESSIONS = 1;
     public static final int SECURITY = 2;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -69,6 +69,7 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.AliasCheck;
 import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.FormFields;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
@@ -164,10 +165,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
 
     private static String __serverInfo = "jetty/" + Server.getVersion();
 
-    public static final String MAX_FORM_KEYS_KEY = "org.eclipse.jetty.server.Request.maxFormKeys";
-    public static final String MAX_FORM_CONTENT_SIZE_KEY = "org.eclipse.jetty.server.Request.maxFormContentSize";
-    public static final int DEFAULT_MAX_FORM_KEYS = 1000;
-    public static final int DEFAULT_MAX_FORM_CONTENT_SIZE = 200000;
+    public static final String MAX_FORM_KEYS_KEY = FormFields.MAX_FIELDS_ATTRIBUTE;
+    public static final String MAX_FORM_CONTENT_SIZE_KEY = FormFields.MAX_LENGTH_ATTRIBUTE;
+    public static final int DEFAULT_MAX_FORM_KEYS = FormFields.MAX_FIELDS_DEFAULT;
+    public static final int DEFAULT_MAX_FORM_CONTENT_SIZE = FormFields.MAX_LENGTH_DEFAULT;
     private boolean _canonicalEncodingURIs = false;
     private boolean _usingSecurityManager = getSecurityManager() != null;
 


### PR DESCRIPTION
Instead of taking defaults from Request attributes, take them from the Context attributes.

Fixes: #11385