### PR TITLE
Experiment with ArrayByteBufferPool performance

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -259,7 +259,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         // We have enough space for this entry, pool it.
         if (entry.release())
         {
-            if (buffer instanceof Buffer b && b.use() % 100 == 1)
+            if (buffer instanceof Buffer b && b.use() % 100 == 0)
                checkMaxMemory(buffer.isDirect());
             return;
         }
@@ -627,7 +627,9 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         private int use()
         {
-            return _usages++;
+            if (++_usages < 0)
+                _usages = 0;
+            return _usages;
         }
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
@@ -64,9 +64,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private final int _maxCapacity;
     private final long _maxHeapMemory;
     private final long _maxDirectMemory;
-    private final AtomicLong _heapMemory = new AtomicLong();
-    private final AtomicLong _directMemory = new AtomicLong();
     private final IntUnaryOperator _bucketIndexFor;
+    private final AtomicBoolean _evictor = new AtomicBoolean(false);
     private boolean _statisticsEnabled;
 
     /**
@@ -215,7 +214,6 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         if (entry != null)
         {
             bucket.recordPooled();
-            subtractMemory(bucket.getCapacity(), direct);
             RetainableByteBuffer buffer = entry.getPooled();
             ((Buffer)buffer).acquire();
             return buffer;
@@ -228,35 +226,25 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     {
         bucket.recordRelease();
 
-        boolean direct = buffer.isDirect();
-        int capacity = bucket.getCapacity();
-
-        // Discard the buffer if maxMemory is exceeded.
-        long excessMemory = addMemoryAndGetExcess(bucket, direct);
-        if (excessMemory > 0)
-        {
-            subtractMemory(capacity, direct);
-            bucket.recordNonPooled();
-            return;
-        }
-
+        // try to reserve an entry to put the buffer into the pool.
         Pool.Entry<RetainableByteBuffer> entry = bucket.getPool().reserve();
-        // Cannot reserve, discard the buffer.
         if (entry == null)
         {
-            subtractMemory(capacity, direct);
             bucket.recordNonPooled();
             return;
         }
 
+        // Add the buffer to the new entry
         ByteBuffer byteBuffer = buffer.getByteBuffer();
         BufferUtil.reset(byteBuffer);
         Buffer pooledBuffer = new Buffer(byteBuffer, b -> release(bucket, entry));
         if (entry.enable(pooledBuffer, false))
+        {
+            checkMaxMemory(buffer.isDirect());
             return;
+        }
 
         // Discard the buffer if the entry cannot be enabled.
-        subtractMemory(capacity, direct);
         bucket.recordNonPooled();
         entry.remove();
     }
@@ -267,46 +255,39 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         RetainableByteBuffer buffer = entry.getPooled();
         BufferUtil.reset(buffer.getByteBuffer());
-        boolean direct = buffer.isDirect();
-        int capacity = bucket.getCapacity();
-        long excessMemory = addMemoryAndGetExcess(bucket, direct);
-        if (excessMemory > 0)
-        {
-            bucket.recordEvict();
-            // If we cannot free enough space for the entry, remove it.
-            if (!evict(excessMemory, bucket, direct))
-            {
-                subtractMemory(capacity, direct);
-                bucket.recordRemove();
-                entry.remove();
-                return;
-            }
-        }
 
         // We have enough space for this entry, pool it.
         if (entry.release())
+        {
+            if (buffer instanceof Buffer b && b.use() % 100 == 1)
+               checkMaxMemory(buffer.isDirect());
             return;
+        }
 
         // Not enough space, discard this buffer.
-        subtractMemory(capacity, direct);
         bucket.recordRemove();
         entry.remove();
     }
 
-    private long addMemoryAndGetExcess(RetainedBucket bucket, boolean direct)
+    private void checkMaxMemory(boolean direct)
     {
-        long maxMemory = direct ? _maxDirectMemory : _maxHeapMemory;
-        if (maxMemory < 0)
-            return -1;
-
-        AtomicLong memory = direct ? _directMemory : _heapMemory;
-        int capacity = bucket.getCapacity();
-        long newMemory = memory.addAndGet(capacity);
-        // Account the excess at most for the bucket capacity.
-        return Math.min(capacity, newMemory - maxMemory);
+        long max = direct ? _maxDirectMemory : _maxHeapMemory;
+        if (max <= 0 || !_evictor.compareAndSet(false, true))
+            return;
+        try
+        {
+            long memory = getMemory(direct);
+            long excess = memory - max;
+            if (excess > 0)
+                evict(excess, direct);
+        }
+        finally
+        {
+            _evictor.set(false);
+        }
     }
 
-    private boolean evict(long excessMemory, RetainedBucket target, boolean direct)
+    private void evict(long excessMemory, boolean direct)
     {
         RetainedBucket[] buckets = direct ? _direct : _indirect;
         int length = buckets.length;
@@ -316,18 +297,12 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             RetainedBucket bucket = buckets[index++];
             if (index == length)
                 index = 0;
-            // Do not evict from the bucket the buffer is released into.
-            if (bucket == target)
-                continue;
 
             int evicted = bucket.evict();
-            subtractMemory(evicted, direct);
-
             excessMemory -= evicted;
             if (excessMemory <= 0)
-                return true;
+                return;
         }
-        return false;
     }
 
     protected ByteBuffer allocate(int capacity)
@@ -415,14 +390,10 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private long getMemory(boolean direct)
     {
-        AtomicLong memory = direct ? _directMemory : _heapMemory;
-        return memory.longValue();
-    }
-
-    private void subtractMemory(int amount, boolean direct)
-    {
-        AtomicLong memory = direct ? _directMemory : _heapMemory;
-        memory.addAndGet(-amount);
+        long size = 0;
+        for (RetainedBucket bucket : direct ? _direct : _indirect)
+            size += (long)bucket.getPool().getIdleCount() * bucket._capacity;
+        return size;
     }
 
     @ManagedAttribute("The available bytes retained by direct ByteBuffers")
@@ -453,9 +424,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     public void clear()
     {
         clearBuckets(_direct);
-        _directMemory.set(0);
         clearBuckets(_indirect);
-        _heapMemory.set(0);
     }
 
     private void clearBuckets(RetainedBucket[] buckets)
@@ -570,6 +539,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
             recordRemove();
             entry.remove();
+            recordEvict();
 
             return getCapacity();
         }
@@ -634,12 +604,13 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private static class Buffer extends AbstractRetainableByteBuffer
     {
-        private final Consumer<RetainableByteBuffer> releaser;
+        private final Consumer<RetainableByteBuffer> _releaser;
+        private int _usages;
 
         private Buffer(ByteBuffer buffer, Consumer<RetainableByteBuffer> releaser)
         {
             super(buffer);
-            this.releaser = releaser;
+            this._releaser = releaser;
         }
 
         @Override
@@ -648,17 +619,22 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             boolean released = super.release();
             if (released)
             {
-                if (releaser != null)
-                    releaser.accept(this);
+                if (_releaser != null)
+                    _releaser.accept(this);
             }
             return released;
+        }
+
+        private int use()
+        {
+            return _usages++;
         }
     }
 
     /**
      * A variant of the {@link ArrayByteBufferPool} that
      * uses buckets of buffers that increase in size by a power of
-     * 2 (eg 1k, 2k, 4k, 8k, etc.).
+     * 2 (e.g. 1k, 2k, 4k, 8k, etc.).
      */
     public static class Quadratic extends ArrayByteBufferPool
     {

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -44,22 +44,8 @@ public class ArrayByteBufferPoolTest
 
         List<RetainableByteBuffer> buffers = new ArrayList<>();
 
-        buffers.add(pool.acquire(10, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(10, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(20, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(20, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(10, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(20, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(10, true));
-        assertThat(pool.getDirectMemory(), is(0L));
-        buffers.add(pool.acquire(20, true));
-        assertThat(pool.getDirectMemory(), is(0L));
+        for (int i = 0; i < 200; i++)
+            buffers.add(pool.acquire(10 + i / 10, true));
 
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(pool.getDirectByteBufferCount(), is(0L));
@@ -73,6 +59,21 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getDirectByteBufferCount(), lessThan((long)buffers.size()));
         assertThat(pool.getDirectMemory(), greaterThan(0L));
         assertThat(pool.getDirectMemory(), lessThan(120L));
+
+        buffers.clear();
+        for (int i = 0; i < 200; i++)
+            buffers.add(pool.acquire(10 + i / 10, true));
+
+        long maxSize = 0;
+        for (RetainableByteBuffer buffer : buffers)
+        {
+            buffer.release();
+            long size = pool.getDirectMemory();
+            maxSize = Math.max(size, maxSize);
+        }
+
+        // Test that size is never too much over target max
+        assertThat(maxSize, lessThan(100L));
     }
 
     @Test

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -73,7 +72,7 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getDirectByteBufferCount(), greaterThan(0L));
         assertThat(pool.getDirectByteBufferCount(), lessThan((long)buffers.size()));
         assertThat(pool.getDirectMemory(), greaterThan(0L));
-        assertThat(pool.getDirectMemory(), lessThanOrEqualTo(40L));
+        assertThat(pool.getDirectMemory(), lessThan(120L));
     }
 
     @Test

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ArrayByteBufferPoolBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/io/jmh/ArrayByteBufferPoolBenchmark.java
@@ -47,7 +47,7 @@ public class ArrayByteBufferPoolBenchmark
             .measurementTime(TimeValue.milliseconds(500))
             .addProfiler(AsyncProfiler.class, "dir=/tmp;output=flamegraph;event=cpu;interval=500000;libPath=" + asyncProfilerPath)
             .forks(1)
-            .threads(10)
+            .threads(32)
             .build();
         new Runner(opt).run();
     }
@@ -123,5 +123,13 @@ public class ArrayByteBufferPoolBenchmark
 
         output.release();
         input.release();
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public void fastPathAcquireRelease()
+    {
+        RetainableByteBuffer buffer = pool.acquire(65535, true);
+        buffer.release();
     }
 }


### PR DESCRIPTION
No overall size accounting
reserved buffer release always checks max memory
released buffers check max memory 1% of the time.
only a single thread can check memory at once.
single pass through buckets so no looping forever.