### PR TITLE
HttpURI toURI passes all info

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
-import org.eclipse.jetty.util.UrlEncoded;
 
 /**
  * Http URI.
@@ -265,8 +264,7 @@ public interface HttpURI
     {
         try
         {
-            String query = getQuery();
-            return new URI(getScheme(), null, getHost(), getPort(), getPath(), query == null ? null : UrlEncoded.decodeString(query), null);
+            return new URI(toString());
         }
         catch (URISyntaxException x)
         {
@@ -510,19 +508,6 @@ public interface HttpURI
         public String toString()
         {
             return asString();
-        }
-
-        @Override
-        public URI toURI()
-        {
-            try
-            {
-                return new URI(_scheme, null, _host, URIUtil.normalizePortForScheme(_scheme, _port), _path, _query == null ? null : UrlEncoded.decodeString(_query), _fragment);
-            }
-            catch (URISyntaxException x)
-            {
-                throw new RuntimeException(x);
-            }
         }
     }
 
@@ -978,18 +963,6 @@ public interface HttpURI
         public String toString()
         {
             return asString();
-        }
-
-        public URI toURI()
-        {
-            try
-            {
-                return new URI(_scheme, null, _host, _port, _path, _query == null ? null : UrlEncoded.decodeString(_query), null);
-            }
-            catch (URISyntaxException x)
-            {
-                throw new RuntimeException(x);
-            }
         }
 
         public Mutable uri(HttpURI uri)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.http;
 import java.io.Serial;
 import java.io.Serializable;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -262,14 +261,7 @@ public interface HttpURI
 
     default URI toURI()
     {
-        try
-        {
-            return new URI(toString());
-        }
-        catch (URISyntaxException x)
-        {
-            throw new RuntimeException(x);
-        }
+        return URI.create(toString());
     }
 
     class Immutable implements HttpURI, Serializable

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -53,6 +53,7 @@ public class HttpURITest
             .path("/ignored/../p%61th;ignored/info")
             .param("param")
             .query("query=value")
+            .fragment("fragment")
             .asImmutable();
 
         assertThat(uri.getScheme(), is("http"));
@@ -63,8 +64,10 @@ public class HttpURITest
         assertThat(uri.getCanonicalPath(), is("/path/info"));
         assertThat(uri.getParam(), is("param"));
         assertThat(uri.getQuery(), is("query=value"));
+        assertThat(uri.getFragment(), is("fragment"));
         assertThat(uri.getAuthority(), is("host:8888"));
-        assertThat(uri.toString(), is("http://user:password@host:8888/ignored/../p%61th;ignored/info;param?query=value"));
+        assertThat(uri.toString(), is("http://user:password@host:8888/ignored/../p%61th;ignored/info;param?query=value#fragment"));
+        assertThat(uri.toURI().toString(), is("http://user:password@host:8888/ignored/../p%61th;ignored/info;param?query=value#fragment"));
 
         uri = HttpURI.build(uri)
             .scheme("https")


### PR DESCRIPTION
Fix #11465 and #7750
HttpURI.toURI user and fragment are retained.
Use to URI(String) constructor, as all URI constructors will parse the URI anyway.