### PR TITLE
Issue #11699 - ISE when Response does not exist.

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -279,7 +279,9 @@ public class ServletChannel
     public ServletContextResponse getServletContextResponse()
     {
         ServletContextRequest request = _servletContextRequest;
-        return request == null ? null : request.getServletContextResponse();
+        if (_servletContextRequest == null)
+            throw new IllegalStateException("Request/Response does not exist (likely recycled)");
+        return request.getServletContextResponse();
     }
 
     /**
@@ -291,6 +293,8 @@ public class ServletChannel
      */
     public Response getResponse()
     {
+        if (_response == null)
+            throw new IllegalStateException("Response does not exist (likely recycled)");
         return _response;
     }
 


### PR DESCRIPTION
Give a more clear Exception for applications and libraries that are doing improper things with request / response lifecycle.

Fixes: #11699