### PR TITLE
Fixes #11403 - Expose SslEndPoint in SslHandshakeListener

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1481,7 +1481,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             for (SslHandshakeListener listener : handshakeListeners)
             {
                 if (event == null)
-                    event = new SslHandshakeListener.Event(sslEngine);
+                    event = new SslHandshakeListener.Event(sslEngine, this);
                 try
                 {
                     listener.handshakeSucceeded(event);
@@ -1503,7 +1503,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             for (SslHandshakeListener listener : handshakeListeners)
             {
                 if (event == null)
-                    event = new SslHandshakeListener.Event(sslEngine);
+                    event = new SslHandshakeListener.Event(sslEngine, this);
                 try
                 {
                     listener.handshakeFailed(event, failure);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslHandshakeListener.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslHandshakeListener.java
@@ -18,6 +18,8 @@ import java.util.EventObject;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
+import org.eclipse.jetty.io.EndPoint;
+
 /**
  * <p>Implementations of this interface are notified of TLS handshake events.</p>
  * <p>Similar to {@link javax.net.ssl.HandshakeCompletedListener}, but for {@link SSLEngine}.</p>
@@ -49,11 +51,26 @@ public interface SslHandshakeListener extends EventListener
     /**
      * <p>The event object carrying information about TLS handshake events.</p>
      */
-    public static class Event extends EventObject
+    class Event extends EventObject
     {
+        private final EndPoint endPoint;
+
+        /**
+         * <p>Creates a new instance with the given event source.</p>
+         *
+         * @param source the source of this event.
+         * @deprecated instances of this class can only be created by the implementation
+         */
+        @Deprecated(forRemoval = true, since = "12.0.7")
         public Event(Object source)
         {
-            super(source);
+            this(source, null);
+        }
+
+        Event(Object sslEngine, EndPoint endPoint)
+        {
+            super(sslEngine);
+            this.endPoint = endPoint;
         }
 
         /**
@@ -62,6 +79,14 @@ public interface SslHandshakeListener extends EventListener
         public SSLEngine getSSLEngine()
         {
             return (SSLEngine)getSource();
+        }
+
+        /**
+         * @return the EndPoint associated to the TLS handshake event
+         */
+        public EndPoint getEndPoint()
+        {
+            return endPoint;
         }
     }
 }


### PR DESCRIPTION
Now also exposing the `EndPoint` in SslHandshakeListener.Event.