### PR TITLE
Fix Maven warning about missing duplicate-finder-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1904,6 +1904,11 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <version>2.0.0</version>
+      </plugin>
       <!-- Build helper maven plugin sets the parsedVersion.osgiVersion property -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -2329,7 +2334,6 @@
           <plugin>
             <groupId>org.basepom.maven</groupId>
             <artifactId>duplicate-finder-maven-plugin</artifactId>
-            <version>2.0.0</version>
             <executions>
               <execution>
                 <id>default</id>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
