### PR TITLE
Restored removed constructor to CookieCache

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -49,6 +49,12 @@ public class CookieCache implements CookieParser.Handler, ComplianceViolation.Li
         _parser = CookieParser.newParser(this, compliance, this);
     }
 
+    @Deprecated(forRemoval = true)
+    public CookieCache(CookieCompliance compliance, ComplianceViolation.Listener complianceListener)
+    {
+        this(compliance);
+    }
+
     @Override
     public void onComplianceViolation(ComplianceViolation.Event event)
     {


### PR DESCRIPTION
Fix #11509 by restoring removed constructor as deprecated