### PR TITLE
Improve HTTP parsing long look-ahead

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -195,7 +195,7 @@ public class HttpGenerator
                 int pos = BufferUtil.flipToFill(header);
                 try
                 {
-                    // generate ResponseLine
+                    // generate request line
                     generateRequestLine(info, header);
 
                     if (info.getHttpVersion() == HttpVersion.HTTP_0_9)
@@ -520,7 +520,7 @@ public class HttpGenerator
         String reason = response.getReason();
         if (preprepared != null)
         {
-            if (reason == null)
+            if (reason == null || preprepared._reason.equals(reason))
                 header.put(preprepared._responseLine);
             else
             {
@@ -779,11 +779,9 @@ public class HttpGenerator
         }
     }
 
+    @Deprecated(forRemoval = true)
     public static byte[] getReasonBuffer(int code)
     {
-        PreparedResponse status = code < __preprepared.length ? __preprepared[code] : null;
-        if (status != null)
-            return status._reason;
         return null;
     }
 
@@ -807,9 +805,16 @@ public class HttpGenerator
     // Build cache of response lines for status
     private static class PreparedResponse
     {
-        byte[] _reason;
-        byte[] _schemeCode;
-        byte[] _responseLine;
+        final String _reason;
+        final byte[] _schemeCode;
+        final byte[] _responseLine;
+
+        private PreparedResponse(String reason, byte[] schemeCode, byte[] responseLine)
+        {
+            _reason = reason;
+            _schemeCode = schemeCode;
+            _responseLine = responseLine;
+        }
     }
 
     private static final PreparedResponse[] __preprepared = new PreparedResponse[HttpStatus.MAX_CODE + 1];
@@ -838,10 +843,7 @@ public class HttpGenerator
             line[versionLength + 5 + reason.length()] = HttpTokens.CARRIAGE_RETURN;
             line[versionLength + 6 + reason.length()] = HttpTokens.LINE_FEED;
 
-            __preprepared[i] = new PreparedResponse();
-            __preprepared[i]._schemeCode = Arrays.copyOfRange(line, 0, versionLength + 5);
-            __preprepared[i]._reason = Arrays.copyOfRange(line, versionLength + 5, line.length - 2);
-            __preprepared[i]._responseLine = line;
+            __preprepared[i] = new PreparedResponse(reason, Arrays.copyOfRange(line, 0, versionLength + 5), line);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
@@ -163,32 +163,32 @@ public enum HttpMethod
     public static HttpMethod lookAheadGet(ByteBuffer buffer)
     {
         int len = buffer.remaining();
-        // Short cut for 3 char methods, mostly for GET optimisation
-        if (len > 3)
-        {
-            switch (buffer.getInt(buffer.position()))
-            {
-                case ACL_AS_INT:
-                    return ACL;
-                case GET_AS_INT:
-                    return GET;
-                case PRI_AS_INT:
-                    return PRI;
-                case PUT_AS_INT:
-                    return PUT;
-                case POST_AS_INT:
-                    if (len > 4 && buffer.get(buffer.position() + 4) == ' ')
-                        return POST;
-                    break;
-                case HEAD_AS_INT:
-                    if (len > 4 && buffer.get(buffer.position() + 4) == ' ')
-                        return HEAD;
-                    break;
-                default:
-                    break;
-            }
-        }
+        // Shortcut for 3 or 4 char methods, mostly for GET optimisation
+        if (len > 4)
+            return lookAheadGet(buffer, buffer.getInt(buffer.position()));
         return LOOK_AHEAD.getBest(buffer, 0, len);
+    }
+
+    /**
+     * Optimized lookup to find a method name and trailing space in a byte array.
+     *
+     * @param buffer buffer containing ISO-8859-1 characters, it is not modified, which must have at least 5 bytes remaining
+     * @param lookAhead The integer representation of the first 4 bytes of the buffer that has previously been fetched
+     *                  with the equivalent of {@code buffer.getInt(buffer.position())}
+     * @return An HttpMethod if a match or null if no easy match.
+     */
+    public static HttpMethod lookAheadGet(ByteBuffer buffer, int lookAhead)
+    {
+        return switch (lookAhead)
+        {
+            case ACL_AS_INT -> ACL;
+            case GET_AS_INT -> GET;
+            case PRI_AS_INT -> PRI;
+            case PUT_AS_INT -> PUT;
+            case POST_AS_INT -> (buffer.get(buffer.position() + 4) == ' ') ? POST : LOOK_AHEAD.getBest(buffer, 0, buffer.remaining());
+            case HEAD_AS_INT -> (buffer.get(buffer.position() + 4) == ' ') ? HEAD : LOOK_AHEAD.getBest(buffer, 0, buffer.remaining());
+            default -> LOOK_AHEAD.getBest(buffer, 0, buffer.remaining());
+        };
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
@@ -177,7 +177,7 @@ public enum HttpMethod
      *                  with the equivalent of {@code buffer.getInt(buffer.position())}
      * @return An HttpMethod if a match or null if no easy match.
      */
-    public static HttpMethod lookAheadGet(ByteBuffer buffer, int lookAhead)
+    static HttpMethod lookAheadGet(ByteBuffer buffer, int lookAhead)
     {
         return switch (lookAhead)
         {

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpParseBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpParseBenchmark.java
@@ -1,0 +1,149 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http.jmh;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.util.BufferUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+public class HttpParseBenchmark
+{
+    private static final long GET_SLASH_HT_AS_LONG = stringAsLong("GET / HT");
+    private static final long TP_SLASH_1_0_CRLF = stringAsLong("TP/1.0\r\n");
+    private static final long TP_SLASH_1_1_CRLF = stringAsLong("TP/1.1\r\n");
+
+    private static long stringAsLong(String s)
+    {
+        if (s == null || s.length() != 8)
+            throw new IllegalArgumentException();
+        long l = 0;
+        for (char c : s.toCharArray())
+        {
+            l = l << 8 | ((long)c & 0xFFL);
+        }
+        return l;
+    }
+
+    private static final ByteBuffer GET = BufferUtil.toBuffer("GET / HTTP/1.1\r\n\r\n");
+    private static final ByteBuffer POST = BufferUtil.toBuffer("POST / HTTP/1.1\r\n\r\n");
+
+    record RequestLine(String method, String uri, HttpVersion version)
+    {
+        @Override
+        public String toString()
+        {
+            return "%s %s %s".formatted(method, uri, version);
+        }
+    }
+
+    @Param({"0", "10", "2000000000"})
+    int hits;
+
+    public static RequestLine parse(ByteBuffer buffer)
+    {
+        HttpMethod method = HttpMethod.lookAheadGet(buffer);
+        if (method == null)
+            return null;
+        buffer.position(buffer.position() + method.asString().length() + 1);
+
+        StringBuilder uri = new StringBuilder();
+        while (buffer.hasRemaining())
+        {
+            byte b = buffer.get();
+            if (b == ' ')
+                break;
+            uri.append((char)b);
+        }
+
+        HttpVersion httpVersion = HttpVersion.CACHE.getBest(buffer);
+        buffer.position(buffer.position() + httpVersion.asString().length());
+        if (buffer.get() != '\r')
+            return null;
+        if (buffer.get() != '\n')
+            return null;
+
+        return new RequestLine(method.asString(), uri.toString(), httpVersion);
+    }
+
+    public static RequestLine lookAhead(ByteBuffer buffer)
+    {
+        if (buffer.getLong(0) != GET_SLASH_HT_AS_LONG)
+            return parse(buffer);
+        long v = buffer.getLong(8);
+        if (v == TP_SLASH_1_1_CRLF)
+        {
+            buffer.position(buffer.position() + 16);
+            return new RequestLine(HttpMethod.GET.asString(), "/", HttpVersion.HTTP_1_1);
+        }
+        if (v == TP_SLASH_1_0_CRLF)
+        {
+            buffer.position(buffer.position() + 16);
+            return new RequestLine(HttpMethod.GET.asString(), "/", HttpVersion.HTTP_1_0);
+        }
+        return parse(buffer);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public RequestLine testParse() throws Exception
+    {
+        ByteBuffer request = (hits == 0 || ThreadLocalRandom.current().nextInt(hits) == 0) ? POST : GET;
+        return parse(request.slice());
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public RequestLine testLookAhead() throws Exception
+    {
+        ByteBuffer request = (hits == 0 || ThreadLocalRandom.current().nextInt(hits) == 0) ? POST : GET;
+        return lookAhead(request.slice());
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(HttpParseBenchmark.class.getSimpleName())
+            .warmupIterations(10)
+            .measurementIterations(10)
+            // .addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}
+
+

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpParseBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpParseBenchmark.java
@@ -68,7 +68,7 @@ public class HttpParseBenchmark
         }
     }
 
-    @Param({"0", "10", "2000000000"})
+    @Param({"100", "10", "1", "0"})
     int hits;
 
     public static RequestLine parse(ByteBuffer buffer)
@@ -117,17 +117,17 @@ public class HttpParseBenchmark
 
     @Benchmark
     @BenchmarkMode({Mode.Throughput})
-    public RequestLine testParse() throws Exception
+    public RequestLine testParse()
     {
-        ByteBuffer request = (hits == 0 || ThreadLocalRandom.current().nextInt(hits) == 0) ? POST : GET;
+        ByteBuffer request = (ThreadLocalRandom.current().nextInt(100) < hits) ? GET : POST;
         return parse(request.slice());
     }
 
     @Benchmark
     @BenchmarkMode({Mode.Throughput})
-    public RequestLine testLookAhead() throws Exception
+    public RequestLine testLookAhead()
     {
-        ByteBuffer request = (hits == 0 || ThreadLocalRandom.current().nextInt(hits) == 0) ? POST : GET;
+        ByteBuffer request = (ThreadLocalRandom.current().nextInt(100) < hits) ? GET : POST;
         return lookAhead(request.slice());
     }
 


### PR DESCRIPTION
Use ByteBuffer.getLong to look for entire request (GET / HTTP/1.1) or response (HTTP/1.1 200 OK) line with 2 long lookups.  Failing that, a single long lookup is sufficient to determine the common methods and/or HttpVersion.