### PR TITLE
Issue #11694 - Extra logging for demand pending issue

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -952,7 +952,10 @@ public class HttpChannelState implements HttpChannel, Components
                 if (!error)
                 {
                     if (httpChannelState._onContentAvailable != null)
+                    {
+                        LOG.warn("demand pending state={} stream={}", httpChannelState, stream);
                         throw new IllegalArgumentException("demand pending");
+                    }
                     httpChannelState._onContentAvailable = demandCallback;
 
                     if (httpChannelState._expects100Continue && httpChannelState._response._writeCallback == null)


### PR DESCRIPTION
Just some extra logging when "demand pending" situation occurs.
Hopefully it will reveal something useful about the state / stream when the issue occurs.