### PR TITLE
Issue #11536 - `ServletContext.getResourceAsStream(String)` must use `URLConnection`

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1939,7 +1939,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
             if (path == null)
                 return null;
             Resource resource = ContextHandler.this.getResource(path);
-            if (Resources.missing(resource))
+            if (Resources.exists(resource))
                 return resource.getURI().toURL();
             return null;
         }


### PR DESCRIPTION
Making Implementations of `ServletContext.getResourceAsStream(String)` use `URLConnection` properly (per spec) in ee10/ee9 codebases.

Fixes #11536