### PR TITLE
Fixes #11371 - Review ArrayByteBufferPool eviction.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -35,6 +35,16 @@ public class CompoundPool<P> implements Pool<P>
         this.secondaryPool = secondaryPool;
     }
 
+    public Pool<P> getPrimaryPool()
+    {
+        return primaryPool;
+    }
+
+    public Pool<P> getSecondaryPool()
+    {
+        return secondaryPool;
+    }
+
     @Override
     public Entry<P> reserve()
     {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -154,7 +154,6 @@ public class QueuedPool<P> implements Pool<P>
             Collection<Entry<P>> copy = new ArrayList<>(queue);
             queue.clear();
             queueSize.set(0);
-            copy.forEach(Entry::remove);
             return copy;
         }
         finally

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -148,6 +148,11 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         leaked.increment();
         if (LOG.isDebugEnabled())
             LOG.debug("Leaked " + holder);
+        leaked();
+    }
+
+    protected void leaked()
+    {
     }
 
     @Override
@@ -194,8 +199,8 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
             Holder<P> holder = entries.get(i);
             if (holder.getEntry() == null)
             {
-                leaked(holder);
                 entries.remove(i--);
+                leaked(holder);
             }
         }
     }
@@ -222,8 +227,8 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
                     ConcurrentEntry<P> entry = (ConcurrentEntry<P>)holder.getEntry();
                     if (entry == null)
                     {
-                        leaked(holder);
                         entries.remove(index);
+                        leaked(holder);
                         continue;
                     }
 
@@ -231,6 +236,7 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
                     {
                         if (LOG.isDebugEnabled())
                             LOG.debug("returning entry {} for {}", entry, this);
+                        onAcquired(entry);
                         return entry;
                     }
                 }
@@ -263,12 +269,22 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         };
     }
 
+    protected void onAcquired(Entry<P> entry)
+    {
+    }
+
     private boolean release(Entry<P> entry)
     {
         boolean released = ((ConcurrentEntry<P>)entry).tryRelease();
         if (LOG.isDebugEnabled())
             LOG.debug("released {} {} for {}", released, entry, this);
+        if (released)
+            onReleased(entry);
         return released;
+    }
+
+    protected void onReleased(Entry<P> entry)
+    {
     }
 
     private boolean remove(Entry<P> entry)


### PR DESCRIPTION
* Eviction is now performed on release(), rather than acquire().
* Memory accounting is done on release(), rather than acquire(). This is because we were always exceeding the maxMemory on acquire(), by returning a non-pooled buffer. We only need to account for what is idle in the pool, and that is done more efficiently on release(), and it is leak-resistant (i.e. if the buffer is not returned, the memory is already non accounted for, keeping the pool consistent).
* Released entries now give precedence to Concurrent.Entry, rather than Queued.Entry, so the queued pool is always kept at minimum size.