### PR TITLE
#11634 Add support for IP segments above 127 in Socks5Proxy

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/Socks5Proxy.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/Socks5Proxy.java
@@ -270,7 +270,7 @@ public class Socks5Proxy extends Proxy
                         .put(Socks5.ADDRESS_TYPE_IPV4);
                     for (int i = 1; i <= 4; ++i)
                     {
-                        byteBuffer.put(Byte.parseByte(matcher.group(i)));
+                        byteBuffer.put((byte)Integer.parseInt(matcher.group(i)));
                     }
                     byteBuffer.putShort(port)
                         .flip();

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/Socks5ProxyTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/Socks5ProxyTest.java
@@ -86,7 +86,7 @@ public class Socks5ProxyTest
         byte ip1 = 127;
         byte ip2 = 0;
         byte ip3 = 0;
-        byte ip4 = 13;
+        short ip4 = 255;
         String serverHost = ip1 + "." + ip2 + "." + ip3 + "." + ip4;
         int serverPort = proxyPort + 1; // Any port will do
         String method = "GET";
@@ -129,7 +129,7 @@ public class Socks5ProxyTest
             assertEquals(ip1, buffer.get());
             assertEquals(ip2, buffer.get());
             assertEquals(ip3, buffer.get());
-            assertEquals(ip4, buffer.get());
+            assertEquals((byte) ip4, buffer.get());
             assertEquals(serverPort, buffer.getShort() & 0xFFFF);
 
             // Write connect response.

--- a/jetty-client/src/test/java/org/eclipse/jetty/client/Socks5ProxyTest.java
+++ b/jetty-client/src/test/java/org/eclipse/jetty/client/Socks5ProxyTest.java
@@ -129,7 +129,7 @@ public class Socks5ProxyTest
             assertEquals(ip1, buffer.get());
             assertEquals(ip2, buffer.get());
             assertEquals(ip3, buffer.get());
-            assertEquals((byte) ip4, buffer.get());
+            assertEquals((byte)ip4, buffer.get());
             assertEquals(serverPort, buffer.getShort() & 0xFFFF);
 
             // Write connect response.


### PR DESCRIPTION
Connected to: https://github.com/jetty/jetty.project/issues/11634