### PR TITLE
Issue #11495 - Add UriCompliance rules that follow the HTTP / URI / Servlet specs for illegal & suspicious characters

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -16,12 +16,10 @@ package org.eclipse.jetty.http;
 import java.io.Serial;
 import java.io.Serializable;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jetty.http.UriCompliance.Violation;
@@ -555,7 +553,7 @@ public interface HttpURI
          * Encoded character sequences that violate the Servlet 6.0 spec
          * https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization
          */
-        private static final Index<Boolean> __suspiciousPathSequences;
+        private static final boolean[] __suspiciousPathCharacters;
 
         /**
          * Unencoded US-ASCII character sequences not allowed by HTTP or URI specs in path segments.
@@ -615,21 +613,14 @@ public interface HttpURI
             __illegalPathCharacters = illegalChars;
             // anything else in the US-ASCII space is not allowed
 
-            // suspicious path sequences
-            Index.Builder<Boolean> suspiciousSequencesBuilder = new Index.Builder<Boolean>();
-            suspiciousSequencesBuilder.caseSensitive(false);
-            List<Byte> suspiciousChars = new ArrayList<>();
-            suspiciousChars.add((byte)'\\'); // backslash
-            suspiciousChars.add((byte)0x7F); // DEL
+            // suspicious path characters
+            boolean[] suspicious = new boolean[128];
+            Arrays.fill(suspicious, false);
+            suspicious['\\'] = true;
+            suspicious[0x7F] = true;
             for (int i = 0; i <= 0x1F; i++)
-                suspiciousChars.add((byte)i);
-            suspiciousChars.forEach(b ->
-            {
-                suspiciousSequencesBuilder.with(Character.toString(b), Boolean.TRUE);
-                suspiciousSequencesBuilder.with(String.format("%%%02x", b), Boolean.TRUE);
-                suspiciousSequencesBuilder.with(String.format("%%u00%02x", b), Boolean.TRUE);
-            });
-            __suspiciousPathSequences = suspiciousSequencesBuilder.build();
+                suspicious[i] = true;
+            __suspiciousPathCharacters = suspicious;
         }
 
         private String _scheme;
@@ -982,7 +973,7 @@ public interface HttpURI
             _path = null;
             _canonicalPath = null;
             // eliminate current _param if provided here
-            if (path.indexOf(';') >= 0)
+            if (_param != null && path.indexOf(';') >= 0)
                 _param = null;
             parse(State.PATH, path);
 
@@ -1107,7 +1098,6 @@ public interface HttpURI
         {
             int mark = 0; // the start of the current section being parsed
             int pathMark = 0; // the start of the path section
-            int paramMark = -1; // the start of the path parameters
             int segment = 0; // the start of the current segment within the path
             boolean encodedPath = false; // set to true if the path contains % encoded characters
             boolean encodedUtf16 = false; // Is the current encoding for UTF16?
@@ -1131,21 +1121,20 @@ public interface HttpURI
                                 state = State.HOST_OR_PATH;
                                 break;
                             case ';':
-                                checkSegment(uri, segment, i, true);
-                                paramMark = i;
+                                checkSegment(uri, false, segment, i, true);
                                 mark = i + 1;
                                 state = State.PARAM;
                                 break;
                             case '?':
                                 // assume empty path (if seen at start)
-                                checkSegment(uri, segment, i, false);
+                                checkSegment(uri, false, segment, i, false);
                                 _path = "";
                                 mark = i + 1;
                                 state = State.QUERY;
                                 break;
                             case '#':
                                 // assume empty path (if seen at start)
-                                checkSegment(uri, segment, i, false);
+                                checkSegment(uri, false, segment, i, false);
                                 _path = "";
                                 mark = i + 1;
                                 state = State.FRAGMENT;
@@ -1197,12 +1186,12 @@ public interface HttpURI
                                 break;
                             case ';':
                                 // must have been in a path
-                                paramMark = i;
                                 mark = i + 1;
                                 state = State.PARAM;
                                 break;
                             case '?':
                                 // must have been in a path
+                                checkSegment(uri, false, segment, i, false);
                                 _path = uri.substring(mark, i);
                                 mark = i + 1;
                                 state = State.QUERY;
@@ -1357,6 +1346,8 @@ public interface HttpURI
                                         addViolation(Violation.AMBIGUOUS_PATH_ENCODING);
                                         break;
                                     default:
+                                        if (encodedValue < __suspiciousPathCharacters.length && __suspiciousPathCharacters[encodedValue])
+                                            addViolation(Violation.SUSPICIOUS_PATH_CHARACTERS);
                                         break;
                                 }
                             }
@@ -1366,19 +1357,18 @@ public interface HttpURI
                             switch (c)
                             {
                                 case ';':
-                                    checkSegment(uri, segment, i, true);
-                                    paramMark = i;
+                                    checkSegment(uri, dot || encodedPath, segment, i, true);
                                     mark = i + 1;
                                     state = State.PARAM;
                                     break;
                                 case '?':
-                                    checkSegment(uri, segment, i, false);
+                                    checkSegment(uri, dot || encodedPath, segment, i, false);
                                     _path = uri.substring(pathMark, i);
                                     mark = i + 1;
                                     state = State.QUERY;
                                     break;
                                 case '#':
-                                    checkSegment(uri, segment, i, false);
+                                    checkSegment(uri, dot || encodedPath, segment, i, false);
                                     _path = uri.substring(pathMark, i);
                                     mark = i + 1;
                                     state = State.FRAGMENT;
@@ -1386,7 +1376,7 @@ public interface HttpURI
                                 case '/':
                                     // There is no leading segment when parsing only a path that starts with slash.
                                     if (i != 0)
-                                        checkSegment(uri, segment, i, false);
+                                        checkSegment(uri, dot || encodedPath, segment, i, false);
                                     segment = i + 1;
                                     break;
                                 case '.':
@@ -1399,6 +1389,11 @@ public interface HttpURI
                                     encodedValue = 0;
                                     break;
                                 default:
+                                    // The RFC does not allow unencoded path characters that are outside the ABNF
+                                    if (c > __illegalPathCharacters.length || __illegalPathCharacters[c])
+                                        addViolation(Violation.ILLEGAL_PATH_CHARACTERS);
+                                    if (c < __suspiciousPathCharacters.length && __suspiciousPathCharacters[c])
+                                       addViolation(Violation.SUSPICIOUS_PATH_CHARACTERS);
                                     break;
                             }
                         }
@@ -1464,7 +1459,7 @@ public interface HttpURI
             {
                 case START:
                     _path = "";
-                    checkSegment(uri, segment, end, false);
+                    checkSegment(uri, false, segment, end, false);
                     break;
                 case ASTERISK:
                     break;
@@ -1486,7 +1481,7 @@ public interface HttpURI
                     _param = uri.substring(mark, end);
                     break;
                 case PATH:
-                    checkSegment(uri, segment, end, false);
+                    checkSegment(uri, dot || encodedPath, segment, end, false);
                     _path = uri.substring(pathMark, end);
                     break;
                 case QUERY:
@@ -1501,10 +1496,10 @@ public interface HttpURI
 
             if (!encodedPath && !dot)
             {
-                if (_param == null || paramMark < 0)
+                if (_param == null)
                     _canonicalPath = _path;
                 else
-                    _canonicalPath = _path.substring(0, paramMark - pathMark);
+                    _canonicalPath = _path.substring(0, _path.length() - _param.length() - 1);
             }
             else if (_path != null)
             {
@@ -1530,10 +1525,11 @@ public interface HttpURI
          * due to possible ambiguity.  Examples include segments like '..;', '%2e', '%2e%2e' etc.
          *
          * @param uri The URI string
+         * @param dotOrEncoded true if the URI might contain dot segments
          * @param segment The inclusive starting index of the segment (excluding any '/')
          * @param end The exclusive end index of the segment
          */
-        private void checkSegment(String uri, int segment, int end, boolean param)
+        private void checkSegment(String uri, boolean dotOrEncoded, int segment, int end, boolean param)
         {
             // This method is called once for every segment parsed.
             // A URI like "/foo/" has two segments: "foo" and an empty segment.
@@ -1556,7 +1552,7 @@ public interface HttpURI
                     return;
                 }
 
-                // Otherwise remember we have seen an empty segment, which is check if we see a subsequent segment.
+                // Otherwise remember we have seen an empty segment, which is checked if we see a subsequent segment.
                 if (!_emptySegment)
                 {
                     _emptySegment = true;
@@ -1565,7 +1561,7 @@ public interface HttpURI
             }
 
             // Look for segment in the ambiguous segment index.
-            Boolean ambiguous = __ambiguousSegments.get(uri, segment, end - segment);
+            Boolean ambiguous = dotOrEncoded ? __ambiguousSegments.get(uri, segment, end - segment) : null;
             if (ambiguous != null)
             {
                 // The segment is always ambiguous.
@@ -1574,22 +1570,6 @@ public interface HttpURI
                 // The segment is ambiguous only when followed by a parameter.
                 if (param)
                     addViolation(Violation.AMBIGUOUS_PATH_PARAMETER);
-            }
-
-            for (int i = segment; i < end; i++)
-            {
-                char c = uri.charAt(i);
-                // The RFC does not allow unencoded path characters that are outside the ABNF
-                if (c > __illegalPathCharacters.length || __illegalPathCharacters[c])
-                    addViolation(Violation.ILLEGAL_PATH_CHARACTERS);
-                // Look for suspicious sequences
-                Boolean suspicious = __suspiciousPathSequences.getBest(uri, i, end - i);
-                if (suspicious != null)
-                {
-                    // The segment is suspicious.
-                    if (Boolean.TRUE.equals(suspicious))
-                        addViolation(Violation.SUSPICIOUS_PATH_CHARACTERS);
-                }
             }
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -972,19 +972,16 @@ public interface HttpURI
             _uri = null;
             _path = null;
             _canonicalPath = null;
-            // eliminate current _param if provided here
-            if (_param != null && path.indexOf(';') >= 0)
-                _param = null;
+            String param = _param;
+            _param = null;
             parse(State.PATH, path);
 
             // If the passed path does not have a parameter, then keep the current parameter
             // else delete the current parameter
-            if (_param != null)
+            if (param != null && path.indexOf(';') < 0)
             {
-                if (path.indexOf(';') >= 0)
-                    _param = null;
-                else
-                    _path = _path + ';' + _param;
+                _param = param;
+                _path = _path + ';' + _param;
             }
 
             return this;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -509,7 +509,6 @@ public interface HttpURI
         private enum State
         {
             START,
-            ASTERISK,
             HOST_OR_PATH,
             SCHEME_OR_PATH,
             HOST,
@@ -518,7 +517,8 @@ public interface HttpURI
             PATH,
             PARAM,
             QUERY,
-            FRAGMENT
+            FRAGMENT,
+            ASTERISK
         }
 
         /**
@@ -703,7 +703,7 @@ public interface HttpURI
             _port = port;
 
             if (pathQuery != null)
-                parse(State.PATH, State.QUERY, pathQuery);
+                parse(State.PATH, pathQuery);
         }
 
         @Override
@@ -960,7 +960,7 @@ public interface HttpURI
         }
 
         /**
-         * @param path the encoded path
+         * @param path the path
          * @return this Mutable
          */
         public Mutable path(String path)
@@ -974,7 +974,7 @@ public interface HttpURI
             _canonicalPath = null;
             String param = _param;
             _param = null;
-            parse(State.PATH, State.PARAM, path);
+            parse(State.PATH, path);
 
             // If the passed path does not have a parameter, then keep the current parameter
             // else delete the current parameter
@@ -997,7 +997,7 @@ public interface HttpURI
             _param = null;
             _query = null;
             if (pathQuery != null)
-                parse(State.PATH, State.QUERY, pathQuery);
+                parse(State.PATH, pathQuery);
             return this;
         }
 
@@ -1092,11 +1092,6 @@ public interface HttpURI
         }
 
         private void parse(State state, final String uri)
-        {
-            parse(state, null, uri);
-        }
-
-        private void parse(State state, State last, final String uri)
         {
             int mark = 0; // the start of the current section being parsed
             int pathMark = 0; // the start of the path section
@@ -1456,9 +1451,6 @@ public interface HttpURI
                     }
                 }
             }
-
-            if (last != null && state.ordinal() > last.ordinal())
-                throw new IllegalArgumentException("uri cannot go beyond " + last);
 
             switch (state)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -509,6 +509,7 @@ public interface HttpURI
         private enum State
         {
             START,
+            ASTERISK,
             HOST_OR_PATH,
             SCHEME_OR_PATH,
             HOST,
@@ -517,8 +518,7 @@ public interface HttpURI
             PATH,
             PARAM,
             QUERY,
-            FRAGMENT,
-            ASTERISK
+            FRAGMENT
         }
 
         /**
@@ -703,7 +703,7 @@ public interface HttpURI
             _port = port;
 
             if (pathQuery != null)
-                parse(State.PATH, pathQuery);
+                parse(State.PATH, State.QUERY, pathQuery);
         }
 
         @Override
@@ -960,7 +960,7 @@ public interface HttpURI
         }
 
         /**
-         * @param path the path
+         * @param path the encoded path
          * @return this Mutable
          */
         public Mutable path(String path)
@@ -974,7 +974,7 @@ public interface HttpURI
             _canonicalPath = null;
             String param = _param;
             _param = null;
-            parse(State.PATH, path);
+            parse(State.PATH, State.PARAM, path);
 
             // If the passed path does not have a parameter, then keep the current parameter
             // else delete the current parameter
@@ -997,7 +997,7 @@ public interface HttpURI
             _param = null;
             _query = null;
             if (pathQuery != null)
-                parse(State.PATH, pathQuery);
+                parse(State.PATH, State.QUERY, pathQuery);
             return this;
         }
 
@@ -1092,6 +1092,11 @@ public interface HttpURI
         }
 
         private void parse(State state, final String uri)
+        {
+            parse(state, null, uri);
+        }
+
+        private void parse(State state, State last, final String uri)
         {
             int mark = 0; // the start of the current section being parsed
             int pathMark = 0; // the start of the path section
@@ -1451,6 +1456,9 @@ public interface HttpURI
                     }
                 }
             }
+
+            if (last != null && state.ordinal() > last.ordinal())
+                throw new IllegalArgumentException("uri cannot go beyond " + last);
 
             switch (state)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -1570,7 +1570,7 @@ public interface HttpURI
             for (int i = segment; i < end; i++)
             {
                 char c = uri.charAt(i);
-                // The RFC does not allow raw path characters that are outside the ABNF {@code unreserved / pct-encoded / sub-delims / ":" / "@"}
+                // The RFC does not allow unencoded path characters that are outside the ABNF
                 if (c > __illegalPathCharacters.length || __illegalPathCharacters[c])
                     addViolation(Violation.ILLEGAL_PATH_CHARACTERS);
                 // Look for suspicious encoded sequence

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -981,6 +981,9 @@ public interface HttpURI
             _uri = null;
             _path = null;
             _canonicalPath = null;
+            // eliminate current _param if provided here
+            if (path.indexOf(';') >= 0)
+                _param = null;
             parse(State.PATH, path);
 
             // If the passed path does not have a parameter, then keep the current parameter
@@ -1104,6 +1107,7 @@ public interface HttpURI
         {
             int mark = 0; // the start of the current section being parsed
             int pathMark = 0; // the start of the path section
+            int paramMark = -1; // the start of the path parameters
             int segment = 0; // the start of the current segment within the path
             boolean encodedPath = false; // set to true if the path contains % encoded characters
             boolean encodedUtf16 = false; // Is the current encoding for UTF16?
@@ -1128,6 +1132,7 @@ public interface HttpURI
                                 break;
                             case ';':
                                 checkSegment(uri, segment, i, true);
+                                paramMark = i;
                                 mark = i + 1;
                                 state = State.PARAM;
                                 break;
@@ -1192,6 +1197,7 @@ public interface HttpURI
                                 break;
                             case ';':
                                 // must have been in a path
+                                paramMark = i;
                                 mark = i + 1;
                                 state = State.PARAM;
                                 break;
@@ -1361,6 +1367,7 @@ public interface HttpURI
                             {
                                 case ';':
                                     checkSegment(uri, segment, i, true);
+                                    paramMark = i;
                                     mark = i + 1;
                                     state = State.PARAM;
                                     break;
@@ -1494,10 +1501,10 @@ public interface HttpURI
 
             if (!encodedPath && !dot)
             {
-                if (_param == null)
+                if (_param == null || paramMark < 0)
                     _canonicalPath = _path;
                 else
-                    _canonicalPath = _path.substring(0, _path.length() - _param.length() - 1);
+                    _canonicalPath = _path.substring(0, paramMark - pathMark);
             }
             else if (_path != null)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -98,7 +98,18 @@ public final class UriCompliance implements ComplianceViolation.Mode
         /**
          * Allow Bad UTF-8 encodings to be substituted by the replacement character.
          */
-        BAD_UTF8_ENCODING("https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.1", "Bad UTF-8 encoding");
+        BAD_UTF8_ENCODING("https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.1", "Bad UTF-8 encoding"),
+
+        /**
+         * Allow encoded path characters not allowed by the Servlet spec rules.
+         */
+        SUSPICIOUS_PATH_CHARACTERS("https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization", "Suspicious Path Character"),
+
+        /**
+         * Allow path characters not allowed in the path portion of the URI and HTTP specs.
+         * <p>This would allow characters that fall outside of the {@code unreserved / pct-encoded / sub-delims / ":" / "@"} ABNF</p>
+         */
+        ILLEGAL_PATH_CHARACTERS("https://datatracker.ietf.org/doc/html/rfc3986#section-3.3", "Illegal Path Character");
 
         private final String _url;
         private final String _description;
@@ -167,7 +178,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
             Violation.UTF16_ENCODINGS));
 
     /**
-     * Compliance mode that allows all URI Violations, including allowing ambiguous paths in non-canonical form.
+     * Compliance mode that allows all URI Violations, including allowing ambiguous paths in non-canonical form, and illegal characters
      */
     public static final UriCompliance UNSAFE = new UriCompliance("UNSAFE", allOf(Violation.class));
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -661,16 +661,21 @@ public class HttpURITest
         return Stream.of(
             // backslash
             Arguments.of("/a%5Cb"),
+            Arguments.of("/a\\b"),
             Arguments.of("/foo/bar/zed/%5c"),
+            Arguments.of("/foo/bar/..\\zed"),
             Arguments.of("/foo/bar/zed/%5C"),
             // TAB
             Arguments.of("/%09b"),
+            Arguments.of("/a\tb"),
             Arguments.of("/%09"),
             // CR / LF
             Arguments.of("/%0A"),
             Arguments.of("/%0a"),
             Arguments.of("/%0D"),
             Arguments.of("/%0d"),
+            Arguments.of("/a/\r/\n/b"),
+            Arguments.of("/foo\r\nbar/"),
             Arguments.of("/%0d%0a")
         );
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -552,6 +552,10 @@ public class HttpURITest
                 {"%2e%2e", null, null, null},
                 {"..;/info", null, null, null},
                 {"..;param/info", null, null, null},
+                {"#n=v", null, null, null},
+                {"/#", null, null, null},
+                {"/foo/#bar", null, null, null},
+                {"/foo#bar", null, null, null},
 
                 // ambiguous dot encodings
                 {"/path/%2e/info", "/path/info", "/path/info", EnumSet.of(Violation.AMBIGUOUS_PATH_SEGMENT)},
@@ -565,7 +569,6 @@ public class HttpURITest
 
                 // empty segment treated as ambiguous
                 {"/", "/", "/", EnumSet.noneOf(Violation.class)},
-                {"/#", "/", "/", EnumSet.noneOf(Violation.class)},
                 {"/path", "/path", "/path", EnumSet.noneOf(Violation.class)},
                 {"/path/", "/path/", "/path/", EnumSet.noneOf(Violation.class)},
                 {"//", "//", "//", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
@@ -573,10 +576,8 @@ public class HttpURITest
                 {"/foo//bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"//foo/bar", "//foo/bar", "//foo/bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"/foo?bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
-                {"/foo#bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
                 {"/foo;bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
                 {"/foo/?bar", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
-                {"/foo/#bar", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
                 {"/foo/;param", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
                 {"/foo/;param/bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"/foo//bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
@@ -591,7 +592,6 @@ public class HttpURITest
                 {";/bar", "/bar", "/bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {";?n=v", "", "", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"?n=v", "", "", EnumSet.noneOf(Violation.class)},
-                {"#n=v", "", "", EnumSet.noneOf(Violation.class)},
                 {"", "", "", EnumSet.noneOf(Violation.class)},
 
                 // ambiguous parameter inclusions

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -552,10 +552,6 @@ public class HttpURITest
                 {"%2e%2e", null, null, null},
                 {"..;/info", null, null, null},
                 {"..;param/info", null, null, null},
-                {"#n=v", null, null, null},
-                {"/#", null, null, null},
-                {"/foo/#bar", null, null, null},
-                {"/foo#bar", null, null, null},
 
                 // ambiguous dot encodings
                 {"/path/%2e/info", "/path/info", "/path/info", EnumSet.of(Violation.AMBIGUOUS_PATH_SEGMENT)},
@@ -569,6 +565,7 @@ public class HttpURITest
 
                 // empty segment treated as ambiguous
                 {"/", "/", "/", EnumSet.noneOf(Violation.class)},
+                {"/#", "/", "/", EnumSet.noneOf(Violation.class)},
                 {"/path", "/path", "/path", EnumSet.noneOf(Violation.class)},
                 {"/path/", "/path/", "/path/", EnumSet.noneOf(Violation.class)},
                 {"//", "//", "//", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
@@ -576,8 +573,10 @@ public class HttpURITest
                 {"/foo//bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"//foo/bar", "//foo/bar", "//foo/bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"/foo?bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
+                {"/foo#bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
                 {"/foo;bar", "/foo", "/foo", EnumSet.noneOf(Violation.class)},
                 {"/foo/?bar", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
+                {"/foo/#bar", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
                 {"/foo/;param", "/foo/", "/foo/", EnumSet.noneOf(Violation.class)},
                 {"/foo/;param/bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"/foo//bar", "/foo//bar", "/foo//bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
@@ -592,6 +591,7 @@ public class HttpURITest
                 {";/bar", "/bar", "/bar", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {";?n=v", "", "", EnumSet.of(Violation.AMBIGUOUS_EMPTY_SEGMENT)},
                 {"?n=v", "", "", EnumSet.noneOf(Violation.class)},
+                {"#n=v", "", "", EnumSet.noneOf(Violation.class)},
                 {"", "", "", EnumSet.noneOf(Violation.class)},
 
                 // ambiguous parameter inclusions

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -701,11 +701,16 @@ public class HttpURITest
             Arguments.of("/a/..\\b"),
             // control character
             Arguments.of("/a\tb"),
-            Arguments.of("/a\r\nb"),
-            // Pipe symbol
+            Arguments.of("/a\rb"),
+            Arguments.of("/a\nb"),
+            // Pipe / piping symbols
             Arguments.of("/a|b"),
+            Arguments.of("/a<b"),
+            Arguments.of("/a>b"),
             // space character
-            Arguments.of("/a b")
+            Arguments.of("/a b"),
+            // double-quotes
+            Arguments.of("/a\"b")
         );
     }
 

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/AbstractRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/AbstractRuleTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.AfterEach;
 public abstract class AbstractRuleTest
 {
     protected Server _server = new Server();
-    protected HttpConfiguration httpConfig = new HttpConfiguration();
-    protected LocalConnector _connector = new LocalConnector(_server, new HttpConnectionFactory(httpConfig));
+    protected HttpConfiguration _httpConfig = new HttpConfiguration();
+    protected LocalConnector _connector = new LocalConnector(_server, new HttpConnectionFactory(_httpConfig));
     protected RewriteHandler _rewriteHandler = new RewriteHandler();
 
     @AfterEach

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
@@ -51,7 +51,7 @@ public class CompactPathRuleTest extends AbstractRuleTest
     @MethodSource("scenarios")
     public void testCompactPathRule(String inputPath, String inputQuery, String expectedPath, String expectedQuery, String expectedPathQuery) throws Exception
     {
-        httpConfig.setUriCompliance(UriCompliance.UNSAFE);
+        _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
         CompactPathRule rule = new CompactPathRule();
         _rewriteHandler.addRule(rule);
         start(new Handler.Abstract()

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/InvalidURIRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/InvalidURIRuleTest.java
@@ -32,6 +32,7 @@ public class InvalidURIRuleTest extends AbstractRuleTest
     private void start(InvalidURIRule rule) throws Exception
     {
         _rewriteHandler.addRule(rule);
+        _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
         start(new Handler.Abstract()
         {
             @Override

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RedirectRegexRuleTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.rewrite.handler;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -29,6 +30,7 @@ public class RedirectRegexRuleTest extends AbstractRuleTest
     private void start(RedirectRegexRule rule) throws Exception
     {
         _rewriteHandler.addRule(rule);
+        _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
         start(new Handler.Abstract()
         {
             @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -88,7 +88,6 @@ import static org.eclipse.jetty.http.tools.matchers.HttpFieldsMatchers.containsH
 import static org.eclipse.jetty.http.tools.matchers.HttpFieldsMatchers.containsHeaderValue;
 import static org.eclipse.jetty.http.tools.matchers.HttpFieldsMatchers.headerValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
@@ -1629,7 +1628,7 @@ public class ResourceHandlerTest
                 \r
                 """);
             HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-            assertThat("Response.status", response.getStatus(), anyOf(is(HttpStatus.NOT_FOUND_404), is(HttpStatus.INTERNAL_SERVER_ERROR_500)));
+            assertThat("Response.status", response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
             assertThat("Response.content", response.getContent(), is(not(containsString(docRoot.toString()))));
         }
     }

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/BalancerServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/BalancerServletTest.java
@@ -28,8 +28,10 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.rewrite.handler.VirtualHostRuleContainer;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionIdManager;
@@ -171,10 +173,14 @@ public class BalancerServletTest
     {
         startBalancer(DumpServlet.class);
         balancer.stop();
+
         RewriteHandler rewrite = new RewriteHandler();
         rewrite.setHandler(balancer.getHandler());
         balancer.setHandler(rewrite);
         rewrite.addRule(new VirtualHostRuleContainer());
+        balancer.getConnectors()[0].getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
+        server1.getConnectors()[0].getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
+        server2.getConnectors()[0].getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         balancer.start();
 
         ContentResponse response = getBalancedResponse("/test/%0A");

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/BalancerServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/BalancerServletTest.java
@@ -177,11 +177,11 @@ public class BalancerServletTest
         rewrite.addRule(new VirtualHostRuleContainer());
         balancer.start();
 
-        ContentResponse response = getBalancedResponse("/test/%0A");
+        ContentResponse response = getBalancedResponse("/test/%22foo%22");
         assertThat(response.getStatus(), is(200));
-        assertThat(response.getContentAsString(), containsString("requestURI='/context/mapping/test/%0A'"));
+        assertThat(response.getContentAsString(), containsString("requestURI='/context/mapping/test/%22foo%22'"));
         assertThat(response.getContentAsString(), containsString("servletPath='/mapping'"));
-        assertThat(response.getContentAsString(), containsString("pathInfo='/test/\n'"));
+        assertThat(response.getContentAsString(), containsString("pathInfo='/test/\"foo\"'"));
     }
 
     private String readFirstLine(byte[] responseBytes) throws IOException

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -56,6 +56,7 @@ import org.eclipse.jetty.http.content.ResourceHttpContentFactory;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.ResourceService;
 import org.eclipse.jetty.server.Server;
@@ -3039,6 +3040,7 @@ public class DefaultServletTest
     @Test
     public void testControlCharacter() throws Exception
     {
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         FS.ensureDirExists(docRoot);
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("resourceBase", docRoot.toFile().getAbsolutePath());

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -112,6 +112,7 @@ public class DefaultServletTest
     private Server server;
     private LocalConnector connector;
     private ServletContextHandler context;
+    HttpConfiguration httpConfiguration;
 
     @BeforeEach
     public void init() throws Exception
@@ -122,7 +123,8 @@ public class DefaultServletTest
         server = new Server();
 
         connector = new LocalConnector(server);
-        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        httpConfiguration = connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration();
+        httpConfiguration.setSendServerVersion(false);
         Path extraJarResources = MavenPaths.findTestResourceFile(ODD_JAR);
         URL[] urls = new URL[]{extraJarResources.toUri().toURL()};
 
@@ -3039,6 +3041,7 @@ public class DefaultServletTest
     @Test
     public void testControlCharacter() throws Exception
     {
+        httpConfiguration.setUriCompliance(UriCompliance.UNSAFE);
         FS.ensureDirExists(docRoot);
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("resourceBase", docRoot.toFile().getAbsolutePath());

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
@@ -25,6 +25,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.StringUtil;
@@ -126,6 +128,7 @@ public class ResponseHeadersTest
 
         contextHandler.addServlet(multilineServlet, "/multiline/*");
         startServer(contextHandler);
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
 
         String actualPathInfo = "%0A%20Content-Type%3A%20image/png%0A%20Content-Length%3A%208%0A%20%0A%20yuck<!--";
 

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/BalancerServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/BalancerServletTest.java
@@ -176,11 +176,11 @@ public class BalancerServletTest
         rewrite.addRule(new VirtualHostRuleContainer());
         balancer.start();
 
-        ContentResponse response = getBalancedResponse("/test/%0A");
+        ContentResponse response = getBalancedResponse("/test/%22foo%22");
         assertThat(response.getStatus(), is(200));
-        assertThat(response.getContentAsString(), containsString("requestURI='/context/mapping/test/%0A'"));
+        assertThat(response.getContentAsString(), containsString("requestURI='/context/mapping/test/%22foo%22'"));
         assertThat(response.getContentAsString(), containsString("servletPath='/mapping'"));
-        assertThat(response.getContentAsString(), containsString("pathInfo='/test/\n'"));
+        assertThat(response.getContentAsString(), containsString("pathInfo='/test/\"foo\"'"));
     }
 
     private String readFirstLine(byte[] responseBytes) throws IOException

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
@@ -46,10 +46,12 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.http.content.ResourceHttpContent;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.AllowedResourceAliasChecker;
 import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
@@ -94,7 +96,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @ExtendWith(WorkDirExtension.class)
 public class DefaultServletTest
 {
-
     public Path docRoot;
 
     // The name of the odd-jar used for testing "jar:file://" based resource access.
@@ -1974,6 +1975,7 @@ public class DefaultServletTest
     @Test
     public void testControlCharacter() throws Exception
     {
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         FS.ensureDirExists(docRoot);
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("resourceBase", docRoot.toFile().getAbsolutePath());

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResponseHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResponseHeadersTest.java
@@ -33,6 +33,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
@@ -224,6 +226,7 @@ public class ResponseHeadersTest
     @Test
     public void testMultilineResponseHeaderValue() throws Exception
     {
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
         String actualPathInfo = "%0a%20Content-Type%3a%20image/png%0a%20Content-Length%3a%208%0A%20%0A%20yuck<!--";
 
         HttpTester.Request request = new HttpTester.Request();


### PR DESCRIPTION
Adds 2 more UriCompliance.Violations

* `ILLEGAL_PATH_CHARACTERS` for both the URI and HTTP spec rules about illegal (not encoded) characters
* `SUSPICIOUS_PATH_CHARACTERS` for Servlet spec rules on suspicious (encoded or not) characters

Fixes: #11495