### PR TITLE
#11353 offer named virtual thread executor

### DIFF
--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
@@ -13,10 +13,7 @@
 
 package org.eclipse.jetty.test.client.transport;
 
-import java.util.Arrays;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.ContentResponse;
@@ -62,12 +59,7 @@ public class VirtualThreadsTest extends AbstractTest
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+            Executor virtualThreadsExecutor = VirtualThreads.getNamedVirtualThreadsExecutor(virtualThreadsName);
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.util;
 import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,6 +115,28 @@ public class VirtualThreads
         {
             warn();
             return false;
+        }
+    }
+
+    /**
+     * Get a virtual threads {@code Executor} that names the virtual threads according to the provided name prefix.
+     *
+     * @param namePrefix the prefix to use for the name of the virtual threads
+     * @return a virtual threads {@code Executor} that will name the virtual threads according to the provided name prefix.
+     */
+    public static Executor getNamedVirtualThreadsExecutor(String namePrefix)
+    {
+        try
+        {
+            Class<?> builderClass = Class.forName("java.lang.Thread$Builder");
+            Object threadBuilder = Thread.class.getMethod("ofVirtual").invoke(null);
+            threadBuilder = builderClass.getMethod("name", String.class, long.class).invoke(threadBuilder, namePrefix, 0L);
+            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(threadBuilder);
+            return (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+        }
+        catch (Throwable x)
+        {
+            return null;
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -120,6 +120,7 @@ public class VirtualThreads
 
     /**
      * Get a virtual threads {@code Executor} that names the virtual threads according to the provided name prefix.
+     * While named virtual threads enable observability they do also incur a minor performance penalty.
      *
      * @param namePrefix the prefix to use for the name of the virtual threads
      * @return a virtual threads {@code Executor} that will name the virtual threads according to the provided name prefix.

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
@@ -14,11 +14,8 @@
 package org.eclipse.jetty.ee10.test.client.transport;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -70,12 +67,7 @@ public class VirtualThreadsTest extends AbstractTest
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+            Executor virtualThreadsExecutor = VirtualThreads.getNamedVirtualThreadsExecutor(virtualThreadsName);
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
@@ -14,11 +14,8 @@
 package org.eclipse.jetty.ee9.test.client.transport;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -70,12 +67,7 @@ public class VirtualThreadsTest extends AbstractTest
         ThreadPool threadPool = server.getThreadPool();
         if (threadPool instanceof VirtualThreads.Configurable)
         {
-            // CAUTION: Java 19 specific reflection code, might change in future Java versions.
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> builderClass = Arrays.stream(Thread.class.getClasses()).filter(klass -> klass.getName().endsWith("$Builder")).findFirst().orElseThrow();
-            builder = builderClass.getMethod("name", String.class, long.class).invoke(builder, virtualThreadsName, 0L);
-            ThreadFactory factory = (ThreadFactory)builderClass.getMethod("factory").invoke(builder);
-            Executor virtualThreadsExecutor = (Executor)Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class).invoke(null, factory);
+            Executor virtualThreadsExecutor = VirtualThreads.getNamedVirtualThreadsExecutor(virtualThreadsName);
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();


### PR DESCRIPTION
Implements https://github.com/jetty/jetty.project/issues/11353#issuecomment-1937053955.

Add `VirtualThreads.getNamedVirtualThreadsExecutor(String namePrefix)` as a commodity to be used by users/libraries.

This PR supersedes https://github.com/jetty/jetty.project/pull/11355 