### PR TITLE
Issue #11514 - Cleanup `jetty.webapp.addServerClasses` property behavior for ee10/ee9/ee8

### DIFF
--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ResourceAnnotationHandler.java
@@ -158,7 +158,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try environment scope next
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.__environment.getName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.ENVIRONMENT.getName(), name, mappedName);
                     
                     //try Server scope next
                     if (!bound)
@@ -313,7 +313,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try the environment's scope
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.__environment.getName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.ENVIRONMENT.getName(), name, mappedName);
                     
                     //try the server's scope
                     if (!bound)

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.plus.webapp;
 
-import java.util.Map;
 import java.util.Set;
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -208,8 +207,8 @@ public class EnvConfiguration extends AbstractConfiguration
         LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
 
-        LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.__environment.getName());
-        doBindings(envCtx, ServletContextHandler.__environment.getName());
+        LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
+        doBindings(envCtx, ServletContextHandler.ENVIRONMENT.getName());
 
         LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/PlusConfiguration.java
@@ -83,13 +83,13 @@ public class PlusConfiguration extends AbstractConfiguration
     {
         try
         {
-            Transaction.bindTransactionToENC(ServletContextHandler.__environment.getName());
+            Transaction.bindTransactionToENC(ServletContextHandler.ENVIRONMENT.getName());
         }
         catch (NameNotFoundException e)
         {
             try
             {
-                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(ServletContextHandler.__environment.getName());
+                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(ServletContextHandler.ENVIRONMENT.getName());
             }
             catch (NameNotFoundException x)
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -130,7 +130,12 @@ import static jakarta.servlet.ServletContext.TEMPDIR;
 public class ServletContextHandler extends ContextHandler
 {
     private static final Logger LOG = LoggerFactory.getLogger(ServletContextHandler.class);
-    public static final Environment __environment = Environment.ensure("ee10");
+    public static final Environment ENVIRONMENT = Environment.ensure("ee10");
+    /**
+     * @deprecated Use {@link ServletContextHandler#ENVIRONMENT} instead. will be removed in Jetty 12.1.0.
+     */
+    @Deprecated(since = "12.0.8", forRemoval = true)
+    public static final Environment __environment = ENVIRONMENT;
     public static final Class<?>[] SERVLET_LISTENER_TYPES =
         {
             ServletContextListener.class,

--- a/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-webapp.xml
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/config/etc/jetty-ee10-webapp.xml
@@ -3,7 +3,6 @@
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.ee10.webapp.WebAppContext" name="addSystemClasses">
-    <Arg><Ref refid="Server"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addSystemClasses"/></Arg>
@@ -12,7 +11,6 @@
   </Call>
 
   <Call class="org.eclipse.jetty.ee10.webapp.WebAppContext" name="addServerClasses">
-    <Arg><Ref refid="Server"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addServerClasses"/></Arg>

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -729,19 +729,19 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             if (__dftSystemClasses.equals(_systemClasses))
             {
                 Object systemClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SYS_CLASSES);
-                if (systemClasses instanceof String[])
-                    systemClasses = new ClassMatcher((String[])systemClasses);
-                if (systemClasses instanceof ClassMatcher)
-                    _systemClasses.add(((ClassMatcher)systemClasses).getPatterns());
+                if (systemClasses instanceof String[] patterns)
+                    _systemClasses.add(patterns);
+                if (systemClasses instanceof ClassMatcher classMatcher)
+                    _systemClasses.add(classMatcher.getPatterns());
             }
 
             if (__dftServerClasses.equals(_serverClasses))
             {
                 Object serverClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SRV_CLASSES);
-                if (serverClasses instanceof String[])
-                    serverClasses = new ClassMatcher((String[])serverClasses);
-                if (serverClasses instanceof ClassMatcher)
-                    _serverClasses.add(((ClassMatcher)serverClasses).getPatterns());
+                if (serverClasses instanceof String[] patterns)
+                    _serverClasses.add(patterns);
+                if (serverClasses instanceof ClassMatcher classMatcher)
+                    _serverClasses.add(classMatcher.getPatterns());
             }
         }
     }
@@ -1402,6 +1402,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public static void addServerClasses(String... patterns)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding {} ServerClasses: {}", ServletContextHandler.ENVIRONMENT, String.join(", ", patterns));
         addClasses(__dftServerClasses, SERVER_SRV_CLASSES, patterns);
     }
 
@@ -1424,6 +1426,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public static void addSystemClasses(String... patterns)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding {} SystemClasses: {}", ServletContextHandler.ENVIRONMENT, String.join(", ", patterns));
         addClasses(__dftSystemClasses, SERVER_SYS_CLASSES, patterns);
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebDescriptor.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebDescriptor.java
@@ -95,7 +95,7 @@ public class WebDescriptor extends Descriptor
         public WebDescriptorParser(boolean validating) throws IOException
         {
             super(validating);
-            String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.__environment.getName());
+            String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.ENVIRONMENT.getName());
             URL url = WebDescriptor.class.getResource(catalogName);
             if (url == null)
                 throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -43,6 +43,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
@@ -72,6 +73,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -801,5 +803,27 @@ public class WebAppContextTest
         server.setHandler(new Handler.Sequence(context, handler));
 
         assertThat(handler.getServer(), sameInstance(server));
+    }
+
+    @Test
+    public void testAddServerClasses() throws Exception
+    {
+        Server server = newServer();
+
+        String testPattern = "org.eclipse.jetty.ee10.webapp.test.";
+
+        WebAppContext.addServerClasses(server, testPattern);
+
+        WebAppContext context = new WebAppContext();
+        context.setContextPath("/");
+        Path warPath = MavenPaths.findTestResourceFile("wars/dump.war");
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+
+        server.setHandler(context);
+        server.start();
+
+        List<String> serverClasses = List.of(context.getServerClasses());
+
+        assertThat(serverClasses, hasItem(testPattern));
     }
 }

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -812,7 +812,7 @@ public class WebAppContextTest
 
         String testPattern = "org.eclipse.jetty.ee10.webapp.test.";
 
-        WebAppContext.addServerClasses(server, testPattern);
+        WebAppContext.addServerClasses(testPattern);
 
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -823,7 +823,33 @@ public class WebAppContextTest
         server.start();
 
         List<String> serverClasses = List.of(context.getServerClasses());
+        assertThat("Should have environment specific test pattern", serverClasses, hasItem(testPattern));
+        assertThat("Should have pattern from JaasConfiguration", serverClasses, hasItem("-org.eclipse.jetty.security.jaas."));
+        for (String defaultServerClass: WebAppContext.__dftServerClasses)
+            assertThat("Should have default patterns", serverClasses, hasItem(defaultServerClass));
+    }
 
-        assertThat(serverClasses, hasItem(testPattern));
+    @Test
+    public void testAddSystemClasses() throws Exception
+    {
+        Server server = newServer();
+
+        String testPattern = "org.eclipse.jetty.ee10.webapp.test.";
+
+        WebAppContext.addSystemClasses(testPattern);
+
+        WebAppContext context = new WebAppContext();
+        context.setContextPath("/");
+        Path warPath = MavenPaths.findTestResourceFile("wars/dump.war");
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+
+        server.setHandler(context);
+        server.start();
+
+        List<String> systemClasses = List.of(context.getSystemClasses());
+        assertThat("Should have environment specific test pattern", systemClasses, hasItem(testPattern));
+        assertThat("Should have pattern from JaasConfiguration", systemClasses, hasItem("org.eclipse.jetty.security.jaas."));
+        for (String defaultSystemClass: WebAppContext.__dftSystemClasses)
+            assertThat("Should have default patterns", systemClasses, hasItem(defaultSystemClass));
     }
 }

--- a/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-webapp.xml
+++ b/jetty-ee8/jetty-ee8-webapp/src/main/config/etc/jetty-ee8-webapp.xml
@@ -3,7 +3,6 @@
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.ee8.webapp.WebAppContext" name="addSystemClasses">
-    <Arg><Ref refid="Environment"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addSystemClasses"/></Arg>
@@ -12,7 +11,6 @@
   </Call>
 
   <Call class="org.eclipse.jetty.ee8.webapp.WebAppContext" name="addServerClasses">
-    <Arg><Ref refid="Environment"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addServerClasses"/></Arg>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-webapp.xml
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/config/etc/jetty-ee9-webapp.xml
@@ -3,7 +3,6 @@
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.ee9.webapp.WebAppContext" name="addSystemClasses">
-    <Arg><Ref refid="Environment"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addSystemClasses"/></Arg>
@@ -12,7 +11,6 @@
   </Call>
 
   <Call class="org.eclipse.jetty.ee9.webapp.WebAppContext" name="addServerClasses">
-    <Arg><Ref refid="Environment"/></Arg>
     <Arg>
       <Call class="org.eclipse.jetty.util.StringUtil" name="csvSplit">
         <Arg><Property name="jetty.webapp.addServerClasses"/></Arg>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -780,7 +780,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         {
             if (__dftSystemClasses.equals(_systemClasses))
             {
-                Object systemClasses = server.getAttribute(SERVER_SYS_CLASSES);
+                Object systemClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SYS_CLASSES);
                 if (systemClasses instanceof String[])
                     systemClasses = new ClassMatcher((String[])systemClasses);
                 if (systemClasses instanceof ClassMatcher)
@@ -789,7 +789,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
             if (__dftServerClasses.equals(_serverClasses))
             {
-                Object serverClasses = server.getAttribute(SERVER_SRV_CLASSES);
+                Object serverClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SRV_CLASSES);
                 if (serverClasses instanceof String[])
                     serverClasses = new ClassMatcher((String[])serverClasses);
                 if (serverClasses instanceof ClassMatcher)
@@ -1472,24 +1472,58 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         return _metadata;
     }
 
-    public static void addServerClasses(Attributes attributes, String... pattern)
+    /**
+     * Add a Server Class pattern to use for all ee9 WebAppContexts.
+     * @param patterns the patterns to use
+     * @see #getServerClassMatcher()
+     * @see #getServerClasses()
+     */
+    public static void addServerClasses(String... patterns)
     {
-        addClasses(__dftServerClasses, SERVER_SRV_CLASSES, attributes, pattern);
+        addClasses(__dftServerClasses, SERVER_SRV_CLASSES, patterns);
     }
 
-    public static void addSystemClasses(Attributes attributes, String... pattern)
+    /**
+     * @param attributes ignored.
+     * @param patterns the patterns to add
+     * @deprecated use {@link #addServerClasses(String...)} instead. will be removed in Jetty 12.1.0
+     */
+    @Deprecated(since = "12.0.8", forRemoval = true)
+    public static void addServerClasses(Attributes attributes, String... patterns)
     {
-        addClasses(__dftSystemClasses, SERVER_SYS_CLASSES, attributes, pattern);
+        addServerClasses(patterns);
     }
 
-    private static void addClasses(ClassMatcher matcher, String attribute, Attributes attributes, String... pattern)
+    /**
+     * Add a System Class pattern to use for all ee9 WebAppContexts.
+     * @param patterns the patterns to use
+     * @see #getSystemClassMatcher()
+     * @see #getSystemClasses()
+     */
+    public static void addSystemClasses(String... patterns)
+    {
+        addClasses(__dftSystemClasses, SERVER_SYS_CLASSES, patterns);
+    }
+
+    /**
+     * @param attributes ignored.
+     * @param patterns the patterns to add
+     * @deprecated use {@link #addSystemClasses(String...)} instead. will be removed in Jetty 12.1.0
+     */
+    @Deprecated(since = "12.0.8", forRemoval = true)
+    public static void addSystemClasses(Attributes attributes, String... patterns)
+    {
+        addSystemClasses(patterns);
+    }
+
+    private static void addClasses(ClassMatcher matcher, String attributeKey, String... pattern)
     {
         if (pattern == null || pattern.length == 0)
             return;
 
-        // look for a Server attribute with the list of System classes
-        // to apply to every web application. If not present, use our defaults.
-        Object o = attributes.getAttribute(attribute);
+        // look for a ClassMatcher attribute with the list of Server / System classes
+        // to apply to every ee9 web application. If not present, use our defaults.
+        Object o = ServletContextHandler.ENVIRONMENT.getAttribute(attributeKey);
         if (o instanceof ClassMatcher)
         {
             ((ClassMatcher)o).add(pattern);
@@ -1504,6 +1538,6 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         int l = classes.length;
         classes = Arrays.copyOf(classes, l + pattern.length);
         System.arraycopy(pattern, 0, classes, l, pattern.length);
-        attributes.setAttribute(attribute, classes);
+        ServletContextHandler.ENVIRONMENT.setAttribute(attributeKey, classes);
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -781,19 +781,19 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             if (__dftSystemClasses.equals(_systemClasses))
             {
                 Object systemClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SYS_CLASSES);
-                if (systemClasses instanceof String[])
-                    systemClasses = new ClassMatcher((String[])systemClasses);
-                if (systemClasses instanceof ClassMatcher)
-                    _systemClasses.add(((ClassMatcher)systemClasses).getPatterns());
+                if (systemClasses instanceof String[] patterns)
+                    _systemClasses.add(patterns);
+                if (systemClasses instanceof ClassMatcher classMatcher)
+                    _systemClasses.add(classMatcher.getPatterns());
             }
 
             if (__dftServerClasses.equals(_serverClasses))
             {
                 Object serverClasses = ServletContextHandler.ENVIRONMENT.getAttribute(SERVER_SRV_CLASSES);
-                if (serverClasses instanceof String[])
-                    serverClasses = new ClassMatcher((String[])serverClasses);
-                if (serverClasses instanceof ClassMatcher)
-                    _serverClasses.add(((ClassMatcher)serverClasses).getPatterns());
+                if (serverClasses instanceof String[] patterns)
+                    _serverClasses.add(patterns);
+                if (serverClasses instanceof ClassMatcher classMatcher)
+                    _serverClasses.add(classMatcher.getPatterns());
             }
         }
     }
@@ -1480,6 +1480,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public static void addServerClasses(String... patterns)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding {} ServerClasses: {}", ServletContextHandler.ENVIRONMENT, String.join(", ", patterns));
         addClasses(__dftServerClasses, SERVER_SRV_CLASSES, patterns);
     }
 
@@ -1502,6 +1504,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public static void addSystemClasses(String... patterns)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding {} SystemClasses: {}", ServletContextHandler.ENVIRONMENT, String.join(", ", patterns));
+
         addClasses(__dftSystemClasses, SERVER_SYS_CLASSES, patterns);
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -803,5 +804,27 @@ public class WebAppContextTest
         Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
         assertThat("URL[0]", urls[0].toURI(), is(extLibs.toUri()));
+    }
+
+    @Test
+    public void testAddServerClasses() throws Exception
+    {
+        Server server = newServer();
+
+        String testPattern = "org.eclipse.jetty.ee9.webapp.test.";
+
+        WebAppContext.addServerClasses(testPattern);
+
+        WebAppContext context = new WebAppContext();
+        context.setContextPath("/");
+        Path warPath = MavenPaths.findTestResourceFile("wars/dump.war");
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+
+        server.setHandler(context);
+        server.start();
+
+        List<String> serverClasses = List.of(context.getServerClasses());
+
+        assertThat(serverClasses, hasItem(testPattern));
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -824,7 +824,35 @@ public class WebAppContextTest
         server.start();
 
         List<String> serverClasses = List.of(context.getServerClasses());
+        assertThat("Should have environment specific test pattern", serverClasses, hasItem(testPattern));
+        assertThat("Should have pattern from JaasConfiguration", serverClasses, hasItem("-org.eclipse.jetty.security.jaas."));
+        for (String defaultServerClass: WebAppContext.__dftServerClasses)
+            assertThat("Should have default patterns", serverClasses, hasItem(defaultServerClass));
+    }
 
-        assertThat(serverClasses, hasItem(testPattern));
+    @Test
+    public void testAddSystemClasses() throws Exception
+    {
+        Server server = newServer();
+
+        String testPattern = "org.eclipse.jetty.ee9.webapp.test.";
+
+        WebAppContext.addSystemClasses(testPattern);
+
+        WebAppContext context = new WebAppContext();
+        context.setContextPath("/");
+        Path warPath = MavenPaths.findTestResourceFile("wars/dump.war");
+        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+
+        server.setHandler(context);
+        server.start();
+
+        List<String> systemClasses = List.of(context.getSystemClasses());
+        assertThat("Should have environment specific test pattern", systemClasses, hasItem(testPattern));
+        assertThat("Should have pattern from JaasConfiguration", systemClasses, hasItem("org.eclipse.jetty.security.jaas."));
+        for (String defaultSystemClass : WebAppContext.__dftSystemClasses)
+        {
+            assertThat("Should have default patterns", systemClasses, hasItem(defaultSystemClass));
+        }
     }
 }


### PR DESCRIPTION
Cleanup of how `jetty.webapp.addServerClasses` and `jetty.webapp.addSystemClasses` properties work in Jetty 12.

* Standardize all storage of configurations in the associated Environment attributes (we had some in Environment, some in Server)
* Deprecate static methods that take the Attributes or Server classes (as those were out of sync with what WebAppContext.setServer(Server) behavior was working.
* Add testing of new `WebAppContext.addServerClasses(String)`

This issue was discovered during the cross context dispatch testing, and is a critical piece of that testing.

Fixes #11514