### PR TITLE
Improve DEBUG during WebInfConfiguration.unpack

### DIFF
--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -473,6 +473,22 @@ public class IOTest
     }
 
     @Test
+    public void testDeleteTreeDeep(WorkDir workDir) throws IOException
+    {
+        Path dir = workDir.getEmptyPathDir();
+        FS.ensureEmpty(dir);
+
+        Files.createDirectory(dir.resolve("foo"));
+        Files.createDirectory(dir.resolve("foo/bar"));
+        Files.createDirectory(dir.resolve("foo/zed"));
+        Files.createDirectory(dir.resolve("foo/zed/one"));
+        Files.writeString(dir.resolve("foo/bar/test.txt"), "Test");
+        Files.writeString(dir.resolve("foo/zed/one/test.txt"), "Test");
+
+        assertTrue(IO.delete(dir));
+    }
+
+    @Test
     public void testIsEmptyNull()
     {
         assertTrue(IO.isEmptyDir(null));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -380,6 +380,12 @@ public class IO
         return file.delete();
     }
 
+    /**
+     * Delete the path, recursively.
+     *
+     * @param path the path to delete
+     * @return true if able to delete the path, false if unable to delete the path.
+     */
     public static boolean delete(Path path)
     {
         if (path == null)
@@ -406,6 +412,8 @@ public class IO
         }
         catch (IOException e)
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to delete path: {}", path, e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -291,8 +291,17 @@ public class WebInfConfiguration extends AbstractConfiguration
                         if (originalWarResource.lastModified().isAfter(Files.getLastModifiedTime(extractedWebAppDir).toInstant()) || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
-                            IO.delete(extractedWebAppDir);
-                            Files.createDirectory(extractedWebAppDir);
+                            // Best effort delete
+                            if (IO.delete(extractedWebAppDir))
+                            {
+                                // Recreate the directory if it was deleted.
+                                Files.createDirectory(extractedWebAppDir);
+                            }
+                            else
+                            {
+                                if (LOG.isInfoEnabled())
+                                    LOG.info("Unable to delete path {}, reusing existing path", extractedWebAppDir);
+                            }
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Extract {} to {}", webApp, extractedWebAppDir);
                             try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -293,8 +293,17 @@ public class WebInfConfiguration extends AbstractConfiguration
                         if (originalWarResource.lastModified().isAfter(Files.getLastModifiedTime(extractedWebAppDir).toInstant()) || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
-                            IO.delete(extractedWebAppDir);
-                            Files.createDirectory(extractedWebAppDir);
+                            // Best effort delete
+                            if (IO.delete(extractedWebAppDir))
+                            {
+                                // Recreate the directory if it was deleted.
+                                Files.createDirectory(extractedWebAppDir);
+                            }
+                            else
+                            {
+                                if (LOG.isInfoEnabled())
+                                    LOG.info("Unable to delete path {}, reusing existing path", extractedWebAppDir);
+                            }
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Extract {} to {}", webApp, extractedWebAppDir);
                             try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())


### PR DESCRIPTION
When issues occur during WebInfConfiguration.unpack() there is inadequate DEBUG to identify the root cause of the issue.

Adding appropriate DEBUG in WebInfConfiguration and IO.delete()