### PR TITLE
Improve Error messages for Ambiguous URIs

### DIFF
--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -1024,6 +1024,8 @@ public class HttpURITest
             // Path choices
             Arguments.of("http", "example.org", 0, "/a/b/c/d", null, null, "http://example.org/a/b/c/d"),
             Arguments.of("http", "example.org", 0, "/a%20b/c%20d", null, null, "http://example.org/a%20b/c%20d"),
+            Arguments.of("http", "example.org", 0, "/foo%2Fbaz", null, null, "http://example.org/foo%2Fbaz"),
+            Arguments.of("http", "example.org", 0, "/foo%252Fbaz", null, null, "http://example.org/foo%252Fbaz"),
             // Query specified
             Arguments.of("http", "example.org", 0, "/", "a=b", null, "http://example.org/?a=b"),
             Arguments.of("http", "example.org", 0, "/documentation/latest/", "a=b", null, "http://example.org/documentation/latest/?a=b"),
@@ -1044,6 +1046,24 @@ public class HttpURITest
     {
         HttpURI httpURI = HttpURI.from(scheme, server, port, path, query, fragment);
         assertThat(httpURI.asString(), is(expectedStr));
+    }
+
+    public static Stream<Arguments> fromStringAsStringCases()
+    {
+        return Stream.of(
+            Arguments.of("http://localhost:4444/", "http://localhost:4444/"),
+            Arguments.of("/foo/baz", "/foo/baz"),
+            Arguments.of("/foo%2Fbaz", "/foo%2Fbaz"),
+            Arguments.of("/foo%252Fbaz", "/foo%252Fbaz")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromStringAsStringCases")
+    public void testFromStringAsString(String input, String expected)
+    {
+        HttpURI httpURI = HttpURI.from(input);
+        assertThat(httpURI.asString(), is(expected));
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1307,21 +1307,24 @@ public class ServletApiRequest implements HttpServletRequest
 
     static class AmbiguousURI extends ServletApiRequest
     {
-        protected AmbiguousURI(ServletContextRequest servletContextRequest)
+        private final String msg;
+
+        protected AmbiguousURI(ServletContextRequest servletContextRequest, String msg)
         {
             super(servletContextRequest);
+            this.msg = msg;
         }
 
         @Override
         public String getPathInfo()
         {
-            throw new HttpException.IllegalArgumentException(HttpStatus.BAD_REQUEST_400, "Ambiguous URI encoding");
+            throw new HttpException.IllegalArgumentException(HttpStatus.BAD_REQUEST_400, msg);
         }
 
         @Override
         public String getServletPath()
         {
-            throw new HttpException.IllegalArgumentException(HttpStatus.BAD_REQUEST_400, "Ambiguous URI encoding");
+            throw new HttpException.IllegalArgumentException(HttpStatus.BAD_REQUEST_400, msg);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -197,11 +197,28 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
         if (getHttpURI().hasViolations() && !getServletChannel().getServletContextHandler().getServletHandler().isDecodeAmbiguousURIs())
         {
             // TODO we should check if current compliance mode allows all the violations?
-
-            for (UriCompliance.Violation violation : getHttpURI().getViolations())
+            if (getHttpURI().hasViolations())
             {
-                if (UriCompliance.AMBIGUOUS_VIOLATIONS.contains(violation))
-                    return new ServletApiRequest.AmbiguousURI(this);
+                StringBuilder msg = null;
+                for (UriCompliance.Violation violation : getHttpURI().getViolations())
+                {
+                    if (UriCompliance.AMBIGUOUS_VIOLATIONS.contains(violation))
+                    {
+                        if (msg == null)
+                        {
+                            msg = new StringBuilder();
+                            msg.append("Ambiguous URI encoding: ");
+                        }
+                        else
+                        {
+                            msg.append(", ");
+                        }
+
+                        msg.append(violation.name());
+                    }
+                }
+                if (msg != null)
+                    return new ServletApiRequest.AmbiguousURI(this, msg.toString());
             }
         }
 


### PR DESCRIPTION
Improves the error message / stacktrace to include the UriCompliance.Violation that occurred.

From 

```
URI: /foo=bar%2Fbaz=baz
STATUS: 400
MESSAGE: Ambiguous URI encoding
SERVLET: jetty12.DemoJerseyConfig
CAUSED BY org.eclipse.jetty.http.HttpException$IllegalArgumentException: 400: Ambiguous URI encoding
org.eclipse.jetty.http.HttpException$IllegalArgumentException: 400: Ambiguous URI encoding
   at org.eclipse.jetty.ee10.servlet.ServletApiRequest$AmbiguousURI.getServletPath(ServletApiRequest.java:1325)
   at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:236)
   at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
   at org.eclipse.jetty.ee10.servlet.ServletHolder.handle(ServletHolder.java:736)
```

To

```
URI: /foo=bar%2Fbaz=baz
STATUS: 400
MESSAGE: Ambiguous URI encoding
SERVLET: jetty12.DemoJerseyConfig
CAUSED BY org.eclipse.jetty.http.HttpException$IllegalArgumentException: 400: Ambiguous URI encoding: AMBIGUOUS_PATH_SEPARATOR
org.eclipse.jetty.http.HttpException$IllegalArgumentException: 400: Ambiguous URI encoding: AMBIGUOUS_PATH_SEPARATOR
   at org.eclipse.jetty.ee10.servlet.ServletApiRequest$AmbiguousURI.getServletPath(ServletApiRequest.java:1325)
   at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:236)
   at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
   at org.eclipse.jetty.ee10.servlet.ServletHolder.handle(ServletHolder.java:736)
```

Fixes #11448