### PR TITLE
Fixes #11370 - IllegalStateException when last write fails.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SizeLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SizeLimitHandler.java
@@ -143,8 +143,8 @@ public class SizeLimitHandler extends Handler.Wrapper
             {
                 if (_responseLimit >= 0 && (_written + content.remaining())  > _responseLimit)
                 {
-                    callback.failed(new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Response body is too large: " +
-                        _written + content.remaining() + ">" + _responseLimit));
+                    String message = "Response body is too large: %d > %d".formatted(_written + content.remaining(), _responseLimit);
+                    callback.failed(new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, message));
                     return;
                 }
                 _written += content.remaining();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SizeLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SizeLimitHandler.java
@@ -143,7 +143,7 @@ public class SizeLimitHandler extends Handler.Wrapper
             {
                 if (_responseLimit >= 0 && (_written + content.remaining())  > _responseLimit)
                 {
-                    String message = "Response body is too large: %d > %d".formatted(_written + content.remaining(), _responseLimit);
+                    String message = "Response body is too large: %d>%d".formatted(_written + content.remaining(), _responseLimit);
                     callback.failed(new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, message));
                     return;
                 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SizeLimitHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SizeLimitHandlerTest.java
@@ -80,7 +80,7 @@ public class SizeLimitHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 response.write(true, BufferUtil.toBuffer("Hello World"), callback);
                 return true;
@@ -99,7 +99,7 @@ public class SizeLimitHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 8 * 1024 + 1);
                 fail();
@@ -120,9 +120,8 @@ public class SizeLimitHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback)
             {
-
                 response.write(true, ByteBuffer.wrap(new byte[8 * 1024 + 1]), callback);
                 return true;
             }
@@ -141,7 +140,7 @@ public class SizeLimitHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 byte[] data = new byte[1024];
                 Arrays.fill(data, (byte)'X');
@@ -199,10 +198,12 @@ public class SizeLimitHandlerTest
         });
         _server.start();
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("POST /ctx/hello HTTP/1.0\r\n" +
-                "Content-Length: 8\r\n" +
-                "\r\n" +
-                "123456\r\n"));
+            _local.getResponse("""
+                POST /ctx/hello HTTP/1.0\r
+                Content-Length: 8\r
+                \r
+                123456\r
+                """));
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getContent(), containsString("OK 8"));
     }
@@ -223,10 +224,11 @@ public class SizeLimitHandlerTest
         });
         _server.start();
         HttpTester.Response response = HttpTester.parseResponse(
-            _local.getResponse("POST /ctx/hello HTTP/1.0\r\n" +
-                "Content-Length: 32768\r\n" +
-                "\r\n" +
-                "123456..."));
+            _local.getResponse("""
+                POST /ctx/hello HTTP/1.0\r
+                Content-Length: 32768\r
+                \r
+                123456..."""));
         assertThat(response.getStatus(), equalTo(413));
         assertThat(response.getContent(), containsString("32768&gt;8192"));
     }
@@ -247,11 +249,13 @@ public class SizeLimitHandlerTest
         });
         _server.start();
 
-        try (LocalConnector.LocalEndPoint endp = _local.executeRequest(
-            "POST /ctx/hello HTTP/1.1\r\n" +
-                "Host: localhost\r\n" +
-                "Transfer-Encoding: chunked\r\n" +
-                "\r\n"))
+        try (LocalConnector.LocalEndPoint endPoint = _local.executeRequest(
+            """
+                POST /ctx/hello HTTP/1.1\r
+                Host: localhost\r
+                Transfer-Encoding: chunked\r
+                \r
+                """))
         {
             byte[] data = new byte[1024];
             Arrays.fill(data, (byte)'X');
@@ -259,9 +263,9 @@ public class SizeLimitHandlerTest
             String text = new String(data, 0, 1024, Charset.defaultCharset());
 
             for (int i = 0; i < 9; i++)
-                endp.addInput("400\r\n" + text + "\r\n");
+                endPoint.addInput("400\r\n" + text + "\r\n");
 
-            HttpTester.Response response = HttpTester.parseResponse(endp.getResponse());
+            HttpTester.Response response = HttpTester.parseResponse(endPoint.getResponse());
 
             assertThat(response.getStatus(), equalTo(413));
             assertThat(response.getContent(), containsString("&gt;8192"));
@@ -275,7 +279,7 @@ public class SizeLimitHandlerTest
         _contextHandler.setHandler(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            public boolean handle(Request request, Response response, Callback callback)
             {
                 response.write(true, BufferUtil.toBuffer(message), callback);
                 return true;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -432,7 +432,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         }
 
         if (content != null)
-            channelWrite(content, true, new CompleteWriteCompleteCB());
+            channelWrite(content, true, new WriteCompleteCB());
     }
 
     /**
@@ -1764,17 +1764,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         public InvocationType getInvocationType()
         {
             return InvocationType.NON_BLOCKING;
-        }
-    }
-
-    private class CompleteWriteCompleteCB extends WriteCompleteCB
-    {
-        @Override
-        public void failed(Throwable x)
-        {
-            // TODO why is this needed for h2/h3?
-            HttpOutput.this._servletChannel.abort(x);
-            super.failed(x);
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -1051,6 +1051,9 @@ public class ServletChannelState
             if (_requestState != RequestState.COMPLETING)
                 throw new IllegalStateException(this.getStatusStringLocked());
 
+            if (failure != null)
+                abortResponse(failure);
+
             if (_event == null)
             {
                 _requestState = RequestState.COMPLETED;


### PR DESCRIPTION
Removed the call to `ServletChannel.abort()` from the write callback.

As the write was issued from `ServletChannel.handle()` case COMPLETE, it was eventually calling `ServletChannelState.completed(Throwable)`, which is expecting the requestState to be COMPLETING. However, calling `abort()` would set the requestState to COMPLETED, causing the IllegalStateException.

There should be no need to call `abort()` from the callback of failed writes, since failing the various callbacks should be enough, eventually failing the `HttpStream`, which would take care of tearing down the connection (HTTP/1) or the stream (HTTP/2+).