### PR TITLE
Fix #10805 zero dynamic table

### DIFF
--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
@@ -56,7 +56,7 @@ public class DynamicTableTest extends AbstractTest
         });
 
         if (clientMaxCapacity >= 0)
-            client.setMaxEncoderTableCapacity(0);
+            client.setMaxEncoderTableCapacity(clientMaxCapacity);
         if (serverMaxCapacity >= 0)
             connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setMaxEncoderTableCapacity(serverMaxCapacity);
 
@@ -103,7 +103,7 @@ public class DynamicTableTest extends AbstractTest
         });
 
         if (clientMaxCapacity >= 0)
-            client.setMaxDecoderTableCapacity(0);
+            client.setMaxDecoderTableCapacity(clientMaxCapacity);
         if (serverMaxCapacity >= 0)
             connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setMaxDecoderTableCapacity(serverMaxCapacity);
 
@@ -151,8 +151,8 @@ public class DynamicTableTest extends AbstractTest
 
         if (clientMaxCapacity >= 0)
         {
-            client.setMaxDecoderTableCapacity(0);
-            client.setMaxEncoderTableCapacity(0);
+            client.setMaxDecoderTableCapacity(clientMaxCapacity);
+            client.setMaxEncoderTableCapacity(clientMaxCapacity);
         }
         if (serverMaxCapacity >= 0)
         {

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
@@ -1,0 +1,132 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2.client;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.SettingsFrame;
+import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DynamicTableTest extends AbstractTest
+{
+    @ParameterizedTest
+    @CsvSource({"0,-1", "-1,0", "0,0"})
+    public void testMaxEncoderTableCapacityZero(int clientMaxCapacity, int serverMaxCapacity) throws Exception
+    {
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setStatus(200);
+                resp.getOutputStream().close();
+            }
+        });
+
+        if (clientMaxCapacity >= 0)
+            client.setMaxEncoderTableCapacity(0);
+        if (serverMaxCapacity >= 0)
+            connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setMaxEncoderTableCapacity(serverMaxCapacity);
+
+        CountDownLatch serverPreface = new CountDownLatch(1);
+        Session session = newClient(new Session.Listener.Adapter()
+        {
+            @Override
+            public void onSettings(Session session, SettingsFrame frame)
+            {
+                serverPreface.countDown();
+            }
+        });
+        assertTrue(serverPreface.await(5, TimeUnit.SECONDS));
+
+        MetaData.Request metaData = newRequest("GET", new HttpFields());
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        CountDownLatch latch = new CountDownLatch(1);
+        session.newStream(frame, new Promise.Adapter<>(), new Stream.Listener.Adapter()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                assertEquals(200, response.getStatus());
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,-1", "-1,0", "0,0"})
+    public void testMaxDecoderTableCapacityZero(int clientMaxCapacity, int serverMaxCapacity) throws Exception
+    {
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setStatus(200);
+                resp.getOutputStream().close();
+            }
+        });
+
+        if (clientMaxCapacity >= 0)
+            client.setMaxDecoderTableCapacity(0);
+        if (serverMaxCapacity >= 0)
+            connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setMaxDecoderTableCapacity(serverMaxCapacity);
+
+        CountDownLatch serverPreface = new CountDownLatch(1);
+        Session session = newClient(new Session.Listener.Adapter()
+        {
+            @Override
+            public void onSettings(Session session, SettingsFrame frame)
+            {
+                serverPreface.countDown();
+            }
+        });
+        assertTrue(serverPreface.await(5, TimeUnit.SECONDS));
+
+        MetaData.Request metaData = newRequest("GET", new HttpFields());
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        CountDownLatch latch = new CountDownLatch(1);
+        session.newStream(frame, new Promise.Adapter<>(), new Stream.Listener.Adapter()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                assertEquals(200, response.getStatus());
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
+++ b/jetty-http2/http2-client/src/test/java/org/eclipse/jetty/http2/client/DynamicTableTest.java
@@ -1,14 +1,19 @@
 //
-// ========================================================================
-// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//  ========================================================================
+//  Copyright (c) 1995-2022 Mort Bay Consulting Pty Ltd and others.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
 //
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0 which is available at
-// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
 //
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-// ========================================================================
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
 //
 
 package org.eclipse.jetty.http2.client;

--- a/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -104,6 +104,7 @@ public class HpackEncoder
     private int _maxHeaderListSize;
     private int _headerListSize;
     private boolean _validateEncoding = true;
+    private boolean _maxDynamicTableSizeSent = false;
 
     @Deprecated
     public HpackEncoder(int localMaxDynamicTableSize)
@@ -128,7 +129,7 @@ public class HpackEncoder
 
     public HpackEncoder()
     {
-        _context = new HpackContext(0);
+        _context = new HpackContext(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
         _debug = LOG.isDebugEnabled();
         setMaxTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
         setTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
@@ -235,8 +236,11 @@ public class HpackEncoder
 
             // If max table size changed, send the correspondent instruction.
             int tableCapacity = getTableCapacity();
-            if (tableCapacity != _context.getMaxDynamicTableSize())
+            if (!_maxDynamicTableSizeSent || tableCapacity != _context.getMaxDynamicTableSize())
+            {
+                _maxDynamicTableSizeSent = true;
                 encodeMaxDynamicTableSize(buffer, tableCapacity);
+            }
 
             // Add Request/response meta fields
             if (metadata.isRequest())


### PR DESCRIPTION
Fix #10805 zero dynamic table:
 + Set the correct default table size in the context
 + just in case, always send the table size on the first encode