### PR TITLE
Introduce various aliases to start.jar options

### DIFF
--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules.adoc
@@ -24,7 +24,7 @@ A Jetty module is defined in a `<name>.mod` file, where `<name>` is the module n
 Jetty module files are read from the typical xref:og-start-configure[configuration source directories], under the `modules/` subdirectory; from higher priority to lower priority:
 
 * The `$JETTY_BASE/modules/` directory.
-* If a directory is specified with the `--include-jetty-dir` option, its `modules/` subdirectory.
+* If a directory is specified with the `--add-config-dir` option, its `modules/` subdirectory.
 * The `$JETTY_HOME/modules/` directory.
 
 The standard Jetty modules that Jetty provides out-of-the-box are under `$JETTY_HOME/modules/`.
@@ -74,7 +74,7 @@ The Jetty XML file of a Jetty module may instantiate and assemble together its o
 The Jetty module's XML files are read from the typical xref:og-start-configure[configuration source directories], under the `etc/` subdirectory; from higher priority to lower priority:
 
 * The `$JETTY_BASE/etc/` directory.
-* If a directory is specified with the `--include-jetty-dir` option, its `etc/` subdirectory.
+* If a directory is specified with the `--add-config-dir` option, its `etc/` subdirectory.
 * The `$JETTY_HOME/etc/` directory.
 
 The standard Jetty modules XML files that Jetty provides out-of-the-box are under `$JETTY_HOME/etc/`.

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-gcloud.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-gcloud.adoc
@@ -65,7 +65,7 @@ Because the Google Cloud DataStore is not a technology provided by the Eclipse F
 As GCloud requires certain Java Commons Logging features to work correctly, Jetty routes these through SLF4J.
 By default, Jetty implements the SLF4J api, but you can choose a different logging implementation by following the instructions xref:og-server-logging[here]
 
-IMPORTANT: If you want to use updated versions of the jar files automatically downloaded during the module enablement, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
+IMPORTANT: If you want to use updated versions of the jar files automatically downloaded during the module enablement, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-create-files=<module name>` command line option to prevent errors when starting your server.
 
 ==== Configuration
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-hazelcast.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-hazelcast.adoc
@@ -27,7 +27,7 @@ Because Hazelcast is not a technology provided by the Eclipse Foundation, you wi
 
 Hazelcast-specific jar files will be downloaded and saved to a directory named `$JETTY_BASE/lib/hazelcast/`.
 
-NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
+NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-create-files=<module name>` command line option to prevent errors when starting your server.
 
 ====== Configuration
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-infinispan.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-infinispan.adoc
@@ -30,7 +30,7 @@ Infinispan-specific jar files are download to the directory named `$JETTY_BASE/l
 
 In addition to adding these modules to the classpath of the server it also added several ini configuration files to the `$JETTY_BASE/start.d` directory.
 
-NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
+NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-create-files=<module name>` command line option to prevent errors when starting your server.
 
 ====== Configuration
 
@@ -83,7 +83,7 @@ Enabling the `session-store-infinispan-embedded` module runs an in-process insta
 Because Infinispan is not a technology provided by the Eclipse Foundation, you will be prompted to assent to the licenses of the external vendor (Apache in this case).
 Infinispan-specific jar files will be downloaded and saved to a directory named `$JETTY_BASE/lib/infinispan/`.
 
-NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
+NOTE: If you have updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-create-files=<module name>` command line option to prevent errors when starting your server.
 
 ====== Configuration
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-mongodb.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-mongodb.adoc
@@ -19,7 +19,7 @@ Enabling the `session-store-mongo` module configures Jetty to store session data
 Because MongoDB is not a technology provided by the Eclipse Foundation, you will be prompted to assent to the licenses of the external vendor (Apache in this case) during the install.
 Jars needed by MongoDB are downloaded and stored into a directory named `$JETTY_BASE/lib/nosql/`.
 
-IMPORTANT: If you want to use updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-file-validation=<module name>` command line option to prevent errors when starting your server.
+IMPORTANT: If you want to use updated versions of the jar files automatically downloaded by Jetty, you can place them in the associated `$JETTY_BASE/lib/` directory and use the `--skip-create-files=<module name>` command line option to prevent errors when starting your server.
 
 ===== Configuration
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/start/start-configure.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/start/start-configure.adoc
@@ -18,7 +18,7 @@ Within the Jetty start mechanism, the source of configurations is layered in thi
 
 * The command line options.
 * The `$JETTY_BASE` directory, and its files.
-* The directory specified with the `--include-jetty-dir` option, and its files.
+* The directory specified with the `--add-config-dir` option, and its files.
 * The `$JETTY_HOME` directory, and its files.
 
 [[og-start-configure-enable]]
@@ -31,7 +31,7 @@ $ java -jar $JETTY_HOME/start.jar --add-modules=server,http
 ----
 
 The Jetty start mechanism will look for the specified modules following the order specified above.
-In the common case (without a `--include-jetty-dir` directory), it will look in `$JETTY_BASE/modules/` first and then in `$JETTY_HOME/modules/`.
+In the common case (without a `--add-config-dir` directory), it will look in `$JETTY_BASE/modules/` first and then in `$JETTY_HOME/modules/`.
 
 Since the `server` and `http` modules are standard Jetty modules, they are present in `$JETTY_HOME/modules/` and loaded from there.
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -1091,7 +1091,7 @@ public class StartArgs
             return environment;
         }
 
-        if (arg.startsWith("--download="))
+        if (arg.startsWith("--download=") || arg.startsWith("--files="))
         {
             addFile(null, Props.getValue(arg));
             run = false;

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -1078,7 +1078,7 @@ public class StartArgs
             return environment;
         }
 
-        if (arg.startsWith("--include-jetty-dir="))
+        if (arg.startsWith("--include-jetty-dir=") || arg.startsWith("--add-base-dir="))
         {
             // valid, but handled in ConfigSources instead
             return environment;

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -1078,7 +1078,7 @@ public class StartArgs
             return environment;
         }
 
-        if (arg.startsWith("--include-jetty-dir=") || arg.startsWith("--add-base-dir="))
+        if (arg.startsWith("--include-jetty-dir=") || arg.startsWith("--add-config-dir="))
         {
             // valid, but handled in ConfigSources instead
             return environment;

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -1277,7 +1277,7 @@ public class StartArgs
         }
 
         // Skip [files] validation on a module
-        if (arg.startsWith("--skip-file-validation="))
+        if (arg.startsWith("--skip-file-validation=") || arg.startsWith("--skip-create-files="))
         {
             List<String> moduleNames = Props.getValues(arg);
             skipFileValidationModules.addAll(moduleNames);

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/ConfigSources.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/ConfigSources.java
@@ -60,7 +60,7 @@ public class ConfigSources implements Iterable<ConfigSource>
         // look for --include-jetty-dir entries
         for (RawArgs.Entry arg : source.getArgs())
         {
-            if (arg.startsWith("--include-jetty-dir"))
+            if (arg.startsWith("--include-jetty-dir") || arg.startsWith("--add-config-dir"))
             {
                 String ref = getValue(arg.getLine());
                 String dirName = getProps().expand(ref);

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
@@ -49,6 +49,7 @@ public class DirConfigSource implements ConfigSource
     static
     {
         // Arguments that are not allowed to be in start.ini or start.d/{name}.ini files
+        // These should only be used on the command line
         BANNED_ARGS = new ArrayList<>();
         BANNED_ARGS.add("--help");
         BANNED_ARGS.add("-?");
@@ -64,8 +65,11 @@ public class DirConfigSource implements ConfigSource
         BANNED_ARGS.add("--write-module-graph");
         BANNED_ARGS.add("--version");
         BANNED_ARGS.add("-v");
+        BANNED_ARGS.add("--file");
         BANNED_ARGS.add("--download");
         BANNED_ARGS.add("--create-files");
+        BANNED_ARGS.add("--skip-create-files");
+        BANNED_ARGS.add("--skip-file-validation");
         BANNED_ARGS.add("--create-startd");
         BANNED_ARGS.add("--create-start-ini");
         BANNED_ARGS.add("--create-start-d");

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/config/DirConfigSource.java
@@ -65,7 +65,7 @@ public class DirConfigSource implements ConfigSource
         BANNED_ARGS.add("--write-module-graph");
         BANNED_ARGS.add("--version");
         BANNED_ARGS.add("-v");
-        BANNED_ARGS.add("--file");
+        BANNED_ARGS.add("--files");
         BANNED_ARGS.add("--download");
         BANNED_ARGS.add("--create-files");
         BANNED_ARGS.add("--skip-create-files");

--- a/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -147,12 +147,27 @@ Options:
                    Adds the specified class-path entries to the the server
                    class-path (or module-path).
 
-  --download=<http-uri>|<location>
-                   Downloads a file from the given HTTP URI, if it does
+  --files=<uri>|<location>
+  --download=<uri>|<location>
+                   Downloads a file from the given URI, if it does
                    not already exist at the given location.
                    Note: the location is always relative to ${jetty.base}.
                    You might need to escape the pipe "\|" to use it in
                    some shell environments.
+                   Supported schemes:
+                     http:     download from http (unsecure) website
+                     https:    download from https (secure) website
+                     maven:    download from maven repository system
+                               first checking local repository
+                               see `maven.local.repo` field below
+                               then global repository
+                               see `maven.repo.uri` field below
+
+                     basehome: download relative path from active
+                               configured jetty dirs (eg: `${jetty.base}`
+                               and any `--include-jetty-dir` and finally
+                               checking the `${jetty.home}`)
+
 
   --exec
                    Executes the generated command line in a forked JVM
@@ -245,9 +260,17 @@ Options:
                    running Jetty server has stopped.
                    If not specified, the stopper will not wait.
 
+  maven.local.repo=<dir>
+                   The maven local repository directory to find
+                   and store maven artifacts.
+                   Defaults to:
+                     1. Environment variable `JETTY_MAVEN_LOCAL_REPO`
+                     2. Environment variable `MAVEN_LOCAL_REPO`
+                     3. Directory ${home}/.m2/repository
+
   maven.repo.uri=<url>
-                  The base URL to use to download Maven dependencies.
-                  Defaults to: https://repo1.maven.org/maven2/.
+                   The base URL to use to download Maven dependencies.
+                   Defaults to: https://repo1.maven.org/maven2/.
 
   <name>=<value>
                   Specifies a property value that overrides the same

--- a/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -225,6 +225,7 @@ Options:
                    config file, but you want to use that module with an
                    *.xml config file instead.
 
+  --add-base-dir=<path>
   --include-jetty-dir=<path>
                    Includes the specified directory as a configuration source.
                    This directory behaves similarly to ${jetty.base} but sits

--- a/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -225,7 +225,7 @@ Options:
                    config file, but you want to use that module with an
                    *.xml config file instead.
 
-  --add-base-dir=<path>
+  --add-config-dir=<path>
   --include-jetty-dir=<path>
                    Includes the specified directory as a configuration source.
                    This directory behaves similarly to ${jetty.base} but sits

--- a/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-core/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -217,6 +217,7 @@ Options:
                    Useful for enabling modules from a script, so that it
                    does not require user interaction.
 
+  --skip-create-files=<moduleName>(,<moduleName>)*
   --skip-file-validation=<moduleName>(,<moduleName>)*
                    Disables the creation of files as specified by the
                    [files] section of the specified modules.

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/AddConfigDirTests.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/AddConfigDirTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(WorkDirExtension.class)
-public class IncludeJettyDirTest
+public class AddConfigDirTests
 {
     private static class MainResult
     {
@@ -131,7 +131,7 @@ public class IncludeJettyDirTest
         // Simple command line reference to include-jetty-dir
         MainResult result = runMain(base, home,
             // direct reference via path
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         List<String> expectedSearchOrder = new ArrayList<>();
         expectedSearchOrder.add("${jetty.base}");
@@ -167,7 +167,7 @@ public class IncludeJettyDirTest
             // property
             "my.common=" + common.toString(),
             // reference via property
-            "--include-jetty-dir=${my.common}");
+            "--add-config-dir=${my.common}");
 
         List<String> expectedSearchOrder = new ArrayList<>();
         expectedSearchOrder.add("${jetty.base}");
@@ -209,7 +209,7 @@ public class IncludeJettyDirTest
             // property to 'opt' dir
             "my.opt=" + opt.toString(),
             // reference via property prefix
-            "--include-jetty-dir=" + dirRef);
+            "--add-config-dir=" + dirRef);
 
         List<String> expectedSearchOrder = new ArrayList<>();
         expectedSearchOrder.add("${jetty.base}");
@@ -253,7 +253,7 @@ public class IncludeJettyDirTest
             // property to commmon dir name
             "my.dir=common",
             // reference via property prefix
-            "--include-jetty-dir=" + dirRef);
+            "--add-config-dir=" + dirRef);
 
         List<String> expectedSearchOrder = new ArrayList<>();
         expectedSearchOrder.add("${jetty.base}");
@@ -283,7 +283,7 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         MainResult result = runMain(base, home);
 
@@ -319,8 +319,8 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString(),
-            "--include-jetty-dir=" + corp.toString());
+            "--add-config-dir=" + common.toString(),
+            "--add-config-dir=" + corp.toString());
 
         MainResult result = runMain(base, home);
 
@@ -352,7 +352,7 @@ public class IncludeJettyDirTest
         Path common = testdir.getPathFile("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp.toString(),
+            "--add-config-dir=" + corp.toString(),
             "jetty.http.port=8080");
 
         // Create base
@@ -360,7 +360,7 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         MainResult result = runMain(base, home);
 
@@ -394,7 +394,7 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "my.corp=" + corp.toString(),
-            "--include-jetty-dir=${my.corp}",
+            "--add-config-dir=${my.corp}",
             "jetty.http.port=8080");
 
         // Create base
@@ -403,7 +403,7 @@ public class IncludeJettyDirTest
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
             "my.common=" + common.toString(),
-            "--include-jetty-dir=${my.common}");
+            "--add-config-dir=${my.common}");
 
         MainResult result = runMain(base, home);
 
@@ -443,7 +443,7 @@ public class IncludeJettyDirTest
         Path common = testdir.getPathFile("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp.toString(),
+            "--add-config-dir=" + corp.toString(),
             "jetty.http.port=8080");
 
         // Create base
@@ -451,11 +451,11 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         MainResult result = runMain(base, home,
             // command line provided include-jetty-dir ref
-            "--include-jetty-dir=" + devops.toString());
+            "--add-config-dir=" + devops.toString());
 
         List<String> expectedSearchOrder = new ArrayList<>();
         expectedSearchOrder.add("${jetty.base}");
@@ -487,7 +487,7 @@ public class IncludeJettyDirTest
         Path common = testdir.getPathFile("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp.toString(),
+            "--add-config-dir=" + corp.toString(),
             "jetty.http.port=8080");
 
         // Create base
@@ -495,7 +495,7 @@ public class IncludeJettyDirTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         MainResult result = runMain(base, home,
             // command line property should override all others
@@ -531,21 +531,21 @@ public class IncludeJettyDirTest
             // standard property
             "jetty.http.port=9090",
             // INTENTIONAL BAD Reference (duplicate)
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         // Populate common
         TestEnv.makeFile(common, "start.ini",
             // standard property
             "jetty.http.port=8080",
             // reference to corp
-            "--include-jetty-dir=" + corp.toString());
+            "--add-config-dir=" + corp.toString());
 
         // Create base
         Path base = testdir.getPathFile("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         UsageException e = assertThrows(UsageException.class, () -> runMain(base, home));
         assertThat("UsageException", e.getMessage(), containsString("Duplicate"));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
@@ -120,7 +120,7 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 
@@ -160,7 +160,7 @@ public class ConfigSourcesTest
             // property
             "my.common=" + common,
             // reference via property
-            "--include-jetty-dir=${my.common}"
+            "--add-config-dir=${my.common}"
         };
 
         sources.add(new CommandLineConfigSource(cmdLine));
@@ -208,7 +208,7 @@ public class ConfigSourcesTest
             // property to 'opt' dir
             "my.opt=" + opt,
             // reference via property prefix
-            "--include-jetty-dir=" + dirRef
+            "--add-config-dir=" + dirRef
         };
 
         sources.add(new CommandLineConfigSource(cmdLine));
@@ -259,7 +259,7 @@ public class ConfigSourcesTest
             // property to common dir name
             "my.dir=common",
             // reference via property prefix
-            "--include-jetty-dir=" + dirRef
+            "--add-config-dir=" + dirRef
         };
 
         sources.add(new CommandLineConfigSource(cmdLine));
@@ -293,7 +293,7 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 
@@ -333,8 +333,8 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common,
-            "--include-jetty-dir=" + corp.toString());
+            "--add-config-dir=" + common,
+            "--add-config-dir=" + corp.toString());
 
         ConfigSources sources = new ConfigSources();
 
@@ -373,7 +373,7 @@ public class ConfigSourcesTest
         Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp,
+            "--add-config-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
@@ -381,7 +381,7 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 
@@ -421,7 +421,7 @@ public class ConfigSourcesTest
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
             "my.corp=" + corp,
-            "--include-jetty-dir=${my.corp}",
+            "--add-config-dir=${my.corp}",
             "jetty.http.port=8080");
 
         // Create base
@@ -430,7 +430,7 @@ public class ConfigSourcesTest
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
             "my.common=" + common,
-            "--include-jetty-dir=${my.common}");
+            "--add-config-dir=${my.common}");
 
         ConfigSources sources = new ConfigSources();
 
@@ -477,7 +477,7 @@ public class ConfigSourcesTest
         Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp,
+            "--add-config-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
@@ -485,13 +485,13 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 
         String[] cmdLine = new String[]{
             // command line provided include-jetty-dir ref
-            "--include-jetty-dir=" + devops
+            "--add-config-dir=" + devops
         };
         sources.add(new CommandLineConfigSource(cmdLine));
         sources.add(new JettyHomeConfigSource(home));
@@ -529,7 +529,7 @@ public class ConfigSourcesTest
         Path common = testdir.resolve("common");
         FS.ensureEmpty(common);
         TestEnv.makeFile(common, "start.ini",
-            "--include-jetty-dir=" + corp,
+            "--add-config-dir=" + corp,
             "jetty.http.port=8080");
 
         // Create base
@@ -537,7 +537,7 @@ public class ConfigSourcesTest
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 
@@ -580,21 +580,21 @@ public class ConfigSourcesTest
             // standard property
             "jetty.http.port=9090",
             // INTENTIONAL BAD Reference (duplicate)
-            "--include-jetty-dir=" + common.toString());
+            "--add-config-dir=" + common.toString());
 
         // Populate common
         TestEnv.makeFile(common, "start.ini",
             // standard property
             "jetty.http.port=8080",
             // reference to corp
-            "--include-jetty-dir=" + corp);
+            "--add-config-dir=" + corp);
 
         // Create base
         Path base = testdir.resolve("base");
         FS.ensureEmpty(base);
         TestEnv.makeFile(base, "start.ini",
             "jetty.http.host=127.0.0.1",
-            "--include-jetty-dir=" + common);
+            "--add-config-dir=" + common);
 
         ConfigSources sources = new ConfigSources();
 


### PR DESCRIPTION
* #5944 - introduce `--files=<uri>|<location>` alias
* #5945 - introduce `--skip-create-files=<moduleName>` alias
* #5946 - introduce `--add-base-dir=<path>` alias

Fixes: #5944 
Fixes: #5945
Fixes: #5946