### PR TITLE
Changed CrossOriginHandler default to allow no origin and no credentials.

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/module-cross-origin.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/module-cross-origin.adoc
@@ -18,10 +18,16 @@ The `cross-origin` module provides support for the link:https://developer.mozill
 
 This module installs the xref:{prog-guide}#pg-server-http-handler-use-cross-origin[`CrossOriginHandler`] in the `Handler` tree; `CrossOriginHandler` inspects cross-origin requests and adds the relevant CORS response headers.
 
-`CrossOriginHandler` should be used when an application performs cross-origin requests to your server, to protect from link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery] attacks.
+`CrossOriginHandler` should be used when an application performs cross-origin requests to your domain, to protect from link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery] attacks.
 
 The module properties are:
 
 ----
 include::{jetty-home}/modules/cross-origin.mod[tags=documentation]
 ----
+
+You must configure at least the property `jetty.crossorigin.allowedOriginPatterns` to allow one or more origins.
+
+It is recommended that you consider configuring also the property `jetty.crossorigin.allowCredentials`.
+When set to `true`, clients send cookies and authentication headers in cross-origin requests to your domain.
+When set to `false`, cookies and authentication headers are not sent.

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/server/http/server-http-handler-use.adoc
@@ -413,7 +413,7 @@ An example of a cross-origin request is when a script downloaded from the origin
 
 This is common, for example, when you embed reusable components such as a chat component into a web page: the web page and the chat component files are downloaded from `+http://domain.com+`, but the chat server is at `+http://chat.domain.com+`, so the chat component must make cross-origin requests to the chat server.
 
-This kind of setup exposes to link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery attacks], and the CORS protocol has been established to protect against this kind of attacks.
+This kind of setup exposes to link:https://owasp.org/www-community/attacks/csrf[cross-site request forgery (CSRF) attacks], and the CORS protocol has been established to protect against this kind of attacks.
 
 For security reasons, browsers by default do not allow cross-origin requests, unless the response from the cross domain contains the right CORS headers.
 
@@ -430,9 +430,9 @@ Server
         └── AppHandler
 ----
 
-The most important `CrossOriginHandler` configuration parameter is `allowedOrigins`, which by default is `*`, allowing any origin.
+The most important `CrossOriginHandler` configuration parameter that must be configured is `allowedOrigins`, which by default is the empty set, therefore disallowing all origins.
 
-You may want to restrict your server to only origins you trust.
+You want to restrict requests to your cross domain to only origins you trust.
 From the chat example above, the chat server at `+http://chat.domain.com+` knows that the chat component is downloaded from the origin server at `+http://domain.com+`, so the `CrossOriginHandler` is configured in this way:
 
 [source,java,indent=0]
@@ -440,7 +440,7 @@ From the chat example above, the chat server at `+http://chat.domain.com+` knows
 include::../../{doc_code}/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=crossOriginAllowedOrigins]
 ----
 
-Browsers send cross-origin request in two ways:
+Browsers send cross-origin requests in two ways:
 
 * Directly, if the cross-origin request meets some simple criteria.
 * By issuing a hidden _preflight_ request before the actual cross-origin request, to verify with the server if it is willing to reply properly to the actual cross-origin request.
@@ -448,6 +448,11 @@ Browsers send cross-origin request in two ways:
 Both preflight requests and cross-origin requests will be handled by `CrossOriginHandler`, which will analyze the request and possibly add appropriate CORS response headers.
 
 By default, preflight requests are not delivered to the `CrossOriginHandler` child `Handler`, but it is possible to configure `CrossOriginHandler` by setting `deliverPreflightRequests=true` so that the web application can fine-tune the CORS response headers.
+
+Another important `CrossOriginHandler` configuration parameter is `allowCredentials`, which controls whether cookies and authentication headers that match the cross-origin request to the cross domain are sent in the cross-origin requests.
+By default, `allowCredentials=false` so that cookies and authentication headers are not sent in cross-origin requests.
+
+If the application deployed in the cross domain requires cookies or authentication, then you must set `allowCredentials=true`, but you also need to restrict the allowed origins only to the ones your trust, otherwise your cross domain application will be vulnerable to CSRF attacks.
 
 For more `CrossOriginHandler` configuration options, refer to the link:{javadoc-url}/org/eclipse/jetty/server/handler/CrossOriginHandler.html[`CrossOriginHandler` javadocs].
 

--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -1134,6 +1134,8 @@ public class HTTPServerDocs
 
         // Add the CrossOriginHandler to protect from CSRF attacks.
         CrossOriginHandler crossOriginHandler = new CrossOriginHandler();
+        crossOriginHandler.setAllowedOriginPatterns(Set.of("http://domain.com"));
+        crossOriginHandler.setAllowCredentials(true);
         server.setHandler(crossOriginHandler);
 
         // Create a ServletContextHandler with contextPath.

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-cross-origin.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-cross-origin.xml
@@ -5,9 +5,7 @@
   <Call name="insertHandler">
     <Arg>
       <New id="CrossOriginHandler" class="org.eclipse.jetty.server.handler.CrossOriginHandler">
-        <Set name="allowCredentials">
-          <Property name="jetty.crossorigin.allowCredentials" default="true" />
-        </Set>
+        <Set name="allowCredentials" property="jetty.crossorigin.allowCredentials" />
         <Call name="setAllowedHeaders">
           <Arg type="Set">
             <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
@@ -30,7 +28,7 @@
           <Arg type="Set">
             <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
               <Arg>
-                <Property name="jetty.crossorigin.allowedOriginPatterns" default="*" />
+                <Property name="jetty.crossorigin.allowedOriginPatterns" default="" />
               </Arg>
             </Call>
           </Arg>

--- a/jetty-core/jetty-server/src/main/config/modules/cross-origin.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/cross-origin.mod
@@ -17,7 +17,7 @@ etc/jetty-cross-origin.xml
 [ini-template]
 #tag::documentation[]
 ## Whether cross-origin requests can include credentials such as cookies or authentication headers.
-# jetty.crossorigin.allowCredentials=true
+# jetty.crossorigin.allowCredentials=false
 
 ## A comma-separated list of headers allowed in cross-origin requests.
 # jetty.crossorigin.allowedHeaders=Content-Type
@@ -26,7 +26,7 @@ etc/jetty-cross-origin.xml
 # jetty.crossorigin.allowedMethods=GET,POST,HEAD
 
 ## A comma-separated list of origins regex patterns allowed in cross-origin requests.
-# jetty.crossorigin.allowedOriginPatterns=*
+# jetty.crossorigin.allowedOriginPatterns=
 
 ## A comma-separated list of timing origins regex patterns allowed in cross-origin requests.
 # jetty.crossorigin.allowedTimingOriginPatterns=


### PR DESCRIPTION
This makes the default configuration more secure and explicitly requires configuration from users.