### PR TITLE
Issue #11648 - Adding RFC 6265 Cookie parsing of Expires Date 

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -20,14 +20,13 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringTokenizer;
 import java.util.TreeMap;
 
 import org.eclipse.jetty.util.Index;
-import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -307,14 +306,6 @@ public interface HttpCookie
      */
     class Immutable implements HttpCookie
     {
-        static final QuotedStringTokenizer DATE_TOKENIZER = QuotedStringTokenizer.builder()
-            .delimiters("\t" + // %x09
-                " !#$%&'()*+,-./" + " + " + // %x20-2F
-                ";<=>?@" + // %x3B-40
-                "[\\]^_`" + // %x5B-60
-                "{|}~" // %x7B-7E
-            )
-            .build();
         static final Index<Integer> MONTH_CACHE = new Index.Builder<Integer>()
             .caseSensitive(false)
             // Note: Calendar.Month fields are zero based.
@@ -343,6 +334,16 @@ public interface HttpCookie
             _value = value;
             _version = version;
             _attributes = attributes == null || attributes.isEmpty() ? Collections.emptyMap() : attributes;
+        }
+
+        protected static StringTokenizer newDateStringTokenizer(String input)
+        {
+            return new StringTokenizer(input, "\t" + // %x09
+                " !\"#$%&'()*+,-./" + " + " + // %x20-2F
+                ";<=>?@" + // %x3B-40
+                "[\\]^_`" + // %x5B-60
+                "{|}~" // %x7B-7E
+            );
         }
 
         @Override
@@ -989,10 +990,10 @@ public interface HttpCookie
         try
         {
             int tokenCount = 0;
-            Iterator<String> tokenIter = Immutable.DATE_TOKENIZER.tokenize(date);
-            while (tokenIter.hasNext())
+            StringTokenizer tokenizer = Immutable.newDateStringTokenizer(date);
+            while (tokenizer.hasMoreTokens())
             {
-                String token = tokenIter.next();
+                String token = tokenizer.nextToken();
                 // ensure we don't exceed the number of expected tokens.
                 if (++tokenCount > 6)
                 {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -988,18 +988,26 @@ public interface HttpCookie
                     hour = StringUtil.toInt(part, 0);
                     minute = StringUtil.toInt(part, 3);
                     second = StringUtil.toInt(part, 6);
-                    continue;
                 }
                 catch (IllegalArgumentException e)
                 {
                     // bad time syntax
+                    throw new DateTimeSyntaxException("Invalid [time]: " + expires);
                 }
+                continue;
             }
 
             // RFC 6265 - Section 5.1.1 - Step 2.2
             if (day == (-1) && part.length() <= 2)
             {
-                day = StringUtil.toInt(part, 0);
+                try
+                {
+                    day = StringUtil.toInt(part, 0);
+                }
+                catch (IllegalArgumentException e)
+                {
+                    throw new DateTimeSyntaxException("Invalid [day]: " + expires);
+                }
                 continue;
             }
 
@@ -1032,14 +1040,22 @@ public interface HttpCookie
             // RFC 6265 - Section 5.1.1 - Step 2.4
             if (year == (-1))
             {
-                if (part.length() <= 2)
+                try
                 {
-                    year = StringUtil.toInt(part, 0);
+                    if (part.length() <= 2)
+                    {
+                        year = StringUtil.toInt(part, 0);
+                    }
+                    else if (part.length() == 4)
+                    {
+                        year = StringUtil.toInt(part, 0);
+                    }
                 }
-                else if (part.length() == 4)
+                catch (IllegalArgumentException e)
                 {
-                    year = StringUtil.toInt(part, 0);
+                    throw new DateTimeSyntaxException("Invalid [year]: " + expires);
                 }
+                continue;
             }
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -960,12 +960,10 @@ public interface HttpCookie
             )
             .build();
 
-        // System.out.println("expires=[" + expires + "]");
         Iterator<String> dateIter = dateTokenizer.tokenize(expires);
         while (dateIter.hasNext())
         {
             String part = dateIter.next();
-            // System.out.println("      p=[" + part + "]");
 
             // RFC 6265 - Section 5.1.1 - Step 2.1 - time (00:00:00)
             if (hour == (-1) && part.length() == 8 && part.charAt(2) == ':' && part.charAt(5) == ':')

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -931,19 +931,6 @@ public interface HttpCookie
     }
 
     /**
-     * <p>Parses the {@code Expires} attribute value
-     * (in RFC 1123 format) into an {@link Instant}.</p>
-     *
-     * @param expires an instant in the RFC 1123 string format
-     * @return an {@link Instant} parsed from the given string
-     */
-    static Instant parseExpiresOld(String expires)
-    {
-        // TODO: RFC 1123 format only for now, see https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1.
-        return ZonedDateTime.parse(expires, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
-    }
-
-    /**
      * <p>Parses the {@code Expires} attribute value using algorithm
      * specified in <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1">RFC6265: Section 5.1.1: Date</a>
      * in into an {@link Instant}.</p>

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -29,6 +29,8 @@ import java.util.TreeMap;
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>Implementation of RFC6265 HTTP Cookies (with fallback support for RFC2965).</p>
@@ -965,11 +967,6 @@ public interface HttpCookie
         return parseCookieDate(expires);
     }
 
-    static Instant parseExpiresOld(String date)
-    {
-        return ZonedDateTime.parse(date, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
-    }
-
     /**
      * <p>Parses a Cookie Date value (such as the {@code Expires} attribute) using algorithm
      * specified in <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1">RFC6265: Section 5.1.1: Date</a>
@@ -1010,9 +1007,9 @@ public interface HttpCookie
                 // if (hour == (-1) && Immutable.PATTERN_TIME.matcher(token).matches())
                 if (hour == (-1) && token.length() == 8 && token.charAt(2) == ':' && token.charAt(5) == ':')
                 {
-                    hour = StringUtil.toInt(token, 0);
-                    minute = StringUtil.toInt(token, 3);
                     second = StringUtil.toInt(token, 6);
+                    minute = StringUtil.toInt(token, 3);
+                    hour = StringUtil.toInt(token, 0);
                     continue;
                 }
 
@@ -1049,9 +1046,11 @@ public interface HttpCookie
                 }
             }
         }
-        catch (Throwable t)
+        catch (Throwable x)
         {
-            throw new DateTimeSyntaxException("Unable to parse date: " + date, t);
+            Logger log = LoggerFactory.getLogger(HttpCookie.class);
+            if (log.isDebugEnabled())
+                log.debug("Ignore: Unable to parse Cookie Date", x);
         }
 
         // RFC 6265 - Section 5.1.1 - Step 3

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -14,14 +14,20 @@
 package org.eclipse.jetty.http;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -104,5 +110,115 @@ public class HttpCookieTest
     {
         assertThrows(failure, () -> HttpCookie.build("A", "1")
             .attribute(name, value));
+    }
+
+    public static Stream<Arguments> expiresDatesValid()
+    {
+        List<Arguments> args = new ArrayList<>();
+
+        // Examples taken from:
+        // - https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.7
+        // - RFC 6265
+        // - issue discussions
+        // - curl results from major players like cloudflare
+
+        // Preferred RFC 1123 syntax
+        args.add(Arguments.of("Wed, 09 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+        args.add(Arguments.of("Sun, 06 Nov 1994 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Tue, 16 Apr 2024 17:28:27 GMT", "2024/04/16 17:28:27 GMT"));
+        args.add(Arguments.of("Thu,  2 Nov 2017 13:37:22 GMT", "2017/11/02 13:37:22 GMT"));
+
+        // Obsolete RFC 850 syntax
+        args.add(Arguments.of("Tue, 10-May-22 21:23:37 GMT", "2022/05/10 21:23:37 GMT"));
+        args.add(Arguments.of("Sun, 03-May-20 18:54:31 GMT", "2020/05/03 18:54:31 GMT"));
+        args.add(Arguments.of("Tue, 16-Apr-24 17:28:27 GMT", "2024/04/16 17:28:27 GMT"));
+        args.add(Arguments.of("Sunday, 06-Nov-94 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Sun, 06-Nov-94 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Mon, 05-May-2014 13:13:45 GMT", "2014/05/05 13:13:45 GMT"));
+        args.add(Arguments.of("Thu, 02-May-2013 13:14:16 GMT", "2013/05/02 13:14:16 GMT"));
+
+        // Obsolete ANSI C's asctime() format
+        args.add(Arguments.of("Sun Nov  6 08:49:37 1994", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Tue Apr 16 09:59:47 0000", "2000/04/16 09:59:47 GMT"));
+        args.add(Arguments.of("Tue Apr 16 09:59:47 00", "2000/04/16 09:59:47 GMT"));
+
+        // Unusual formats seen elsewhere
+        // unix epoch (and zero time)
+        args.add(Arguments.of("Thu, 01 Jan 1970 00:00:00 GMT", "1970/01/01 00:00:00 GMT"));
+        // seemingly invalid day (looks negative, but it isn't, as '-' is a delimiter per spec)
+        args.add(Arguments.of("Thu, -2 Nov 2017 13:37:22 GMT", "2017/11/02 13:37:22 GMT"));
+        // year zero (which is a valid year, assumed to be the year 2000 per spec)
+        args.add(Arguments.of("Thu, 22 Nov 0000 23:45:12 GMT", "2000/11/22 23:45:12 GMT"));
+        args.add(Arguments.of("Sun, 03-May-00 18:54:31 GMT", "2000/05/03 18:54:31 GMT"));
+        // unexpected timezone (the timezone is ignored per spec)
+        args.add(Arguments.of("Sun, 06 Nov 1994 08:49:37 PST", "1994/11/06 08:49:37 GMT"));
+        // long weekday (weekday is ignored per spec)
+        args.add(Arguments.of("Wednesday, 09 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+
+        return args.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("expiresDatesValid")
+    public void testParseExpires(String input, String expected)
+    {
+        Instant actual = HttpCookie.parseExpires(input);
+        DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();
+        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual.atZone(ZoneId.of("GMT")));
+        assertEquals(expected, actualStr);
+    }
+
+    public static Stream<Arguments> expiresDatesInvalid()
+    {
+        List<Arguments> args = new ArrayList<>();
+
+        // Preferred RFC 1123 syntax
+        // - invalid Year
+        args.add(Arguments.of("Sun, 06 Nov 65535 08:49:37 GMT", "Missing [year]"));
+        args.add(Arguments.of("Wed, 09 Jun -123 10:18:14 GMT", "Missing [year]"));
+        // - no year
+        args.add(Arguments.of("Wed, 09 Jun 10:18:14 GMT", "Missing [year]"));
+
+        // - invalid day
+        args.add(Arguments.of("Tue, 00 Apr 2024 17:28:27 GMT", "Invalid [day]"));
+        // - no day
+        args.add(Arguments.of("Thu, Nov 2017 13:37:22 GMT", "Missing [day]"));
+
+        // - no time
+        args.add(Arguments.of("Thu, 01 Jan 1970 GMT", "Missing [time]"));
+
+        // Obsolete RFC 850 syntax
+        // - invalid year
+        args.add(Arguments.of("Sun, 03-May-65535 18:54:31 GMT", "Missing [year]"));
+        // - no year
+        args.add(Arguments.of("Tue, 16-Apr- 17:28:27 GMT", "Missing [year]"));
+        // - invalid day
+        args.add(Arguments.of("Sunday, 00-Nov-94 08:49:37 GMT", "Invalid [day]"));
+        // - no day (the '94' is parsed as day)
+        args.add(Arguments.of("Sun, Nov-94 08:49:37 GMT", "Missing [year]"));
+
+        // - no time
+        args.add(Arguments.of("Mon, 05-May-2014 GMT", "Missing [time]"));
+        // - bad time (no seconds)
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 GMT", "Missing [time]"));
+        // - bad time (am/pm)
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Missing [time]"));
+
+        // Obsolete ANSI C's asctime() format
+        // - invalid year
+        args.add(Arguments.of("Sun Nov  6 08:49:37 65535", "Missing [year]"));
+
+        return args.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("expiresDatesInvalid")
+    public void testParseExpiresInvalid(String input, String expectedMsg)
+    {
+        HttpCookie.DateTimeSyntaxException syntaxException = assertThrows(
+            HttpCookie.DateTimeSyntaxException.class, () ->
+            HttpCookie.parseExpires(input)
+        );
+        assertThat(syntaxException.getMessage(), containsString(expectedMsg));
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -142,6 +142,10 @@ public class HttpCookieTest
         args.add(Arguments.of("Tue Apr 16 09:59:47 00", "2000/04/16 09:59:47 GMT"));
 
         // Unusual formats seen elsewhere
+        // RFC 1123 syntax with single digit day
+        args.add(Arguments.of("Wed, 9 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+        // RFC 850 with single digit day
+        args.add(Arguments.of("Sun, 3-May-20 18:54:31 GMT", "2020/05/03 18:54:31 GMT"));
         // unix epoch (and zero time)
         args.add(Arguments.of("Thu, 01 Jan 1970 00:00:00 GMT", "1970/01/01 00:00:00 GMT"));
         // seemingly invalid day (looks negative, but it isn't, as '-' is a delimiter per spec)
@@ -182,6 +186,8 @@ public class HttpCookieTest
         args.add(Arguments.of("Tue, 00 Apr 2024 17:28:27 GMT", "Invalid [day]"));
         // - no day
         args.add(Arguments.of("Thu, Nov 2017 13:37:22 GMT", "Missing [day]"));
+        // - single digit hour
+        args.add(Arguments.of("Wed, 09 Jun 2021 2:18:14 GMT", "Missing [time]"));
 
         // - no time
         args.add(Arguments.of("Thu, 01 Jan 1970 GMT", "Missing [time]"));
@@ -193,15 +199,18 @@ public class HttpCookieTest
         args.add(Arguments.of("Tue, 16-Apr- 17:28:27 GMT", "Missing [year]"));
         // - invalid day
         args.add(Arguments.of("Sunday, 00-Nov-94 08:49:37 GMT", "Invalid [day]"));
-        // - no day (the '94' is parsed as day)
+        // - single digit hour
+        args.add(Arguments.of("Sunday, 01-Nov-94 8:49:37 GMT", "Missing [time]"));
+
+        // - no day (the '94' is parsed as day as its the first 2 digit number in the string)
         args.add(Arguments.of("Sun, Nov-94 08:49:37 GMT", "Missing [year]"));
 
         // - no time
         args.add(Arguments.of("Mon, 05-May-2014 GMT", "Missing [time]"));
-        // - bad time (no seconds)
+        // - bad time (no seconds) - will not find time
         args.add(Arguments.of("Thu, 02-May-2013 13:14 GMT", "Missing [time]"));
-        // - bad time (am/pm) - will not understand the AM/PM
-        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Unable to parse date"));
+        // - bad time (am/pm) - will not find time, and will not understand the AM/PM
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Missing [time]"));
 
         // Obsolete ANSI C's asctime() format
         // - invalid year

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -17,7 +17,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -96,7 +95,7 @@ public class HttpCookieTest
     public static List<Arguments> invalidAttributes()
     {
         return List.of(
-            Arguments.of("Expires", "blah", DateTimeParseException.class),
+            Arguments.of("Expires", "blah", HttpCookie.DateTimeSyntaxException.class),
             Arguments.of("HttpOnly", "blah", IllegalArgumentException.class),
             Arguments.of("Max-Age", "blah", NumberFormatException.class),
             Arguments.of("SameSite", "blah", IllegalArgumentException.class),

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -111,7 +111,7 @@ public class HttpCookieTest
             .attribute(name, value));
     }
 
-    public static Stream<Arguments> expiresDatesValid()
+    public static Stream<Arguments> cookieDatesValid()
     {
         List<Arguments> args = new ArrayList<>();
 
@@ -158,16 +158,16 @@ public class HttpCookieTest
     }
 
     @ParameterizedTest
-    @MethodSource("expiresDatesValid")
-    public void testParseExpires(String input, String expected)
+    @MethodSource("cookieDatesValid")
+    public void testParseCookieDate(String input, String expected)
     {
-        Instant actual = HttpCookie.parseExpires(input);
+        Instant actual = HttpCookie.parseCookieDate(input);
         DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();
         String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual.atZone(ZoneId.of("GMT")));
         assertEquals(expected, actualStr);
     }
 
-    public static Stream<Arguments> expiresDatesInvalid()
+    public static Stream<Arguments> cookieDatesInvalid()
     {
         List<Arguments> args = new ArrayList<>();
 
@@ -200,8 +200,8 @@ public class HttpCookieTest
         args.add(Arguments.of("Mon, 05-May-2014 GMT", "Missing [time]"));
         // - bad time (no seconds)
         args.add(Arguments.of("Thu, 02-May-2013 13:14 GMT", "Missing [time]"));
-        // - bad time (am/pm)
-        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Missing [time]"));
+        // - bad time (am/pm) - will not understand the AM/PM
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Unable to parse date"));
 
         // Obsolete ANSI C's asctime() format
         // - invalid year
@@ -211,12 +211,12 @@ public class HttpCookieTest
     }
 
     @ParameterizedTest
-    @MethodSource("expiresDatesInvalid")
-    public void testParseExpiresInvalid(String input, String expectedMsg)
+    @MethodSource("cookieDatesInvalid")
+    public void testParseCookieDateInvalid(String input, String expectedMsg)
     {
         HttpCookie.DateTimeSyntaxException syntaxException = assertThrows(
             HttpCookie.DateTimeSyntaxException.class, () ->
-            HttpCookie.parseExpires(input)
+            HttpCookie.parseCookieDate(input)
         );
         assertThat(syntaxException.getMessage(), containsString(expectedMsg));
     }

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
@@ -68,7 +68,7 @@ public class HttpCookieParseExpireBenchmark
     public Instant testParseOld()
     {
         int entry = ThreadLocalRandom.current().nextInt(size);
-        return HttpCookie.parseExpiresOld(expires[entry]);
+        return ZonedDateTime.parse(expires[entry], DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
     }
 
     @Benchmark

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
@@ -65,7 +65,7 @@ public class HttpCookieParseExpireBenchmark
 
     @Benchmark
     @BenchmarkMode({Mode.Throughput})
-    public Instant testParseOld()
+    public Instant testParseExpiresOld()
     {
         int entry = ThreadLocalRandom.current().nextInt(size);
         return ZonedDateTime.parse(expires[entry], DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
@@ -76,7 +76,7 @@ public class HttpCookieParseExpireBenchmark
     public Instant testParse()
     {
         int entry = ThreadLocalRandom.current().nextInt(size);
-        return HttpCookie.parseExpires(expires[entry]);
+        return HttpCookie.parseCookieDate(expires[entry]);
     }
 
     public static void main(String[] args) throws RunnerException

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpCookieParseExpireBenchmark.java
@@ -1,0 +1,97 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http.jmh;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.HttpCookie;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+public class HttpCookieParseExpireBenchmark
+{
+    String[] expires;
+    int size;
+
+    @Setup
+    public void prepare()
+    {
+        size = 40;
+        expires = new String[size];
+
+        long startTime = ZonedDateTime.parse("Mon, 01 Jan 1900 01:00:00 GMT", DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond();
+        long endTime = ZonedDateTime.parse("Fri, 31 Dec 2100 23:59:59 GMT", DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond();
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        ZoneId zoneGMT = ZoneId.of("GMT");
+
+        for (int i = 0; i < size; i++)
+        {
+            long randomTime = random.nextLong(startTime, endTime);
+            expires[i] = Instant.ofEpochSecond(randomTime).atZone(zoneGMT).format(DateTimeFormatter.RFC_1123_DATE_TIME);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public Instant testParseOld()
+    {
+        int entry = ThreadLocalRandom.current().nextInt(size);
+        return HttpCookie.parseExpiresOld(expires[entry]);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public Instant testParse()
+    {
+        int entry = ThreadLocalRandom.current().nextInt(size);
+        return HttpCookie.parseExpires(expires[entry]);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(HttpCookieParseExpireBenchmark.class.getSimpleName())
+            .warmupIterations(10)
+            .measurementIterations(10)
+            // .addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}
+
+


### PR DESCRIPTION
Implemented the algorithm recommended by https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1 to parse the `Expires` date in the `Set-Cookie` line.

This will impact Jetty HttpClient, but not the Jetty Server implementation (as `Set-Cookie` is only parsed by the client).


Fixes: #11648 

