### PR TITLE
Allows to change the default ErrorHandler response type

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -127,7 +127,7 @@ public class ErrorHandler implements Request.Handler
                 callback.succeeded();
                 return;
             }
-            acceptable = Collections.singletonList(Type.TEXT_HTML.asString());
+            acceptable = Collections.singletonList(defaultResponseMimeType().asString());
         }
         List<Charset> charsets = request.getHeaders().getQualityCSV(HttpHeader.ACCEPT_CHARSET).stream()
             .map(s ->
@@ -161,6 +161,10 @@ public class ErrorHandler implements Request.Handler
                 return;
         }
         callback.succeeded();
+    }
+
+    protected Type defaultResponseMimeType() {
+        return Type.TEXT_HTML;
     }
 
     protected boolean generateAcceptableResponse(Request request, Response response, Callback callback, String contentType, List<Charset> charsets, int code, String message, Throwable cause) throws IOException

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -74,7 +74,7 @@ public class ErrorHandler implements Request.Handler
 
     boolean _showStacks = true;
     boolean _showMessageInTitle = true;
-    Type _defaultResponseMimeType = Type.TEXT_HTML;
+    String _defaultResponseMimeType = Type.TEXT_HTML.asString();
     HttpField _cacheControl = new PreEncodedHttpField(HttpHeader.CACHE_CONTROL, "must-revalidate,no-cache,no-store");
 
     public ErrorHandler()
@@ -128,7 +128,7 @@ public class ErrorHandler implements Request.Handler
                 callback.succeeded();
                 return;
             }
-            acceptable = Collections.singletonList(_defaultResponseMimeType.asString());
+            acceptable = Collections.singletonList(_defaultResponseMimeType);
         }
         List<Charset> charsets = request.getHeaders().getQualityCSV(HttpHeader.ACCEPT_CHARSET).stream()
             .map(s ->
@@ -482,7 +482,7 @@ public class ErrorHandler implements Request.Handler
      * @return The mime type to be used when a client does not specify an Accept header, or the request did not fully parse
      */
     @ManagedAttribute("Mime type to be used when a client does not specify an Accept header, or the request did not fully parse")
-    public Type getDefaultResponseMimeType()
+    public String getDefaultResponseMimeType()
     {
         return _defaultResponseMimeType;
     }
@@ -490,9 +490,9 @@ public class ErrorHandler implements Request.Handler
     /**
      * @param defaultResponseMimeType The mime type to be used when a client does not specify an Accept header, or the request did not fully parse
      */
-    public void setDefaultResponseMimeType(Type defaultResponseMimeType)
+    public void setDefaultResponseMimeType(String defaultResponseMimeType)
     {
-        _defaultResponseMimeType = defaultResponseMimeType;
+        _defaultResponseMimeType = Objects.requireNonNull(defaultResponseMimeType);;
     }
 
     protected void write(Writer writer, String string) throws IOException

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -74,6 +74,7 @@ public class ErrorHandler implements Request.Handler
 
     boolean _showStacks = true;
     boolean _showMessageInTitle = true;
+    Type _defaultResponseMimeType = Type.TEXT_HTML;
     HttpField _cacheControl = new PreEncodedHttpField(HttpHeader.CACHE_CONTROL, "must-revalidate,no-cache,no-store");
 
     public ErrorHandler()
@@ -127,7 +128,7 @@ public class ErrorHandler implements Request.Handler
                 callback.succeeded();
                 return;
             }
-            acceptable = Collections.singletonList(defaultResponseMimeType().asString());
+            acceptable = Collections.singletonList(_defaultResponseMimeType.asString());
         }
         List<Charset> charsets = request.getHeaders().getQualityCSV(HttpHeader.ACCEPT_CHARSET).stream()
             .map(s ->
@@ -161,10 +162,6 @@ public class ErrorHandler implements Request.Handler
                 return;
         }
         callback.succeeded();
-    }
-
-    protected Type defaultResponseMimeType() {
-        return Type.TEXT_HTML;
     }
 
     protected boolean generateAcceptableResponse(Request request, Response response, Callback callback, String contentType, List<Charset> charsets, int code, String message, Throwable cause) throws IOException
@@ -479,6 +476,23 @@ public class ErrorHandler implements Request.Handler
     public void setShowMessageInTitle(boolean showMessageInTitle)
     {
         _showMessageInTitle = showMessageInTitle;
+    }
+
+    /**
+     * @return The mime type to be used when a client does not specify an Accept header, or the request did not fully parse
+     */
+    @ManagedAttribute("Mime type to be used when a client does not specify an Accept header, or the request did not fully parse")
+    public Type getDefaultResponseMimeType()
+    {
+        return _defaultResponseMimeType;
+    }
+
+    /**
+     * @param defaultResponseMimeType The mime type to be used when a client does not specify an Accept header, or the request did not fully parse
+     */
+    public void setDefaultResponseMimeType(Type defaultResponseMimeType)
+    {
+        _defaultResponseMimeType = defaultResponseMimeType;
     }
 
     protected void write(Writer writer, String string) throws IOException

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -167,10 +167,11 @@ public class ErrorHandlerTest
         errorHandler.setDefaultResponseMimeType(MimeTypes.Type.APPLICATION_JSON.asString());
         server.setErrorHandler(errorHandler);
 
-        String rawResponse = connector.getResponse(
-                "GET / HTTP/1.1\r\n" +
-                        "Host: Localhost\r\n" +
-                        "\r\n");
+        String rawResponse = connector.getResponse("""
+                        GET / HTTP/1.1
+                        Host: Localhost
+                        
+                        """);
 
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -164,7 +164,7 @@ public class ErrorHandlerTest
     public void test404NoAcceptButSpecifiedDefaultResponseMimeType() throws Exception
     {
         ErrorHandler errorHandler = new ErrorHandler();
-        errorHandler.setDefaultResponseMimeType(MimeTypes.Type.APPLICATION_JSON);
+        errorHandler.setDefaultResponseMimeType(MimeTypes.Type.APPLICATION_JSON.asString());
         server.setErrorHandler(errorHandler);
 
         String rawResponse = connector.getResponse(

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.logging.StacklessLogging;
@@ -155,6 +156,30 @@ public class ErrorHandlerTest
         assertThat("Response Content-Type", response.get(HttpHeader.CONTENT_TYPE), containsString("text/html;charset=ISO-8859-1"));
         assertThat(response.get(HttpHeader.DATE), notNullValue());
         assertThat(response.getContent(), containsString("content=\"text/html;charset=ISO-8859-1\""));
+
+        assertContent(response);
+    }
+
+    @Test
+    public void test404NoAcceptButSpecifiedDefaultResponseMimeType() throws Exception
+    {
+        ErrorHandler errorHandler = new ErrorHandler();
+        errorHandler.setDefaultResponseMimeType(MimeTypes.Type.APPLICATION_JSON);
+        server.setErrorHandler(errorHandler);
+
+        String rawResponse = connector.getResponse(
+                "GET / HTTP/1.1\r\n" +
+                        "Host: Localhost\r\n" +
+                        "\r\n");
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+
+        assertThat("Response status code", response.getStatus(), is(404));
+        assertThat("Response Content-Length", response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
+        assertThat("Response Content-Type", response.get(HttpHeader.CONTENT_TYPE), containsString("application/json"));
+        assertThat(response.get(HttpHeader.DATE), notNullValue());
+        assertThat(response.getContent(), containsString("\"status\":\"404\""));
+        assertThat(response.getContent(), containsString("\"message\":\"Not Found\""));
 
         assertContent(response);
     }


### PR DESCRIPTION
Currently, the server returns HTML responses by default. It would be great to easily change this without having to overwrite the whole error handler.

The error handler tries to find the right/accepted response type using the `ACCEPT` header, but in some cases the header is not yet there when an error happens, e.g. with an URI violation, it seems the request is not yet fully parsed and therefore the requested content type not recognised.