### PR TITLE
Issue #11310 - multipart parser dropping some relevant CR bytes in parts

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -1392,6 +1392,7 @@ public class MultiPart
             partialBoundaryMatch = boundaryFinder.endsWith(buffer);
             if (partialBoundaryMatch > 0)
             {
+                notifyCRContent();
                 int limit = buffer.limit();
                 int sliceLimit = limit - partialBoundaryMatch;
                 // BoundaryFinder is configured to search for '\n--Boundary';

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -1408,7 +1408,7 @@ public class MultiPart
                 // BoundaryFinder is configured to search for '\n--Boundary';
                 // if '\r\n--Bo' is found, then the '\r' may not be content,
                 // but remember it in case there is a boundary mismatch.
-                if (sliceLimit > 0 && buffer.get(sliceLimit - 1) == '\r')
+                if (buffer.get(sliceLimit - 1) == '\r')
                 {
                     crContent = true;
                     --sliceLimit;

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
@@ -218,11 +218,11 @@ public class MultiPartTest
             parser.parse(Content.Chunk.from(ByteBuffer.wrap(new byte[]{bytes[i]}), i == bytes.length - 1));
         }
 
-        assertEquals(16, listener.events.size());
+        assertEquals(15, listener.events.size());
         assertEquals("begin", listener.events.poll());
         assertEquals("header name: value", listener.events.poll());
         assertEquals("headers", listener.events.poll());
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < 9; i++)
         {
             assertEquals("content last: false length: 1", listener.events.poll());
         }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartTest.java
@@ -218,11 +218,11 @@ public class MultiPartTest
             parser.parse(Content.Chunk.from(ByteBuffer.wrap(new byte[]{bytes[i]}), i == bytes.length - 1));
         }
 
-        assertEquals(15, listener.events.size());
+        assertEquals(16, listener.events.size());
         assertEquals("begin", listener.events.poll());
         assertEquals("header name: value", listener.events.poll());
         assertEquals("headers", listener.events.poll());
-        for (int i = 0; i < 9; i++)
+        for (int i = 0; i < 10; i++)
         {
             assertEquals("content last: false length: 1", listener.events.poll());
         }


### PR DESCRIPTION
Fixing the MultiPart.Parser handling of part content that would drop occasional CR bytes if the CR occurs at the border of a network buffer.

This was fixed in PR #11388 (as the bug was first isolated during testing in that PR) but this is more fundamental bug unrelated to the goals of that PR so I created a standalone PR for this bug (also so that it shows up in the changelog for 12.0.7 appropriately)

Fixes #11310 