### PR TITLE
Issue #11398 - allow frames to be demanded in WebSocket onOpen

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -220,9 +220,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         BufferUtil.flipToFlush(buffer, 0);
     }
 
-    /**
-     * Physical connection Open.
-     */
     @Override
     public void onOpen()
     {
@@ -236,11 +233,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             fillAndParse();
     }
 
-    /**
-     * Physical connection disconnect.
-     * <p>
-     * Not related to WebSocket close handshake.
-     */
     @Override
     public void onClose(Throwable cause)
     {
@@ -273,11 +265,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         return true;
     }
 
-    /**
-     * Event for no activity on connection (read or write)
-     *
-     * @return true to signal that the endpoint must be closed, false to keep the endpoint open
-     */
     @Override
     protected boolean onReadTimeout(TimeoutException timeout)
     {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -431,7 +431,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 case NOT_DEMANDING ->
                 {
                     fillingAndParsing = false;
-                    if (!networkBuffer.hasRemaining())
+                    if (networkBuffer != null && !networkBuffer.hasRemaining())
                         releaseNetworkBuffer();
                     return false;
                 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -199,40 +199,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         this.useOutputDirectByteBuffers = useOutputDirectByteBuffers;
     }
 
-    /**
-     * Extra bytes from the initial HTTP upgrade that need to
-     * be processed by the websocket parser before starting
-     * to read bytes from the connection
-     *
-     * @param initialBuffer the bytes of extra content encountered during upgrade
-     */
-    protected void setInitialBuffer(ByteBuffer initialBuffer)
-    {
-        if (LOG.isDebugEnabled())
-            LOG.debug("Set initial buffer - {}", BufferUtil.toDetailString(initialBuffer));
-        try (AutoLock l = lock.lock())
-        {
-            networkBuffer = newNetworkBuffer(initialBuffer.remaining());
-        }
-        ByteBuffer buffer = networkBuffer.getByteBuffer();
-        BufferUtil.clearToFill(buffer);
-        BufferUtil.put(initialBuffer, buffer);
-        BufferUtil.flipToFlush(buffer, 0);
-    }
-
-    @Override
-    public void onOpen()
-    {
-        if (LOG.isDebugEnabled())
-            LOG.debug("onOpen() {}", this);
-
-        // Open Session
-        super.onOpen();
-        coreSession.onOpen();
-        if (moreDemand())
-            fillAndParse();
-    }
-
     @Override
     public void onClose(Throwable cause)
     {
@@ -531,6 +497,40 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             }
             coreSession.processConnectionError(t, Callback.NOOP);
         }
+    }
+
+    /**
+     * Extra bytes from the initial HTTP upgrade that need to
+     * be processed by the websocket parser before starting
+     * to read bytes from the connection
+     *
+     * @param initialBuffer the bytes of extra content encountered during upgrade
+     */
+    protected void setInitialBuffer(ByteBuffer initialBuffer)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Set initial buffer - {}", BufferUtil.toDetailString(initialBuffer));
+        try (AutoLock l = lock.lock())
+        {
+            networkBuffer = newNetworkBuffer(initialBuffer.remaining());
+        }
+        ByteBuffer buffer = networkBuffer.getByteBuffer();
+        BufferUtil.clearToFill(buffer);
+        BufferUtil.put(initialBuffer, buffer);
+        BufferUtil.flipToFlush(buffer, 0);
+    }
+
+    @Override
+    public void onOpen()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("onOpen() {}", this);
+
+        // Open Session
+        super.onOpen();
+        coreSession.onOpen();
+        if (moreDemand())
+            fillAndParse();
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
@@ -90,7 +90,7 @@ public class WebSocketSessionState
     public boolean isInputOpen()
     {
         State state = getState();
-        return (state == State.CONNECTED || state == State.OPEN || state == State.OSHUT);
+        return (state == State.OPEN || state == State.OSHUT);
     }
 
     public boolean isOutputOpen()

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/WebSocketSessionState.java
@@ -90,7 +90,7 @@ public class WebSocketSessionState
     public boolean isInputOpen()
     {
         State state = getState();
-        return (state == State.OPEN || state == State.OSHUT);
+        return (state == State.CONNECTED || state == State.OPEN || state == State.OSHUT);
     }
 
     public boolean isOutputOpen()

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
@@ -109,7 +109,6 @@ public class ExplicitDemandTest
             if (frame.getOpCode() == OpCode.TEXT)
                 textMessages.add(BufferUtil.toString(frame.getPayload()));
             callback.succeed();
-
         }
     }
 
@@ -265,7 +264,7 @@ public class ExplicitDemandTest
         Session session = connect.get(5, TimeUnit.SECONDS);
         session.sendText("test-text", Callback.NOOP);
 
-        // We cannot receive messages in onOpen even if we have demanded.
+        // We cannot receive messages while in onOpen, even if we have demanded.
         assertNull(onOpenSocket.textMessages.poll(1, TimeUnit.SECONDS));
 
         // Once we leave onOpen we receive the message.

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
@@ -265,9 +265,13 @@ public class ExplicitDemandTest
         Session session = connect.get(5, TimeUnit.SECONDS);
         session.sendText("test-text", Callback.NOOP);
 
+        // We cannot receive messages in onOpen even if we have demanded.
+        assertNull(onOpenSocket.textMessages.poll(1, TimeUnit.SECONDS));
+
+        // Once we leave onOpen we receive the message.
+        onOpenSocket.onOpen.countDown();
         String received = onOpenSocket.textMessages.poll(5, TimeUnit.SECONDS);
         assertThat(received, equalTo("test-text"));
-        onOpenSocket.onOpen.countDown();
 
         session.close();
         assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));


### PR DESCRIPTION
closes #11398

An alternate to this fix would be succeeding the `FrameHandler.onOpen` callback before calling the `openHandle` in `JettyWebSocketFrameHandler`.