### PR TITLE
Fixes #5857 - Deprecate AbstractConnectionPool "callback" methods.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -453,7 +453,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
      * @param connection the {@link Connection} that become idle
      * @param close whether this pool is closing
      * @return {@code true} to indicate that the connection is idle, {@code false} otherwise
-     * @deprecated do not override because its usage is racy
+     * @deprecated Racy API. Do not use. There is no replacement.
      */
     @Deprecated(since = "12.0.8", forRemoval = true)
     protected boolean idle(Connection connection, boolean close)
@@ -463,7 +463,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     /**
      * @param connection the {@link Connection} that was acquired
-     * @deprecated do not override because its usage is racy
+     * @deprecated Racy API. Do not use. There is no replacement.
      */
     @Deprecated(since = "12.0.8", forRemoval = true)
     protected void acquired(Connection connection)
@@ -472,7 +472,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     /**
      * @param connection the {@link Connection} that was released
-     * @deprecated do not override because its usage is racy
+     * @deprecated Racy API. Do not use. There is no replacement.
      */
     @Deprecated(since = "12.0.8", forRemoval = true)
     protected void released(Connection connection)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -494,7 +494,7 @@ public class ConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }
@@ -548,7 +548,7 @@ public class ConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MultiplexedConnectionPoolTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MultiplexedConnectionPoolTest.java
@@ -121,7 +121,7 @@ public class MultiplexedConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }
@@ -226,7 +226,7 @@ public class MultiplexedConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }
@@ -301,7 +301,7 @@ public class MultiplexedConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }
@@ -372,7 +372,7 @@ public class MultiplexedConnectionPoolTest
                 }
 
                 @Override
-                protected void removed(Connection connection)
+                protected void onRemoved(Connection connection)
                 {
                     poolRemoveCounter.incrementAndGet();
                 }


### PR DESCRIPTION
Deprecated idle(), acquired(), released() for removal. 
Renamed removed(), now deprecated, to onRemoved() to match with onCreated(). 
Kept onCreated() and onRemoved() as they are the only methods that are not racy.