### PR TITLE
`Resource.copyTo()` throws `UnsupportedOperationException` for `PathResource` instances

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -327,7 +327,6 @@ public abstract class Resource implements Iterable<Resource>
                 // to a directory, preserve the filename
                 Path destPath = destination.resolve(src.getFileName().toString());
                 Files.copy(src, destPath,
-                    StandardCopyOption.ATOMIC_MOVE,
                     StandardCopyOption.COPY_ATTRIBUTES,
                     StandardCopyOption.REPLACE_EXISTING);
             }
@@ -335,7 +334,6 @@ public abstract class Resource implements Iterable<Resource>
             {
                 // to a file, use destination as-is
                 Files.copy(src, destination,
-                    StandardCopyOption.ATOMIC_MOVE,
                     StandardCopyOption.COPY_ATTRIBUTES,
                     StandardCopyOption.REPLACE_EXISTING);
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -308,6 +308,9 @@ public abstract class Resource implements Iterable<Resource>
         {
             if (!isDirectory())
             {
+                if (Files.isDirectory(destination))
+                    destination = destination.resolve(getFileName());
+
                 // use old school stream based copy
                 try (InputStream in = newInputStream(); OutputStream out = Files.newOutputStream(destination))
                 {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MemoryResourceTest.java
@@ -13,22 +13,57 @@
 
 package org.eclipse.jetty.util.resource;
 
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Loader;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class MemoryResourceTest
 {
+    public WorkDir workDir;
+
     @Test
     public void testJettyLogging() throws Exception
     {
         Resource resource = ResourceFactory.root().newMemoryResource(Loader.getResource("jetty-logging.properties"));
         assertTrue(resource.exists());
-        String contents = IO.toString(resource.newInputStream());
-        assertThat(contents, startsWith("#org.eclipse.jetty.util.LEVEL=DEBUG"));
+        try (InputStream in = resource.newInputStream())
+        {
+            String contents = IO.toString(in);
+            assertThat(contents, startsWith("#org.eclipse.jetty.util.LEVEL=DEBUG"));
+        }
+    }
+
+    @Test
+    public void testCopyToFile() throws Exception
+    {
+        Resource resource = ResourceFactory.root().newMemoryResource(Loader.getResource("jetty-logging.properties"));
+        Path targetFile = workDir.getEmptyPathDir().resolve("target-jetty-logging.properties");
+        resource.copyTo(targetFile);
+
+        assertThat(Files.exists(targetFile), is(true));
+    }
+
+    @Test
+    public void testCopyToFolder() throws Exception
+    {
+        Resource resource = ResourceFactory.root().newMemoryResource(Loader.getResource("jetty-logging.properties"));
+        Path targetDir = workDir.getEmptyPathDir();
+        resource.copyTo(targetDir);
+
+        Path resolved = targetDir.resolve("jetty-logging.properties");
+        assertThat(Files.exists(resolved), is(true));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -298,10 +298,11 @@ public class ResourceTest
         Resource resource = data.getResource();
         Assumptions.assumeTrue(resource != null);
 
-        Path targetDir = workDir.getEmptyPathDir().resolve(resource.getFileName());
+        Path targetDir = workDir.getEmptyPathDir();
         resource.copyTo(targetDir);
 
-        assertResourceSameAsPath(resource, targetDir);
+        Path targetToTest = resource.isDirectory() ? targetDir : targetDir.resolve(resource.getFileName());
+        assertResourceSameAsPath(resource, targetToTest);
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -312,7 +312,7 @@ public class ResourceTest
     {
         Resource resource = data.getResource();
         Assumptions.assumeTrue(resource != null);
-        Assumptions.assumeTrue(!resource.isDirectory());
+        Assumptions.assumeFalse(resource.isDirectory());
 
         String filename = resource.getFileName();
         Path targetDir = workDir.getEmptyPathDir();


### PR DESCRIPTION
During one of the numerous cleanups done as part of #11364, I stumbled upon this `Resource` bug: 

`Resource.copyTo()` throws `UnsupportedOperationException: 'ATOMIC_MOVE' is not a recognized copy option`


Note: the `ATOMIC_MOVE` flag was added as part of #11440.