### PR TITLE
Issue #11659 - Properly ignore OWS before field values.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1228,11 +1228,21 @@ public class HttpParser
 
         for (int i = 0; i < length; i++)
         {
-            char c = valueString.charAt(i);
-            if (c < '0' || c > '9')
-                throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
+            char ch = valueString.charAt(i);
+            HttpTokens.Token t = HttpTokens.getToken(ch);
 
-            value = Math.addExact(Math.multiplyExact(value, 10), c - '0');
+            switch (t.getType())
+            {
+                case SPACE:
+                case HTAB:
+                    // ignore OWS
+                    continue;
+                case DIGIT:
+                    value = Math.addExact(Math.multiplyExact(value, 10), ch - '0');
+                    break;
+                default:
+                    throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
+            }
         }
         return value;
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -2023,12 +2023,84 @@ public class HttpParserTest
         assertEquals("GET", _methodOrVersion);
         assertEquals("/test", _uriOrStatus);
         assertEquals("HTTP/1.1", _versionOrReason);
-        assertEquals("localhost", _val[0]);
         assertEquals("Host", _hdr[0]);
         assertEquals("localhost", _val[0]);
 
         assertEquals(_content.length(), 10);
         assertEquals(parser.getContentLength(), 10);
+        assertTrue(_headerCompleted);
+        assertTrue(_messageCompleted);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        " chunked ",
+        "chunked ",
+        " chunked",
+        "\tchunked",
+        "\tchunked\t",
+        "chunked\t",
+        " \t \t \t chunked"
+    })
+    public void testTransferEncodingWithOWS(String transferEncoding)
+    {
+        String rawRequest = """
+            GET /test HTTP/1.1\r
+            Host: localhost\r
+            Transfer-Encoding: @TE@\r
+            \r
+            1\r
+            X\r
+            0\r
+            \r
+            """.replace("@TE@", transferEncoding);
+        ByteBuffer buffer = BufferUtil.toBuffer(rawRequest);
+
+        HttpParser.RequestHandler handler = new Handler();
+        HttpParser parser = new HttpParser(handler);
+        parseAll(parser, buffer);
+
+        assertEquals("GET", _methodOrVersion);
+        assertEquals("/test", _uriOrStatus);
+        assertEquals("HTTP/1.1", _versionOrReason);
+        assertEquals("Host", _hdr[0]);
+        assertEquals("localhost", _val[0]);
+        assertEquals("Transfer-Encoding", _hdr[1]);
+        assertEquals("chunked", _val[1]);
+
+        assertTrue(_headerCompleted);
+        assertTrue(_messageCompleted);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        " testhost ",
+        "testhost ",
+        " testhost",
+        "\ttesthost",
+        "\ttesthost\t",
+        "testhost\t",
+        " \t \t \t testhost"
+    })
+    public void testHostWithOWS(String host)
+    {
+        String rawRequest = """
+            GET /test HTTP/1.1\r
+            Host: @HOST@\r
+            \r
+            """.replace("@HOST@", host);
+        ByteBuffer buffer = BufferUtil.toBuffer(rawRequest);
+
+        HttpParser.RequestHandler handler = new Handler();
+        HttpParser parser = new HttpParser(handler);
+        parseAll(parser, buffer);
+
+        assertEquals("GET", _methodOrVersion);
+        assertEquals("/test", _uriOrStatus);
+        assertEquals("HTTP/1.1", _versionOrReason);
+        assertEquals("Host", _hdr[0]);
+        assertEquals("testhost", _val[0]);
+
         assertTrue(_headerCompleted);
         assertTrue(_messageCompleted);
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -1971,7 +1971,8 @@ public class HttpParserTest
         "+10",
         "1.0",
         "1,0",
-        "10,"
+        "10,",
+        "10A"
     })
     public void testBadContentLengths(String contentLength)
     {
@@ -1992,6 +1993,44 @@ public class HttpParserTest
         parser.atEOF();
         parser.parseNext(BufferUtil.EMPTY_BUFFER);
         assertEquals(HttpParser.State.CLOSED, parser.getState());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        " 10 ",
+        "10 ",
+        " 10",
+        "\t10",
+        "\t10\t",
+        "10\t",
+        " \t \t \t 10"
+    })
+    public void testContentLengthWithOWS(String contentLength)
+    {
+        String rawRequest = """
+            GET /test HTTP/1.1\r
+            Host: localhost\r
+            Content-Length: @LEN@\r
+            \r
+            1234567890
+            """.replace("@LEN@", contentLength);
+        ByteBuffer buffer = BufferUtil.toBuffer(rawRequest);
+
+        HttpParser.RequestHandler handler = new Handler();
+        HttpParser parser = new HttpParser(handler);
+        parseAll(parser, buffer);
+
+        assertEquals("GET", _methodOrVersion);
+        assertEquals("/test", _uriOrStatus);
+        assertEquals("HTTP/1.1", _versionOrReason);
+        assertEquals("localhost", _val[0]);
+        assertEquals("Host", _hdr[0]);
+        assertEquals("localhost", _val[0]);
+
+        assertEquals(_content.length(), 10);
+        assertEquals(parser.getContentLength(), 10);
+        assertTrue(_headerCompleted);
+        assertTrue(_messageCompleted);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Update HttpParser.CACHE to handle UNMATCHED_VALUE scenarios (like `Content-Length:       10`) by restoring Jetty 9/10/11 behavior of header only matches from CACHE, allowing `HttpParser.parseFields()` to handle OWS properly.

Fixes #11659 