### PR TITLE
use of context handler rather than trying to get context via servlet …

### DIFF
--- a/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
+++ b/jetty-servlet/src/main/java/org/eclipse/jetty/servlet/ServletHolder.java
@@ -675,7 +675,7 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentity.Scope
         File scratch;
         if (getInitParameter("scratchdir") == null)
         {
-            File tmp = (File)getServletHandler().getServletContext().getAttribute(ServletContext.TEMPDIR);
+            File tmp = (File) ch.getAttribute(ServletContext.TEMPDIR);
             scratch = new File(tmp, "jsp");
             setInitParameter("scratchdir", scratch.getAbsolutePath());
         }


### PR DESCRIPTION
…handler which helps getting current context

- i have legacy code base where jetty is upgraded from 9.2.21 to 9.4.54 which is hitting NPE.

as below

Caused by: java.lang.NullPointerException: null
	at org.eclipse.jetty.servlet.ServletHolder.initJspServlet(ServletHolder.java:678)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:619)
	... 54 common frames omitted


this looks like helping with it.