### PR TITLE
Jetty 12.0.x 11377 fix jettyhome osgi path

### DIFF
--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EE10Activator.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EE10Activator.java
@@ -48,6 +48,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
@@ -357,7 +358,7 @@ public class EE10Activator implements BundleActivator
         {
             OSGiApp osgiApp = OSGiApp.class.cast(app);
             String jettyHome = (String)app.getDeploymentManager().getServer().getAttribute(OSGiServerConstants.JETTY_HOME);
-            Path jettyHomePath = (StringUtil.isBlank(jettyHome) ? null : Paths.get(jettyHome));
+            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : Paths.get(URIUtil.toURI(jettyHome));
 
             WebAppContext webApp = new WebAppContext();
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -239,7 +239,8 @@ public class WebInfConfiguration extends AbstractConfiguration
 
                 if (war != null)
                 {
-                    Path warPath = Path.of(war);
+                    Path warPath = Path.of(URIUtil.toURI(war));
+                    
                     // look for a sibling like "foo/" to a "foo.war"
                     if (FileID.isWebArchive(warPath) && Files.exists(warPath))
                     {

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/boot/EE9Activator.java
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/boot/EE9Activator.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
@@ -356,7 +357,7 @@ public class EE9Activator implements BundleActivator
         {
             OSGiApp osgiApp = OSGiApp.class.cast(app);
             String jettyHome = (String)app.getDeploymentManager().getServer().getAttribute(OSGiServerConstants.JETTY_HOME);
-            Path jettyHomePath = (StringUtil.isBlank(jettyHome) ? null : Paths.get(jettyHome));
+            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : Paths.get(URIUtil.toURI(jettyHome));
 
             WebAppContext webApp = new WebAppContext();
 


### PR DESCRIPTION
Closes #11377

Fix usage of paths in osgi code so that files resolve against jettyhome or jettybundlehome correctly on other operating systems, eg windows.