### PR TITLE
Issue #11539 restore old behavior of `Resource.copyTo()` with regards to existing destination files.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -277,7 +277,9 @@ public class IO
      * @param destDir the destination directory (must exist)
      * @param copyOptions the options to use on the {@link Files#copy(Path, Path, CopyOption...)} commands.
      * @throws IOException if unable to copy the file
+     * @deprecated use {@link #copyDir(Path, Path)} instead to avoid foreign target behavior across FileSystems.
      */
+    @Deprecated(since = "12.0.8", forRemoval = true)
     public static void copyDir(Path srcDir, Path destDir, CopyOption... copyOptions) throws IOException
     {
         if (!Files.isDirectory(Objects.requireNonNull(srcDir)))

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -319,11 +319,14 @@ public class IO
      * </p>
      *
      * @param basePath the base Path
-     * @param relative the Path to resolve against base Path
+     * @param relative the relative Path to resolve against base Path
      * @return the new Path object relative to the base Path
      */
     public static Path resolvePath(Path basePath, Path relative)
     {
+        if (relative.isAbsolute())
+            throw new IllegalArgumentException("Relative path cannot be absolute");
+
         if (basePath.getFileSystem().equals(relative.getFileSystem()))
         {
             return basePath.resolve(relative);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -237,15 +237,18 @@ public class IO
      * </p>
      *
      * @param srcDir the source directory
-     * @param destDir the destination directory (must exist)
+     * @param destDir the destination directory
      * @throws IOException if unable to copy the file
      */
     public static void copyDir(Path srcDir, Path destDir) throws IOException
     {
         if (!Files.isDirectory(Objects.requireNonNull(srcDir)))
             throw new IllegalArgumentException("Source is not a directory: " + srcDir);
-        if (!Files.isDirectory(Objects.requireNonNull(destDir)))
-            throw new IllegalArgumentException("Dest is not a directory: " + destDir);
+        Objects.requireNonNull(destDir);
+        if (Files.exists(destDir) && !Files.isDirectory(destDir))
+            throw new IllegalArgumentException("Destination is not a directory: " + destDir);
+        else if (!Files.exists(destDir))
+            Files.createDirectory(destDir); // only attempt top create 1 level of directory (parent must exist)
 
         try (Stream<Path> sourceStream = Files.walk(srcDir))
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/CombinedResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/CombinedResource.java
@@ -14,12 +14,8 @@
 package org.eclipse.jetty.util.resource;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -290,9 +286,7 @@ public class CombinedResource extends Resource
         for (Resource r : all)
         {
             Path relative = getPathTo(r);
-            Path pathTo = Objects.equals(relative.getFileSystem(), destination.getFileSystem())
-                ? destination.resolve(relative)
-                : resolveDifferentFileSystem(destination, relative);
+            Path pathTo = IO.resolvePath(destination, relative);
 
             if (r.isDirectory())
             {
@@ -301,19 +295,7 @@ public class CombinedResource extends Resource
             else
             {
                 ensureDirExists(pathTo.getParent());
-                Path pathFrom = r.getPath();
-                if (pathFrom != null)
-                {
-                    Files.copy(pathFrom, pathTo, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
-                }
-                else
-                {
-                    // use old school stream based copy
-                    try (InputStream in = r.newInputStream(); OutputStream out = Files.newOutputStream(pathTo))
-                    {
-                        IO.copy(in, out);
-                    }
-                }
+                r.copyTo(pathTo);
             }
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/CombinedResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/CombinedResource.java
@@ -276,12 +276,6 @@ public class CombinedResource extends Resource
     @Override
     public void copyTo(Path destination) throws IOException
     {
-        // This method could be implemented with the simple:
-        //     List<Resource> entries = getResources();
-        //     for (int r = entries.size(); r-- > 0; )
-        //       entries.get(r).copyTo(destination);
-        // However, that may copy large overlayed resources. The implementation below avoids that:
-
         Collection<Resource> all = getAllResources();
         for (Resource r : all)
         {
@@ -290,11 +284,11 @@ public class CombinedResource extends Resource
 
             if (r.isDirectory())
             {
-                ensureDirExists(pathTo);
+                IO.ensureDirExists(pathTo);
             }
             else
             {
-                ensureDirExists(pathTo.getParent());
+                IO.ensureDirExists(pathTo.getParent());
                 r.copyTo(pathTo);
             }
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -309,10 +309,10 @@ public abstract class Resource implements Iterable<Resource>
      *     <li>And the {@code destination} does not exist then
      *         the destination is created as a directory via {@link Files#createDirectories(Path, FileAttribute[])}
      *         before the {@link IO#copyDir(Path, Path)} method is used.</li>
-     *     <li>And the {@code destination} is a File then results in .</li>
-     *     <li>And the {@code destination} is a Directory then
-     *         a new {@link Path} reference is created in the destination with the same
-     *         filename as this Resource, which is used via {@link IO#copyFile(Path, Path)}.</li>
+     *     <li>And the {@code destination} is a File then this results in an {@link IllegalArgumentException}.</li>
+     *     <li>And the {@code destination} is a Directory then all files in this Resource
+     *         directory tree are copied to the {@code destination}, using {@link IO#copyFile(Path, Path)}
+     *         maintaining the same directory structure.</li>
      * </ul>
      *
      * <p>If this Resource is not backed by a {@link Path}, use {@link #newInputStream()}:</p>
@@ -335,7 +335,7 @@ public abstract class Resource implements Iterable<Resource>
         Path src = getPath();
         if (src == null)
         {
-            // this implementation does is not backed by a Path.
+            // this implementation is not backed by a Path.
 
             // is this a Directory?
             if (isDirectory())

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -390,7 +390,6 @@ public abstract class Resource implements Iterable<Resource>
         // wanting to copy to a destination directory (that might not exist yet)
         assert isDirectory();
 
-        IO.ensureDirExists(destination);
         IO.copyDir(src, destination);
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -295,41 +295,36 @@ public abstract class Resource implements Iterable<Resource>
     /**
      * Copy the Resource to the new destination file or directory.
      *
-     * <p>
-     *     If this Resource is a File:
-     *     <ul>
-     *         <li>And the {@code destination} does not exist then {@link IO#copyFile(Path, Path)} is used.</li>
-     *         <li>And the {@code destination} is a File then {@link IO#copyFile(Path, Path)} is used.</li>
-     *         <li>And the {@code destination} is a Directory then
-     *             a new {@link Path} reference is created in the destination with the same
-     *             filename as this Resource, which is used via {@link IO#copyFile(Path, Path)}.</li>
-     *     </ul>
-     * </p>
-     * <p>
-     *     If this Resource is a Directory:
-     *     <ul>
-     *         <li>And the {@code destination} does not exist then
-     *             the destination is created as a directory via {@link Files#createDirectories(Path, FileAttribute[])}
-     *             before the {@link IO#copyDir(Path, Path)} method is used.</li>
-     *         <li>And the {@code destination} is a File then results in .</li>
-     *         <li>And the {@code destination} is a Directory then
-     *             a new {@link Path} reference is created in the destination with the same
-     *             filename as this Resource, which is used via {@link IO#copyFile(Path, Path)}.</li>
-     *     </ul>
-     * </p>
+     * <p>If this Resource is a File:</p>
+     * <ul>
+     *     <li>And the {@code destination} does not exist then {@link IO#copyFile(Path, Path)} is used.</li>
+     *     <li>And the {@code destination} is a File then {@link IO#copyFile(Path, Path)} is used.</li>
+     *     <li>And the {@code destination} is a Directory then
+     *         a new {@link Path} reference is created in the destination with the same
+     *         filename as this Resource, which is used via {@link IO#copyFile(Path, Path)}.</li>
+     * </ul>
      *
-     * <p>
-     *     If this Resource is not backed by a {@link Path}, use {@link #newInputStream()}:
-     *     <ul>
-     *         <li>And the {@code destination} does not exist, copy {@link InputStream}
-     *             to the {@code destination} as a new file.</li>
-     *         <li>And the {@code destination} is a File, copy {@link InputStream}
-     *             to the existing {@code destination} file.</li>
-     *         <li>And the {@code destination} is a Directory, copy {@link InputStream}
-     *             to a new {@code destination} file in the destination directory
-     *             based on this the result of {@link #getFileName()} as the filename.</li>
-     *     </ul>
-     * </p>
+     * <p>If this Resource is a Directory:</p>
+     * <ul>
+     *     <li>And the {@code destination} does not exist then
+     *         the destination is created as a directory via {@link Files#createDirectories(Path, FileAttribute[])}
+     *         before the {@link IO#copyDir(Path, Path)} method is used.</li>
+     *     <li>And the {@code destination} is a File then results in .</li>
+     *     <li>And the {@code destination} is a Directory then
+     *         a new {@link Path} reference is created in the destination with the same
+     *         filename as this Resource, which is used via {@link IO#copyFile(Path, Path)}.</li>
+     * </ul>
+     *
+     * <p>If this Resource is not backed by a {@link Path}, use {@link #newInputStream()}:</p>
+     * <ul>
+     *     <li>And the {@code destination} does not exist, copy {@link InputStream}
+     *         to the {@code destination} as a new file.</li>
+     *     <li>And the {@code destination} is a File, copy {@link InputStream}
+     *         to the existing {@code destination} file.</li>
+     *     <li>And the {@code destination} is a Directory, copy {@link InputStream}
+     *         to a new {@code destination} file in the destination directory
+     *         based on this the result of {@link #getFileName()} as the filename.</li>
+     * </ul>
      *
      * @param destination the destination file or directory to use (created if it does not exist).
      * @throws IOException if unable to copy the resource

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/Overlay.java
@@ -89,6 +89,8 @@ public class Overlay
         // only unpack if the overlay is newer
         if (!Files.exists(pathDir))
         {
+            // create directory
+            Files.createDirectories(pathDir);
             getResource().copyTo(pathDir);
         }
         else

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/Overlay.java
@@ -90,6 +90,8 @@ public class Overlay
         // only unpack if the overlay is newer
         if (!Files.exists(pathDir))
         {
+            // create directory
+            Files.createDirectories(pathDir);
             getResource().copyTo(pathDir);
         }
         else


### PR DESCRIPTION
+ Do not delete destination resource if it exists before copy to restore the behavior to what we had in Jetty 9/10/11.

Fixes: #11539