### PR TITLE
Fix `HttpFields.Mutable.Wrapper.computeField()`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1386,7 +1386,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         default Mutable computeField(HttpHeader header, BiFunction<HttpHeader, List<HttpField>, HttpField> computeFn)
         {
             Objects.requireNonNull(header);
-            HttpField result = computeFn.apply(header, stream().filter(f -> f.getHeader() == header).collect(Collectors.toList()));
+            HttpField result = computeFn.apply(header, stream().filter(f -> f.getHeader() == header).toList());
             return result != null ? put(result) : remove(header);
         }
 
@@ -1401,7 +1401,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         default Mutable computeField(String name, BiFunction<String, List<HttpField>, HttpField> computeFn)
         {
             Objects.requireNonNull(name);
-            HttpField result = computeFn.apply(name, stream().filter(f -> f.is(name)).collect(Collectors.toList()));
+            HttpField result = computeFn.apply(name, stream().filter(f -> f.is(name)).toList());
             return result != null ? put(result) : remove(name);
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -898,8 +898,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, String value)
         {
-            if (value == null)
-                throw new IllegalArgumentException("null value");
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(value);
             return add(new HttpField(name, value));
         }
 
@@ -914,6 +914,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, long value)
         {
+            Objects.requireNonNull(name);
             return add(new HttpField.LongValueHttpField(name, value));
         }
 
@@ -928,6 +929,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(HttpHeader header, HttpHeaderValue value)
         {
+            Objects.requireNonNull(header);
+            Objects.requireNonNull(value);
             return add(header, value.toString());
         }
 
@@ -942,8 +945,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(HttpHeader header, String value)
         {
-            if (value == null)
-                throw new IllegalArgumentException("null value");
+            Objects.requireNonNull(header);
+            Objects.requireNonNull(value);
             return add(new HttpField(header, value));
         }
 
@@ -958,6 +961,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(HttpHeader header, long value)
         {
+            Objects.requireNonNull(header);
             return add(new HttpField.LongValueHttpField(header, value));
         }
 
@@ -969,6 +973,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(HttpField field)
         {
+            Objects.requireNonNull(field);
             ListIterator<HttpField> i = listIterator(size());
             i.add(field);
             return this;
@@ -1024,6 +1029,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable addCSV(HttpHeader header, String... values)
         {
+            Objects.requireNonNull(header);
             QuotedCSV existing = null;
             for (HttpField f : this)
             {
@@ -1051,6 +1057,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable addCSV(String name, String... values)
         {
+            Objects.requireNonNull(name);
             QuotedCSV existing = null;
             for (HttpField f : this)
             {
@@ -1078,6 +1085,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable addDateField(String name, long date)
         {
+            Objects.requireNonNull(name);
             add(name, DateGenerator.formatDate(date));
             return this;
         }
@@ -1107,6 +1115,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default void ensureField(HttpField field)
         {
+            Objects.requireNonNull(field);
             HttpHeader header = field.getHeader();
             // Is the field value multi valued?
             if (field.getValue().indexOf(',') < 0)
@@ -1138,6 +1147,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(HttpField field)
         {
+            Objects.requireNonNull(field);
             boolean put = false;
             ListIterator<HttpField> i = listIterator();
             while (i.hasNext())
@@ -1172,6 +1182,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(String name, String value)
         {
+            Objects.requireNonNull(name);
             if (value == null)
                 return remove(name);
             return put(new HttpField(name, value));
@@ -1188,6 +1199,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(HttpHeader header, HttpHeaderValue value)
         {
+            Objects.requireNonNull(header);
             if (value == null)
                 return remove(header);
             return put(new HttpField(header, value.toString()));
@@ -1204,6 +1216,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(HttpHeader header, String value)
         {
+            Objects.requireNonNull(header);
             if (value == null)
                 return remove(header);
             return put(new HttpField(header, value));
@@ -1243,6 +1256,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable putDate(HttpHeader name, long date)
         {
+            Objects.requireNonNull(name);
             return put(name, DateGenerator.formatDate(date));
         }
 
@@ -1258,6 +1272,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable putDate(String name, long date)
         {
+            Objects.requireNonNull(name);
             return put(name, DateGenerator.formatDate(date));
         }
 
@@ -1271,6 +1286,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(HttpHeader header, long value)
         {
+            Objects.requireNonNull(header);
             if (value == 0 && header == HttpHeader.CONTENT_LENGTH)
                 return put(HttpFields.CONTENT_LENGTH_0);
             return put(new HttpField.LongValueHttpField(header, value));
@@ -1286,6 +1302,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable put(String name, long value)
         {
+            Objects.requireNonNull(name);
             if (value == 0 && HttpHeader.CONTENT_LENGTH.is(name))
                 return put(HttpFields.CONTENT_LENGTH_0);
             return put(new HttpField.LongValueHttpField(name, value));
@@ -1369,7 +1386,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable computeField(HttpHeader header, BiFunction<HttpHeader, List<HttpField>, HttpField> computeFn)
         {
-            return put(computeFn.apply(header, stream().filter(f -> f.getHeader() == header).collect(Collectors.toList())));
+            Objects.requireNonNull(header);
+            HttpField result = computeFn.apply(header, stream().filter(f -> f.getHeader() == header).collect(Collectors.toList()));
+            return result != null ? put(result) : remove(header);
         }
 
         /**
@@ -1382,7 +1401,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable computeField(String name, BiFunction<String, List<HttpField>, HttpField> computeFn)
         {
-            return put(computeFn.apply(name, stream().filter(f -> f.is(name)).collect(Collectors.toList())));
+            Objects.requireNonNull(name);
+            HttpField result = computeFn.apply(name, stream().filter(f -> f.is(name)).collect(Collectors.toList()));
+            return result != null ? put(result) : remove(name);
         }
 
         /**
@@ -1393,6 +1414,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable remove(HttpHeader header)
         {
+            Objects.requireNonNull(header);
             Iterator<HttpField> i = iterator();
             while (i.hasNext())
             {
@@ -1430,6 +1452,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable remove(String name)
         {
+            Objects.requireNonNull(name);
             for (ListIterator<HttpField> i = listIterator(); i.hasNext(); )
             {
                 HttpField f = i.next();
@@ -1658,6 +1681,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
             @Override
             public Mutable put(HttpField field)
             {
+                Objects.requireNonNull(field);
                 // rewrite put to ensure that removes are called before replace
                 int put = -1;
                 ListIterator<HttpField> i = _fields.listIterator();
@@ -1677,7 +1701,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
                 {
                     field = onAddField(field);
                     if (field != null)
-                        add(field);
+                        _fields.add(field);
                 }
                 else
                 {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1005,8 +1005,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         default Mutable add(String name, List<String> list)
         {
             Objects.requireNonNull(name);
-            if (list == null)
-                throw new IllegalArgumentException("null list");
+            Objects.requireNonNull(list);
             if (list.isEmpty())
                 return this;
             if (list.size() == 1)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1004,7 +1004,7 @@ public class HttpFieldsTest
     public void testAddNullValueList()
     {
         HttpFields.Mutable fields = HttpFields.build();
-        assertThrows(IllegalArgumentException.class, () -> fields.add("name", (List<String>)null));
+        assertThrows(NullPointerException.class, () -> fields.add("name", (List<String>)null));
         assertThat(fields.size(), is(0));
         List<String> list = new ArrayList<>();
         fields.add("name", list);

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1374,4 +1374,56 @@ public class HttpFieldsTest
         fields.ensureField(new HttpField("Test", "three, four"));
         assertThat(fields.stream().map(HttpField::toString).collect(Collectors.toList()), contains("Test: one, two, three, four"));
     }
+
+    @Test
+    public void testWrapperComputeFieldCallingOnField()
+    {
+        var wrapper = new HttpFields.Mutable.Wrapper(HttpFields.build())
+        {
+            final List<String> actions = new ArrayList<>();
+
+            @Override
+            public HttpField onAddField(HttpField field)
+            {
+                actions.add("onAddField");
+                return super.onAddField(field);
+            }
+
+            @Override
+            public boolean onRemoveField(HttpField field)
+            {
+                actions.add("onRemoveField");
+                return super.onRemoveField(field);
+            }
+
+            @Override
+            public HttpField onReplaceField(HttpField oldField, HttpField newField)
+            {
+                actions.add("onReplaceField");
+                return super.onReplaceField(oldField, newField);
+            }
+        };
+
+        wrapper.computeField("non-existent", (name, httpFields) -> null);
+        assertThat(wrapper.size(), is(0));
+        assertThat(wrapper.actions, is(List.of()));
+
+        wrapper.computeField("non-existent", (name, httpFields) -> new HttpField("non-existent", "a"));
+        wrapper.computeField("non-existent", (name, httpFields) -> new HttpField("non-existent", "b"));
+        wrapper.computeField("non-existent", (name, httpFields) -> null);
+        assertThat(wrapper.size(), is(0));
+        assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField", "onRemoveField")));
+        wrapper.actions.clear();
+
+        wrapper.computeField(HttpHeader.VARY, (name, httpFields) -> null);
+        assertThat(wrapper.size(), is(0));
+        assertThat(wrapper.actions, is(List.of()));
+
+        wrapper.computeField(HttpHeader.VARY, (name, httpFields) -> new HttpField(HttpHeader.VARY, "a"));
+        wrapper.computeField(HttpHeader.VARY, (name, httpFields) -> new HttpField(HttpHeader.VARY, "b"));
+        wrapper.computeField(HttpHeader.VARY, (name, httpFields) -> null);
+        assertThat(wrapper.size(), is(0));
+        assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField", "onRemoveField")));
+        wrapper.actions.clear();
+    }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
@@ -99,8 +99,8 @@ public class HttpGeneratorClientTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Host", "something");
-        assertThrows(IllegalArgumentException.class, () -> fields.add("Null", (String)null));
-        assertThrows(IllegalArgumentException.class, () -> fields.add("Null", (List<String>)null));
+        assertThrows(NullPointerException.class, () -> fields.add("Null", (String)null));
+        assertThrows(NullPointerException.class, () -> fields.add("Null", (List<String>)null));
         fields.add("Empty", "");
         RequestInfo info = new RequestInfo("GET", "/index.html", fields);
         assertFalse(gen.isChunking());


### PR DESCRIPTION
Make `HttpFields.Mutable.Wrapper.computeField()` call `onRemoveField()` and remove the field when null is returned by `computeFn`.

Also add a bunch of null checks.

Fixes #11687