### PR TITLE
Remove usages of URIUtil.toURI and URIUtil.split

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
@@ -34,7 +34,7 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
     public ResourceHttpContentFactory(Resource baseResource, MimeTypes mimeTypes)
     {
         Objects.requireNonNull(mimeTypes, "MimeTypes cannot be null");
-        _baseResource = baseResource;
+        _baseResource = Objects.requireNonNull(baseResource);
         _mimeTypes = mimeTypes;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 
 /**
@@ -29,13 +28,13 @@ import org.eclipse.jetty.util.resource.Resources;
  */
 public class ResourceHttpContentFactory implements HttpContent.Factory
 {
-    private final ResourceFactory _factory;
+    private final Resource _baseResource;
     private final MimeTypes _mimeTypes;
 
-    public ResourceHttpContentFactory(ResourceFactory factory, MimeTypes mimeTypes)
+    public ResourceHttpContentFactory(Resource baseResource, MimeTypes mimeTypes)
     {
         Objects.requireNonNull(mimeTypes, "MimeTypes cannot be null");
-        _factory = factory;
+        _baseResource = baseResource;
         _mimeTypes = mimeTypes;
     }
 
@@ -45,7 +44,7 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
         try
         {
             // try loading the content from our factory.
-            Resource resource = this._factory.newResource(pathInContext);
+            Resource resource = _baseResource.resolve(pathInContext);
             if (Resources.missing(resource))
                 return null;
             return load(pathInContext, resource);
@@ -75,6 +74,6 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
     @Override
     public String toString()
     {
-        return "ResourceContentFactory[" + _factory + "]@" + hashCode();
+        return "ResourceContentFactory[" + _baseResource + "]@" + hashCode();
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
@@ -43,7 +43,6 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
     {
         try
         {
-            // try loading the content from our factory.
             Resource resource = resolve(pathInContext);
             if (Resources.missing(resource))
                 return null;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 
 /**
@@ -34,7 +35,7 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
     public ResourceHttpContentFactory(Resource baseResource, MimeTypes mimeTypes)
     {
         Objects.requireNonNull(mimeTypes, "MimeTypes cannot be null");
-        _baseResource = Objects.requireNonNull(baseResource);
+        _baseResource = Objects.requireNonNullElse(baseResource, ResourceFactory.root().newResource("."));
         _mimeTypes = mimeTypes;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContentFactory.java
@@ -44,7 +44,7 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
         try
         {
             // try loading the content from our factory.
-            Resource resource = _baseResource.resolve(pathInContext);
+            Resource resource = resolve(pathInContext);
             if (Resources.missing(resource))
                 return null;
             return load(pathInContext, resource);
@@ -62,6 +62,11 @@ public class ResourceHttpContentFactory implements HttpContent.Factory
             saferException.initCause(t);
             throw saferException;
         }
+    }
+
+    protected Resource resolve(String pathInContext)
+    {
+        return _baseResource.resolve(pathInContext);
     }
 
     private HttpContent load(String pathInContext, Resource resource)

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -30,6 +30,7 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(WorkDirExtension.class) 
 public class IOTest
@@ -580,7 +582,18 @@ public class IOTest
         FS.touch(realPath);
 
         Path linkPath = dir.resolve("link");
-        Files.createSymbolicLink(linkPath, realPath);
+        boolean symlinkSupported;
+        try
+        {
+            Files.createSymbolicLink(linkPath, realPath);
+            symlinkSupported = true;
+        }
+        catch (UnsupportedOperationException | FileSystemException e)
+        {
+            symlinkSupported = false;
+        }
+
+        assumeTrue(symlinkSupported, "Symlink not supported");
         Path targPath = linkPath.toRealPath();
 
         System.err.printf("realPath = %s%n", realPath);
@@ -604,7 +617,18 @@ public class IOTest
         Files.createDirectories(realDirPath);
 
         Path linkDirPath = dir.resolve("link");
-        Files.createSymbolicLink(linkDirPath, realDirPath);
+        boolean symlinkSupported;
+        try
+        {
+            Files.createSymbolicLink(linkDirPath, realDirPath);
+            symlinkSupported = true;
+        }
+        catch (UnsupportedOperationException | FileSystemException e)
+        {
+            symlinkSupported = false;
+        }
+
+        assumeTrue(symlinkSupported, "Symlink not supported");
 
         Path realPath = realDirPath.resolve("file");
         FS.touch(realPath);

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
@@ -29,7 +29,6 @@ import java.util.StringTokenizer;
 
 import org.eclipse.jetty.osgi.OSGiServerConstants;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
@@ -61,22 +60,24 @@ public class Util
         if (StringUtil.isBlank(path))
             return null;
 
-        if (path.startsWith("/") || path.startsWith("file:/")) //absolute location
-            return URIUtil.toURI(path);
-        else
+        if (path.startsWith("file:/"))
+            return new URI(path);
+
+        if (path.startsWith("/") && File.pathSeparatorChar != '/')
+            return new URI("file:" + path);
+
+        try
         {
-            try
-            {
-                Path p = FileSystems.getDefault().getPath(path);
-                if (p.isAbsolute())
-                    return p.toUri();
-            }
-            catch (InvalidPathException x)
-            {
-                //ignore and try via the jetty bundle instead
-                LOG.trace("IGNORED", x);
-            }
+            Path p = FileSystems.getDefault().getPath(path);
+            if (p.isAbsolute())
+                return p.toUri();
         }
+        catch (InvalidPathException x)
+        {
+            //ignore and try via the jetty bundle instead
+            LOG.trace("IGNORED", x);
+        }
+
         
         //relative location
         //try inside the bundle first

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
@@ -63,7 +63,7 @@ public class Util
         if (path.startsWith("file:/"))
             return new URI(path);
 
-        if (path.startsWith("/") && File.pathSeparatorChar != '/')
+        if (path.startsWith("/") && File.separatorChar != '/')
             return new URI("file:" + path);
 
         try

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -42,22 +42,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Resource Handler.
- *
- * This handle will serve static content and handle If-Modified-Since headers. No caching is done. Requests for resources that do not exist are let pass (Eg no
- * 404's).
- * TODO there is a lot of URI manipulation, this should be factored out in a utility class.
- *
- * TODO GW: Work out how this logic can be reused by the DefaultServlet... potentially for wrapped output streams
- *
- * Missing:
- *  - current context' mime types
- *  - Default stylesheet (needs Resource impl for classpath resources)
- *  - request ranges
- *  - a way to configure caching or not
+ * Resource Handler will serve static content and handle If-Modified-Since headers. No caching is done.
+ * Requests for resources that do not exist are let pass (Eg no 404's).
  */
 public class ResourceHandler extends Handler.Wrapper
 {
+    // TODO there is a lot of URI manipulation, this should be factored out in a utility class.
+    // TODO Missing:
+    //    - current context' mime types
+    //    - Default stylesheet (needs Resource impl for classpath resources)
+    //    - request ranges
+    //    - a way to configure caching or not
     private static final Logger LOG = LoggerFactory.getLogger(ResourceHandler.class);
 
     private final ResourceService _resourceService = newResourceService();
@@ -131,7 +126,7 @@ public class ResourceHandler extends Handler.Wrapper
 
     protected HttpContent.Factory newHttpContentFactory()
     {
-        HttpContent.Factory contentFactory = new ResourceHttpContentFactory(ResourceFactory.of(getBaseResource()), getMimeTypes());
+        HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), getMimeTypes());
         if (isUseFileMapping())
             contentFactory = new FileMappingHttpContentFactory(contentFactory);
         contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css");

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -67,6 +67,7 @@ import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -3934,10 +3935,20 @@ public class ResourceHandlerTest
 
     private void setupQuestionMarkDir(Path base) throws IOException
     {
-        Path dirQ = base.resolve("dir?");
-        Files.createDirectories(dirQ);
-        Path welcome = dirQ.resolve("welcome.txt");
-        Files.writeString(welcome, "Hello");
+        boolean filesystemSupportsQuestionMarkDir = false;
+        try
+        {
+            Path dirQ = base.resolve("dir?");
+            Files.createDirectories(dirQ);
+            Path welcome = dirQ.resolve("welcome.txt");
+            Files.writeString(welcome, "Hello");
+            filesystemSupportsQuestionMarkDir = true;
+        }
+        catch (InvalidPathException e)
+        {
+            filesystemSupportsQuestionMarkDir = false;
+        }
+        Assumptions.assumeTrue(filesystemSupportsQuestionMarkDir);
     }
 
     private void setupSimpleText(Path base) throws IOException

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -665,7 +665,7 @@ public class ResourceHandlerTest
             @Override
             protected HttpContent.Factory newHttpContentFactory()
             {
-                HttpContent.Factory contentFactory = new ResourceHttpContentFactory(ResourceFactory.of(getBaseResource()), getMimeTypes());
+                HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), getMimeTypes());
                 contentFactory = new FileMappingHttpContentFactory(contentFactory);
                 contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css");
                 contentFactory = new PreCompressedHttpContentFactory(contentFactory, getPrecompressedFormats());

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -104,7 +103,7 @@ public class TryPathsHandlerTest
             protected HttpContent.Factory newHttpContentFactory()
             {
                 // We don't want to cache not found entries for this test.
-                return new ResourceHttpContentFactory(ResourceFactory.of(getBaseResource()), getMimeTypes());
+                return new ResourceHttpContentFactory(getBaseResource(), getMimeTypes());
             }
         };
 
@@ -175,7 +174,7 @@ public class TryPathsHandlerTest
             protected HttpContent.Factory newHttpContentFactory()
             {
                 // We don't want to cache not found entries for this test.
-                return new ResourceHttpContentFactory(ResourceFactory.of(getBaseResource()), getMimeTypes());
+                return new ResourceHttpContentFactory(getBaseResource(), getMimeTypes());
             }
         };
         resourceHandler.setDirAllowed(false);
@@ -303,7 +302,7 @@ public class TryPathsHandlerTest
             protected HttpContent.Factory newHttpContentFactory()
             {
                 // We don't want to cache not found entries for this test.
-                return new ResourceHttpContentFactory(ResourceFactory.of(getBaseResource()), getMimeTypes());
+                return new ResourceHttpContentFactory(getBaseResource(), getMimeTypes());
             }
         };
         resourceHandler.setDirAllowed(false);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1772,7 +1772,9 @@ public final class URIUtil
      *
      * @param str the input string of references
      * @see #toJarFileUri(URI)
+     * @deprecated use {@link ResourceFactory#split(String}
      */
+    @Deprecated(since = "12.0.8", forRemoval = true)
     public static List<URI> split(String str)
     {
         List<URI> uris = new ArrayList<>();
@@ -1898,7 +1900,6 @@ public final class URIUtil
                     // Input is a possible Windows path disguised as a URI "D:/path/to/resource.txt".
                     try
                     {
-                        // TODO remove this method or at least move this aspect of it to a ResourceFactory
                         return toURI(Paths.get(resource).toUri().toASCIIString());
                     }
                     catch (InvalidPathException x)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1772,7 +1772,7 @@ public final class URIUtil
      *
      * @param str the input string of references
      * @see #toJarFileUri(URI)
-     * @deprecated use {@link ResourceFactory#split(String}
+     * @deprecated use {@link ResourceFactory#split(String)}
      */
     @Deprecated(since = "12.0.8", forRemoval = true)
     public static List<URI> split(String str)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1875,7 +1875,10 @@ public final class URIUtil
      * @param resource If the string starts with one of the ALLOWED_SCHEMES, then it is assumed to be a
      * representation of a {@link URI}, otherwise it is treated as a {@link Path}.
      * @return The {@link URI} form of the resource.
+     * @deprecated This method is currently resolving relative paths against the current directory, which is a mechanism
+     * that should be implemented by a {@link ResourceFactory}.   All calls to this method need to be reviewed.
      */
+    @Deprecated(since = "12.0.8")
     public static URI toURI(String resource)
     {
         Objects.requireNonNull(resource);
@@ -1895,6 +1898,7 @@ public final class URIUtil
                     // Input is a possible Windows path disguised as a URI "D:/path/to/resource.txt".
                     try
                     {
+                        // TODO remove this method or at least move this aspect of it to a ResourceFactory
                         return toURI(Paths.get(resource).toUri().toASCIIString());
                     }
                     catch (InvalidPathException x)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -589,9 +589,21 @@ public final class URIUtil
         return true;
     }
 
+    /**
+     * Test if a string is a relative path or a URI
+     * @param uriOrPath A string that is either a path, a URI path segment or an absolute URI
+     * @return True if the string does not start with any absolute URI or file characters sequences.
+     */
     public static boolean isRelative(String uriOrPath)
     {
-        return uriOrPath.isEmpty() || (!URIUtil.hasScheme(uriOrPath) && !uriOrPath.startsWith("/"));
+        if (uriOrPath.isEmpty())
+            return true;
+
+        char c = uriOrPath.charAt(0);
+        if (c == '/' || (File.separatorChar != '/' && c == File.separatorChar))
+            return false;
+
+        return !URIUtil.hasScheme(uriOrPath);
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -589,6 +589,11 @@ public final class URIUtil
         return true;
     }
 
+    public static boolean isRelative(String uriOrPath)
+    {
+        return uriOrPath.isEmpty() || (!URIUtil.hasScheme(uriOrPath) && !uriOrPath.startsWith("/"));
+    }
+
     /**
      * Test if codepoint is safe and unambiguous to pass as input to {@link URI}
      *

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -151,7 +151,9 @@ public class FileSystemPool implements Dumpable
     {
         String rawURI = uri.toASCIIString();
         int idx = rawURI.indexOf("!/");
-        return URI.create(rawURI.substring(0, idx + 2));
+        if (idx > 0)
+            return URI.create(rawURI.substring(0, idx + 2));
+        return uri;
     }
 
     private void unmount(URI fsUri)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -26,7 +26,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -51,15 +50,6 @@ public abstract class Resource implements Iterable<Resource>
 {
     private static final Logger LOG = LoggerFactory.getLogger(Resource.class);
     private static final LinkOption[] NO_FOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
-
-    public static final Comparator<Resource> COMPARATOR_BY_NAME = new Comparator<Resource>()
-    {
-        @Override
-        public int compare(Resource r1, Resource r2)
-        {
-            return r1.getName().compareTo(r2.getName());
-        }
-    };
 
     public static String dump(Resource resource)
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -26,6 +26,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -50,6 +51,15 @@ public abstract class Resource implements Iterable<Resource>
 {
     private static final Logger LOG = LoggerFactory.getLogger(Resource.class);
     private static final LinkOption[] NO_FOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
+
+    public static final Comparator<Resource> COMPARATOR_BY_NAME = new Comparator<Resource>()
+    {
+        @Override
+        public int compare(Resource r1, Resource r2)
+        {
+            return r1.getName().compareTo(r2.getName());
+        }
+    };
 
     public static String dump(Resource resource)
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -321,24 +321,6 @@ public interface ResourceFactory
     }
 
     /**
-     * Construct a resource from a string.
-     *
-     * @param resource A URL or filename.
-     * @param base Resource base.
-     * @return A Resource object, or null if the string points to a location
-     *    that does not exist
-     * @throws IllegalArgumentException if resource is invalid
-     */
-    default Resource newResource(Resource base, String resource)
-    {
-        if (StringUtil.isBlank(resource))
-            throw new IllegalArgumentException("Resource String is invalid: " + resource);
-        if (URIUtil.isRelative(resource))
-            return base.resolve(resource);
-        return newResource(URIUtil.toURI(resource));
-    }
-
-    /**
      * Construct a Resource from provided path.
      *
      * @param path the path
@@ -516,7 +498,9 @@ public interface ResourceFactory
      *
      * @param baseResource the resource to base this ResourceFactory from
      * @return the ResourceFactory that builds from the Resource
+     * @deprecated Use {@link Resource#resolve(String)}
      */
+    @Deprecated (since = "12.0.8", forRemoval = true)
     static ResourceFactory of(Resource baseResource)
     {
         Objects.requireNonNull(baseResource);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -151,13 +151,6 @@ public interface ResourceFactory
         return CombinedResource.combine(List.of(resources));
     }
 
-    static Resource resolveElseNew(Resource base, String pathOrUri, Function<String, Resource> factory)
-    {
-        if (URIUtil.isRelative(pathOrUri))
-            return base.resolve(pathOrUri);
-        return factory.apply(pathOrUri);
-    }
-
     /**
      * Construct a resource from a uri.
      *

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -468,7 +468,7 @@ public interface ResourceFactory
                     {
 
                         List<Resource> expanded = dir.list();
-                        expanded.sort(Resource.COMPARATOR_BY_NAME);
+                        expanded.sort(ResourceCollators.byName(true));
                         list.addAll(expanded);
                     }
                 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -321,6 +321,24 @@ public interface ResourceFactory
     }
 
     /**
+     * Construct a resource from a string.
+     *
+     * @param resource A URL or filename.
+     * @param base Resource base.
+     * @return A Resource object, or null if the string points to a location
+     *    that does not exist
+     * @throws IllegalArgumentException if resource is invalid
+     */
+    default Resource newResource(Resource base, String resource)
+    {
+        if (StringUtil.isBlank(resource))
+            throw new IllegalArgumentException("Resource String is invalid: " + resource);
+        if (URIUtil.isRelative(resource))
+            return base.resolve(resource);
+        return newResource(URIUtil.toURI(resource));
+    }
+
+    /**
      * Construct a Resource from provided path.
      *
      * @param path the path

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -466,10 +466,10 @@ public interface ResourceFactory
                     Resource dir = newResource(reference.substring(0, reference.length() - 2));
                     if (dir.isDirectory())
                     {
-
                         List<Resource> expanded = dir.list();
                         expanded.sort(ResourceCollators.byName(true));
-                        list.addAll(expanded);
+                        // TODO it is unclear why non archive files are not expanded into the list
+                        expanded.stream().filter(r -> FileID.isLibArchive(r.getName())).forEach(list::add);
                     }
                 }
                 else

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AttributeNormalizerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AttributeNormalizerTest.java
@@ -342,7 +342,7 @@ public class AttributeNormalizerTest
 
         // If file cannot be found it just uses the first resource.
         assertThat(normalizer.expand("${WAR.uri}/file4"), containsString("/dir1/file4"));
-        assertThat(normalizer.expand("${WAR.path}/file4"), containsString(File.separator + "dir1/file4"));
+        assertThat(normalizer.expand("${WAR.path}/file4"), containsString(File.separator + "dir1" + File.separator +  "file4"));
     }
 
     public static class Scenario

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
@@ -426,12 +426,12 @@ public class CombinedResourceTest
         String config = String.format("%s,%s,%s", dir, foo, bar);
 
         // To use this, we need to split it (and optionally honor globs)
-        List<URI> uris = URIUtil.split(config);
+        List<Resource> resources = resourceFactory.split(config);
         // Now let's create a ResourceCollection from this list of URIs
         // Since this is user space, we cannot know ahead of time what
         // this list contains, so we mount because we assume there
         // will be necessary things to mount
-        Resource rc = resourceFactory.newResource(uris);
+        Resource rc = ResourceFactory.combine(resources);
         assertThat(getContent(rc, "test.txt"), is("Test"));
     }
 
@@ -452,12 +452,12 @@ public class CombinedResourceTest
         String config = String.format("%s;%s;%s%s*", dir, foo, bar, File.separator);
 
         // To use this, we need to split it (and optionally honor globs)
-        List<URI> uris = URIUtil.split(config);
+        List<Resource> resources = resourceFactory.split(config);
         // Now let's create a ResourceCollection from this list of URIs
         // Since this is user space, we cannot know ahead of time what
         // this list contains, so we mount because we assume there
         // will be necessary things to mount
-        Resource rc = resourceFactory.newResource(uris);
+        Resource rc = ResourceFactory.combine(resources);
         assertThat(getContent(rc, "test.txt"), is("Test inside lib-foo.jar"));
         assertThat(getContent(rc, "testZed.txt"), is("TestZed inside lib-zed.jar"));
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -252,104 +252,122 @@ public class ResourceFactoryTest
     @MethodSource("newResourceCases")
     public void testNewResource(String inputRaw, String expectedUri)
     {
-        URI actual = ResourceFactory.root().newResource(inputRaw).getURI();
-        URI expected = URI.create(expectedUri);
-        assertEquals(expected, actual);
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            URI actual = resourceFactory.newResource(inputRaw).getURI();
+            URI expected = URI.create(expectedUri);
+            assertEquals(expected, actual);
+        }
     }
 
     @Test
     public void testSplitSingleJar()
     {
-        Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
-        String input = testJar.toUri().toASCIIString();
-        List<Resource> resources = ResourceFactory.root().split(input);
-        String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
-        assertThat(resources.get(0).getURI().toString(), is(expected));
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+            String input = testJar.toUri().toASCIIString();
+            List<Resource> resources = resourceFactory.split(input);
+            String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+            assertThat(resources.get(0).getURI().toString(), is(expected));
+        }
     }
 
     @Test
     public void testSplitSinglePath()
     {
-        Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
-        String input = testJar.toString();
-        List<Resource> resources = ResourceFactory.root().split(input);
-        String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
-        assertThat(resources.get(0).getURI().toString(), is(expected));
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+            String input = testJar.toString();
+            List<Resource> resources = resourceFactory.split(input);
+            String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+            assertThat(resources.get(0).getURI().toString(), is(expected));
+        }
     }
 
     @Test
     public void testSplitOnComma()
     {
-        Path base = workDir.getEmptyPathDir();
-        Path dir = base.resolve("dir");
-        FS.ensureDirExists(dir);
-        Path foo = dir.resolve("foo");
-        FS.ensureDirExists(foo);
-        Path bar = dir.resolve("bar");
-        FS.ensureDirExists(bar);
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path base = workDir.getEmptyPathDir();
+            Path dir = base.resolve("dir");
+            FS.ensureDirExists(dir);
+            Path foo = dir.resolve("foo");
+            FS.ensureDirExists(foo);
+            Path bar = dir.resolve("bar");
+            FS.ensureDirExists(bar);
 
-        // This represents the user-space raw configuration
-        String config = String.format("%s,%s,%s", dir, foo, bar);
+            // This represents the user-space raw configuration
+            String config = String.format("%s,%s,%s", dir, foo, bar);
 
-        // Split using commas
-        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+            // Split using commas
+            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
 
-        URI[] expected = new URI[] {
-            dir.toUri(),
-            foo.toUri(),
-            bar.toUri()
-        };
-        assertThat(uris, contains(expected));
+            URI[] expected = new URI[]{
+                dir.toUri(),
+                foo.toUri(),
+                bar.toUri()
+            };
+            assertThat(uris, contains(expected));
+        }
     }
 
     @Test
     public void testSplitOnPipe()
     {
-        Path base = workDir.getEmptyPathDir();
-        Path dir = base.resolve("dir");
-        FS.ensureDirExists(dir);
-        Path foo = dir.resolve("foo");
-        FS.ensureDirExists(foo);
-        Path bar = dir.resolve("bar");
-        FS.ensureDirExists(bar);
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path base = workDir.getEmptyPathDir();
+            Path dir = base.resolve("dir");
+            FS.ensureDirExists(dir);
+            Path foo = dir.resolve("foo");
+            FS.ensureDirExists(foo);
+            Path bar = dir.resolve("bar");
+            FS.ensureDirExists(bar);
 
-        // This represents the user-space raw configuration
-        String config = String.format("%s|%s|%s", dir, foo, bar);
+            // This represents the user-space raw configuration
+            String config = String.format("%s|%s|%s", dir, foo, bar);
 
-        // Split using commas
-        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+            // Split using commas
+            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
 
-        URI[] expected = new URI[] {
-            dir.toUri(),
-            foo.toUri(),
-            bar.toUri()
-        };
-        assertThat(uris, contains(expected));
+            URI[] expected = new URI[]{
+                dir.toUri(),
+                foo.toUri(),
+                bar.toUri()
+            };
+            assertThat(uris, contains(expected));
+        }
     }
 
     @Test
     public void testSplitOnSemicolon()
     {
-        Path base = workDir.getEmptyPathDir();
-        Path dir = base.resolve("dir");
-        FS.ensureDirExists(dir);
-        Path foo = dir.resolve("foo");
-        FS.ensureDirExists(foo);
-        Path bar = dir.resolve("bar");
-        FS.ensureDirExists(bar);
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path base = workDir.getEmptyPathDir();
+            Path dir = base.resolve("dir");
+            FS.ensureDirExists(dir);
+            Path foo = dir.resolve("foo");
+            FS.ensureDirExists(foo);
+            Path bar = dir.resolve("bar");
+            FS.ensureDirExists(bar);
 
-        // This represents the user-space raw configuration
-        String config = String.format("%s;%s;%s", dir, foo, bar);
+            // This represents the user-space raw configuration
+            String config = String.format("%s;%s;%s", dir, foo, bar);
 
-        // Split using commas
-        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+            // Split using commas
+            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
 
-        URI[] expected = new URI[] {
-            dir.toUri(),
-            foo.toUri(),
-            bar.toUri()
-        };
-        assertThat(uris, contains(expected));
+            URI[] expected = new URI[]{
+                dir.toUri(),
+                foo.toUri(),
+                bar.toUri()
+            };
+            assertThat(uris, contains(expected));
+        }
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -13,32 +13,48 @@
 
 package org.eclipse.jetty.util.resource;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(WorkDirExtension.class)
 public class ResourceFactoryTest
 {
+    public WorkDir workDir;
+
     @ParameterizedTest
     @ValueSource(strings = {
         "keystore.p12", "/keystore.p12",
@@ -194,6 +210,179 @@ public class ResourceFactoryTest
         Resource subResource = resource.resolve("favicon.ico");
         assertThat(subResource.getFileName(), is("favicon.ico"));
         assertThat(subResource.length(), greaterThan(0L));
+    }
+
+    public static Stream<Arguments> newResourceCases()
+    {
+        List<Arguments> args = new ArrayList<>();
+
+        if (OS.WINDOWS.isCurrentOs())
+        {
+            // Windows format (absolute and relative)
+            args.add(Arguments.of("C:\\path\\to\\foo.jar", "file:///C:/path/to/foo.jar"));
+            args.add(Arguments.of("D:\\path\\to\\bogus.txt", "file:///D:/path/to/bogus.txt"));
+            args.add(Arguments.of("\\path\\to\\foo.jar", "file:///C:/path/to/foo.jar"));
+            args.add(Arguments.of("\\path\\to\\bogus.txt", "file:///C:/path/to/bogus.txt"));
+            // unix format (relative)
+            args.add(Arguments.of("C:/path/to/foo.jar", "file:///C:/path/to/foo.jar"));
+            args.add(Arguments.of("D:/path/to/bogus.txt", "file:///D:/path/to/bogus.txt"));
+            args.add(Arguments.of("/path/to/foo.jar", "file:///C:/path/to/foo.jar"));
+            args.add(Arguments.of("/path/to/bogus.txt", "file:///C:/path/to/bogus.txt"));
+            // URI format (absolute)
+            args.add(Arguments.of("file:///D:/path/to/zed.jar", "file:///D:/path/to/zed.jar"));
+            args.add(Arguments.of("file:/e:/zed/yotta.txt", "file:///e:/zed/yotta.txt"));
+            args.add(Arguments.of("jar:file:///E:/path/to/bar.jar", "jar:file:///E:/path/to/bar.jar"));
+        }
+        else
+        {
+            // URI (and unix) format (relative)
+            args.add(Arguments.of("/path/to/foo.jar", "file:///path/to/foo.jar"));
+            args.add(Arguments.of("/path/to/bogus.txt", "file:///path/to/bogus.txt"));
+        }
+        // URI format (absolute)
+        args.add(Arguments.of("file:///path/to/zed.jar", "file:///path/to/zed.jar"));
+        Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        URI jarFileUri = URIUtil.toJarFileUri(testJar.toUri());
+        args.add(Arguments.of(jarFileUri.toASCIIString(), jarFileUri.toASCIIString()));
+
+        return args.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("newResourceCases")
+    public void testNewResource(String inputRaw, String expectedUri)
+    {
+        URI actual = ResourceFactory.root().newResource(inputRaw).getURI();
+        URI expected = URI.create(expectedUri);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSplitSingleJar()
+    {
+        Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        String input = testJar.toUri().toASCIIString();
+        List<Resource> resources = ResourceFactory.root().split(input);
+        String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+        assertThat(resources.get(0).getURI().toString(), is(expected));
+    }
+
+    @Test
+    public void testSplitSinglePath()
+    {
+        Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        String input = testJar.toString();
+        List<Resource> resources = ResourceFactory.root().split(input);
+        String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+        assertThat(resources.get(0).getURI().toString(), is(expected));
+    }
+
+    @Test
+    public void testSplitOnComma()
+    {
+        Path base = workDir.getEmptyPathDir();
+        Path dir = base.resolve("dir");
+        FS.ensureDirExists(dir);
+        Path foo = dir.resolve("foo");
+        FS.ensureDirExists(foo);
+        Path bar = dir.resolve("bar");
+        FS.ensureDirExists(bar);
+
+        // This represents the user-space raw configuration
+        String config = String.format("%s,%s,%s", dir, foo, bar);
+
+        // Split using commas
+        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+
+        URI[] expected = new URI[] {
+            dir.toUri(),
+            foo.toUri(),
+            bar.toUri()
+        };
+        assertThat(uris, contains(expected));
+    }
+
+    @Test
+    public void testSplitOnPipe()
+    {
+        Path base = workDir.getEmptyPathDir();
+        Path dir = base.resolve("dir");
+        FS.ensureDirExists(dir);
+        Path foo = dir.resolve("foo");
+        FS.ensureDirExists(foo);
+        Path bar = dir.resolve("bar");
+        FS.ensureDirExists(bar);
+
+        // This represents the user-space raw configuration
+        String config = String.format("%s|%s|%s", dir, foo, bar);
+
+        // Split using commas
+        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+
+        URI[] expected = new URI[] {
+            dir.toUri(),
+            foo.toUri(),
+            bar.toUri()
+        };
+        assertThat(uris, contains(expected));
+    }
+
+    @Test
+    public void testSplitOnSemicolon()
+    {
+        Path base = workDir.getEmptyPathDir();
+        Path dir = base.resolve("dir");
+        FS.ensureDirExists(dir);
+        Path foo = dir.resolve("foo");
+        FS.ensureDirExists(foo);
+        Path bar = dir.resolve("bar");
+        FS.ensureDirExists(bar);
+
+        // This represents the user-space raw configuration
+        String config = String.format("%s;%s;%s", dir, foo, bar);
+
+        // Split using commas
+        List<URI> uris = ResourceFactory.root().split(config).stream().map(Resource::getURI).toList();
+
+        URI[] expected = new URI[] {
+            dir.toUri(),
+            foo.toUri(),
+            bar.toUri()
+        };
+        assertThat(uris, contains(expected));
+    }
+
+    @Test
+    public void testSplitOnPipeWithGlob() throws IOException
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path base = workDir.getEmptyPathDir();
+            Path dir = base.resolve("dir");
+            FS.ensureDirExists(dir);
+            Path foo = dir.resolve("foo");
+            FS.ensureDirExists(foo);
+            Path bar = dir.resolve("bar");
+            FS.ensureDirExists(bar);
+            Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-foo.jar"));
+            Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-zed.zip"));
+
+            // This represents the user-space raw configuration with a glob
+            String config = String.format("%s;%s;%s%s*", dir, foo, bar, File.separator);
+
+            // Split using commas
+            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
+
+            URI[] expected = new URI[]{
+                dir.toUri(),
+                foo.toUri(),
+                // Should see the two archives as `jar:file:` URI entries
+                URIUtil.toJarFileUri(bar.resolve("lib-foo.jar").toUri()),
+                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri())
+            };
+
+            assertThat(uris, contains(expected));
+        }
     }
 
     public static class CustomResourceFactory implements ResourceFactory

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -231,7 +231,6 @@ public class ResourceFactoryTest
             // URI format (absolute)
             args.add(Arguments.of("file:///D:/path/to/zed.jar", "file:///D:/path/to/zed.jar"));
             args.add(Arguments.of("file:/e:/zed/yotta.txt", "file:///e:/zed/yotta.txt"));
-            args.add(Arguments.of("jar:file:///E:/path/to/bar.jar", "jar:file:///E:/path/to/bar.jar"));
         }
         else
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -397,6 +398,7 @@ public class ResourceTest
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
+    @Disabled("This will create different Resource objects, not sure if this is still results in a problem")
     public void testEqualsWindowsCaseInsensitiveDrive() throws Exception
     {
         URI a = new URI("file:///c:/foo/bar");

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/WebAppPropertyConverter.java
@@ -17,7 +17,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -29,9 +28,9 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
 /**
@@ -226,9 +225,8 @@ public class WebAppPropertyConverter
         if (!StringUtil.isBlank(str))
         {
             // This is a use provided list of overlays, which could have mountable entries.
-            List<URI> uris = URIUtil.split(str);
             webApp.setWar(null);
-            webApp.setBaseResource(webApp.getResourceFactory().newResource(uris));
+            webApp.setBaseResource(ResourceFactory.combine(webApp.getResourceFactory().split(str)));
         }
 
         str = webAppProperties.getProperty(WAR_FILE);

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EE10Activator.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EE10Activator.java
@@ -48,7 +48,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
@@ -356,9 +355,11 @@ public class EE10Activator implements BundleActivator
         public ContextHandler createContextHandler(AbstractContextProvider provider, App app)
             throws Exception
         {
-            OSGiApp osgiApp = OSGiApp.class.cast(app);
+            if (!(app instanceof OSGiApp osgiApp))
+                throw new IllegalArgumentException("App is not OSGi");
+
             String jettyHome = (String)app.getDeploymentManager().getServer().getAttribute(OSGiServerConstants.JETTY_HOME);
-            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : Paths.get(URIUtil.toURI(jettyHome));
+            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : ResourceFactory.of(provider.getServer()).newResource(jettyHome).getPath();
 
             WebAppContext webApp = new WebAppContext();
 

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartDescriptorProcessor.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartDescriptorProcessor.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.AttributeNormalizer;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -189,7 +188,7 @@ public class QuickStartDescriptorProcessor extends IterativeDescriptorProcessor 
                 for (String i : values)
                 {
                     String entry = normalizer.expand(i);
-                    tlds.add(URIUtil.toURI(entry).toURL());
+                    tlds.add(context.getResourceFactory().newResource(entry).getURI().toURL());
                 }
 
                 //empty list signals that tlds were prescanned but none found.
@@ -200,7 +199,8 @@ public class QuickStartDescriptorProcessor extends IterativeDescriptorProcessor 
             {
                 List<URI> uris = values.stream()
                     .map(normalizer::expand)
-                    .map(URIUtil::toURI)
+                    .map(context.getResourceFactory()::newResource)
+                    .map(Resource::getURI)
                     .toList();
 
                 for (URI uri : uris)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -58,6 +58,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,9 +190,7 @@ public class DefaultServlet extends HttpServlet
         {
             try
             {
-                baseResource = URIUtil.isRelative(rb)
-                    ? _contextHandler.getBaseResource().resolve(rb)
-                    : _contextHandler.newResource(rb);
+                baseResource = ResourceFactory.resolveElseNew(_contextHandler.getBaseResource(), rb, _contextHandler::newResource);
             }
             catch (Exception e)
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -58,7 +58,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,7 +189,7 @@ public class DefaultServlet extends HttpServlet
         {
             try
             {
-                baseResource = ResourceFactory.resolveElseNew(_contextHandler.getBaseResource(), rb, _contextHandler::newResource);
+                baseResource = URIUtil.isRelative(rb) ? _contextHandler.getBaseResource().resolve(rb) :  _contextHandler.newResource(rb);
             }
             catch (Exception e)
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -208,7 +208,7 @@ public class DefaultServlet extends HttpServlet
         if (contentFactory == null)
         {
             MimeTypes mimeTypes = _contextHandler.getMimeTypes();
-            contentFactory = new ResourceHttpContentFactory(Objects.requireNonNullElse(baseResource, _contextHandler.getBaseResource()), mimeTypes);
+            contentFactory = new ResourceHttpContentFactory(baseResource, mimeTypes);
 
             // Use the servers default stylesheet unless there is one explicitly set by an init param.
             Resource styleSheet = _contextHandler.getServer().getDefaultStyleSheet();

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.servlet;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.InvalidPathException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -59,7 +58,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -191,7 +189,9 @@ public class DefaultServlet extends HttpServlet
         {
             try
             {
-                baseResource = Objects.requireNonNull(_contextHandler.newResource(rb));
+                baseResource = URIUtil.isRelative(rb)
+                    ? _contextHandler.getBaseResource().resolve(rb)
+                    : _contextHandler.newResource(rb);
             }
             catch (Exception e)
             {
@@ -208,8 +208,7 @@ public class DefaultServlet extends HttpServlet
         if (contentFactory == null)
         {
             MimeTypes mimeTypes = _contextHandler.getMimeTypes();
-            ResourceFactory resourceFactory = baseResource != null ? ResourceFactory.of(baseResource) : this::getResource;
-            contentFactory = new ResourceHttpContentFactory(resourceFactory, mimeTypes);
+            contentFactory = new ResourceHttpContentFactory(Objects.requireNonNullElse(baseResource, _contextHandler.getBaseResource()), mimeTypes);
 
             // Use the servers default stylesheet unless there is one explicitly set by an init param.
             Resource styleSheet = _contextHandler.getServer().getDefaultStyleSheet();
@@ -583,23 +582,6 @@ public class DefaultServlet extends HttpServlet
     {
         // override to eliminate TRACE that the default HttpServlet impl adds
         resp.setHeader("Allow", "GET, HEAD, OPTIONS");
-    }
-
-    private Resource getResource(URI uri)
-    {
-        String uriPath = uri.getRawPath();
-        Resource result = null;
-        try
-        {
-            result = _contextHandler.getResource(uriPath);
-        }
-        catch (IOException x)
-        {
-            LOG.trace("IGNORED", x);
-        }
-        if (LOG.isDebugEnabled())
-            LOG.debug("Resource {}={}", uriPath, result);
-        return result;
     }
 
     private class ServletResourceService extends ResourceService implements ResourceService.WelcomeFactory

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DefaultServlet.java
@@ -199,6 +199,8 @@ public class DefaultServlet extends HttpServlet
                 throw new UnavailableException(e.toString());
             }
         }
+        if (baseResource != null && !(baseResource.isDirectory() && baseResource.isReadable()))
+            LOG.warn("baseResource {} is not a readable directory", baseResource);
 
         List<CompressedContentFormat> precompressedFormats = parsePrecompressedFormats(getInitParameter("precompressed"),
             getInitBoolean("gzip"), _resourceService.getPrecompressedFormats());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -789,7 +789,7 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(URI uri) throws IOException
     {
-        return ResourceFactory.root().newResource(uri);
+        return ResourceFactory.of(this).newResource(uri);
     }
 
     /**
@@ -801,7 +801,7 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(String urlOrPath) throws IOException
     {
-        return ResourceFactory.of(this).newResource(urlOrPath);
+        return ResourceFactory.of(this).newResource(getBaseResource(), urlOrPath);
     }
 
     public Set<String> getResourcePaths(String path)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -785,11 +785,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @throws IOException if unable to create a Resource from the URL
      */
-    public Resource newResource(URI uri) throws IOException
+    public Resource newResource(URI uri)
     {
-        // TODO wrong factory
         return ResourceFactory.of(this).newResource(uri);
     }
 
@@ -798,11 +796,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @throws IOException The Resource could not be created.
      */
-    public Resource newResource(String urlOrPath) throws IOException
+    public Resource newResource(String urlOrPath)
     {
-        // TODO wrong factory
         return ResourceFactory.of(this).newResource(urlOrPath);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -789,6 +789,7 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(URI uri) throws IOException
     {
+        // TODO wrong factory
         return ResourceFactory.of(this).newResource(uri);
     }
 
@@ -801,7 +802,8 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(String urlOrPath) throws IOException
     {
-        return ResourceFactory.of(this).newResource(getBaseResource(), urlOrPath);
+        // TODO wrong factory
+        return ResourceFactory.of(this).newResource(urlOrPath);
     }
 
     public Set<String> getResourcePaths(String path)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -789,7 +789,6 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(URI uri) throws IOException
     {
-        // TODO wrong factory
         return ResourceFactory.of(this).newResource(uri);
     }
 
@@ -802,7 +801,6 @@ public class ServletContextHandler extends ContextHandler
      */
     public Resource newResource(String urlOrPath) throws IOException
     {
-        // TODO wrong factory
         return ResourceFactory.of(this).newResource(urlOrPath);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -374,7 +374,7 @@ public class DefaultServletTest
     @Test
     public void testListingWithSession() throws Exception
     {
-        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
         defholder.setInitParameter("redirectWelcome", "false");
         defholder.setInitParameter("gzip", "false");
@@ -405,7 +405,7 @@ public class DefaultServletTest
     @Test
     public void testListingXSS() throws Exception
     {
-        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
         defholder.setInitParameter("redirectWelcome", "false");
         defholder.setInitParameter("gzip", "false");
@@ -453,7 +453,7 @@ public class DefaultServletTest
     @Test
     public void testListingWithQuestionMarks() throws Exception
     {
-        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
         defholder.setInitParameter("redirectWelcome", "false");
         defholder.setInitParameter("gzip", "false");
@@ -481,7 +481,7 @@ public class DefaultServletTest
     @Test
     public void testSimpleListing() throws Exception
     {
-        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
         defHolder.setInitParameter("dirAllowed", "true");
 
         String rawResponse = connector.getResponse("""
@@ -501,7 +501,7 @@ public class DefaultServletTest
     @Test
     public void testIncludeListingAllowed() throws Exception
     {
-        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
         defHolder.setInitParameter("dirAllowed", "true");
 
         /* create a file with a non-fully ASCII name in the docroot */
@@ -541,7 +541,7 @@ public class DefaultServletTest
     @Test
     public void testIncludeListingForbidden() throws Exception
     {
-        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
         defHolder.setInitParameter("dirAllowed", "false");
 
         ServletHolder incHolder = new ServletHolder();
@@ -581,7 +581,7 @@ public class DefaultServletTest
     @Test
     public void testListingFilenamesOnly() throws Exception
     {
-        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
         defholder.setInitParameter("redirectWelcome", "false");
         defholder.setInitParameter("gzip", "false");
@@ -719,7 +719,7 @@ public class DefaultServletTest
     @Test
     public void testListingProperUrlEncoding() throws Exception
     {
-        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/*");
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("dirAllowed", "true");
         defholder.setInitParameter("redirectWelcome", "false");
         defholder.setInitParameter("gzip", "false");
@@ -1325,6 +1325,52 @@ public class DefaultServletTest
                 assertThat(response.toString(), response.getStatus(), is(HttpStatus.FORBIDDEN_403));
             }
         }
+    }
+
+    @Test
+    public void testDifferentBaseAbsolute() throws Exception
+    {
+        Path altRoot = workDir.getEmptyPathDir().resolve("altroot");
+        FS.ensureDirExists(altRoot);
+
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/alt/*");
+        defholder.setInitParameter("resourceBase", altRoot.toAbsolutePath().toUri().toASCIIString());
+
+        Path file = altRoot.resolve("file.txt");
+        Files.writeString(file, "How now brown cow", UTF_8);
+
+        String rawResponse = connector.getResponse("""
+            GET /context/alt/file.txt HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.toString(), response.getContent(), is("How now brown cow"));
+    }
+
+    @Test
+    public void testDifferentBaseRelative() throws Exception
+    {
+        Path alt = docRoot.resolve("alt");
+        FS.ensureDirExists(alt);
+
+        ServletHolder defholder = context.addServlet(DefaultServlet.class, "/alt/*");
+        defholder.setInitParameter("resourceBase", "alt");
+
+        Path file = alt.resolve("file.txt");
+        Files.writeString(file, "How now brown cow", UTF_8);
+
+        String rawResponse = connector.getResponse("""
+            GET /context/alt/file.txt HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.toString(), response.getContent(), is("How now brown cow"));
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/test/resources/altroot/dir/file.txt
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/resources/altroot/dir/file.txt
@@ -1,0 +1,1 @@
+this is alt content.

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -160,7 +160,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (classPath != null)
         {
             Stream.of(classPath.split(File.pathSeparator))
-                .map(URIUtil::toURI)
+                .map(resourceFactory::newResource)
+                .map(Resource::getURI)
                 .filter(uriPatternPredicate)
                 .forEach(addContainerResource);
         }
@@ -174,7 +175,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             List<Path> matchingBasePaths =
                 Stream.of(modulePath.split(File.pathSeparator))
-                    .map(URIUtil::toURI)
+                    .map(resourceFactory::newResource)
+                    .map(Resource::getURI)
                     .filter(uriPatternPredicate)
                     .map(Paths::get)
                     .toList();

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoader.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppClassLoader.java
@@ -254,9 +254,7 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
         if (classPathList == null)
             return;
 
-        URIUtil.split(classPathList).stream()
-            .map(_resourceFactory::newResource)
-            .forEach(this::addClassPath);
+        _resourceFactory.split(classPathList).forEach(this::addClassPath);
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.webapp;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -29,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletRegistration.Dynamic;
 import jakarta.servlet.ServletSecurityElement;
@@ -53,7 +51,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
@@ -1168,8 +1165,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath)
     {
-        List<URI> uris = URIUtil.split(extraClasspath);
-        setExtraClasspath(uris.stream().map(this.getResourceFactory()::newResource).collect(Collectors.toList()));
+        setExtraClasspath(getResourceFactory().split(extraClasspath));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -238,10 +238,10 @@ public class WebInfConfiguration extends AbstractConfiguration
 
                 if (war != null)
                 {
-                    Path warPath = Path.of(URIUtil.toURI(war));
-                    
+                    Path warPath = context.getResourceFactory().newResource(war).getPath();
+
                     // look for a sibling like "foo/" to a "foo.war"
-                    if (FileID.isWebArchive(warPath) && Files.exists(warPath))
+                    if (warPath != null && FileID.isWebArchive(warPath) && Files.exists(warPath))
                     {
                         Path sibling = warPath.getParent().resolve(FileID.getBasename(warPath));
                         if (Files.exists(sibling) && Files.isDirectory(sibling) && Files.isWritable(sibling))

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/WebAppPropertyConverter.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee9.maven.plugin;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -28,9 +27,9 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.ee9.quickstart.QuickStartConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
 /**
@@ -225,9 +224,8 @@ public class WebAppPropertyConverter
         if (!StringUtil.isBlank(str))
         {
             // This is a use provided list of overlays, which could have mountable entries.
-            List<URI> uris = URIUtil.split(str);
             webApp.setWar(null);
-            webApp.setBaseResource(webApp.getResourceFactory().newResource(uris));
+            webApp.setBaseResource(ResourceFactory.combine(webApp.getResourceFactory().split(str)));
         }
 
         str = webAppProperties.getProperty(WAR_FILE);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1590,7 +1590,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      */
     public Resource newResource(String uriOrPath) throws IOException
     {
-        // TODO WRONG FACTORY
         return ResourceFactory.of(this).newResource(uriOrPath);
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1590,7 +1590,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      */
     public Resource newResource(String uriOrPath) throws IOException
     {
-        return ResourceFactory.of(this).newResource(getBaseResource(), uriOrPath);
+        // TODO WRONG FACTORY
+        return ResourceFactory.of(this).newResource(uriOrPath);
     }
 
     public Set<String> getResourcePaths(String path)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1590,7 +1590,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      */
     public Resource newResource(String uriOrPath) throws IOException
     {
-        return ResourceFactory.of(this).newResource(uriOrPath);
+        return ResourceFactory.of(this).newResource(getBaseResource(), uriOrPath);
     }
 
     public Set<String> getResourcePaths(String path)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceHandler.java
@@ -129,8 +129,6 @@ public class ResourceHandler extends HandlerWrapper implements WelcomeFactory
     protected HttpContent.Factory newHttpContentFactory()
     {
         Resource baseResource = getBaseResource();
-        if (baseResource == null)
-            baseResource = _context.getBaseResource();
         HttpContent.Factory contentFactory = new ResourceHttpContentFactory(baseResource, _mimeTypes);
         contentFactory = new FileMappingHttpContentFactory(contentFactory);
         contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css");

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceHandler.java
@@ -128,7 +128,10 @@ public class ResourceHandler extends HandlerWrapper implements WelcomeFactory
 
     protected HttpContent.Factory newHttpContentFactory()
     {
-        HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), _mimeTypes);
+        Resource baseResource = getBaseResource();
+        if (baseResource == null)
+            baseResource = _context.getBaseResource();
+        HttpContent.Factory contentFactory = new ResourceHttpContentFactory(baseResource, _mimeTypes);
         contentFactory = new FileMappingHttpContentFactory(contentFactory);
         contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css");
         contentFactory = new PreCompressedHttpContentFactory(contentFactory, _resourceService.getPrecompressedFormats());
@@ -142,7 +145,7 @@ public class ResourceHandler extends HandlerWrapper implements WelcomeFactory
     public Resource getBaseResource()
     {
         if (_baseResource == null)
-            return null;
+            return _context.getBaseResource();
         return _baseResource;
     }
 

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/boot/EE9Activator.java
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/boot/EE9Activator.java
@@ -48,7 +48,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
@@ -354,9 +353,11 @@ public class EE9Activator implements BundleActivator
         public ContextHandler createContextHandler(AbstractContextProvider provider, App app)
             throws Exception
         {
-            OSGiApp osgiApp = OSGiApp.class.cast(app);
+            if (!(app instanceof OSGiApp osgiApp))
+                throw new IllegalArgumentException("App is not OSGi");
+
             String jettyHome = (String)app.getDeploymentManager().getServer().getAttribute(OSGiServerConstants.JETTY_HOME);
-            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : Paths.get(URIUtil.toURI(jettyHome));
+            Path jettyHomePath = StringUtil.isBlank(jettyHome) ? null : ResourceFactory.of(provider.getServer()).newResource(jettyHome).getPath();
 
             WebAppContext webApp = new WebAppContext();
 

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartDescriptorProcessor.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.AttributeNormalizer;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -188,7 +187,7 @@ public class QuickStartDescriptorProcessor extends IterativeDescriptorProcessor 
                 for (String i : values)
                 {
                     String entry = normalizer.expand(i);
-                    tlds.add(URIUtil.toURI(entry).toURL());
+                    tlds.add(context.getResourceFactory().newResource(entry).getURI().toURL());
                 }
 
                 //empty list signals that tlds were prescanned but none found.
@@ -199,7 +198,8 @@ public class QuickStartDescriptorProcessor extends IterativeDescriptorProcessor 
             {
                 List<URI> uris = values.stream()
                     .map(normalizer::expand)
-                    .map(URIUtil::toURI)
+                    .map(context.getResourceFactory()::newResource)
+                    .map(Resource::getURI)
                     .toList();
 
                 for (URI uri : uris)

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -255,7 +255,14 @@ public class DefaultServlet extends HttpServlet implements WelcomeFactory
             HttpContent.Factory contentFactory = (HttpContent.Factory)getServletContext().getAttribute(HttpContent.Factory.class.getName());
             if (contentFactory == null)
             {
-                contentFactory = new ResourceHttpContentFactory(_baseResource, _mimeTypes);
+                contentFactory = new ResourceHttpContentFactory(_baseResource, _mimeTypes)
+                {
+                    @Override
+                    protected Resource resolve(String pathInContext)
+                    {
+                        return DefaultServlet.this.resolve(pathInContext);
+                    }
+                };
                 if (_useFileMappedBuffer)
                     contentFactory = new FileMappingHttpContentFactory(contentFactory);
                 contentFactory = new VirtualHttpContentFactory(contentFactory, _styleSheet, "text/css");

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -141,16 +141,17 @@ public class MetaInfConfiguration extends AbstractConfiguration
         // Apply an initial name filter to the jars to select which will be eventually
         // scanned for META-INF info and annotations. The filter is based on inclusion patterns.
         UriPatternPredicate uriPatternPredicate = new UriPatternPredicate(pattern, false);
-        Consumer<URI> addContainerResource = (uri) ->
+        Consumer<Resource> addContainerResource = (resource) ->
         {
-            Resource resource = resourceFactory.newResource(uri);
             if (Resources.missing(resource))
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Classpath URI doesn't exist: " + uri);
+                    LOG.debug("Classpath URI doesn't exist: " + resource);
             }
             else
+            {
                 context.getMetaData().addContainerResource(resource);
+            }
         };
 
         List<URI> containerUris = getAllContainerJars(context);
@@ -158,6 +159,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             LOG.debug("All container urls {}", containerUris);
         containerUris.stream()
             .filter(uriPatternPredicate)
+            .map(resourceFactory::newResource)
             .forEach(addContainerResource);
 
         // When running on jvm 9 or above, we won't be able to look at the application
@@ -167,8 +169,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             Stream.of(classPath.split(File.pathSeparator))
                 .map(resourceFactory::newResource)
-                .map(Resource::getURI)
-                .filter(uriPatternPredicate)
+                .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);
         }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -166,7 +166,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (classPath != null)
         {
             Stream.of(classPath.split(File.pathSeparator))
-                .map(URIUtil::toURI)
+                .map(resourceFactory::newResource)
+                .map(Resource::getURI)
                 .filter(uriPatternPredicate)
                 .forEach(addContainerResource);
         }
@@ -180,7 +181,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         {
             List<Path> matchingBasePaths =
                 Stream.of(modulePath.split(File.pathSeparator))
-                    .map(URIUtil::toURI)
+                    .map(resourceFactory::newResource)
+                    .map(Resource::getURI)
                     .filter(uriPatternPredicate)
                     .map(Paths::get)
                     .toList();

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -136,7 +137,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         if (StringUtil.isBlank(pattern))
             return; // TODO review if this short cut will allow later code simplifications
 
-        ResourceFactory resourceFactory = ResourceFactory.of(context);
+        ResourceFactory resourceFactory = context.getResourceFactory();
 
         // Apply an initial name filter to the jars to select which will be eventually
         // scanned for META-INF info and annotations. The filter is based on inclusion patterns.
@@ -160,6 +161,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         containerUris.stream()
             .filter(uriPatternPredicate)
             .map(resourceFactory::newResource)
+            .filter(Objects::nonNull)
             .forEach(addContainerResource);
 
         // When running on jvm 9 or above, we won't be able to look at the application
@@ -183,6 +185,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             List<Path> matchingBasePaths =
                 Stream.of(modulePath.split(File.pathSeparator))
                     .map(resourceFactory::newResource)
+                    .filter(Objects::nonNull)
                     .map(Resource::getURI)
                     .filter(uriPatternPredicate)
                     .map(Paths::get)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoader.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppClassLoader.java
@@ -257,9 +257,7 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
         if (classPathList == null)
             return;
 
-        URIUtil.split(classPathList).stream()
-            .map(_resourceFactory::newResource)
-            .forEach(this::addClassPath);
+        _resourceFactory.split(classPathList).forEach(this::addClassPath);
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee9.webapp;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.PermissionCollection;
@@ -30,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRegistration.Dynamic;
@@ -59,7 +57,6 @@ import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
@@ -1242,8 +1239,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath) throws IOException
     {
-        List<URI> uris = URIUtil.split(extraClasspath);
-        setExtraClasspath(uris.stream().map(this.getResourceFactory()::newResource).collect(Collectors.toList()));
+        setExtraClasspath(getResourceFactory().split(extraClasspath));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)


### PR DESCRIPTION
Use Resources APIs instead.

This builds on #11568 and completes the move away from explicit URI handling.