### PR TITLE
Migrate some URIUtil methods to HttpScheme for proper normalization

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -20,10 +20,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.HostPort;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * <p>Class that groups the elements that uniquely identify a destination.</p>
@@ -122,9 +122,7 @@ public class Origin
 
     public String asString()
     {
-        StringBuilder result = new StringBuilder();
-        URIUtil.appendSchemeHostPort(result, scheme, address.host, address.port);
-        return result.toString();
+        return HttpScheme.normalizeUri(scheme, address.host, address.port);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -122,7 +122,7 @@ public class Origin
 
     public String asString()
     {
-        return HttpScheme.normalizeUri(scheme, address.host, address.port);
+        return HttpScheme.normalizeURI(scheme, address.host, address.port);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -55,11 +55,11 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.URIUtil;
 
 public class HttpRequest implements Request
 {
@@ -122,9 +122,7 @@ public class HttpRequest implements Request
     {
         if (newURI == null)
         {
-            StringBuilder builder = new StringBuilder(64);
-            URIUtil.appendSchemeHostPort(builder, getScheme(), getHost(), getPort());
-            newURI = URI.create(builder.toString());
+            newURI = URI.create(HttpScheme.normalizeUri(getScheme(), getHost(), getPort()));
         }
 
         HttpRequest newRequest = copyInstance(newURI);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -122,7 +122,7 @@ public class HttpRequest implements Request
     {
         if (newURI == null)
         {
-            newURI = URI.create(HttpScheme.normalizeUri(getScheme(), getHost(), getPort()));
+            newURI = URI.create(HttpScheme.normalizeURI(getScheme(), getHost(), getPort()));
         }
 
         HttpRequest newRequest = copyInstance(newURI);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
@@ -69,7 +69,7 @@ public class HttpClientURITest extends AbstractHttpClientServerTest
 
         assertEquals(host, request.getHost());
         StringBuilder uri = new StringBuilder();
-        HttpScheme.appendNormalizedUri(uri, scenario.getScheme(), host, connector.getLocalPort());
+        HttpScheme.concatNormalizedURI(uri, scenario.getScheme(), host, connector.getLocalPort());
         assertEquals(uri.toString(), request.getURI().toString());
 
         assertEquals(HttpStatus.OK_200, request.send().getStatus());

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -38,7 +39,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -69,7 +69,7 @@ public class HttpClientURITest extends AbstractHttpClientServerTest
 
         assertEquals(host, request.getHost());
         StringBuilder uri = new StringBuilder();
-        URIUtil.appendSchemeHostPort(uri, scenario.getScheme(), host, connector.getLocalPort());
+        HttpScheme.appendNormalizedUri(uri, scenario.getScheme(), host, connector.getLocalPort());
         assertEquals(uri.toString(), request.getURI().toString());
 
         assertEquals(HttpStatus.OK_200, request.send().getStatus());

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.deploy.test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -45,7 +44,6 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.PathMatchers;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -249,9 +247,7 @@ public class XmlConfiguredJetty
 
     public URI getServerURI() throws UnknownHostException
     {
-        StringBuilder uri = new StringBuilder();
-        URIUtil.appendSchemeHostPort(uri, getScheme(), InetAddress.getLocalHost().getHostAddress(), getServerPort());
-        return URI.create(uri.toString());
+        return _server.getURI().resolve("/");
     }
 
     public Path getJettyBasePath()

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
@@ -98,11 +98,11 @@ public enum HttpScheme
      * @param port the port
      * @return the String representation following the general format {@code <scheme>://<server>:<port>}, where
      * the returned String might not include a port, and will not include the ending {@code /} character.
-     * @see #appendNormalizedUri(StringBuilder, String, String, int)
+     * @see #concatNormalizedURI(StringBuilder, String, String, int)
      */
-    public static String normalizeUri(String scheme, String server, int port)
+    public static String normalizeURI(String scheme, String server, int port)
     {
-        return normalizeUri(scheme, server, port, null, null);
+        return normalizeURI(scheme, server, port, null, null, null);
     }
 
     /**
@@ -115,12 +115,12 @@ public enum HttpScheme
      * @param query the optional query, may be null (not included in output if path is null)
      * @return the String representation following the general format {@code <scheme>://<server>:<port>/<path>?<query>}, where
      * the returned String might not include a port.
-     * @see #appendNormalizedUri(StringBuilder, String, String, int)
+     * @see #concatNormalizedURI(StringBuilder, String, String, int)
      */
-    public static String normalizeUri(String scheme, String server, int port, String path, String query)
+    public static String normalizeURI(String scheme, String server, int port, String path, String query, String fragment)
     {
         StringBuilder builder = new StringBuilder();
-        appendNormalizedUri(builder, scheme, server, port, path, query);
+        concatNormalizedURI(builder, scheme, server, port, path, query, fragment);
         return builder.toString();
     }
 
@@ -141,12 +141,35 @@ public enum HttpScheme
      * @param server the server hostname, may not be blank or null.
      * @param port the port
      */
-    public static void appendNormalizedUri(StringBuilder url, String scheme, String server, int port)
+    public static void concatNormalizedURI(StringBuilder url, String scheme, String server, int port)
     {
-        appendNormalizedUri(url, scheme, server, port, null, null);
+        concatNormalizedURI(url, scheme, server, port, null, null, null);
     }
 
-    public static void appendNormalizedUri(StringBuilder url, String scheme, String server, int port, String path, String query)
+    /**
+     * Normalize a provided scheme, server, port, path, query, and fragment and append to StringBuilder.
+     *
+     * <p>
+     * Performing the following:
+     * </p>
+     * <ul>
+     *     <li>Scheme is reduced to lowercase</li>
+     *     <li>Server is normalized via {@link HostPort#normalizeHost(String)}</li>
+     *     <li>Port is only added if provided and it does not match the scheme default.</li>
+     *     <li>Path is only added if provided, no encoding is performed.</li>
+     *     <li>Query is only added if provided, and Path exists, no encoding is performed.</li>
+     *     <li>Fragment is only added if provided, and Path exists, no encoding is performed.</li>
+     * </ul>
+     *
+     * @param url the StringBuilder to build normalized URI into.
+     * @param scheme the scheme, may not be blank or null.
+     * @param server the server hostname, may not be blank or null.
+     * @param port the port (only numbers greater than 0 are considered)
+     * @param path the optional path to add (any encoding is assumed to be performed already)
+     * @param query the optional query (any encoding is assumed to be performed already)
+     * @param fragment the optional fragment (any encoding is assumed to be performed already)
+     */
+    public static void concatNormalizedURI(StringBuilder url, String scheme, String server, int port, String path, String query, String fragment)
     {
         if (StringUtil.isBlank(scheme))
             throw new IllegalArgumentException("scheme is blank");
@@ -175,9 +198,10 @@ public enum HttpScheme
         {
             url.append(path);
             if (StringUtil.isNotBlank(query))
-            {
                 url.append('?').append(query);
-            }
+
+            if (StringUtil.isNotBlank(fragment))
+                url.append("#").append(fragment);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
@@ -120,7 +120,7 @@ public enum HttpScheme
     public static String normalizeUri(String scheme, String server, int port, String path, String query)
     {
         StringBuilder builder = new StringBuilder();
-        appendNormalizedUri(builder, scheme, server, port, null, null);
+        appendNormalizedUri(builder, scheme, server, port, path, query);
         return builder.toString();
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpScheme.java
@@ -14,9 +14,12 @@
 package org.eclipse.jetty.http;
 
 import java.nio.ByteBuffer;
+import java.util.Locale;
 
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Index;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * HTTP and WebSocket Schemes
@@ -85,6 +88,97 @@ public enum HttpScheme
     {
         HttpScheme httpScheme = scheme == null ? null : CACHE.get(scheme);
         return httpScheme == null ? port : httpScheme.normalizePort(port);
+    }
+
+    /**
+     * Normalize a provided scheme, server, and port into a String form.
+     *
+     * @param scheme the scheme, may not be blank or null.
+     * @param server the server hostname, may not be blank or null.
+     * @param port the port
+     * @return the String representation following the general format {@code <scheme>://<server>:<port>}, where
+     * the returned String might not include a port, and will not include the ending {@code /} character.
+     * @see #appendNormalizedUri(StringBuilder, String, String, int)
+     */
+    public static String normalizeUri(String scheme, String server, int port)
+    {
+        return normalizeUri(scheme, server, port, null, null);
+    }
+
+    /**
+     * Normalize a provided scheme, server, and port into a String form.
+     *
+     * @param scheme the scheme, may not be blank or null.
+     * @param server the server hostname, may not be blank or null.
+     * @param port the port
+     * @param path the optional path, may be null
+     * @param query the optional query, may be null (not included in output if path is null)
+     * @return the String representation following the general format {@code <scheme>://<server>:<port>/<path>?<query>}, where
+     * the returned String might not include a port.
+     * @see #appendNormalizedUri(StringBuilder, String, String, int)
+     */
+    public static String normalizeUri(String scheme, String server, int port, String path, String query)
+    {
+        StringBuilder builder = new StringBuilder();
+        appendNormalizedUri(builder, scheme, server, port, null, null);
+        return builder.toString();
+    }
+
+    /**
+     * Normalize a provided scheme, server, and port and append to StringBuilder.
+     *
+     * <p>
+     * Performing the following:
+     * </p>
+     * <ul>
+     *     <li>Scheme is reduced to lowercase</li>
+     *     <li>Server is normalized via {@link HostPort#normalizeHost(String)}</li>
+     *     <li>Port is only added if provided and it does not match the scheme default.</li>
+     * </ul>
+     *
+     * @param url the StringBuilder to build normalized URI into.
+     * @param scheme the scheme, may not be blank or null.
+     * @param server the server hostname, may not be blank or null.
+     * @param port the port
+     */
+    public static void appendNormalizedUri(StringBuilder url, String scheme, String server, int port)
+    {
+        appendNormalizedUri(url, scheme, server, port, null, null);
+    }
+
+    public static void appendNormalizedUri(StringBuilder url, String scheme, String server, int port, String path, String query)
+    {
+        if (StringUtil.isBlank(scheme))
+            throw new IllegalArgumentException("scheme is blank");
+        if (StringUtil.isBlank(server))
+            throw new IllegalArgumentException("server is blank");
+
+        HttpScheme httpScheme = CACHE.get(scheme);
+
+        if (httpScheme != null)
+            url.append(httpScheme.asString());
+        else
+            url.append(scheme.toLowerCase(Locale.ENGLISH));
+
+        url.append("://");
+        url.append(HostPort.normalizeHost(server));
+
+        if (port > 0)
+        {
+            boolean secure = isSecure(scheme);
+            if ((secure && port != 443) ||
+                (!secure && port != 80))
+                url.append(':').append(Integer.toString(port));
+        }
+
+        if (path != null)
+        {
+            url.append(path);
+            if (StringUtil.isNotBlank(query))
+            {
+                url.append('?').append(query);
+            }
+        }
     }
 
     public static boolean isSecure(String scheme)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
@@ -126,35 +126,46 @@ public class HttpSchemeTest
     {
         return Stream.of(
             // Default behaviors of stripping a port number based on scheme
-            Arguments.of("http", "example.org", 80, "/", null, null, "http://example.org"),
-            Arguments.of("https", "example.org", 443, "/", null, null, "https://example.org"),
-            Arguments.of("ws", "example.org", 80, "/", null, null, "ws://example.org"),
-            Arguments.of("wss", "example.org", 443, "/", null, null, "wss://example.org"),
+            Arguments.of("http", "example.org", 80, "/", null, null, "http://example.org/"),
+            Arguments.of("https", "example.org", 443, "/", null, null, "https://example.org/"),
+            Arguments.of("ws", "example.org", 80, "/", null, null, "ws://example.org/"),
+            Arguments.of("wss", "example.org", 443, "/", null, null, "wss://example.org/"),
             // Mismatches between scheme and port
-            Arguments.of("http", "example.org", 443, "/", null, null, "http://example.org:443"),
-            Arguments.of("https", "example.org", 80, "/", null, null, "https://example.org:80"),
-            Arguments.of("ws", "example.org", 443, "/", null, null, "ws://example.org:443"),
-            Arguments.of("wss", "example.org", 80, "/", null, null, "wss://example.org:80"),
+            Arguments.of("http", "example.org", 443, "/", null, null, "http://example.org:443/"),
+            Arguments.of("https", "example.org", 80, "/", null, null, "https://example.org:80/"),
+            Arguments.of("ws", "example.org", 443, "/", null, null, "ws://example.org:443/"),
+            Arguments.of("wss", "example.org", 80, "/", null, null, "wss://example.org:80/"),
             // Odd ports
-            Arguments.of("http", "example.org", 12345, "/", null, null, "http://example.org:12345"),
-            Arguments.of("https", "example.org", 54321, "/", null, null, "https://example.org:54321"),
-            Arguments.of("ws", "example.org", 6666, "/", null, null, "ws://example.org:6666"),
-            Arguments.of("wss", "example.org", 7777, "/", null, null, "wss://example.org:7777"),
+            Arguments.of("http", "example.org", 12345, "/", null, null, "http://example.org:12345/"),
+            Arguments.of("https", "example.org", 54321, "/", null, null, "https://example.org:54321/"),
+            Arguments.of("ws", "example.org", 6666, "/", null, null, "ws://example.org:6666/"),
+            Arguments.of("wss", "example.org", 7777, "/", null, null, "wss://example.org:7777/"),
             // Non-lowercase Schemes
-            Arguments.of("HTTP", "example.org", 8181, "/", null, null, "http://example.org:8181"),
-            Arguments.of("hTTps", "example.org", 443, "/", null, null, "https://example.org"),
-            Arguments.of("WS", "example.org", 8282, "/", null, null, "ws://example.org:8282"),
-            Arguments.of("wsS", "example.org", 8383, "/", null, null, "wss://example.org:8383"),
+            Arguments.of("HTTP", "example.org", 8181, "/", null, null, "http://example.org:8181/"),
+            Arguments.of("hTTps", "example.org", 443, "/", null, null, "https://example.org/"),
+            Arguments.of("WS", "example.org", 8282, "/", null, null, "ws://example.org:8282/"),
+            Arguments.of("wsS", "example.org", 8383, "/", null, null, "wss://example.org:8383/"),
             // Undefined Ports
-            Arguments.of("http", "example.org", 0, "/", null, null, "http://example.org"),
-            Arguments.of("https", "example.org", -1, "/", null, null, "https://example.org"),
-            Arguments.of("ws", "example.org", -80, "/", null, null, "ws://example.org"),
-            Arguments.of("wss", "example.org", -2, "/", null, null, "wss://example.org"),
+            Arguments.of("http", "example.org", 0, "/", null, null, "http://example.org/"),
+            Arguments.of("https", "example.org", -1, "/", null, null, "https://example.org/"),
+            Arguments.of("ws", "example.org", -80, "/", null, null, "ws://example.org/"),
+            Arguments.of("wss", "example.org", -2, "/", null, null, "wss://example.org/"),
             // Unrecognized (non-http) schemes
-            Arguments.of("foo", "example.org", 0, "/", null, null, "foo://example.org"),
-            Arguments.of("ssh", "example.org", 22, "/", null, null, "ssh://example.org:22"),
-            Arguments.of("ftp", "example.org", 21, "/", null, null, "ftp://example.org:21"),
-            Arguments.of("file", "etc", -1, "/", null, null, "file://etc")
+            Arguments.of("foo", "example.org", 0, "/", null, null, "foo://example.org/"),
+            Arguments.of("ssh", "example.org", 22, "/", null, null, "ssh://example.org:22/"),
+            Arguments.of("ftp", "example.org", 21, "/", null, null, "ftp://example.org:21/"),
+            // Path choices
+            Arguments.of("http", "example.org", 0, "/a/b/c/d", null, null, "http://example.org/a/b/c/d"),
+            Arguments.of("http", "example.org", 0, "/a%20b/c%20d", null, null, "http://example.org/a%20b/c%20d"),
+            // Query specified
+            Arguments.of("http", "example.org", 0, "/", "a=b", null, "http://example.org/?a=b"),
+            Arguments.of("http", "example.org", 0, "/documentation/latest/", "a=b", null, "http://example.org/documentation/latest/?a=b"),
+            // - no path specified == no query output
+            Arguments.of("http", "example.org", 0, null, "a=b", null, "http://example.org"),
+            // Fragment specified
+            Arguments.of("http", "example.org", 0, "/", null, "toc", "http://example.org/#toc"),
+            // - no path specified == no fragment output
+            Arguments.of("http", "example.org", 0, null, null, "toc", "http://example.org")
         );
     }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
@@ -14,11 +14,16 @@
 package org.eclipse.jetty.http;
 
 import java.nio.ByteBuffer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -28,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class HttpSchemeTest
 {
-
     @Test
     public void testIsReturningTrue()
     {
@@ -71,5 +75,78 @@ public class HttpSchemeTest
         assertTrue(byteBuffer.isReadOnly());
         assertFalse(byteBuffer.isDirect());
         assertTrue(byteBuffer.hasRemaining());
+    }
+
+    public static Stream<Arguments> appendNormalizedUriCases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "http://example.org"),
+            Arguments.of("https", "example.org", 443, "https://example.org"),
+            Arguments.of("ws", "example.org", 80, "ws://example.org"),
+            Arguments.of("wss", "example.org", 443, "wss://example.org"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "http://example.org:443"),
+            Arguments.of("https", "example.org", 80, "https://example.org:80"),
+            Arguments.of("ws", "example.org", 443, "ws://example.org:443"),
+            Arguments.of("wss", "example.org", 80, "wss://example.org:80"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "http://example.org:12345"),
+            Arguments.of("https", "example.org", 54321, "https://example.org:54321"),
+            Arguments.of("ws", "example.org", 6666, "ws://example.org:6666"),
+            Arguments.of("wss", "example.org", 7777, "wss://example.org:7777"),
+            // Non-lowercase Schemes
+            Arguments.of("HTTP", "example.org", 8181, "http://example.org:8181"),
+            Arguments.of("hTTps", "example.org", 443, "https://example.org"),
+            Arguments.of("WS", "example.org", 8282, "ws://example.org:8282"),
+            Arguments.of("wsS", "example.org", 8383, "wss://example.org:8383"),
+            // Undefined Ports
+            Arguments.of("http", "example.org", 0, "http://example.org"),
+            Arguments.of("https", "example.org", -1, "https://example.org"),
+            Arguments.of("ws", "example.org", -80, "ws://example.org"),
+            Arguments.of("wss", "example.org", -2, "wss://example.org"),
+            // Unrecognized (non-http) schemes
+            Arguments.of("foo", "example.org", 0, "foo://example.org"),
+            Arguments.of("ssh", "example.org", 22, "ssh://example.org:22"),
+            Arguments.of("ftp", "example.org", 21, "ftp://example.org:21"),
+            Arguments.of("file", "etc", -1, "file://etc")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendNormalizedUriCases")
+    public void testAppendNormalizedUri(String scheme, String server, int port, String expectedStr)
+    {
+        StringBuilder actual = new StringBuilder();
+        HttpScheme.appendNormalizedUri(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
+
+    /**
+     * Tests of parameters that would trigger an IllegalStateException from
+     * {@link HttpScheme#appendNormalizedUri(StringBuilder, String, String, int)}
+     */
+    public static Stream<Arguments> appendNormalizedUriBadArgs()
+    {
+        return Stream.of(
+            // bad schemes
+            Arguments.of(null, "example.org", 0),
+            Arguments.of("", "example.org", 0),
+            Arguments.of("\t", "example.org", 0),
+            Arguments.of("    ", "example.org", 0),
+            // bad servers
+            Arguments.of("http", null, 0),
+            Arguments.of("http", "", 0),
+            Arguments.of("http", "\t", 0),
+            Arguments.of("http", "    ", 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendNormalizedUriBadArgs")
+    public void testAppendNormalizedUriBadArgs(String scheme, String server, int port)
+    {
+        StringBuilder actual = new StringBuilder();
+        assertThrows(IllegalArgumentException.class, () -> HttpScheme.appendNormalizedUri(actual, scheme, server, port));
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpSchemeTest.java
@@ -77,7 +77,7 @@ public class HttpSchemeTest
         assertTrue(byteBuffer.hasRemaining());
     }
 
-    public static Stream<Arguments> appendNormalizedUriCases()
+    public static Stream<Arguments> concatNormalizedURIShortCases()
     {
         return Stream.of(
             // Default behaviors of stripping a port number based on scheme
@@ -114,19 +114,64 @@ public class HttpSchemeTest
     }
 
     @ParameterizedTest
-    @MethodSource("appendNormalizedUriCases")
-    public void testAppendNormalizedUri(String scheme, String server, int port, String expectedStr)
+    @MethodSource("concatNormalizedURIShortCases")
+    public void testConcatNormalizedShortURI(String scheme, String server, int port, String expectedStr)
     {
         StringBuilder actual = new StringBuilder();
-        HttpScheme.appendNormalizedUri(actual, scheme, server, port);
+        HttpScheme.concatNormalizedURI(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
+
+    public static Stream<Arguments> concatNormalizedURICases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "/", null, null, "http://example.org"),
+            Arguments.of("https", "example.org", 443, "/", null, null, "https://example.org"),
+            Arguments.of("ws", "example.org", 80, "/", null, null, "ws://example.org"),
+            Arguments.of("wss", "example.org", 443, "/", null, null, "wss://example.org"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "/", null, null, "http://example.org:443"),
+            Arguments.of("https", "example.org", 80, "/", null, null, "https://example.org:80"),
+            Arguments.of("ws", "example.org", 443, "/", null, null, "ws://example.org:443"),
+            Arguments.of("wss", "example.org", 80, "/", null, null, "wss://example.org:80"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "/", null, null, "http://example.org:12345"),
+            Arguments.of("https", "example.org", 54321, "/", null, null, "https://example.org:54321"),
+            Arguments.of("ws", "example.org", 6666, "/", null, null, "ws://example.org:6666"),
+            Arguments.of("wss", "example.org", 7777, "/", null, null, "wss://example.org:7777"),
+            // Non-lowercase Schemes
+            Arguments.of("HTTP", "example.org", 8181, "/", null, null, "http://example.org:8181"),
+            Arguments.of("hTTps", "example.org", 443, "/", null, null, "https://example.org"),
+            Arguments.of("WS", "example.org", 8282, "/", null, null, "ws://example.org:8282"),
+            Arguments.of("wsS", "example.org", 8383, "/", null, null, "wss://example.org:8383"),
+            // Undefined Ports
+            Arguments.of("http", "example.org", 0, "/", null, null, "http://example.org"),
+            Arguments.of("https", "example.org", -1, "/", null, null, "https://example.org"),
+            Arguments.of("ws", "example.org", -80, "/", null, null, "ws://example.org"),
+            Arguments.of("wss", "example.org", -2, "/", null, null, "wss://example.org"),
+            // Unrecognized (non-http) schemes
+            Arguments.of("foo", "example.org", 0, "/", null, null, "foo://example.org"),
+            Arguments.of("ssh", "example.org", 22, "/", null, null, "ssh://example.org:22"),
+            Arguments.of("ftp", "example.org", 21, "/", null, null, "ftp://example.org:21"),
+            Arguments.of("file", "etc", -1, "/", null, null, "file://etc")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("concatNormalizedURICases")
+    public void testConcatNormalizedURI(String scheme, String server, int port, String path, String query, String fragment, String expectedStr)
+    {
+        StringBuilder actual = new StringBuilder();
+        HttpScheme.concatNormalizedURI(actual, scheme, server, port, path, query, fragment);
         assertEquals(expectedStr, actual.toString());
     }
 
     /**
      * Tests of parameters that would trigger an IllegalStateException from
-     * {@link HttpScheme#appendNormalizedUri(StringBuilder, String, String, int)}
+     * {@link HttpScheme#concatNormalizedURI(StringBuilder, String, String, int)}
      */
-    public static Stream<Arguments> appendNormalizedUriBadArgs()
+    public static Stream<Arguments> concatNormalizedURIBadArgs()
     {
         return Stream.of(
             // bad schemes
@@ -143,10 +188,10 @@ public class HttpSchemeTest
     }
 
     @ParameterizedTest
-    @MethodSource("appendNormalizedUriBadArgs")
-    public void testAppendNormalizedUriBadArgs(String scheme, String server, int port)
+    @MethodSource("concatNormalizedURIBadArgs")
+    public void testConcatNormalizedURIBadArgs(String scheme, String server, int port)
     {
         StringBuilder actual = new StringBuilder();
-        assertThrows(IllegalArgumentException.class, () -> HttpScheme.appendNormalizedUri(actual, scheme, server, port));
+        assertThrows(IllegalArgumentException.class, () -> HttpScheme.concatNormalizedURI(actual, scheme, server, port));
     }
 }

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.pathmap.MappedResource;
@@ -46,7 +47,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -604,7 +604,7 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
             String scheme = httpConfig.getSecureScheme();
             int port = httpConfig.getSecurePort();
 
-            String url = URIUtil.newURI(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            String url = HttpScheme.normalizeUri(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
             response.getHeaders().put(HttpFields.CONTENT_LENGTH_0);
 
             Response.sendRedirect(request, response, callback, HttpStatus.MOVED_TEMPORARILY_302, url, true);

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -604,7 +604,7 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
             String scheme = httpConfig.getSecureScheme();
             int port = httpConfig.getSecurePort();
 
-            String url = HttpScheme.normalizeUri(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            String url = HttpScheme.normalizeURI(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery(), null);
             response.getHeaders().put(HttpFields.CONTENT_LENGTH_0);
 
             Response.sendRedirect(request, response, callback, HttpStatus.MOVED_TEMPORARILY_302, url, true);

--- a/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/SecurityHandlerTest.java
+++ b/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/SecurityHandlerTest.java
@@ -52,7 +52,7 @@ public class SecurityHandlerTest
         HttpConnectionFactory http = new HttpConnectionFactory();
         HttpConfiguration httpConfiguration = http.getHttpConfiguration();
         httpConfiguration.setSecurePort(9999);
-        httpConfiguration.setSecureScheme("BWTP");
+        httpConfiguration.setSecureScheme("bwtp");
         httpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
         _connector = new LocalConnector(_server, http);
         _connector.setIdleTimeout(300000);
@@ -134,7 +134,7 @@ public class SecurityHandlerTest
 
         response = _connector.getResponse("GET /ctx/confidential/info HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 302 Found"));
-        assertThat(response, containsString("Location: BWTP://"));
+        assertThat(response, containsString("Location: bwtp://"));
         assertThat(response, containsString(":9999"));
         assertThat(response, not(containsString("OK")));
 
@@ -161,7 +161,7 @@ public class SecurityHandlerTest
 
         response = _connector.getResponse("GET /ctx/confidential/info HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 302 Found"));
-        assertThat(response, containsString("Location: BWTP://"));
+        assertThat(response, containsString("Location: bwtp://"));
         assertThat(response, containsString(":9999"));
         assertThat(response, not(containsString("OK")));
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
@@ -357,7 +358,7 @@ public interface Response extends Content.Sink
             {
                 // make the location an absolute URI
                 StringBuilder url = new StringBuilder(128);
-                URIUtil.appendSchemeHostPort(url, uri.getScheme(), Request.getServerName(request), Request.getServerPort(request));
+                HttpScheme.appendNormalizedUri(url, uri.getScheme(), Request.getServerName(request), Request.getServerPort(request));
                 url.append(location);
                 location = url.toString();
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -358,7 +358,7 @@ public interface Response extends Content.Sink
             {
                 // make the location an absolute URI
                 StringBuilder url = new StringBuilder(128);
-                HttpScheme.appendNormalizedUri(url, uri.getScheme(), Request.getServerName(request), Request.getServerPort(request));
+                HttpScheme.concatNormalizedURI(url, uri.getScheme(), Request.getServerName(request), Request.getServerPort(request));
                 url.append(location);
                 location = url.toString();
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -98,7 +98,13 @@ public class SecuredRedirectHandler extends Handler.Wrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = HttpScheme.normalizeUri(secureScheme, Request.getServerName(request), securePort, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            String url = HttpScheme.normalizeURI(
+                secureScheme,
+                Request.getServerName(request),
+                securePort,
+                request.getHttpURI().getPath(),
+                request.getHttpURI().getQuery(),
+                null);
             Response.sendRedirect(request, response, callback, _redirectCode, url, false);
         }
         else

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.jetty.server.handler;
 
-import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * Forces a redirect to the secure form of the resource before allowed to access the resource.
@@ -99,11 +98,8 @@ public class SecuredRedirectHandler extends Handler.Wrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = URIUtil.newURI(secureScheme, Request.getServerName(request), securePort, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
-            // TODO need a utility for this
-            response.getHeaders().put(HttpHeader.LOCATION, url);
-            response.setStatus(_redirectCode);
-            response.write(true, null, callback);
+            String url = HttpScheme.normalizeUri(secureScheme, Request.getServerName(request), securePort, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            Response.sendRedirect(request, response, callback, _redirectCode, url, false);
         }
         else
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1368,7 +1368,9 @@ public final class URIUtil
      * @param path the URI path
      * @param query the URI query
      * @return A String URI
+     * @deprecated use {@code HttpScheme} from {@code jetty-http} instead (as it does a proper job with normalization).  Will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static String newURI(String scheme, String server, int port, String path, String query)
     {
         StringBuilder builder = newURIBuilder(scheme, server, port);
@@ -1385,7 +1387,9 @@ public final class URIUtil
      * @param server the URI server
      * @param port the URI port
      * @return a StringBuilder containing URI prefix
+     * @deprecated use {@code HttpScheme} from {@code jetty-http} instead (as it does a proper job with normalization).  Will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static StringBuilder newURIBuilder(String scheme, String server, int port)
     {
         StringBuilder builder = new StringBuilder();
@@ -1400,7 +1404,9 @@ public final class URIUtil
      * @param scheme the URI scheme
      * @param server the URI server
      * @param port the URI port
+     * @deprecated use {@code HttpScheme} from {@code jetty-http} instead (as it does a proper job with normalization).  Will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuilder url, String scheme, String server, int port)
     {
         url.append(scheme).append("://").append(HostPort.normalizeHost(server));
@@ -1434,7 +1440,9 @@ public final class URIUtil
      * @param scheme the URI scheme
      * @param server the URI server
      * @param port the URI port
+     * @deprecated use {@code HttpScheme} from {@code jetty-http} instead (as it does a proper job with normalization).  Will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuffer url, String scheme, String server, int port)
     {
         url.append(scheme).append("://").append(HostPort.normalizeHost(server));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1409,11 +1409,13 @@ public final class URIUtil
         {
             switch (scheme)
             {
+                case "ws":
                 case "http":
                     if (port != 80)
                         url.append(':').append(port);
                     break;
 
+                case "wss":
                 case "https":
                     if (port != 443)
                         url.append(':').append(port);
@@ -1441,11 +1443,13 @@ public final class URIUtil
         {
             switch (scheme)
             {
+                case "ws":
                 case "http":
                     if (port != 80)
                         url.append(':').append(port);
                     break;
 
+                case "wss":
                 case "https":
                     if (port != 443)
                         url.append(':').append(port);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -1185,4 +1185,43 @@ public class URIUtilTest
         };
         assertThat(uris, contains(expected));
     }
+
+    public static Stream<Arguments> appendSchemeHostPortCases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "http://example.org"),
+            Arguments.of("https", "example.org", 443, "https://example.org"),
+            Arguments.of("ws", "example.org", 80, "ws://example.org"),
+            Arguments.of("wss", "example.org", 443, "wss://example.org"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "http://example.org:443"),
+            Arguments.of("https", "example.org", 80, "https://example.org:80"),
+            Arguments.of("ws", "example.org", 443, "ws://example.org:443"),
+            Arguments.of("wss", "example.org", 80, "wss://example.org:80"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "http://example.org:12345"),
+            Arguments.of("https", "example.org", 54321, "https://example.org:54321"),
+            Arguments.of("ws", "example.org", 6666, "ws://example.org:6666"),
+            Arguments.of("wss", "example.org", 7777, "wss://example.org:7777")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendSchemeHostPortCases")
+    public void testAppendSchemeHostPortBuilder(String scheme, String server, int port, String expectedStr)
+    {
+        StringBuilder actual = new StringBuilder();
+        URIUtil.appendSchemeHostPort(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendSchemeHostPortCases")
+    public void testAppendSchemeHostPortBuffer(String scheme, String server, int port, String expectedStr)
+    {
+        StringBuffer actual = new StringBuffer();
+        URIUtil.appendSchemeHostPort(actual, scheme, server, port);
+        assertEquals(expectedStr, actual.toString());
+    }
 }

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
@@ -217,18 +217,14 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = new StringBuilder();
-                HttpScheme.appendNormalizedUri(newURI, request.getScheme(), request.getServerName(), request.getServerPort());
-                String component = locationURI.getRawPath();
-                if (component != null)
-                    newURI.append(component);
-                component = locationURI.getRawQuery();
-                if (component != null)
-                    newURI.append('?').append(component);
-                component = locationURI.getRawFragment();
-                if (component != null)
-                    newURI.append('#').append(component);
-                return URI.create(newURI.toString()).normalize().toString();
+                String newURI = HttpScheme.normalizeURI(
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort(),
+                    locationURI.getRawPath(),
+                    locationURI.getRawQuery(),
+                    locationURI.getRawFragment());
+                return URI.create(newURI).normalize().toString();
             }
         }
         return headerValue;

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
@@ -27,7 +27,7 @@ import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.client.Response;
-import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.http.HttpScheme;
 
 public class BalancerServlet extends ProxyServlet
 {
@@ -217,7 +217,8 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = URIUtil.newURIBuilder(request.getScheme(), request.getServerName(), request.getServerPort());
+                StringBuilder newURI = new StringBuilder();
+                HttpScheme.appendNormalizedUri(newURI, request.getScheme(), request.getServerName(), request.getServerPort());
                 String component = locationURI.getRawPath();
                 if (component != null)
                     newURI.append(component);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1179,7 +1179,7 @@ public class Request implements HttpServletRequest
     public StringBuilder getRootURL()
     {
         StringBuilder url = new StringBuilder(128);
-        HttpScheme.appendNormalizedUri(url, getScheme(), getServerName(), getServerPort());
+        HttpScheme.concatNormalizedURI(url, getScheme(), getServerName(), getServerPort());
         return url;
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -73,6 +73,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
@@ -1178,7 +1179,7 @@ public class Request implements HttpServletRequest
     public StringBuilder getRootURL()
     {
         StringBuilder url = new StringBuilder(128);
-        URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
+        HttpScheme.appendNormalizedUri(url, getScheme(), getServerName(), getServerPort());
         return url;
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
@@ -81,9 +81,9 @@ public class SecuredRedirectHandler extends HandlerWrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = HttpScheme.normalizeUri(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString());
+            String url = HttpScheme.normalizeURI(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString(), null);
             response.setContentLength(0);
-            baseRequest.getResponse().sendRedirect(_redirectCode, url.toString(), true);
+            baseRequest.getResponse().sendRedirect(_redirectCode, url, true);
         }
         else
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
@@ -18,9 +18,9 @@ import java.io.IOException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * <p>SecuredRedirectHandler redirects from {@code http} to {@code https}.</p>
@@ -81,9 +81,9 @@ public class SecuredRedirectHandler extends HandlerWrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = URIUtil.newURI(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString());
+            String url = HttpScheme.normalizeUri(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString());
             response.setContentLength(0);
-            baseRequest.getResponse().sendRedirect(_redirectCode, url, true);
+            baseRequest.getResponse().sendRedirect(_redirectCode, url.toString(), true);
         }
         else
         {

--- a/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
@@ -294,7 +294,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             if (_logoutRedirectPath != null)
             {
                 StringBuilder sb = new StringBuilder(128);
-                HttpScheme.appendNormalizedUri(sb, request.getScheme(), request.getServerName(), request.getServerPort());
+                HttpScheme.concatNormalizedURI(sb, request.getScheme(), request.getServerName(), request.getServerPort());
                 sb.append(baseRequest.getContextPath());
                 sb.append(_logoutRedirectPath);
                 redirectUri = sb.toString();

--- a/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.ee9.security.authentication.DeferredAuthentication;
 import org.eclipse.jetty.ee9.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.ee9.security.authentication.SessionAuthentication;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.LoginService;
@@ -293,7 +294,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             if (_logoutRedirectPath != null)
             {
                 StringBuilder sb = new StringBuilder(128);
-                URIUtil.appendSchemeHostPort(sb, request.getScheme(), request.getServerName(), request.getServerPort());
+                HttpScheme.appendNormalizedUri(sb, request.getScheme(), request.getServerName(), request.getServerPort());
                 sb.append(baseRequest.getContextPath());
                 sb.append(_logoutRedirectPath);
                 redirectUri = sb.toString();

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
@@ -27,7 +27,7 @@ import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.client.Response;
-import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.http.HttpScheme;
 
 public class BalancerServlet extends ProxyServlet
 {
@@ -217,14 +217,14 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = URIUtil.newURIBuilder(request.getScheme(), request.getServerName(), request.getServerPort());
-                String component = locationURI.getRawPath();
-                if (component != null)
-                    newURI.append(component);
-                component = locationURI.getRawQuery();
-                if (component != null)
-                    newURI.append('?').append(component);
-                component = locationURI.getRawFragment();
+                StringBuilder newURI = new StringBuilder();
+                HttpScheme.appendNormalizedUri(newURI,
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort(),
+                    locationURI.getRawPath(),
+                    locationURI.getRawQuery());
+                String component = locationURI.getRawFragment();
                 if (component != null)
                     newURI.append('#').append(component);
                 return URI.create(newURI.toString()).normalize().toString();

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
@@ -217,17 +217,14 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = new StringBuilder();
-                HttpScheme.appendNormalizedUri(newURI,
+                String newURI = HttpScheme.normalizeURI(
                     request.getScheme(),
                     request.getServerName(),
                     request.getServerPort(),
                     locationURI.getRawPath(),
-                    locationURI.getRawQuery());
-                String component = locationURI.getRawFragment();
-                if (component != null)
-                    newURI.append('#').append(component);
-                return URI.create(newURI.toString()).normalize().toString();
+                    locationURI.getRawQuery(),
+                    locationURI.getRawFragment());
+                return URI.create(newURI).normalize().toString();
             }
         }
         return headerValue;

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -652,9 +652,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 String scheme = httpConfig.getSecureScheme();
                 int port = httpConfig.getSecurePort();
 
-                String url = HttpScheme.normalizeUri(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString());
+                String url = HttpScheme.normalizeURI(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString(), null);
                 response.setContentLength(0);
-                response.sendRedirect(url.toString(), true);
+                response.sendRedirect(url, true);
             }
             else
                 response.sendError(HttpStatus.FORBIDDEN_403, "!Secure");

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.ee9.nested.ContextHandler;
 import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.ee9.nested.Response;
 import org.eclipse.jetty.ee9.nested.ServletConstraint;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
@@ -44,7 +45,6 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -652,9 +652,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 String scheme = httpConfig.getSecureScheme();
                 int port = httpConfig.getSecurePort();
 
-                String url = URIUtil.newURI(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString());
+                String url = HttpScheme.normalizeUri(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString());
                 response.setContentLength(0);
-                response.sendRedirect(url, true);
+                response.sendRedirect(url.toString(), true);
             }
             else
                 response.sendError(HttpStatus.FORBIDDEN_403, "!Secure");

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/DataConstraintsTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/DataConstraintsTest.java
@@ -59,7 +59,7 @@ public class DataConstraintsTest
 
         HttpConnectionFactory http = new HttpConnectionFactory();
         http.getHttpConfiguration().setSecurePort(9999);
-        http.getHttpConfiguration().setSecureScheme("BWTP");
+        http.getHttpConfiguration().setSecureScheme("bwtp");
         _connector = new LocalConnector(_server, http);
         _connector.setIdleTimeout(300000);
 
@@ -138,7 +138,7 @@ public class DataConstraintsTest
 
         response = _connector.getResponse("GET /ctx/integral/info HTTP/1.0\r\n\r\n");
         assertThat(response, Matchers.containsString("HTTP/1.1 302 Found"));
-        assertThat(response, Matchers.containsString("Location: BWTP://"));
+        assertThat(response, Matchers.containsString("Location: bwtp://"));
         assertThat(response, Matchers.containsString(":9999"));
 
         response = _connectorS.getResponse("GET /ctx/integral/info HTTP/1.0\r\n\r\n");
@@ -166,7 +166,7 @@ public class DataConstraintsTest
 
         response = _connector.getResponse("GET /ctx/confid/info HTTP/1.0\r\n\r\n");
         assertThat(response, Matchers.containsString("HTTP/1.1 302 Found"));
-        assertThat(response, Matchers.containsString("Location: BWTP://"));
+        assertThat(response, Matchers.containsString("Location: bwtp://"));
         assertThat(response, Matchers.containsString(":9999"));
 
         response = _connectorS.getResponse("GET /ctx/confid/info HTTP/1.0\r\n\r\n");


### PR DESCRIPTION
* Deprecate URIUtil methods that are not normalizing URI strings properly from component parts.
* Add relevant HttpScheme methods to perform proper normalization of URI components.
* Migrate all existing code to use new HttpScheme methods.