### PR TITLE
Disable Conscrypt tests on aarch64

### DIFF
--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 
-@EnabledOnOs({LINUX}) // TODO review if should be enabled on other OS
+@EnabledOnOs(value = LINUX, architectures = "amd64") // TODO review if should be enabled on other OS
 public class ConscryptHTTP2ClientTest
 {
     @Tag("external")

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
@@ -36,12 +36,11 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.condition.OS.LINUX;
 
-@EnabledOnOs(value = LINUX, architectures = "amd64") // TODO review if should be enabled on other OS
+@DisabledOnOs(architectures = "aarch64", disabledReason = "Conscrypt does not provide aarch64 native libs as of version 2.5.2")
 public class ConscryptHTTP2ClientTest
 {
     @Tag("external")

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
@@ -41,12 +41,14 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test server that verifies that the Conscrypt ALPN mechanism works for both server and client side
  */
+@DisabledOnOs(architectures = "aarch64")
 public class ConscryptHTTP2ServerTest
 {
     static

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test server that verifies that the Conscrypt ALPN mechanism works for both server and client side
  */
-@DisabledOnOs(architectures = "aarch64")
+@DisabledOnOs(architectures = "aarch64", disabledReason = "Conscrypt does not provide aarch64 native libs as of version 2.5.2")
 public class ConscryptHTTP2ServerTest
 {
     static


### PR DESCRIPTION
The Conscrypt java lib does not bundle native libs for aarch64, which make our Conscrypt tests fail on Linux for ARM and Macos for Apple Silicon.

Let's just disable the tests when running on ARM cpu.