### PR TITLE
Allow spec port stripping of 80/443 on websocket too.

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1175,11 +1175,13 @@ public class URIUtil
         {
             switch (scheme)
             {
+                case "ws":
                 case "http":
                     if (port != 80)
                         url.append(':').append(port);
                     break;
 
+                case "wss":
                 case "https":
                     if (port != 443)
                         url.append(':').append(port);
@@ -1209,11 +1211,13 @@ public class URIUtil
             {
                 switch (scheme)
                 {
+                    case "ws":
                     case "http":
                         if (port != 80)
                             url.append(':').append(port);
                         break;
 
+                    case "wss":
                     case "https":
                         if (port != 443)
                             url.append(':').append(port);

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -756,4 +756,43 @@ public class URIUtilTest
         String decoded = URIUtil.decodePath(encoded);
         assertEquals(path, decoded);
     }
+
+    public static Stream<Arguments> appendSchemeHostPortCases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "http://example.org"),
+            Arguments.of("https", "example.org", 443, "https://example.org"),
+            Arguments.of("ws", "example.org", 80, "ws://example.org"),
+            Arguments.of("wss", "example.org", 443, "wss://example.org"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "http://example.org:443"),
+            Arguments.of("https", "example.org", 80, "https://example.org:80"),
+            Arguments.of("ws", "example.org", 443, "ws://example.org:443"),
+            Arguments.of("wss", "example.org", 80, "wss://example.org:80"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "http://example.org:12345"),
+            Arguments.of("https", "example.org", 54321, "https://example.org:54321"),
+            Arguments.of("ws", "example.org", 6666, "ws://example.org:6666"),
+            Arguments.of("wss", "example.org", 7777, "wss://example.org:7777")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendSchemeHostPortCases")
+    public void testAppendSchemeHostPortBuilder(String scheme, String server, int port, String expectedStr)
+    {
+        StringBuilder actual = new StringBuilder();
+        URIUtil.appendSchemeHostPort(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendSchemeHostPortCases")
+    public void testAppendSchemeHostPortBuffer(String scheme, String server, int port, String expectedStr)
+    {
+        StringBuffer actual = new StringBuffer();
+        URIUtil.appendSchemeHostPort(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
 }


### PR DESCRIPTION
Both `URIUtil.appendSchemeHostPort()` methods do not strip the default ports 80 and 443 in case of non-http schemes (like websocket).

Adding knowledge about websocket schemes (and test cases) to these methods.