### PR TITLE
Fixes #8887 - Jetty-12 client calls onDataAvailable with producing thread.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpChannel.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpChannel.java
@@ -165,7 +165,7 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
         else
             responsePromise.succeeded(false);
 
-        requestPromise.thenAcceptBoth(responsePromise, (requestAborted, responseAborted) -> promise.succeeded(requestAborted || responseAborted));
+        promise.completeWith(requestPromise.thenCombine(responsePromise, (requestAborted, responseAborted) -> requestAborted || responseAborted));
     }
 
     public void abortResponse(HttpExchange exchange, Throwable failure, Promise<Boolean> promise)

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.client.ProxyConfiguration;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.HTTP2ClientConnectionFactory;
@@ -168,9 +169,9 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         return factory.newConnection(endPoint, context);
     }
 
-    protected Connection newConnection(Destination destination, Session session)
+    protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
     {
-        return new HttpConnectionOverHTTP2(destination, session);
+        return new HttpConnectionOverHTTP2(destination, session, connection);
     }
 
     protected void onClose(Connection connection, GoAwayFrame frame)
@@ -186,9 +187,9 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         }
 
         @Override
-        protected Connection newConnection(Destination destination, Session session)
+        protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
         {
-            return HttpClientTransportOverHTTP2.this.newConnection(destination, session);
+            return HttpClientTransportOverHTTP2.this.newConnection(destination, session, connection);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HTTPSessionListenerPromise.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HTTPSessionListenerPromise.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicMarkableReference;
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.frames.GoAwayFrame;
@@ -72,7 +73,8 @@ public class HTTPSessionListenerPromise implements Session.Listener, Promise<Ses
 
     private void onServerPreface(Session session)
     {
-        HttpConnectionOverHTTP2 connection = (HttpConnectionOverHTTP2)newConnection(destination(), session);
+        HTTP2Connection http2Connection = (HTTP2Connection)context.get(HTTP2Connection.class.getName());
+        HttpConnectionOverHTTP2 connection = (HttpConnectionOverHTTP2)newConnection(destination(), session, http2Connection);
         if (this.connection.compareAndSet(null, connection, false, true))
         {
             // The connection promise must be called synchronously
@@ -82,9 +84,9 @@ public class HTTPSessionListenerPromise implements Session.Listener, Promise<Ses
         }
     }
 
-    protected Connection newConnection(Destination destination, Session session)
+    protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
     {
-        return new HttpConnectionOverHTTP2(destination, session);
+        return new HttpConnectionOverHTTP2(destination, session, connection);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -197,29 +197,28 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         public void onDataAvailable(Stream stream)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            channel.onDataAvailable();
+            connection.offerTask(channel.onDataAvailable(), false);
         }
 
         @Override
         public void onReset(Stream stream, ResetFrame frame, Callback callback)
         {
-            // TODO: needs to call HTTP2Channel?
-            receiver.onReset(frame);
-            callback.succeeded();
+            HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
+            connection.offerTask(channel.onReset(frame, callback), false);
         }
 
         @Override
         public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            channel.onTimeout(x, promise);
+            connection.offerTask(channel.onTimeout(x, promise), false);
         }
 
         @Override
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            channel.onFailure(failure, callback);
+            connection.offerTask(channel.onFailure(failure, callback), false);
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -39,6 +39,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
@@ -57,12 +58,14 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicInteger sweeps = new AtomicInteger();
     private final Session session;
+    private final HTTP2Connection connection;
     private boolean recycleHttpChannels = true;
 
-    public HttpConnectionOverHTTP2(Destination destination, Session session)
+    public HttpConnectionOverHTTP2(Destination destination, Session session, HTTP2Connection connection)
     {
         super((HttpDestination)destination);
         this.session = session;
+        this.connection = connection;
     }
 
     public Session getSession()
@@ -275,6 +278,12 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         if (!isClosed())
             return false;
         return sweeps.incrementAndGet() >= 4;
+    }
+
+    void offerTask(Runnable task, boolean dispatch)
+    {
+        if (task != null)
+            connection.offerTask(task, dispatch);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -68,6 +68,7 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
             session.setStreamIdleTimeout(streamIdleTimeout);
 
         HTTP2ClientConnection connection = new HTTP2ClientConnection(client, endPoint, session, sessionPromise, listener);
+        context.put(HTTP2Connection.class.getName(), connection);
         connection.addEventListener(connectionListener);
         parser.init(connection);
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
 
@@ -33,11 +34,13 @@ public interface HTTP2Channel
      */
     public interface Client
     {
-        public void onDataAvailable();
+        public Runnable onDataAvailable();
 
-        public void onTimeout(TimeoutException failure, Promise<Boolean> promise);
+        public Runnable onReset(ResetFrame frame, Callback callback);
 
-        public void onFailure(Throwable failure, Callback callback);
+        public Runnable onTimeout(TimeoutException failure, Promise<Boolean> promise);
+
+        public Runnable onFailure(Throwable failure, Callback callback);
     }
 
     /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -187,7 +187,7 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
         return false;
     }
 
-    protected void offerTask(Runnable task, boolean dispatch)
+    public void offerTask(Runnable task, boolean dispatch)
     {
         offerTask(task);
         if (dispatch)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
@@ -497,6 +497,12 @@ public abstract class HTTP2StreamEndPoint implements EndPoint
             callback.succeeded();
     }
 
+    protected Invocable.InvocationType getInvocationType()
+    {
+        Callback callback = readCallback.get();
+        return callback == null ? Invocable.InvocationType.NON_BLOCKING : callback.getInvocationType();
+    }
+
     @Override
     public String toString()
     {

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -309,13 +309,6 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         return true;
     }
 
-    // Overridden for visibility.
-    @Override
-    protected void offerTask(Runnable task, boolean dispatch)
-    {
-        super.offerTask(task, dispatch);
-    }
-
     @Override
     public String getId()
     {

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -48,6 +48,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.RateControl;
 import org.eclipse.jetty.http2.api.Session;
@@ -326,9 +327,9 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)
         {
             @Override
-            protected Connection newConnection(Destination destination, Session session)
+            protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
             {
-                return new HttpConnectionOverHTTP2(destination, session)
+                return new HttpConnectionOverHTTP2(destination, session, connection)
                 {
                     @Override
                     protected HttpChannelOverHTTP2 newHttpChannel()
@@ -520,10 +521,10 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             HttpClient client = new HttpClient(new HttpClientTransportOverHTTP2(h2Client)
             {
                 @Override
-                protected Connection newConnection(Destination destination, Session session)
+                protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
                 {
                     sessions.add(session);
-                    return super.newConnection(destination, session);
+                    return super.newConnection(destination, session, connection);
                 }
             });
             QueuedThreadPool clientExecutor = new QueuedThreadPool();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
 import org.eclipse.jetty.fcgi.client.transport.HttpClientTransportOverFCGI;
 import org.eclipse.jetty.fcgi.client.transport.internal.HttpChannelOverFCGI;
 import org.eclipse.jetty.fcgi.client.transport.internal.HttpConnectionOverFCGI;
+import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
@@ -147,9 +148,9 @@ public class HttpChannelAssociationTest extends AbstractTest
                 yield new HttpClientTransportOverHTTP2(http2Client)
                 {
                     @Override
-                    protected Connection newConnection(Destination destination, Session session)
+                    protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
                     {
-                        return new HttpConnectionOverHTTP2(destination, session)
+                        return new HttpConnectionOverHTTP2(destination, session, connection)
                         {
                             @Override
                             protected HttpChannelOverHTTP2 newHttpChannel()


### PR DESCRIPTION
Now the calls to the upper layer produce tasks that are fed to the ExecutionFactory in HTTP2Connection.