### PR TITLE
Fixes #11371 - Review ArrayByteBufferPool eviction.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
@@ -287,8 +288,13 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private boolean evict(long excessMemory, boolean direct)
     {
         RetainedBucket[] buckets = direct ? _direct : _indirect;
-        for (RetainedBucket bucket : buckets)
+        int length = buckets.length;
+        int index = ThreadLocalRandom.current().nextInt(length);
+        for (int c = 0; c < length; ++c)
         {
+            RetainedBucket bucket = buckets[index++];
+            if (index == length)
+                index = 0;
             excessMemory -= bucket.evict();
             if (excessMemory <= 0)
                 return true;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -66,7 +66,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private final LongAdder _heapMemory = new LongAdder();
     private final LongAdder _directMemory = new LongAdder();
     private final IntUnaryOperator _bucketIndexFor;
-    private boolean _statisticsEnabled = true;
+    private boolean _statisticsEnabled;
 
     /**
      * Creates a new ArrayByteBufferPool with a default configuration.

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -260,7 +260,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             bucket._evicts.incrementAndGet();
             // If we cannot free enough space for the entry, remove it.
-            if (!evict(excessMemory, direct))
+            if (!evict(excessMemory, bucket, direct))
             {
                 bucket._removes.incrementAndGet();
                 entry.remove();
@@ -290,7 +290,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         return memory - maxMemory;
     }
 
-    private boolean evict(long excessMemory, boolean direct)
+    private boolean evict(long excessMemory, RetainedBucket target, boolean direct)
     {
         RetainedBucket[] buckets = direct ? _direct : _indirect;
         int length = buckets.length;
@@ -300,6 +300,9 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             RetainedBucket bucket = buckets[index++];
             if (index == length)
                 index = 0;
+            // Do not evict from the bucket the buffer is released into.
+            if (bucket == target)
+                continue;
 
             int evicted = bucket.evict();
             updateMemory(-evicted, direct);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -593,13 +593,17 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                     inUse++;
             }
 
-            return String.format("%s{capacity=%d,in-use=%d/%d,pooled/acquires=%d/%d,non-pooled/evicts/removes/releases=%d/%d/%d/%d}",
+            long pooled = _pooled.longValue();
+            long acquires = _acquires.longValue();
+            float hitRatio = acquires == 0 ? Float.NaN : pooled * 100F / acquires;
+            return String.format("%s{capacity=%d,in-use=%d/%d,pooled/acquires=%d/%d(%.3f%%),non-pooled/evicts/removes/releases=%d/%d/%d/%d}",
                 super.toString(),
                 getCapacity(),
                 inUse,
                 entries,
-                _pooled.longValue(),
-                _acquires.longValue(),
+                pooled,
+                acquires,
+                hitRatio,
                 _nonPooled.longValue(),
                 _evicts.longValue(),
                 _removes.longValue(),

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -270,7 +270,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         // We have enough space for this entry, pool it.
         if (!entry.release())
         {
-            bucket._evicts.incrementAndGet();
+            bucket._removes.incrementAndGet();
             entry.remove();
         }
     }
@@ -425,7 +425,9 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     public void clear()
     {
         clearBuckets(_direct);
+        _directMemory.set(0);
         clearBuckets(_indirect);
+        _heapMemory.set(0);
     }
 
     private void clearBuckets(RetainedBucket[] buckets)
@@ -516,11 +518,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             _evicts.set(0);
             _removes.set(0);
             _releases.set(0);
-            getPool().stream().forEach(entry ->
-            {
-                if (entry.remove())
-                    updateMemory(-_capacity, entry.getPooled().isDirect());
-            });
+            getPool().stream().forEach(Pool.Entry::remove);
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -91,4 +91,28 @@ public class CompoundPool<P> implements Pool<P>
     {
         return Stream.concat(primaryPool.stream(), secondaryPool.stream());
     }
+
+    @Override
+    public int getReservedCount()
+    {
+        return primaryPool.getReservedCount() + secondaryPool.getReservedCount();
+    }
+
+    @Override
+    public int getIdleCount()
+    {
+        return primaryPool.getIdleCount() + secondaryPool.getIdleCount();
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        return primaryPool.getInUseCount() + secondaryPool.getInUseCount();
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        return primaryPool.getTerminatedCount() + secondaryPool.getTerminatedCount();
+    }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -35,6 +35,16 @@ public class CompoundPool<P> implements Pool<P>
         this.secondaryPool = secondaryPool;
     }
 
+    public Pool<P> getPrimaryPool()
+    {
+        return primaryPool;
+    }
+
+    public Pool<P> getSecondaryPool()
+    {
+        return secondaryPool;
+    }
+
     @Override
     public Entry<P> reserve()
     {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -107,7 +107,6 @@ public class QueuedPool<P> implements Pool<P>
             {
                 queueSize.decrementAndGet();
                 entry.acquire();
-                onAcquired(entry);
             }
             return entry;
         }
@@ -115,14 +114,6 @@ public class QueuedPool<P> implements Pool<P>
         {
             rwLock.readLock().unlock();
         }
-    }
-
-    protected void onAcquired(Entry<P> entry)
-    {
-    }
-
-    protected void onReleased(Entry<P> entry)
-    {
     }
 
     @Override
@@ -272,10 +263,7 @@ public class QueuedPool<P> implements Pool<P>
             if (p == null || !inUse[0])
                 return false;
             pooled.set(p, false);
-            boolean reQueued = pool.requeue(this);
-            if (reQueued)
-                pool.onReleased(this);
-            return reQueued;
+            return pool.requeue(this);
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -180,6 +180,30 @@ public class QueuedPool<P> implements Pool<P>
         return queue.stream();
     }
 
+    @Override
+    public int getReservedCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getIdleCount()
+    {
+        return size();
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        return 0;
+    }
+
     private static class QueuedEntry<P> implements Entry<P>
     {
         private final QueuedPool<P> pool;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -154,7 +154,6 @@ public class QueuedPool<P> implements Pool<P>
             Collection<Entry<P>> copy = new ArrayList<>(queue);
             queue.clear();
             queueSize.set(0);
-            copy.forEach(Entry::remove);
             return copy;
         }
         finally

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
@@ -8,5 +8,6 @@
     <Arg type="int"><Property name="jetty.byteBufferPool.maxBucketSize" default="-1"/></Arg>
     <Arg type="long"><Property name="jetty.byteBufferPool.maxHeapMemory" default="0"/></Arg>
     <Arg type="long"><Property name="jetty.byteBufferPool.maxDirectMemory" default="0"/></Arg>
+    <Set name="statisticsEnabled" property="jetty.byteBufferPool.statisticsEnabled" />
   </New>
 </Configure>

--- a/jetty-core/jetty-server/src/main/config/modules/bytebufferpool.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/bytebufferpool.mod
@@ -31,3 +31,6 @@ etc/jetty-bytebufferpool.xml
 
 ## Maximum direct memory held idle by the pool (0 for heuristic, -1 for unlimited).
 #jetty.byteBufferPool.maxDirectMemory=0
+
+## Whether statistics are enabled.
+#jetty.byteBufferPool.statisticsEnabled=false

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 
@@ -362,6 +363,42 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
     public Stream<Entry<P>> stream()
     {
         return entries.stream().map(Holder::getEntry).filter(Objects::nonNull);
+    }
+
+    @Override
+    public int getReservedCount()
+    {
+        return getCount(Entry::isReserved);
+    }
+
+    @Override
+    public int getIdleCount()
+    {
+        return getCount(Entry::isIdle);
+    }
+
+    @Override
+    public int getInUseCount()
+    {
+        return getCount(Entry::isInUse);
+    }
+
+    @Override
+    public int getTerminatedCount()
+    {
+        return getCount(Entry::isTerminated);
+    }
+
+    private int getCount(Predicate<Entry<P>> predicate)
+    {
+        int count = 0;
+        for (Holder<P> holder : entries)
+        {
+            Entry<P> entry = holder.getEntry();
+            if (entry != null && predicate.test(entry))
+                count++;
+        }
+        return count;
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -148,6 +148,11 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         leaked.increment();
         if (LOG.isDebugEnabled())
             LOG.debug("Leaked " + holder);
+        leaked();
+    }
+
+    protected void leaked()
+    {
     }
 
     @Override
@@ -194,8 +199,8 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
             Holder<P> holder = entries.get(i);
             if (holder.getEntry() == null)
             {
-                leaked(holder);
                 entries.remove(i--);
+                leaked(holder);
             }
         }
     }
@@ -222,8 +227,8 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
                     ConcurrentEntry<P> entry = (ConcurrentEntry<P>)holder.getEntry();
                     if (entry == null)
                     {
-                        leaked(holder);
                         entries.remove(index);
+                        leaked(holder);
                         continue;
                     }
 
@@ -231,6 +236,7 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
                     {
                         if (LOG.isDebugEnabled())
                             LOG.debug("returning entry {} for {}", entry, this);
+                        onAcquired(entry);
                         return entry;
                     }
                 }
@@ -263,12 +269,22 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         };
     }
 
+    protected void onAcquired(Entry<P> entry)
+    {
+    }
+
     private boolean release(Entry<P> entry)
     {
         boolean released = ((ConcurrentEntry<P>)entry).tryRelease();
         if (LOG.isDebugEnabled())
             LOG.debug("released {} {} for {}", released, entry, this);
+        if (released)
+            onReleased(entry);
         return released;
+    }
+
+    protected void onReleased(Entry<P> entry)
+    {
     }
 
     private boolean remove(Entry<P> entry)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -237,7 +237,6 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
                     {
                         if (LOG.isDebugEnabled())
                             LOG.debug("returning entry {} for {}", entry, this);
-                        onAcquired(entry);
                         return entry;
                     }
                 }
@@ -270,22 +269,12 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
         };
     }
 
-    protected void onAcquired(Entry<P> entry)
-    {
-    }
-
     private boolean release(Entry<P> entry)
     {
         boolean released = ((ConcurrentEntry<P>)entry).tryRelease();
         if (LOG.isDebugEnabled())
             LOG.debug("released {} {} for {}", released, entry, this);
-        if (released)
-            onReleased(entry);
         return released;
-    }
-
-    protected void onReleased(Entry<P> entry)
-    {
     }
 
     private boolean remove(Entry<P> entry)

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ArrayByteBufferPoolBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ArrayByteBufferPoolBenchmark.java
@@ -1,0 +1,127 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io.jmh;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.profile.AsyncProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State(Scope.Benchmark)
+public class ArrayByteBufferPoolBenchmark
+{
+    public static void main(String[] args) throws RunnerException
+    {
+        String asyncProfilerPath = "/home/simon/programs/async-profiler/lib/libasyncProfiler.so";
+        Options opt = new OptionsBuilder()
+            .include(ArrayByteBufferPoolBenchmark.class.getSimpleName())
+            .warmupIterations(10)
+            .warmupTime(TimeValue.milliseconds(500))
+            .measurementIterations(10)
+            .measurementTime(TimeValue.milliseconds(500))
+            .addProfiler(AsyncProfiler.class, "dir=/tmp;output=flamegraph;event=cpu;interval=500000;libPath=" + asyncProfilerPath)
+            .forks(1)
+            .threads(10)
+            .build();
+        new Runner(opt).run();
+    }
+
+    @Param("0")
+    int minCapacity;
+    @Param("65536")
+    int maxCapacity;
+    @Param("4096")
+    int factor;
+    @Param("-1")
+    int maxBucketSize;
+    @Param({"0", "1048576"})
+    long maxMemory;
+    @Param({"true"})
+    boolean statisticsEnabled;
+
+    ArrayByteBufferPool pool;
+
+    @Setup
+    public void prepare()
+    {
+        pool = new ArrayByteBufferPool(minCapacity, factor, maxCapacity, maxBucketSize, maxMemory, maxMemory);
+        pool.setStatisticsEnabled(statisticsEnabled);
+    }
+
+    @TearDown
+    public void dispose()
+    {
+        System.out.println(pool.dump());
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void inputFixedCapacityOutputRandomCapacity()
+    {
+        // Simulate a read from the network.
+        RetainableByteBuffer input = pool.acquire(61440, true);
+
+        // Simulate a write of random size from the application.
+        int capacity = ThreadLocalRandom.current().nextInt(minCapacity, maxCapacity);
+        RetainableByteBuffer output = pool.acquire(capacity, true);
+
+        output.release();
+        input.release();
+    }
+
+    int iterations;
+
+    @Setup(Level.Iteration)
+    public void migrate()
+    {
+        ++iterations;
+        if (iterations == 15)
+            System.out.println(pool.dump());
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void inputFixedCapacityOutputRandomCapacityMigrating()
+    {
+        // Simulate a read from the network.
+        RetainableByteBuffer input = pool.acquire(8192, true);
+
+        // Simulate a write of random size from the application.
+        // Simulate a change in buffer sizes after half of the iterations.
+        int capacity;
+        if (iterations <= 15)
+            capacity = ThreadLocalRandom.current().nextInt(minCapacity, maxCapacity / 2);
+        else
+            capacity = ThreadLocalRandom.current().nextInt(maxCapacity / 2, maxCapacity);
+        RetainableByteBuffer output = pool.acquire(capacity, true);
+
+        output.release();
+        input.release();
+    }
+}


### PR DESCRIPTION
* Eviction is now performed on release(), rather than acquire().
* Memory accounting is done on release(), rather than acquire().
This is because we were always exceeding the maxMemory on acquire(), by returning a non-pooled buffer.
We only need to account for what is idle in the pool, and that is done more efficiently on release(), and it is leak-resistant (i.e. if the buffer is not returned, the memory is already non accounted for, keeping the pool consistent).
* Released entries now give precedence to Concurrent.Entry, rather than Queued.Entry, so the queued pool is always kept at minimum size.
* Eviction is performed by running through the buckets, starting at a random bucket, and removing, if present, an idle buffer until the excess memory is freed.