### PR TITLE
Ensure request is set for ContextScopeListener in EE10

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1219,7 +1219,12 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         @Override
         public void execute(Runnable runnable)
         {
-            getServer().getContext().execute(() -> run(runnable));
+            execute(runnable, null);
+        }
+
+        public void execute(Runnable runnable, Request request)
+        {
+            getServer().getContext().execute(() -> run(runnable, request));
         }
 
         protected DecoratedObjectFactory getDecoratedObjectFactory()

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
@@ -20,13 +20,12 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.thread.Scheduler;
 
 public class AsyncContextEvent extends AsyncEvent implements Runnable
 {
     private final ServletContext _servletContext;
-    private final ContextHandler.ScopedContext _context;
+    private final ServletContextHandler.ServletScopedContext _context;
     private final AsyncContextState _asyncContext;
     private final HttpURI _baseURI;
     private final ServletChannelState _state;
@@ -35,7 +34,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
     private volatile Scheduler.Task _timeoutTask;
     private Throwable _throwable;
 
-    public AsyncContextEvent(ContextHandler.ScopedContext context, AsyncContextState asyncContext, ServletChannelState state, ServletRequest request, ServletResponse response)
+    public AsyncContextEvent(ServletContextHandler.ServletScopedContext context, AsyncContextState asyncContext, ServletChannelState state, ServletRequest request, ServletResponse response)
     {
         super(null, request, response, null);
         _context = context;
@@ -76,7 +75,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         return _dispatchContext == null ? _servletContext : _dispatchContext;
     }
 
-    public ContextHandler.ScopedContext getContext()
+    public ServletContextHandler.ServletScopedContext getContext()
     {
         return _context;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextState.java
@@ -141,7 +141,7 @@ public class AsyncContextState implements AsyncContext
             {
                 task.run();
             }
-        });
+        }, _state.getServletChannel().getRequest());
     }
 
     public void reset()

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -788,6 +788,11 @@ public class ServletChannel
         _context.execute(task);
     }
 
+    protected void execute(Runnable task, Request request)
+    {
+        _context.execute(task, request);
+    }
+
     /**
      * If a write or similar operation to this channel fails,
      * then this method should be called.

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -1174,7 +1174,7 @@ public class ServletChannelState
 
     protected void scheduleDispatch()
     {
-        _servletChannel.execute(_servletChannel::handle);
+        _servletChannel.execute(_servletChannel::handle, _servletChannel.getRequest());
     }
 
     protected void cancelTimeout()

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
@@ -1,0 +1,133 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ContextScopeListenerTest
+{
+    private Server _server;
+    private ServerConnector _connector;
+    private HttpClient _client;
+    private final List<String> _history = new CopyOnWriteArrayList<>();
+    private ServletContextHandler _contextHandler;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        _contextHandler = new ServletContextHandler();
+        _server.setHandler(_contextHandler);
+        _server.start();
+
+        _client = new HttpClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testAsyncServlet() throws Exception
+    {
+        _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                if  (req.getDispatcherType() == DispatcherType.ASYNC)
+                {
+                    _history.add("asyncDispatch");
+                    return;
+                }
+
+                _history.add("doGet");
+                AsyncContext asyncContext = req.startAsync();
+                asyncContext.start(() ->
+                {
+                    _history.add("asyncRunnable");
+                    asyncContext.dispatch("/dispatch");
+                });
+            }
+        }), "/");
+
+        _contextHandler.addEventListener(new ContextHandler.ContextScopeListener() {
+            @Override
+            public void enterScope(Context context, Request request)
+            {
+                String pathInContext = (request == null) ? "null" : Request.getPathInContext(request);
+                _history.add("enterScope " + pathInContext);
+            }
+
+            @Override
+            public void exitScope(Context context, Request request)
+            {
+                String pathInContext = (request == null) ? "null" : Request.getPathInContext(request);
+                _history.add("exitScope " + pathInContext);
+            }
+        });
+
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/initialPath");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertHistory(
+            "enterScope /initialPath",
+            "doGet",
+            "exitScope /initialPath",
+            "enterScope /initialPath",
+            "asyncRunnable",
+            "exitScope /initialPath",
+            "enterScope /initialPath",
+            "asyncDispatch",
+            "exitScope /initialPath"
+        );
+    }
+
+    private void assertHistory(String... values)
+    {
+        assertThat(_history.toString(), _history.size(), equalTo(values.length));
+        for (int i = 0; i < values.length; i++)
+        {
+            assertThat(_history.toString(), _history.get(i), equalTo(values[i]));
+        }
+    }
+}

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
@@ -70,7 +70,8 @@ public class ContextScopeListenerTest
     @Test
     public void testAsyncServlet() throws Exception
     {
-        _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+        _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+        {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp)
             {
@@ -90,7 +91,8 @@ public class ContextScopeListenerTest
             }
         }), "/");
 
-        _contextHandler.addEventListener(new ContextHandler.ContextScopeListener() {
+        _contextHandler.addEventListener(new ContextHandler.ContextScopeListener()
+        {
             @Override
             public void enterScope(Context context, Request request)
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ContextScopeListenerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee10.servlet;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -126,10 +127,6 @@ public class ContextScopeListenerTest
 
     private void assertHistory(String... values)
     {
-        assertThat(_history.toString(), _history.size(), equalTo(values.length));
-        for (int i = 0; i < values.length; i++)
-        {
-            assertThat(_history.toString(), _history.get(i), equalTo(values[i]));
-        }
+        assertThat(_history, equalTo(Arrays.asList(values)));
     }
 }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
@@ -1,0 +1,135 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.servlet;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee9.nested.ContextHandler;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.URIUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ContextScopeListenerTest
+{
+    private Server _server;
+    private ServerConnector _connector;
+    private HttpClient _client;
+    private final List<String> _history = new CopyOnWriteArrayList<>();
+    private ServletContextHandler _contextHandler;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        _contextHandler = new ServletContextHandler();
+        _server.setHandler(_contextHandler);
+        _server.start();
+
+        _client = new HttpClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testAsyncServlet() throws Exception
+    {
+        _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                if  (req.getDispatcherType() == DispatcherType.ASYNC)
+                {
+                    _history.add("asyncDispatch");
+                    return;
+                }
+
+                _history.add("doGet");
+                AsyncContext asyncContext = req.startAsync();
+                asyncContext.start(() ->
+                {
+                    _history.add("asyncRunnable");
+                    asyncContext.dispatch("/dispatch");
+                });
+            }
+        }), "/");
+
+        _contextHandler.addEventListener(new ContextHandler.ContextScopeListener()
+        {
+            @Override
+            public void enterScope(ContextHandler.APIContext context, org.eclipse.jetty.ee9.nested.Request request, Object reason)
+            {
+                String pathInContext = (request == null) ? "null" : URIUtil.addPaths(request.getServletPath(), request.getPathInfo());
+                _history.add("enterScope " + pathInContext);
+            }
+
+            @Override
+            public void exitScope(ContextHandler.APIContext context, org.eclipse.jetty.ee9.nested.Request request)
+            {
+                String pathInContext = (request == null) ? "null" : URIUtil.addPaths(request.getServletPath(), request.getPathInfo());
+                _history.add("exitScope " + pathInContext);
+            }
+        });
+
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + "/initialPath");
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertHistory(
+            "enterScope /initialPath",
+            "doGet",
+            "exitScope /initialPath",
+            "enterScope /initialPath",
+            "asyncRunnable",
+            "exitScope /initialPath",
+            "enterScope /dispatch",
+            "asyncDispatch",
+            "exitScope /dispatch",
+            "enterScope /dispatch",
+            "exitScope /dispatch"
+        );
+    }
+
+    private void assertHistory(String... values)
+    {
+        assertThat(_history.toString(), _history.size(), equalTo(values.length));
+        for (int i = 0; i < values.length; i++)
+        {
+            assertThat(_history.toString(), _history.get(i), equalTo(values[i]));
+        }
+    }
+}

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
@@ -69,7 +69,8 @@ public class ContextScopeListenerTest
     @Test
     public void testAsyncServlet() throws Exception
     {
-        _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+        _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+        {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp)
             {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ContextScopeListenerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee9.servlet;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -127,10 +128,6 @@ public class ContextScopeListenerTest
 
     private void assertHistory(String... values)
     {
-        assertThat(_history.toString(), _history.size(), equalTo(values.length));
-        for (int i = 0; i < values.length; i++)
-        {
-            assertThat(_history.toString(), _history.get(i), equalTo(values[i]));
-        }
+        assertThat(_history, equalTo(Arrays.asList(values)));
     }
 }


### PR DESCRIPTION
This is needed for https://github.com/GoogleCloudPlatform/appengine-java-standard/pull/96

Currently on async requests the `ContextScopeListener` will have a null request. This PR ensures that the request is set.