### PR TITLE
Issue #11414 - use HttpURI for spec behaviors on scheme and port

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1101,9 +1101,7 @@ public class HttpClient extends ContainerLifeCycle
 
     public static int normalizePort(String scheme, int port)
     {
-        if (port > 0)
-            return port;
-        return HttpScheme.getDefaultPort(scheme);
+        return HttpScheme.normalizePort(scheme, port);
     }
 
     public ClientConnectionFactory newSslClientConnectionFactory(SslContextFactory.Client sslContextFactory, ClientConnectionFactory connectionFactory)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1099,9 +1099,17 @@ public class HttpClient extends ContainerLifeCycle
         return proxyConfig;
     }
 
+    /**
+     * Return a normalized port suitable for use by Origin and Address
+     * @param scheme the scheme to use for the default port (if port is unspecified)
+     * @param port the port (0 or negative means the port is unspecified)
+     * @return the normalized port.
+     */
     public static int normalizePort(String scheme, int port)
     {
-        return HttpScheme.normalizePort(scheme, port);
+        if (port > 0)
+            return port;
+        return HttpScheme.getDefaultPort(scheme);
     }
 
     public ClientConnectionFactory newSslClientConnectionFactory(SslContextFactory.Client sslContextFactory, ClientConnectionFactory connectionFactory)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -278,7 +279,7 @@ public class HttpRedirector
             Matcher matcher = URI_PATTERN.matcher(location);
             if (matcher.matches())
             {
-                String scheme = matcher.group(2);
+                String scheme = StringUtil.asciiToLowerCase(matcher.group(2));
                 String authority = matcher.group(3);
                 String path = matcher.group(4);
                 String query = matcher.group(5);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -20,10 +20,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.HostPort;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * <p>Class that groups the elements that uniquely identify a destination.</p>
@@ -122,9 +122,7 @@ public class Origin
 
     public String asString()
     {
-        StringBuilder result = new StringBuilder();
-        URIUtil.appendSchemeHostPort(result, scheme, address.host, address.port);
-        return result.toString();
+        return HttpURI.from(scheme, address.host, address.port, null).asString();
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.HostPort;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Class that groups the elements that uniquely identify a destination.</p>
@@ -74,7 +75,7 @@ public class Origin
 
     public Origin(String scheme, Address address, Object tag, Protocol protocol)
     {
-        this.scheme = Objects.requireNonNull(scheme);
+        this.scheme = StringUtil.asciiToLowerCase(Objects.requireNonNull(scheme));
         this.address = address;
         this.tag = tag;
         this.protocol = protocol;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -60,6 +60,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.StringUtil;
 
 public class HttpRequest implements Request
 {
@@ -182,7 +183,7 @@ public class HttpRequest implements Request
     @Override
     public Request scheme(String scheme)
     {
-        this.scheme = scheme;
+        this.scheme = StringUtil.asciiToLowerCase(scheme);
         this.uri = null;
         return this;
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -55,11 +55,11 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.URIUtil;
 
 public class HttpRequest implements Request
 {
@@ -122,9 +122,7 @@ public class HttpRequest implements Request
     {
         if (newURI == null)
         {
-            StringBuilder builder = new StringBuilder(64);
-            URIUtil.appendSchemeHostPort(builder, getScheme(), getHost(), getPort());
-            newURI = URI.create(builder.toString());
+            newURI = HttpURI.from(getScheme(), getHost(), getPort(), null).toURI();
         }
 
         HttpRequest newRequest = copyInstance(newURI);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientURITest.java
@@ -32,13 +32,13 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -68,9 +68,8 @@ public class HttpClientURITest extends AbstractHttpClientServerTest
             .timeout(5, TimeUnit.SECONDS);
 
         assertEquals(host, request.getHost());
-        StringBuilder uri = new StringBuilder();
-        URIUtil.appendSchemeHostPort(uri, scenario.getScheme(), host, connector.getLocalPort());
-        assertEquals(uri.toString(), request.getURI().toString());
+        HttpURI httpURI = HttpURI.from(scenario.getScheme(), host, connector.getLocalPort(), null);
+        assertEquals(httpURI.asString(), request.getURI().toString());
 
         assertEquals(HttpStatus.OK_200, request.send().getStatus());
     }

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -45,7 +46,6 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.PathMatchers;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -249,9 +249,7 @@ public class XmlConfiguredJetty
 
     public URI getServerURI() throws UnknownHostException
     {
-        StringBuilder uri = new StringBuilder();
-        URIUtil.appendSchemeHostPort(uri, getScheme(), InetAddress.getLocalHost().getHostAddress(), getServerPort());
-        return URI.create(uri.toString());
+        return HttpURI.from(getScheme(), InetAddress.getLocalHost().getHostAddress(), getServerPort(), null).toURI();
     }
 
     public Path getJettyBasePath()

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/test/XmlConfiguredJetty.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.PathMatchers;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -330,7 +331,7 @@ public class XmlConfiguredJetty
 
     public void setScheme(String scheme)
     {
-        this._scheme = scheme;
+        this._scheme = StringUtil.asciiToLowerCase(scheme);
     }
 
     public void start() throws Exception

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -510,7 +510,7 @@ public interface HttpURI
         {
             try
             {
-                return new URI(_scheme, null, _host, _port, _path, _query == null ? null : UrlEncoded.decodeString(_query), _fragment);
+                return new URI(_scheme, null, _host, HttpScheme.normalizePort(_scheme, _port), _path, _query == null ? null : UrlEncoded.decodeString(_query), _fragment);
             }
             catch (URISyntaxException x)
             {
@@ -974,7 +974,7 @@ public interface HttpURI
 
         public Mutable scheme(String scheme)
         {
-            _scheme = scheme;
+            _scheme = StringUtil.asciiToLowerCase(scheme);
             _uri = null;
             return this;
         }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -940,4 +940,134 @@ public class HttpURITest
     {
         assertThat(UriCompliance.from(UriCompliance.DEFAULT.getName()), sameInstance(UriCompliance.DEFAULT));
     }
+
+    public static Stream<Arguments> concatNormalizedURIShortCases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "http://example.org"),
+            Arguments.of("https", "example.org", 443, "https://example.org"),
+            Arguments.of("ws", "example.org", 80, "ws://example.org"),
+            Arguments.of("wss", "example.org", 443, "wss://example.org"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "http://example.org:443"),
+            Arguments.of("https", "example.org", 80, "https://example.org:80"),
+            Arguments.of("ws", "example.org", 443, "ws://example.org:443"),
+            Arguments.of("wss", "example.org", 80, "wss://example.org:80"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "http://example.org:12345"),
+            Arguments.of("https", "example.org", 54321, "https://example.org:54321"),
+            Arguments.of("ws", "example.org", 6666, "ws://example.org:6666"),
+            Arguments.of("wss", "example.org", 7777, "wss://example.org:7777"),
+            // Non-lowercase Schemes
+            Arguments.of("HTTP", "example.org", 8181, "http://example.org:8181"),
+            Arguments.of("hTTps", "example.org", 443, "https://example.org"),
+            Arguments.of("WS", "example.org", 8282, "ws://example.org:8282"),
+            Arguments.of("wsS", "example.org", 8383, "wss://example.org:8383"),
+            // Undefined Ports
+            Arguments.of("http", "example.org", 0, "http://example.org"),
+            Arguments.of("https", "example.org", -1, "https://example.org"),
+            Arguments.of("ws", "example.org", -80, "ws://example.org"),
+            Arguments.of("wss", "example.org", -2, "wss://example.org"),
+            // Unrecognized (non-http) schemes
+            Arguments.of("foo", "example.org", 0, "foo://example.org"),
+            Arguments.of("ssh", "example.org", 22, "ssh://example.org:22"),
+            Arguments.of("ftp", "example.org", 21, "ftp://example.org:21"),
+            Arguments.of("file", "etc", -1, "file://etc")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("concatNormalizedURIShortCases")
+    public void testFromShortAsStringNormalized(String scheme, String server, int port, String expectedStr)
+    {
+        HttpURI httpURI = HttpURI.from(scheme, server, port, null);
+        assertThat(httpURI.asString(), is(expectedStr));
+    }
+
+    public static Stream<Arguments> concatNormalizedURICases()
+    {
+        return Stream.of(
+            // Default behaviors of stripping a port number based on scheme
+            Arguments.of("http", "example.org", 80, "/", null, null, "http://example.org/"),
+            Arguments.of("https", "example.org", 443, "/", null, null, "https://example.org/"),
+            Arguments.of("ws", "example.org", 80, "/", null, null, "ws://example.org/"),
+            Arguments.of("wss", "example.org", 443, "/", null, null, "wss://example.org/"),
+            // Mismatches between scheme and port
+            Arguments.of("http", "example.org", 443, "/", null, null, "http://example.org:443/"),
+            Arguments.of("https", "example.org", 80, "/", null, null, "https://example.org:80/"),
+            Arguments.of("ws", "example.org", 443, "/", null, null, "ws://example.org:443/"),
+            Arguments.of("wss", "example.org", 80, "/", null, null, "wss://example.org:80/"),
+            // Odd ports
+            Arguments.of("http", "example.org", 12345, "/", null, null, "http://example.org:12345/"),
+            Arguments.of("https", "example.org", 54321, "/", null, null, "https://example.org:54321/"),
+            Arguments.of("ws", "example.org", 6666, "/", null, null, "ws://example.org:6666/"),
+            Arguments.of("wss", "example.org", 7777, "/", null, null, "wss://example.org:7777/"),
+            // Non-lowercase Schemes
+            Arguments.of("HTTP", "example.org", 8181, "/", null, null, "http://example.org:8181/"),
+            Arguments.of("hTTps", "example.org", 443, "/", null, null, "https://example.org/"),
+            Arguments.of("WS", "example.org", 8282, "/", null, null, "ws://example.org:8282/"),
+            Arguments.of("wsS", "example.org", 8383, "/", null, null, "wss://example.org:8383/"),
+            // Undefined Ports
+            Arguments.of("http", "example.org", 0, "/", null, null, "http://example.org/"),
+            Arguments.of("https", "example.org", -1, "/", null, null, "https://example.org/"),
+            Arguments.of("ws", "example.org", -80, "/", null, null, "ws://example.org/"),
+            Arguments.of("wss", "example.org", -2, "/", null, null, "wss://example.org/"),
+            // Unrecognized (non-http) schemes
+            Arguments.of("foo", "example.org", 0, "/", null, null, "foo://example.org/"),
+            Arguments.of("ssh", "example.org", 22, "/", null, null, "ssh://example.org:22/"),
+            Arguments.of("ftp", "example.org", 21, "/", null, null, "ftp://example.org:21/"),
+            // Path choices
+            Arguments.of("http", "example.org", 0, "/a/b/c/d", null, null, "http://example.org/a/b/c/d"),
+            Arguments.of("http", "example.org", 0, "/a%20b/c%20d", null, null, "http://example.org/a%20b/c%20d"),
+            // Query specified
+            Arguments.of("http", "example.org", 0, "/", "a=b", null, "http://example.org/?a=b"),
+            Arguments.of("http", "example.org", 0, "/documentation/latest/", "a=b", null, "http://example.org/documentation/latest/?a=b"),
+            Arguments.of("http", "example.org", 0, null, "a=b", null, "http://example.org?a=b"),
+            // Fragment specified
+            Arguments.of("http", "example.org", 0, "/", null, "toc", "http://example.org/#toc"),
+            Arguments.of("http", "example.org", 0, null, null, "toc", "http://example.org#toc")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("concatNormalizedURICases")
+    public void testFromAsStringNormalized(String scheme, String server, int port, String path, String query, String fragment, String expectedStr)
+    {
+        HttpURI httpURI = HttpURI.from(scheme, server, port, path, query, fragment);
+        assertThat(httpURI.asString(), is(expectedStr));
+    }
+
+    /**
+     * Tests of parameters that result in undesired behaviors.
+     * TODO: Should these trigger an IllegalStateException?
+     * {@link HttpURI#from(String, String, int, String)}
+     */
+    public static Stream<Arguments> fromBad()
+    {
+        return Stream.of(
+            // bad schemes
+            Arguments.of(null, "example.org", 0, "//example.org"),
+            Arguments.of("", "example.org", 0, "://example.org"),
+            Arguments.of("\t", "example.org", 0, "\t://example.org"),
+            Arguments.of("    ", "example.org", 0, "    ://example.org"),
+            // bad ports
+            Arguments.of("http", "example.org", 1_000_000, "http://example.org:1000000"),
+            // bad ports
+            Arguments.of("ws", "example.org", -222333, "ws://example.org"), // TODO: drop port? or ISE?
+            // bad servers
+            Arguments.of("http", null, 0, "http:"),
+            Arguments.of("http", "", 0, "http://"),
+            Arguments.of("http", "\t", 0, "http://\t"),
+            Arguments.of("http", "    ", 0, "http://    ")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromBad")
+    public void testFromBad(String scheme, String server, int port, String expectedStr)
+    {
+        HttpURI httpURI = HttpURI.from(scheme, server, port, null);
+        assertThat(httpURI.asString(), is(expectedStr));
+    }
 }

--- a/jetty-core/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-core/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -672,11 +672,12 @@ public class OpenIdAuthenticator extends LoginAuthenticator
 
     private String getRedirectUri(Request request)
     {
-        final StringBuffer redirectUri = new StringBuffer(128);
-        URIUtil.appendSchemeHostPort(redirectUri, request.getHttpURI().getScheme(),
-            Request.getServerName(request), Request.getServerPort(request));
-        redirectUri.append(URIUtil.addPaths(request.getContext().getContextPath(), _redirectPath));
-        return redirectUri.toString();
+        return HttpURI.from(
+            request.getHttpURI().getScheme(),
+            Request.getServerName(request),
+            Request.getServerPort(request),
+            URIUtil.addPaths(request.getContext().getContextPath(), _redirectPath)
+        ).asString();
     }
 
     protected String getChallengeUri(Request request)

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/ForwardedSchemeHeaderRule.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.rewrite.handler;
 
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Sets the request URI scheme, by default {@code https}.</p>
@@ -29,7 +30,7 @@ public class ForwardedSchemeHeaderRule extends HeaderRule
 
     public void setScheme(String scheme)
     {
-        _scheme = scheme;
+        _scheme = StringUtil.asciiToLowerCase(scheme);
     }
 
     @Override

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -46,7 +46,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -604,7 +603,7 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
             String scheme = httpConfig.getSecureScheme();
             int port = httpConfig.getSecurePort();
 
-            String url = URIUtil.newURI(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            String url = HttpURI.from(scheme, Request.getServerName(request), port, request.getHttpURI().getPath(), request.getHttpURI().getQuery(), null).asString();
             response.getHeaders().put(HttpFields.CONTENT_LENGTH_0);
 
             Response.sendRedirect(request, response, callback, HttpStatus.MOVED_TEMPORARILY_302, url, true);

--- a/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/SecurityHandlerTest.java
+++ b/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/SecurityHandlerTest.java
@@ -134,7 +134,7 @@ public class SecurityHandlerTest
 
         response = _connector.getResponse("GET /ctx/confidential/info HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 302 Found"));
-        assertThat(response, containsString("Location: BWTP://"));
+        assertThat(response, containsString("Location: bwtp://"));
         assertThat(response, containsString(":9999"));
         assertThat(response, not(containsString("OK")));
 
@@ -161,7 +161,7 @@ public class SecurityHandlerTest
 
         response = _connector.getResponse("GET /ctx/confidential/info HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 302 Found"));
-        assertThat(response, containsString("Location: BWTP://"));
+        assertThat(response, containsString("Location: bwtp://"));
         assertThat(response, containsString(":9999"));
         assertThat(response, not(containsString("OK")));
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.Jetty;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.Dumpable;
@@ -476,7 +477,7 @@ public class HttpConfiguration implements Dumpable
      */
     public void setSecureScheme(String secureScheme)
     {
-        _secureScheme = secureScheme;
+        _secureScheme = StringUtil.asciiToLowerCase(secureScheme);
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -356,10 +356,7 @@ public interface Response extends Content.Sink
             if (!request.getConnectionMetaData().getHttpConfiguration().isRelativeRedirectAllowed())
             {
                 // make the location an absolute URI
-                StringBuilder url = new StringBuilder(128);
-                URIUtil.appendSchemeHostPort(url, uri.getScheme(), Request.getServerName(request), Request.getServerPort(request));
-                url.append(location);
-                location = url.toString();
+                location = HttpURI.from(uri.getScheme(), Request.getServerName(request), Request.getServerPort(request), location).asString();
             }
         }
         return location;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SecuredRedirectHandler.java
@@ -15,12 +15,12 @@ package org.eclipse.jetty.server.handler;
 
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * Forces a redirect to the secure form of the resource before allowed to access the resource.
@@ -99,7 +99,7 @@ public class SecuredRedirectHandler extends Handler.Wrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = URIUtil.newURI(secureScheme, Request.getServerName(request), securePort, request.getHttpURI().getPath(), request.getHttpURI().getQuery());
+            String url = HttpURI.from(secureScheme, Request.getServerName(request), securePort, request.getHttpURI().getPath(), request.getHttpURI().getQuery(), null).asString();
             // TODO need a utility for this
             response.getHeaders().put(HttpHeader.LOCATION, url);
             response.setStatus(_redirectCode);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1409,11 +1409,12 @@ public final class URIUtil
     @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuilder url, String scheme, String server, int port)
     {
-        url.append(scheme).append("://").append(HostPort.normalizeHost(server));
+        String schemeSpec = StringUtil.asciiToLowerCase(scheme);
+        url.append(schemeSpec).append("://").append(HostPort.normalizeHost(server));
 
         if (port > 0)
         {
-            switch (scheme)
+            switch (schemeSpec)
             {
                 case "ws":
                 case "http":
@@ -1445,19 +1446,20 @@ public final class URIUtil
     @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuffer url, String scheme, String server, int port)
     {
-        url.append(scheme).append("://").append(HostPort.normalizeHost(server));
+        String schemeSpec = StringUtil.asciiToLowerCase(scheme);
+        url.append(schemeSpec).append("://").append(HostPort.normalizeHost(server));
 
         if (port > 0)
         {
-            switch (scheme)
+            switch (schemeSpec)
             {
-                    case "ws":
+                case "ws":
                 case "http":
                     if (port != 80)
                         url.append(':').append(port);
                     break;
 
-                    case "wss":
+                case "wss":
                 case "https":
                     if (port != 443)
                         url.append(':').append(port);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1368,7 +1368,9 @@ public final class URIUtil
      * @param path the URI path
      * @param query the URI query
      * @return A String URI
+     * @deprecated use {@code HttpURI} from {@code jetty-http} instead (as it does a proper job with normalization).  This will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static String newURI(String scheme, String server, int port, String path, String query)
     {
         StringBuilder builder = newURIBuilder(scheme, server, port);
@@ -1385,7 +1387,9 @@ public final class URIUtil
      * @param server the URI server
      * @param port the URI port
      * @return a StringBuilder containing URI prefix
+     * @deprecated use {@code HttpURI} from {@code jetty-http} instead (as it does a proper job with normalization).  This will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static StringBuilder newURIBuilder(String scheme, String server, int port)
     {
         StringBuilder builder = new StringBuilder();
@@ -1400,7 +1404,9 @@ public final class URIUtil
      * @param scheme the URI scheme
      * @param server the URI server
      * @param port the URI port
+     * @deprecated use {@code HttpURI} from {@code jetty-http} instead (as it does a proper job with normalization).  This will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuilder url, String scheme, String server, int port)
     {
         url.append(scheme).append("://").append(HostPort.normalizeHost(server));
@@ -1434,7 +1440,9 @@ public final class URIUtil
      * @param scheme the URI scheme
      * @param server the URI server
      * @param port the URI port
+     * @deprecated use {@code HttpURI} from {@code jetty-http} instead (as it does a proper job with normalization).  This will be removed in Jetty 12.1.0.
      */
+    @Deprecated(forRemoval = true, since = "12.0.7")
     public static void appendSchemeHostPort(StringBuffer url, String scheme, String server, int port)
     {
         url.append(scheme).append("://").append(HostPort.normalizeHost(server));

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -77,7 +78,7 @@ public class WebSocketCloseTest extends WebSocketTester
     public void setup(State state, String scheme) throws Exception
     {
         boolean tls;
-        switch (scheme)
+        switch (StringUtil.asciiToLowerCase(scheme))
         {
             case "ws":
                 tls = false;

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/BalancerServlet.java
@@ -27,7 +27,7 @@ import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.client.Response;
-import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.http.HttpURI;
 
 public class BalancerServlet extends ProxyServlet
 {
@@ -217,17 +217,14 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = URIUtil.newURIBuilder(request.getScheme(), request.getServerName(), request.getServerPort());
-                String component = locationURI.getRawPath();
-                if (component != null)
-                    newURI.append(component);
-                component = locationURI.getRawQuery();
-                if (component != null)
-                    newURI.append('?').append(component);
-                component = locationURI.getRawFragment();
-                if (component != null)
-                    newURI.append('#').append(component);
-                return URI.create(newURI.toString()).normalize().toString();
+                HttpURI httpURI = HttpURI.from(
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort(),
+                    locationURI.getRawPath(),
+                    locationURI.getRawQuery(),
+                    locationURI.getRawFragment());
+                return httpURI.toURI().normalize().toString();
             }
         }
         return headerValue;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
@@ -26,9 +26,11 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -168,7 +170,7 @@ public class XmlBasedJettyServer
 
     public void setScheme(String scheme)
     {
-        this._scheme = scheme;
+        this._scheme = StringUtil.asciiToLowerCase(scheme);
     }
 
     public void start() throws Exception
@@ -196,11 +198,10 @@ public class XmlBasedJettyServer
 
     public URI getServerURI()
     {
-        StringBuffer uri = new StringBuffer();
-        uri.append(this._scheme).append("://");
-        uri.append(InetAddress.getLoopbackAddress().getHostAddress());
-        uri.append(":").append(this._serverPort);
-        return URI.create(uri.toString());
+        return HttpURI.from(_scheme,
+            InetAddress.getLoopbackAddress().getHostAddress(),
+            _serverPort,
+            null).toURI();
     }
 
     public Server getServer()

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1152,12 +1152,7 @@ public class Request implements HttpServletRequest
     @Override
     public StringBuffer getRequestURL()
     {
-        final StringBuffer url = new StringBuffer(128);
-        URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        String path = getRequestURI();
-        if (path != null)
-            url.append(path);
-        return url;
+        return new StringBuffer(HttpURI.from(getScheme(), getServerName(), getServerPort(), getRequestURI()).asString());
     }
 
     public Response getResponse()
@@ -1177,9 +1172,7 @@ public class Request implements HttpServletRequest
      */
     public StringBuilder getRootURL()
     {
-        StringBuilder url = new StringBuilder(128);
-        URIUtil.appendSchemeHostPort(url, getScheme(), getServerName(), getServerPort());
-        return url;
+        return new StringBuilder(HttpURI.from(getScheme(), getServerName(), getServerPort(), null).asString());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SecuredRedirectHandler.java
@@ -19,8 +19,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.util.URIUtil;
 
 /**
  * <p>SecuredRedirectHandler redirects from {@code http} to {@code https}.</p>
@@ -81,7 +81,7 @@ public class SecuredRedirectHandler extends HandlerWrapper
         if (securePort > 0)
         {
             String secureScheme = httpConfig.getSecureScheme();
-            String url = URIUtil.newURI(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString());
+            String url = HttpURI.from(secureScheme, baseRequest.getServerName(), securePort, baseRequest.getRequestURI(), baseRequest.getQueryString(), null).asString();
             response.setContentLength(0);
             baseRequest.getResponse().sendRedirect(_redirectCode, url, true);
         }

--- a/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.ee9.security.authentication.DeferredAuthentication;
 import org.eclipse.jetty.ee9.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.ee9.security.authentication.SessionAuthentication;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.LoginService;
@@ -292,11 +293,12 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             String redirectUri = null;
             if (_logoutRedirectPath != null)
             {
-                StringBuilder sb = new StringBuilder(128);
-                URIUtil.appendSchemeHostPort(sb, request.getScheme(), request.getServerName(), request.getServerPort());
-                sb.append(baseRequest.getContextPath());
-                sb.append(_logoutRedirectPath);
-                redirectUri = sb.toString();
+                redirectUri = HttpURI.from(
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort(),
+                    URIUtil.addPaths(baseRequest.getContextPath(), _logoutRedirectPath)
+                    ).asString();
             }
 
             HttpSession session = baseRequest.getSession(false);
@@ -614,12 +616,12 @@ public class OpenIdAuthenticator extends LoginAuthenticator
 
     private String getRedirectUri(HttpServletRequest request)
     {
-        final StringBuffer redirectUri = new StringBuffer(128);
-        URIUtil.appendSchemeHostPort(redirectUri, request.getScheme(),
-            request.getServerName(), request.getServerPort());
-        redirectUri.append(request.getContextPath());
-        redirectUri.append(_redirectPath);
-        return redirectUri.toString();
+        return HttpURI.from(
+            request.getScheme(),
+            request.getServerName(),
+            request.getServerPort(),
+            URIUtil.addPaths(request.getContextPath(), _redirectPath)
+        ).asString();
     }
 
     protected String getChallengeUri(Request request)

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/BalancerServlet.java
@@ -27,7 +27,7 @@ import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.client.Response;
-import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.http.HttpURI;
 
 public class BalancerServlet extends ProxyServlet
 {
@@ -217,17 +217,14 @@ public class BalancerServlet extends ProxyServlet
             URI locationURI = URI.create(headerValue).normalize();
             if (locationURI.isAbsolute() && isBackendLocation(locationURI))
             {
-                StringBuilder newURI = URIUtil.newURIBuilder(request.getScheme(), request.getServerName(), request.getServerPort());
-                String component = locationURI.getRawPath();
-                if (component != null)
-                    newURI.append(component);
-                component = locationURI.getRawQuery();
-                if (component != null)
-                    newURI.append('?').append(component);
-                component = locationURI.getRawFragment();
-                if (component != null)
-                    newURI.append('#').append(component);
-                return URI.create(newURI.toString()).normalize().toString();
+                HttpURI httpURI = HttpURI.from(
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort(),
+                    locationURI.getRawPath(),
+                    locationURI.getRawQuery(),
+                    locationURI.getRawFragment());
+                return httpURI.toURI().normalize().toString();
             }
         }
         return headerValue;

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
@@ -841,7 +841,7 @@ public class ProxyServletTest
         int serverPort = serverConnector.getLocalPort();
         if (HttpScheme.HTTPS.is(scheme))
             serverPort = tlsServerConnector.getLocalPort();
-        String proxyTo = scheme + "://localhost:" + serverPort;
+        String proxyTo = StringUtil.asciiToLowerCase(scheme) + "://localhost:" + serverPort;
         Map<String, String> params = new HashMap<>();
         params.put("proxyTo", proxyTo);
         params.put("prefix", prefix);

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.ee9.nested.Response;
 import org.eclipse.jetty.ee9.nested.ServletConstraint;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
@@ -44,7 +45,6 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -652,7 +652,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 String scheme = httpConfig.getSecureScheme();
                 int port = httpConfig.getSecurePort();
 
-                String url = URIUtil.newURI(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString());
+                String url = HttpURI.from(scheme, request.getServerName(), port, request.getRequestURI(), request.getQueryString(), null).asString();
                 response.setContentLength(0);
                 response.sendRedirect(url, true);
             }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/support/XmlBasedJettyServer.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee9.test.support;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -30,6 +29,7 @@ import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -169,7 +169,7 @@ public class XmlBasedJettyServer
 
     public void setScheme(String scheme)
     {
-        this._scheme = scheme;
+        this._scheme = StringUtil.asciiToLowerCase(scheme);
     }
 
     public void start() throws Exception


### PR DESCRIPTION
Using HttpURI instead of URIUtil to have a single point of spec behavior.

Fixes #11414