### PR TITLE
 Issue #10387 configure doclint to not generate verbose useless warning, remove obsolete parameter

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DateCache.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DateCache.java
@@ -26,7 +26,7 @@ import java.util.TimeZone;
  * <p>
  * If consecutive calls are frequently very different, then this
  * may be a little slower than a normal DateFormat.
- * <p>
+ * </p>
  * @see DateTimeFormatter for date formatting patterns.
  */
 public class DateCache

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoader.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoader.java
@@ -124,9 +124,8 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
      * <p>Run the passed {@link PrivilegedExceptionAction} with the classloader
      * configured so as to allow server classes to be visible</p>
      *
-     * @param <T> The type returned by the action
      * @param action The action to run
-     * @param <T> the type of PrivilegedExceptionAction
+     * @param <T> the type of PrivilegedExceptionAction and the type returned by the action
      * @return The return from the action
      * @throws Exception if thrown by the action
      */

--- a/pom.xml
+++ b/pom.xml
@@ -1409,8 +1409,8 @@
             <charset>UTF-8</charset>
             <docencoding>UTF-8</docencoding>
             <encoding>UTF-8</encoding>
-            <additionalOptions>-html5</additionalOptions>
             <docfilessubdirs>true</docfilessubdirs>
+            <doclint>all,-missing</doclint>
             <detectLinks>false</detectLinks>
             <detectJavaApiLink>false</detectJavaApiLink>
             <detectOfflineLinks>false</detectOfflineLinks>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
