### PR TITLE
Issue #11410 - PathMappingsHandler does not set Server on added handlers

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -75,14 +75,14 @@ public class PathMappingsHandler extends Handler.AbstractContainer
         Server server = getServer();
         if (server != null)
         {
-            InvocationType serverInvocationType = server.getInvocationType();
-            InvocationType invocationType = InvocationType.NON_BLOCKING;
-            invocationType = Invocable.combine(invocationType, handler.getInvocationType());
             handler.setServer(server);
 
             // If the collection can be changed dynamically, then the risk is that if we switch from NON_BLOCKING to BLOCKING
             // whilst the execution strategy may have already dispatched the very last available thread, thinking it would
             // never block, only for it to lose the race and find a newly added BLOCKING handler.
+            InvocationType serverInvocationType = server.getInvocationType();
+            InvocationType invocationType = InvocationType.NON_BLOCKING;
+            invocationType = Invocable.combine(invocationType, handler.getInvocationType());
             if (isDynamic() && server.isStarted() && serverInvocationType != invocationType && serverInvocationType != InvocationType.BLOCKING)
                 throw new IllegalArgumentException("Cannot change invocation type of started server");
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -73,17 +73,19 @@ public class PathMappingsHandler extends Handler.AbstractContainer
             throw new IllegalStateException("loop detected: " + handler);
 
         Server server = getServer();
-        InvocationType serverInvocationType = server == null ? null : server.getInvocationType();
-        InvocationType invocationType = InvocationType.NON_BLOCKING;
-        invocationType = Invocable.combine(invocationType, handler.getInvocationType());
         if (server != null)
+        {
+            InvocationType serverInvocationType = server.getInvocationType();
+            InvocationType invocationType = InvocationType.NON_BLOCKING;
+            invocationType = Invocable.combine(invocationType, handler.getInvocationType());
             handler.setServer(server);
 
-        // If the collection can be changed dynamically, then the risk is that if we switch from NON_BLOCKING to BLOCKING
-        // whilst the execution strategy may have already dispatched the very last available thread, thinking it would
-        // never block, only for it to lose the race and find a newly added BLOCKING handler.
-        if (isDynamic() && server != null && server.isStarted() && serverInvocationType != invocationType && serverInvocationType != InvocationType.BLOCKING)
-            throw new IllegalArgumentException("Cannot change invocation type of started server");
+            // If the collection can be changed dynamically, then the risk is that if we switch from NON_BLOCKING to BLOCKING
+            // whilst the execution strategy may have already dispatched the very last available thread, thinking it would
+            // never block, only for it to lose the race and find a newly added BLOCKING handler.
+            if (isDynamic() && server.isStarted() && serverInvocationType != invocationType && serverInvocationType != InvocationType.BLOCKING)
+                throw new IllegalArgumentException("Cannot change invocation type of started server");
+        }
 
         // add new mapping and remove any old
         Handler old = mappings.get(pathSpec);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -64,11 +64,11 @@ public class PathMappingsHandler extends Handler.AbstractContainer
         if (!isDynamic() && isStarted())
             throw new IllegalStateException("Cannot add mapping: " + this);
 
-        // check that self isn't present
+        // Check that self isn't present.
         if (handler == this)
             throw new IllegalStateException("Unable to addHandler of self: " + handler);
 
-        // check for loops
+        // Check for loops.
         if (handler instanceof Handler.Container container && container.getDescendants().contains(this))
             throw new IllegalStateException("loop detected: " + handler);
 
@@ -87,7 +87,7 @@ public class PathMappingsHandler extends Handler.AbstractContainer
                 throw new IllegalArgumentException("Cannot change invocation type of started server");
         }
 
-        // add new mapping and remove any old
+        // Add new mapping and remove any old.
         Handler old = mappings.get(pathSpec);
         mappings.put(pathSpec, handler);
         updateBean(old, handler);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.slf4j.Logger;
@@ -77,6 +78,15 @@ public class PathMappingsHandler extends Handler.AbstractContainer
     public void dump(Appendable out, String indent) throws IOException
     {
         Dumpable.dumpObjects(out, indent, this, mappings);
+    }
+
+    @Override
+    protected void doStart() throws Exception
+    {
+        Server server = getServer();
+        for (MappedResource<Handler> mapping: mappings)
+            mapping.getResource().setServer(server);
+        super.doStart();
     }
 
     @Override


### PR DESCRIPTION
When `PathMappingsHandler` starts, the added `Handler` instances do not get their `Handler.setServer(Server)` method called.

With most Handler's this isn't a big deal, but with `ResourceHandler` this results in a badly started `ResourceHandler`.

This PR fixes this specific issue with `PathMappingsHandler`

Issue: #11410