### PR TITLE
Add method to get the defaultServlet MappedResource from ServletHandler

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java
@@ -263,6 +263,14 @@ public class PathMappings<E> extends AbstractMap<PathSpec, E> implements Iterabl
     }
 
     /**
+     * @return The {@link MappedResource} of the default servlet, or null if it is not set.
+     */
+    public MappedResource<E> getDefault()
+    {
+        return _servletDefault;
+    }
+
+    /**
      * <p>Find the best single match for a path.</p>
      * <p>The match may be found by optimized direct lookups when possible, otherwise all mappings
      * are iterated over and the first match returned</p>

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -478,7 +478,7 @@ public class ServletHandler extends Handler.Wrapper
      */
     public MatchedResource<MappedServlet> getMatchedServlet(String target)
     {
-        if (target.startsWith("/") || target.length() == 0)
+        if (target.startsWith("/") || target.isEmpty())
         {
             if (_servletPathMap == null)
                 return null;
@@ -489,6 +489,18 @@ public class ServletHandler extends Handler.Wrapper
         if (holder == null)
             return null;
         return new MatchedResource<>(holder, null, MatchedPath.EMPTY);
+    }
+
+    /**
+     * ServletHolder for the default servlet.
+     *
+     * @return MatchedResource, pointing to the {@link MappedResource} for the {@link ServletHolder}.
+     */
+    public MappedResource<MappedServlet> getDefaultServlet()
+    {
+        if (_servletPathMap == null)
+            return null;
+        return _servletPathMap.getDefault();
     }
 
     /**


### PR DESCRIPTION
This is needed to improve the way we find the servlet mapped to the default mapping in appengine:
https://github.com/GoogleCloudPlatform/appengine-java-standard/blob/97f644a3b5a3edfccb06e58f7401e047b6d28c48/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/ResourceFileServlet.java#L259

Currently it does `handler.getMappedServlet("/")` which will actually return the servlet from a context root mapping so is incorrect.