### PR TITLE
Fixes #10870 - How to set HttpConfiguration.securePort when the HTTPS port is dynamic?

### DIFF
--- a/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty-documentation/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -92,7 +92,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
-import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -332,21 +331,18 @@ public class HTTPServerDocs
 
         // Set up a listener so that when the secure connector starts,
         // it configures the other connectors that have not started yet.
-        secureConnector.addEventListener(new LifeCycle.Listener()
+        secureConnector.addEventListener(new NetworkConnector.Listener()
         {
             @Override
-            public void lifeCycleStarted(LifeCycle lifeCycle)
+            public void onOpen(NetworkConnector connector)
             {
-                if (lifeCycle instanceof NetworkConnector networkConnector)
-                {
-                    int port = networkConnector.getLocalPort();
+                int port = connector.getLocalPort();
 
-                    // Configure the plain connector for secure redirects from http to https.
-                    plainConfig.setSecurePort(port);
+                // Configure the plain connector for secure redirects from http to https.
+                plainConfig.setSecurePort(port);
 
-                    // Configure the HTTP3 connector port to be the same as HTTPS/HTTP2.
-                    http3Connector.setPort(port);
-                }
+                // Configure the HTTP3 connector port to be the same as HTTPS/HTTP2.
+                http3Connector.setPort(port);
             }
         });
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -982,18 +982,7 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
 
     private class CloseConnections implements SelectorUpdate
     {
-        private final Set<Closeable> _closed;
         private final CountDownLatch _complete = new CountDownLatch(1);
-
-        private CloseConnections()
-        {
-            this(null);
-        }
-
-        private CloseConnections(Set<Closeable> closed)
-        {
-            _closed = closed;
-        }
 
         @Override
         public void update(Selector selector)
@@ -1006,27 +995,14 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
                 {
                     if (key != null && key.isValid())
                     {
-                        Closeable closeable = null;
+                        Closeable closeable = key.channel();
                         Object attachment = key.attachment();
-                        if (attachment instanceof EndPoint)
+                        if (attachment instanceof EndPoint endPoint)
                         {
-                            EndPoint endPoint = (EndPoint)attachment;
                             Connection connection = endPoint.getConnection();
                             closeable = Objects.requireNonNullElse(connection, endPoint);
                         }
-
-                        if (closeable != null)
-                        {
-                            if (_closed == null)
-                            {
-                                IO.close(closeable);
-                            }
-                            else if (!_closed.contains(closeable))
-                            {
-                                _closed.add(closeable);
-                                IO.close(closeable);
-                            }
-                        }
+                        IO.close(closeable);
                     }
                 }
             }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -995,13 +995,9 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
                 {
                     if (key != null && key.isValid())
                     {
-                        Closeable closeable = key.channel();
-                        Object attachment = key.attachment();
-                        if (attachment instanceof EndPoint endPoint)
-                        {
-                            Connection connection = endPoint.getConnection();
-                            closeable = Objects.requireNonNullElse(connection, endPoint);
-                        }
+                        Closeable closeable = (key.attachment() instanceof EndPoint endPoint)
+                            ? Objects.requireNonNullElse(endPoint.getConnection(), endPoint)
+                            : key.channel();
                         IO.close(closeable);
                     }
                 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
@@ -85,11 +85,55 @@ public abstract class AbstractNetworkConnector extends AbstractConnector impleme
     @Override
     public void open() throws IOException
     {
+        notifyOpen();
+    }
+
+    private void notifyOpen()
+    {
+        getEventListeners().stream()
+            .filter(l -> l instanceof NetworkConnector.Listener)
+            .map(NetworkConnector.Listener.class::cast)
+            .forEach(this::notifyOpen);
+    }
+
+    private void notifyOpen(NetworkConnector.Listener listener)
+    {
+        try
+        {
+            listener.onOpen(this);
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("failure while notifying listener " + listener, x);
+        }
     }
 
     @Override
     public void close()
     {
+        notifyClose();
+    }
+
+    private void notifyClose()
+    {
+        getEventListeners().stream()
+            .filter(l -> l instanceof NetworkConnector.Listener)
+            .map(NetworkConnector.Listener.class::cast)
+            .forEach(this::notifyClose);
+    }
+
+    private void notifyClose(NetworkConnector.Listener listener)
+    {
+        try
+        {
+            listener.onClose(this);
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("failure while notifying listener " + listener, x);
+        }
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
@@ -105,7 +105,7 @@ public abstract class AbstractNetworkConnector extends AbstractConnector impleme
         catch (Throwable x)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("failure while notifying listener " + listener, x);
+                LOG.debug("failure while notifying listener {}", listener, x);
         }
     }
 
@@ -132,7 +132,7 @@ public abstract class AbstractNetworkConnector extends AbstractConnector impleme
         catch (Throwable x)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("failure while notifying listener " + listener, x);
+                LOG.debug("failure while notifying listener {}", listener, x);
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.server;
 
 import java.io.IOException;
+import java.util.EventListener;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -85,54 +86,40 @@ public abstract class AbstractNetworkConnector extends AbstractConnector impleme
     @Override
     public void open() throws IOException
     {
-        notifyOpen();
-    }
-
-    private void notifyOpen()
-    {
-        getEventListeners().stream()
-            .filter(l -> l instanceof NetworkConnector.Listener)
-            .map(NetworkConnector.Listener.class::cast)
-            .forEach(this::notifyOpen);
-    }
-
-    private void notifyOpen(NetworkConnector.Listener listener)
-    {
-        try
+        for (EventListener l : getEventListeners())
         {
-            listener.onOpen(this);
-        }
-        catch (Throwable x)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("failure while notifying listener {}", listener, x);
+            if (l instanceof NetworkConnector.Listener listener)
+            {
+                try
+                {
+                    listener.onOpen(this);
+                }
+                catch (Throwable x)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("failure while notifying listener {}", listener, x);
+                }
+            }
         }
     }
 
     @Override
     public void close()
     {
-        notifyClose();
-    }
-
-    private void notifyClose()
-    {
-        getEventListeners().stream()
-            .filter(l -> l instanceof NetworkConnector.Listener)
-            .map(NetworkConnector.Listener.class::cast)
-            .forEach(this::notifyClose);
-    }
-
-    private void notifyClose(NetworkConnector.Listener listener)
-    {
-        try
+        for (EventListener l : getEventListeners())
         {
-            listener.onClose(this);
-        }
-        catch (Throwable x)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("failure while notifying listener {}", listener, x);
+            if (l instanceof NetworkConnector.Listener listener)
+            {
+                try
+                {
+                    listener.onClose(this);
+                }
+                catch (Throwable x)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("failure while notifying listener {}", listener, x);
+                }
+            }
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NetworkConnector.java
@@ -35,8 +35,9 @@ public interface NetworkConnector extends Connector, Closeable
     /**
      * <p>Performs the activities needed to close the network communication
      * (for example, to stop accepting network connections).</p>
-     * Once a connector has been closed, it cannot be opened again without first
-     * calling {@link #stop()} and it will not be active again until a subsequent call to {@link #start()}
+     * <p>Once a connector has been closed, it cannot be opened again without first
+     * calling {@link #stop()} and it will not be active again until a subsequent call to {@link #start()}.</p>
+     * <p>Implementation must be idempotent.</p>
      */
     @Override
     void close();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NetworkConnector.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.server;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.EventListener;
 
 /**
  * <p>A {@link Connector} for TCP/IP network connectors</p>
@@ -24,6 +25,7 @@ public interface NetworkConnector extends Connector, Closeable
     /**
      * <p>Performs the activities needed to open the network communication
      * (for example, to start accepting incoming network connections).</p>
+     * <p>Implementation must be idempotent.</p>
      *
      * @throws IOException if this connector cannot be opened
      * @see #close()
@@ -64,4 +66,29 @@ public interface NetworkConnector extends Connector, Closeable
      * -1 if it has not been opened, or -2 if it has been closed.
      */
     int getLocalPort();
+
+    /**
+     * <p>Receives notifications of the {@link NetworkConnector#open()}
+     * and {@link NetworkConnector#close()} events.</p>
+     */
+    interface Listener extends EventListener
+    {
+        /**
+         * <p>Invoked when the given {@link NetworkConnector} has been opened.</p>
+         *
+         * @param connector the {@link NetworkConnector} that has been opened
+         */
+        default void onOpen(NetworkConnector connector)
+        {
+        }
+
+        /**
+         * <p>Invoked when the given {@link NetworkConnector} has been closed.</p>
+         *
+         * @param connector the {@link NetworkConnector} that has been closed
+         */
+        default void onClose(NetworkConnector connector)
+        {
+        }
+    }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -223,6 +223,8 @@ public class ServerConnector extends AbstractNetworkConnector
     @Override
     protected void doStart() throws Exception
     {
+        addBean(_acceptChannel);
+
         for (EventListener l : getBeans(SelectorManager.SelectorManagerListener.class))
             _manager.addEventListener(l);
 
@@ -238,7 +240,13 @@ public class ServerConnector extends AbstractNetworkConnector
     @Override
     protected void doStop() throws Exception
     {
+        _acceptor.set(null);
+
         super.doStop();
+
+        removeBean(_acceptChannel);
+        _acceptChannel = null;
+
         for (EventListener l : getBeans(EventListener.class))
         {
             _manager.removeEventListener(l);
@@ -290,8 +298,8 @@ public class ServerConnector extends AbstractNetworkConnector
     {
         if (isStarted())
             throw new IllegalStateException(getState());
-        updateBean(_acceptChannel, acceptChannel);
         _acceptChannel = acceptChannel;
+        _acceptChannel.configureBlocking(true);
         _localPort = _acceptChannel.socket().getLocalPort();
         if (_localPort <= 0)
             throw new IOException("Server channel not bound");
@@ -302,12 +310,8 @@ public class ServerConnector extends AbstractNetworkConnector
     {
         if (_acceptChannel == null)
         {
-            _acceptChannel = openAcceptChannel();
-            _acceptChannel.configureBlocking(true);
-            _localPort = _acceptChannel.socket().getLocalPort();
-            if (_localPort <= 0)
-                throw new IOException("Server channel not bound");
-            addBean(_acceptChannel);
+            open(openAcceptChannel());
+            super.open();
         }
     }
 
@@ -367,24 +371,9 @@ public class ServerConnector extends AbstractNetworkConnector
     {
         super.close();
 
-        ServerSocketChannel serverChannel = _acceptChannel;
-        _acceptChannel = null;
-        if (serverChannel != null)
-        {
-            removeBean(serverChannel);
+        if (getAcceptors() > 0)
+            IO.close(_acceptChannel);
 
-            if (serverChannel.isOpen())
-            {
-                try
-                {
-                    serverChannel.close();
-                }
-                catch (IOException e)
-                {
-                    LOG.warn("Unable to close {}", serverChannel, e);
-                }
-            }
-        }
         _localPort = -2;
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -371,6 +371,9 @@ public class ServerConnector extends AbstractNetworkConnector
     {
         super.close();
 
+        // When acceptors == 0, we want the ServerSocketChannel
+        // to be closed by the SelectorManager when the
+        // SelectorManager is stopped (as a bean) in doStop().
         if (getAcceptors() > 0)
             IO.close(_acceptChannel);
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ManyConnectorsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ManyConnectorsTest.java
@@ -1,0 +1,103 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.client.transport;
+
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.ServerSocketChannel;
+
+import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.quic.server.QuicServerConnector;
+import org.eclipse.jetty.quic.server.ServerQuicConfiguration;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(WorkDirExtension.class)
+public class ManyConnectorsTest
+{
+    public WorkDir workDir;
+    private Server server = new Server();
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testManyConnectors(int acceptors) throws Exception
+    {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        ServerConnector connector1 = new ServerConnector(server, acceptors, 1, new HttpConnectionFactory(httpConfig));
+        server.addConnector(connector1);
+
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
+        sslContextFactory.setKeyStorePassword("storepwd");
+        ServerQuicConfiguration quicConfig = new ServerQuicConfiguration(sslContextFactory, workDir.getEmptyPathDir());
+        QuicServerConnector connector2 = new QuicServerConnector(server, quicConfig, new HTTP3ServerConnectionFactory(quicConfig, httpConfig));
+        server.addConnector(connector2);
+
+        connector1.addEventListener(new NetworkConnector.Listener()
+        {
+            @Override
+            public void onOpen(NetworkConnector connector)
+            {
+                connector2.setPort(connector.getLocalPort());
+            }
+        });
+
+        server.start();
+
+        // Make sure both connectors are on the same port.
+        assertEquals(connector1.getLocalPort(), connector2.getLocalPort());
+
+        ServerSocketChannel serverSocketChannel = (ServerSocketChannel)connector1.getTransport();
+        int beanSize1 = connector1.getBeans().size();
+
+        DatagramChannel datagramChannel = (DatagramChannel)connector2.getTransport();
+        int beanSize2 = connector2.getBeans().size();
+
+        // Test that stop+start works and does not leak beans.
+
+        server.stop();
+
+        assertFalse(serverSocketChannel.isOpen());
+        assertFalse(connector1.contains(serverSocketChannel));
+
+        assertFalse(datagramChannel.isOpen());
+        assertFalse(connector2.contains(datagramChannel));
+
+        server.start();
+
+        assertEquals(connector1.getLocalPort(), connector2.getLocalPort());
+        assertEquals(beanSize1, connector1.getBeans().size());
+        assertEquals(beanSize2, connector2.getBeans().size());
+    }
+}


### PR DESCRIPTION
Introduced NetworkConnector.Listener to notify of open/close events. 
Applications can register a listener on one NetworkConnector, be notified when it opens, and configure other components (for example using the NetworkConnector.localPort).

Cleaned up ManagedSelector.CloseConnections, which had code that was not used, and fixed the close of non-connection elements such as the ServerSocketChannel and DatagramChannel (when acceptors=0).