### PR TITLE
Upgrade quiche to version 0.20.1

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
@@ -89,7 +89,10 @@ public interface Quiche
         QUICHE_ERR_OUT_OF_IDENTIFIERS = -18,
 
         // Error in key update.
-        QUICHE_ERR_KEY_UPDATE = -19;
+        QUICHE_ERR_KEY_UPDATE = -19,
+
+        // The peer sent more data in CRYPTO frames than we can buffer.
+        QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED = -20;
 
         static String errToString(long err)
         {
@@ -131,6 +134,8 @@ public interface Quiche
                 return "QUICHE_ERR_OUT_OF_IDENTIFIERS";
             if (err == QUICHE_ERR_KEY_UPDATE)
                 return "QUICHE_ERR_KEY_UPDATE";
+            if (err == QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED)
+                return "QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED";
             return "?? " + err;
         }
     }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
@@ -33,7 +33,7 @@ public class quiche_h
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    private static final String EXPECTED_QUICHE_VERSION = "0.20.0";
+    private static final String EXPECTED_QUICHE_VERSION = "0.20.1";
 
     public static final byte C_FALSE = 0;
     public static final byte C_TRUE = 1;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -31,7 +31,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.20.0";
+    String EXPECTED_QUICHE_VERSION = "0.20.1";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.5.3.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.20.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.20.1</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
This is the first version for which we add support for `linux-aarch64`.