### PR TITLE
Issue #11648 - Introducing HttpDateTime class.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/DateParser.java
@@ -22,7 +22,9 @@ import org.eclipse.jetty.util.thread.ThreadIdPool;
 
 /**
  * ThreadLocal data parsers for HTTP style dates
+ * @deprecated use {@link HttpDateTime} instead
  */
+@Deprecated(since = "12.0.9", forRemoval = true)
 public class DateParser
 {
     private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
@@ -47,6 +49,10 @@ public class DateParser
         "EEE dd-MMM-yy HH:mm:ss zzz", "EEE dd-MMM-yy HH:mm:ss"
     };
 
+    /**
+     * @deprecated use {@link HttpDateTime#parseToEpoch(String)} instead
+     */
+    @Deprecated(since = "12.0.9", forRemoval = true)
     public static long parseDate(String date)
     {
         return DATE_PARSER.apply(DateParser::new, DateParser::parse, date);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -930,7 +930,7 @@ public interface HttpCookie
      */
     static Instant parseExpires(String expires)
     {
-        return HttpDateTime.parse(expires);
+        return HttpDateTime.parse(expires).toInstant();
     }
 
     private static Map<String, String> lazyAttributePut(Map<String, String> attributes, String key, String value)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -14,9 +14,6 @@
 package org.eclipse.jetty.http;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -921,22 +918,19 @@ public interface HttpCookie
      */
     static String formatExpires(Instant expires)
     {
-        return DateTimeFormatter.RFC_1123_DATE_TIME
-            .withZone(ZoneOffset.UTC)
-            .format(expires);
+        return HttpDateTime.format(expires);
     }
 
     /**
-     * <p>Parses the {@code Expires} attribute value
-     * (in RFC 1123 format) into an {@link Instant}.</p>
+     * <p>Parses the {@code Expires} Date/Time attribute value
+     * into an {@link Instant}.</p>
      *
-     * @param expires an instant in the RFC 1123 string format
+     * @param expires a date/time in one of the RFC6265 supported formats
      * @return an {@link Instant} parsed from the given string
      */
     static Instant parseExpires(String expires)
     {
-        // TODO: RFC 1123 format only for now, see https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1.
-        return ZonedDateTime.parse(expires, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
+        return HttpDateTime.parse(expires);
     }
 
     private static Map<String, String> lazyAttributePut(Map<String, String> attributes, String key, String value)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.http;
 
 import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -29,6 +27,8 @@ import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.time.ZoneOffset.UTC;
 
 /**
  * HTTP Date/Time parsing and formatting.
@@ -47,8 +47,6 @@ import org.slf4j.LoggerFactory;
 public class HttpDateTime
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpDateTime.class);
-    private static final ZoneId GMT = ZoneId.of("GMT");
-    private static final ZoneId UTC = ZoneOffset.UTC;
     private static final Index<Integer> MONTH_CACHE = new Index.Builder<Integer>()
         .caseSensitive(false)
         // Note: Calendar.Month fields are zero based.
@@ -244,7 +242,7 @@ public class HttpDateTime
     public static String format(TemporalAccessor datetime)
     {
         return DateTimeFormatter.RFC_1123_DATE_TIME
-            .withZone(GMT)
+            .withZone(UTC)
             .format(datetime);
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http;
 
 import java.nio.charset.StandardCharsets;
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -219,11 +220,18 @@ public class HttpDateTime
             throw new IllegalArgumentException("Invalid [second]: " + datetime);
 
         // RFC 6265 - Section 5.1.1 - Step 6
-        ZonedDateTime dateTime = ZonedDateTime.of(year,
-            month, day, hour, minute, second, 0, UTC);
+        try
+        {
+            ZonedDateTime dateTime = ZonedDateTime.of(year,
+                month, day, hour, minute, second, 0, UTC);
 
-        // RFC 6265 - Section 5.1.1 - Step 7
-        return dateTime;
+            // RFC 6265 - Section 5.1.1 - Step 7
+            return dateTime;
+        }
+        catch (DateTimeException e)
+        {
+            throw new IllegalArgumentException("Invalid date/time: " + datetime, e);
+        }
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
@@ -1,0 +1,229 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Objects;
+import java.util.StringTokenizer;
+
+import org.eclipse.jetty.util.Index;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HTTP Date/Time parsing and formatting.
+ *
+ * <p>
+ *     Also covers RFC6265 Cookie Date parsing and formatting.
+ * </p>
+ */
+public class HttpDateTime
+{
+    private static final Logger LOG = LoggerFactory.getLogger(HttpDateTime.class);
+
+    private static final Index<Integer> MONTH_CACHE = new Index.Builder<Integer>()
+        .caseSensitive(false)
+        // Note: Calendar.Month fields are zero based.
+        .with("Jan", Calendar.JANUARY + 1)
+        .with("Feb", Calendar.FEBRUARY + 1)
+        .with("Mar", Calendar.MARCH + 1)
+        .with("Apr", Calendar.APRIL + 1)
+        .with("May", Calendar.MAY + 1)
+        .with("Jun", Calendar.JUNE + 1)
+        .with("Jul", Calendar.JULY + 1)
+        .with("Aug", Calendar.AUGUST + 1)
+        .with("Sep", Calendar.SEPTEMBER + 1)
+        .with("Oct", Calendar.OCTOBER + 1)
+        .with("Nov", Calendar.NOVEMBER + 1)
+        .with("Dec", Calendar.DECEMBER + 1)
+        .build();
+
+    private HttpDateTime()
+    {
+    }
+
+    /**
+     * Similar to {@link #parse(String)} but returns unix epoch
+     *
+     * @param datetime the Date/Time to parse.
+     * @return unix epoch in milliseconds, or -1 if unable to parse the input date/time
+     */
+    public static long parseToEpoch(String datetime)
+    {
+        try
+        {
+            Instant instant = parse(datetime);
+            return instant.toEpochMilli();
+        }
+        catch (IllegalArgumentException e)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to parse Date/Time: {}", datetime, e);
+            return -1;
+        }
+    }
+
+    /**
+     * <p>Parses a Date/Time value</p>
+     *
+     * <p>Supports the following Date/Time formats found in both
+     *  <a href="https://datatracker.ietf.org/doc/html/rfc9110#name-date-time-formats">RFC 9110 (HTTP Semantics)</a> and
+     *  <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1">RFC 6265 (HTTP State Management Mechanism)</a>
+     * </p>
+     *
+     * <ul>
+     *     <li>{@code Sun, 06 Nov 1994 08:49:37 GMT} - RFC 1123 (preferred)</li>
+     *     <li>{@code Sunday, 06-Nov-94 08:49:37 GMT} - RFC 850 (obsolete)</li>
+     *     <li>{@code Sun Nov  6 08:49:37 1994} - ANSI C's {@code asctime()} format</li>
+     * </ul>
+     *
+     * <p>
+     *  Parsing is done according to the algorithm specified in
+     *  <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1">RFC6265: Section 5.1.1: Date</a>
+     * </p>
+     *
+     * @param datetime a Date/Time string in a supported format
+     * @return an {@link Instant} parsed from the given string
+     * @throws IllegalArgumentException if unable to parse date/time
+     */
+    public static Instant parse(String datetime)
+    {
+        Objects.requireNonNull(datetime, "Date/Time string cannot be null");
+
+        int year = -1;
+        int month = -1;
+        int day = -1;
+        int hour = -1;
+        int minute = -1;
+        int second = -1;
+
+        try
+        {
+            int tokenCount = 0;
+            StringTokenizer tokenizer = new StringTokenizer(datetime, "\t" + // %x09
+                " !\"#$%&'()*+,-./" + " + " + // %x20-2F
+                ";<=>?@" + // %x3B-40
+                "[\\]^_`" + // %x5B-60
+                "{|}~" // %x7B-7E
+            );
+            while (tokenizer.hasMoreTokens())
+            {
+                String token = tokenizer.nextToken();
+                // ensure we don't exceed the number of expected tokens.
+                if (++tokenCount > 6)
+                {
+                    // This is a horribly bad syntax / format
+                    throw new IllegalStateException("Too many delimiters for a Date/Time format");
+                }
+
+                if (token.isBlank())
+                    continue; // skip blank tokens
+
+                // RFC 6265 - Section 5.1.1 - Step 2.1 - time (00:00:00)
+                if (hour == (-1) && token.length() == 8 && token.charAt(2) == ':' && token.charAt(5) == ':')
+                {
+                    second = StringUtil.toInt(token, 6);
+                    minute = StringUtil.toInt(token, 3);
+                    hour = StringUtil.toInt(token, 0);
+                    continue;
+                }
+
+                // RFC 6265 - Section 5.1.1 - Step 2.2
+                if (day == (-1) && token.length() <= 2)
+                {
+                    day = StringUtil.toInt(token, 0);
+                    continue;
+                }
+
+                // RFC 6265 - Section 5.1.1 - Step 2.3
+                if (month == (-1) && token.length() == 3)
+                {
+                    Integer m = MONTH_CACHE.getBest(token);
+                    if (m != null)
+                    {
+                        month = m;
+                        continue;
+                    }
+                }
+
+                // RFC 6265 - Section 5.1.1 - Step 2.4
+                if (year == (-1))
+                {
+                    if (token.length() <= 2)
+                    {
+                        year = StringUtil.toInt(token, 0);
+                    }
+                    else if (token.length() == 4)
+                    {
+                        year = StringUtil.toInt(token, 0);
+                    }
+                    continue;
+                }
+            }
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Ignore: Unable to parse Date/Time", x);
+        }
+
+        // RFC 6265 - Section 5.1.1 - Step 3
+        if ((year > 70) && (year <= 99))
+            year += 1900;
+        // RFC 6265 - Section 5.1.1 - Step 4
+        if ((year >= 0) && (year <= 69))
+            year += 2000;
+
+        // RFC 6265 - Section 5.1.1 - Step 5
+        if (day == (-1))
+            throw new IllegalArgumentException("Missing [day]: " + datetime);
+        if (month == (-1))
+            throw new IllegalArgumentException("Missing [month]: " + datetime);
+        if (year == (-1))
+            throw new IllegalArgumentException("Missing [year]: " + datetime);
+        if (hour == (-1))
+            throw new IllegalArgumentException("Missing [time]: " + datetime);
+        if (day < 1 || day > 31)
+            throw new IllegalArgumentException("Invalid [day]: " + datetime);
+        if (month < 1 || month > 31)
+            throw new IllegalArgumentException("Invalid [month]: " + datetime);
+        if (hour > 23)
+            throw new IllegalArgumentException("Invalid [hour]: " + datetime);
+        if (minute > 59)
+            throw new IllegalArgumentException("Invalid [minute]: " + datetime);
+        if (second > 59)
+            throw new IllegalArgumentException("Invalid [second]: " + datetime);
+
+        // RFC 6265 - Section 5.1.1 - Step 6
+        ZonedDateTime dateTime = ZonedDateTime.of(year,
+            month, day, hour, minute, second, 0,
+            ZoneId.of("GMT"));
+
+        // RFC 6265 - Section 5.1.1 - Step 7
+        return dateTime.toInstant();
+    }
+
+    public static String format(Instant instant)
+    {
+        return DateTimeFormatter.RFC_1123_DATE_TIME
+            .withZone(ZoneOffset.UTC)
+            .format(instant);
+    }
+}

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpDateTime.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http;
 
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -46,6 +47,7 @@ public class HttpDateTime
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpDateTime.class);
     private static final ZoneId GMT = ZoneId.of("GMT");
+    private static final ZoneId UTC = ZoneOffset.UTC;
     private static final Index<Integer> MONTH_CACHE = new Index.Builder<Integer>()
         .caseSensitive(false)
         // Note: Calendar.Month fields are zero based.
@@ -218,7 +220,7 @@ public class HttpDateTime
 
         // RFC 6265 - Section 5.1.1 - Step 6
         ZonedDateTime dateTime = ZonedDateTime.of(year,
-            month, day, hour, minute, second, 0, GMT);
+            month, day, hour, minute, second, 0, UTC);
 
         // RFC 6265 - Section 5.1.1 - Step 7
         return dateTime;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -517,10 +517,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         if (val == null)
             return -1;
 
-        final long date = DateParser.parseDate(val);
-        if (date == -1)
-            throw new IllegalArgumentException("Cannot convert date: " + val);
-        return date;
+        return HttpDateTime.parse(val).toEpochMilli();
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -517,7 +518,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         if (val == null)
             return -1;
 
-        return HttpDateTime.parse(val).toEpochMilli();
+        return TimeUnit.SECONDS.toMillis(HttpDateTime.parse(val).toEpochSecond());
     }
 
     /**

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.http;
 
 import java.time.Instant;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -90,7 +89,7 @@ public class HttpCookieTest
     public static List<Arguments> invalidAttributes()
     {
         return List.of(
-            Arguments.of("Expires", "blah", DateTimeParseException.class),
+            Arguments.of("Expires", "blah", IllegalArgumentException.class),
             Arguments.of("HttpOnly", "blah", IllegalArgumentException.class),
             Arguments.of("Max-Age", "blah", NumberFormatException.class),
             Arguments.of("SameSite", "blah", IllegalArgumentException.class),
@@ -105,4 +104,5 @@ public class HttpCookieTest
         assertThrows(failure, () -> HttpCookie.build("A", "1")
             .attribute(name, value));
     }
+
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.http;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -189,5 +191,24 @@ public class HttpDateTimeTest
     {
         long epoch = HttpDateTime.parseToEpoch("Fri, 13 Mar 1964 11:22:33 GMT");
         assertThat(epoch, is(-183127047000L));
+    }
+
+    @Test
+    public void testFormatZonedDateTime()
+    {
+        // When "Back to the Future" released
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(1984, 7, 3, 8, 10, 30, 0, ZoneId.of("US/Pacific"));
+        String actual = HttpDateTime.format(zonedDateTime);
+        assertThat(actual, is("Tue, 3 Jul 1984 15:10:30 GMT"));
+    }
+
+    @Test
+    public void testFormatInstant()
+    {
+        // When "Tron" released
+        long epochMillis = 395054120000L;
+        Instant instant = Instant.ofEpochMilli(epochMillis);
+        String actual = HttpDateTime.format(instant);
+        assertThat(actual, is("Fri, 9 Jul 1982 09:15:20 GMT"));
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -13,8 +13,7 @@
 
 package org.eclipse.jetty.http;
 
-import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
@@ -92,9 +91,9 @@ public class HttpDateTimeTest
     @MethodSource("dateTimeValid")
     public void testParseValid(String input, String expected)
     {
-        Instant actual = HttpDateTime.parse(input);
+        ZonedDateTime actual = HttpDateTime.parse(input);
         DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();
-        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual.atZone(ZoneId.of("GMT")));
+        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual);
         assertEquals(expected, actualStr);
     }
 
@@ -105,6 +104,7 @@ public class HttpDateTimeTest
         // Preferred RFC 1123 syntax
         // - invalid Year
         args.add(Arguments.of("Sun, 06 Nov 65535 08:49:37 GMT", "Missing [year]"));
+        args.add(Arguments.of("Thu, 14 Oct 1535 01:02:00 GMT", "Too far in past [year]"));
         args.add(Arguments.of("Wed, 09 Jun -123 10:18:14 GMT", "Missing [year]"));
         // - no year
         args.add(Arguments.of("Wed, 09 Jun 10:18:14 GMT", "Missing [year]"));

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -1,0 +1,164 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttpDateTimeTest
+{
+    public static Stream<Arguments> dateTimeValid()
+    {
+        List<Arguments> args = new ArrayList<>();
+
+        // Examples taken from:
+        // - https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.7
+        // - RFC 6265
+        // - issue discussions
+        // - curl results from major players like cloudflare
+
+        // Preferred RFC 1123 syntax
+        args.add(Arguments.of("Wed, 09 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+        args.add(Arguments.of("Sun, 06 Nov 1994 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Tue, 16 Apr 2024 17:28:27 GMT", "2024/04/16 17:28:27 GMT"));
+        args.add(Arguments.of("Thu,  2 Nov 2017 13:37:22 GMT", "2017/11/02 13:37:22 GMT"));
+
+        // Obsolete RFC 850 syntax
+        args.add(Arguments.of("Tue, 10-May-22 21:23:37 GMT", "2022/05/10 21:23:37 GMT"));
+        args.add(Arguments.of("Sun, 03-May-20 18:54:31 GMT", "2020/05/03 18:54:31 GMT"));
+        args.add(Arguments.of("Tue, 16-Apr-24 17:28:27 GMT", "2024/04/16 17:28:27 GMT"));
+        args.add(Arguments.of("Sunday, 06-Nov-94 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Sun, 06-Nov-94 08:49:37 GMT", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Mon, 05-May-2014 13:13:45 GMT", "2014/05/05 13:13:45 GMT"));
+        args.add(Arguments.of("Thu, 02-May-2013 13:14:16 GMT", "2013/05/02 13:14:16 GMT"));
+
+        // Obsolete ANSI C's asctime() format
+        args.add(Arguments.of("Sun Nov  6 08:49:37 1994", "1994/11/06 08:49:37 GMT"));
+        args.add(Arguments.of("Tue Apr 16 09:59:47 0000", "2000/04/16 09:59:47 GMT"));
+        args.add(Arguments.of("Tue Apr 16 09:59:47 00", "2000/04/16 09:59:47 GMT"));
+
+        // Unusual formats seen elsewhere
+        // RFC 1123 syntax with single digit day
+        args.add(Arguments.of("Wed, 9 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+        // RFC 850 with single digit day
+        args.add(Arguments.of("Sun, 3-May-20 18:54:31 GMT", "2020/05/03 18:54:31 GMT"));
+        // unix epoch (and zero time)
+        args.add(Arguments.of("Thu, 01 Jan 1970 00:00:00 GMT", "1970/01/01 00:00:00 GMT"));
+        // seemingly invalid day (looks negative, but it isn't, as '-' is a delimiter per spec)
+        args.add(Arguments.of("Thu, -2 Nov 2017 13:37:22 GMT", "2017/11/02 13:37:22 GMT"));
+        // year zero (which is a valid year, assumed to be the year 2000 per spec)
+        args.add(Arguments.of("Thu, 22 Nov 0000 23:45:12 GMT", "2000/11/22 23:45:12 GMT"));
+        args.add(Arguments.of("Sun, 03-May-00 18:54:31 GMT", "2000/05/03 18:54:31 GMT"));
+        // unexpected timezone (the timezone is ignored per spec)
+        args.add(Arguments.of("Sun, 06 Nov 1994 08:49:37 PST", "1994/11/06 08:49:37 GMT"));
+        // long weekday (weekday is ignored per spec)
+        args.add(Arguments.of("Wednesday, 09 Jun 2021 10:18:14 GMT", "2021/06/09 10:18:14 GMT"));
+
+        return args.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateTimeValid")
+    public void testParseValid(String input, String expected)
+    {
+        Instant actual = HttpDateTime.parse(input);
+        DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();
+        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual.atZone(ZoneId.of("GMT")));
+        assertEquals(expected, actualStr);
+    }
+
+    public static Stream<Arguments> dateTimeInvalid()
+    {
+        List<Arguments> args = new ArrayList<>();
+
+        // Preferred RFC 1123 syntax
+        // - invalid Year
+        args.add(Arguments.of("Sun, 06 Nov 65535 08:49:37 GMT", "Missing [year]"));
+        args.add(Arguments.of("Wed, 09 Jun -123 10:18:14 GMT", "Missing [year]"));
+        // - no year
+        args.add(Arguments.of("Wed, 09 Jun 10:18:14 GMT", "Missing [year]"));
+
+        // - invalid day
+        args.add(Arguments.of("Tue, 00 Apr 2024 17:28:27 GMT", "Invalid [day]"));
+        // - no day
+        args.add(Arguments.of("Thu, Nov 2017 13:37:22 GMT", "Missing [day]"));
+        // - single digit hour
+        args.add(Arguments.of("Wed, 09 Jun 2021 2:18:14 GMT", "Missing [time]"));
+
+        // - no time
+        args.add(Arguments.of("Thu, 01 Jan 1970 GMT", "Missing [time]"));
+
+        // Obsolete RFC 850 syntax
+        // - invalid year
+        args.add(Arguments.of("Sun, 03-May-65535 18:54:31 GMT", "Missing [year]"));
+        // - no year
+        args.add(Arguments.of("Tue, 16-Apr- 17:28:27 GMT", "Missing [year]"));
+        // - invalid day
+        args.add(Arguments.of("Sunday, 00-Nov-94 08:49:37 GMT", "Invalid [day]"));
+        // - single digit hour
+        args.add(Arguments.of("Sunday, 01-Nov-94 8:49:37 GMT", "Missing [time]"));
+
+        // - no day (the '94' is parsed as day as its the first 2 digit number in the string)
+        args.add(Arguments.of("Sun, Nov-94 08:49:37 GMT", "Missing [year]"));
+
+        // - no time
+        args.add(Arguments.of("Mon, 05-May-2014 GMT", "Missing [time]"));
+        // - bad time (no seconds) - will not find time
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 GMT", "Missing [time]"));
+        // - bad time (am/pm) - will not find time, and will not understand the AM/PM
+        args.add(Arguments.of("Thu, 02-May-2013 13:14 PM GMT", "Missing [time]"));
+
+        // Obsolete ANSI C's asctime() format
+        // - invalid year
+        args.add(Arguments.of("Sun Nov  6 08:49:37 65535", "Missing [year]"));
+
+        // Horribly bad Date/Time formats
+        args.add(Arguments.of("3%~", "Missing [month]"));
+        args.add(Arguments.of("3%~ GMT", "Missing [month]"));
+
+        return args.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateTimeInvalid")
+    public void testParseInvalid(String input, String expectedMsg)
+    {
+        IllegalArgumentException syntaxException = assertThrows(
+            IllegalArgumentException.class, () -> HttpDateTime.parse(input)
+        );
+        assertThat(syntaxException.getMessage(), containsString(expectedMsg));
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateTimeInvalid")
+    public void testParseToEpochInvalid(String input, String expectedMsg)
+    {
+        assertThat(HttpDateTime.parseToEpoch(input), is(-1L));
+    }
+}

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -111,6 +111,7 @@ public class HttpDateTimeTest
 
         // - invalid day
         args.add(Arguments.of("Tue, 00 Apr 2024 17:28:27 GMT", "Invalid [day]"));
+        args.add(Arguments.of("Tue, 31 Feb 2020 17:28:27 GMT", "Invalid date/time"));
         // - long form month
         args.add(Arguments.of("Wed, 22 August 1984 01:02:03 GMT", "Missing [month]"));
         // - no day

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.http.ByteRange;
 import org.eclipse.jetty.http.CompressedContentFormat;
-import org.eclipse.jetty.http.DateParser;
 import org.eclipse.jetty.http.EtagUtils;
+import org.eclipse.jetty.http.HttpDateTime;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -372,7 +372,8 @@ public class ResourceService
                     return true;
                 }
 
-                long ifmsl = DateParser.parseDate(ifms);
+                // TODO: what should we do when we get a crappy date?
+                long ifmsl = HttpDateTime.parseToEpoch(ifms);
                 if (ifmsl != -1)
                 {
                     long lm = content.getResource().lastModified().toEpochMilli();
@@ -387,7 +388,8 @@ public class ResourceService
             // Parse the if[un]modified dates and compare to resource
             if (ifums != null && ifm == null)
             {
-                long ifumsl = DateParser.parseDate(ifums);
+                // TODO: what should we do when we get a crappy date?
+                long ifumsl = HttpDateTime.parseToEpoch(ifums);
                 if (ifumsl != -1)
                 {
                     long lm = content.getResource().lastModified().toEpochMilli();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -40,8 +40,8 @@ import org.eclipse.jetty.ee9.nested.resource.HttpContentRangeWriter;
 import org.eclipse.jetty.ee9.nested.resource.RangeWriter;
 import org.eclipse.jetty.ee9.nested.resource.SeekableByteChannelRangeWriter;
 import org.eclipse.jetty.http.CompressedContentFormat;
-import org.eclipse.jetty.http.DateParser;
 import org.eclipse.jetty.http.EtagUtils;
+import org.eclipse.jetty.http.HttpDateTime;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -616,7 +616,8 @@ public class ResourceService
                     return false;
                 }
 
-                long ifmsl = DateParser.parseDate(ifms);
+                // TODO: what should we do when we get a crappy date?
+                long ifmsl = HttpDateTime.parseToEpoch(ifms);
                 if (ifmsl != -1)
                 {
                     long lm = content.getResource().lastModified().toEpochMilli();
@@ -631,7 +632,8 @@ public class ResourceService
             // Parse the if[un]modified dates and compare to resource
             if (ifums != null && ifm == null)
             {
-                long ifumsl = DateParser.parseDate(ifums);
+                // TODO: what should we do when we get a crappy date?
+                long ifumsl = HttpDateTime.parseToEpoch(ifums);
                 if (ifumsl != -1)
                 {
                     long lm = content.getResource().lastModified().toEpochMilli();

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpDateTimeParseBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpDateTimeParseBenchmark.java
@@ -74,7 +74,7 @@ public class HttpDateTimeParseBenchmark
 
     @Benchmark
     @BenchmarkMode({Mode.Throughput})
-    public Instant testParseNew()
+    public ZonedDateTime testParseNew()
     {
         int entry = ThreadLocalRandom.current().nextInt(size);
         return HttpDateTime.parse(expires[entry]);

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpDateTimeParseBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/http/jmh/HttpDateTimeParseBenchmark.java
@@ -1,0 +1,98 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http.jmh;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.DateParser;
+import org.eclipse.jetty.http.HttpDateTime;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Threads(4)
+@Warmup(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+public class HttpDateTimeParseBenchmark
+{
+    String[] expires;
+    int size;
+
+    @Setup
+    public void prepare()
+    {
+        size = 40;
+        expires = new String[size];
+
+        long startTime = ZonedDateTime.parse("Mon, 01 Jan 1900 01:00:00 GMT", DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond();
+        long endTime = ZonedDateTime.parse("Fri, 31 Dec 2100 23:59:59 GMT", DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond();
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        ZoneId zoneGMT = ZoneId.of("GMT");
+
+        for (int i = 0; i < size; i++)
+        {
+            long randomTime = random.nextLong(startTime, endTime);
+            expires[i] = Instant.ofEpochSecond(randomTime).atZone(zoneGMT).format(DateTimeFormatter.RFC_1123_DATE_TIME);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public long testParseDateTimeOld()
+    {
+        int entry = ThreadLocalRandom.current().nextInt(size);
+        return DateParser.parseDate(expires[entry]);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.Throughput})
+    public Instant testParseNew()
+    {
+        int entry = ThreadLocalRandom.current().nextInt(size);
+        return HttpDateTime.parse(expires[entry]);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(HttpDateTimeParseBenchmark.class.getSimpleName())
+            .warmupIterations(10)
+            .measurementIterations(10)
+            // .addProfiler(GCProfiler.class)
+            .forks(1)
+            .threads(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}
+
+


### PR DESCRIPTION
+ Introduces HTTP (and Cookie) Date/Time parsing according to spec algorithms.
+ Introduces formatting according to spec mandated preferred RFC 1123 format.
+ Deprecate DateParser

This an alternative implementation for PR #11658

Fixes: #11648