### PR TITLE
Fix `IllegalArgumentException: demand pending`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
@@ -271,6 +271,9 @@ class AsyncContentProducer implements ContentProducer
         return _servletChannel.getServletRequestState().isInputUnready();
     }
 
+    /**
+     * Never returns an empty chunk that isn't a failure and/or last.
+     */
     private Content.Chunk produceChunk()
     {
         if (LOG.isDebugEnabled())

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ContentProducer.java
@@ -94,7 +94,7 @@ public interface ContentProducer
      * After this call, state can be either of UNREADY or IDLE.
      *
      * @return the next content chunk that can be read from or null if the implementation does not block
-     * and has no available content.
+     * and has no available content. The returned chunk can be empty IFF it is a failure and/or last.
      */
     Content.Chunk nextChunk();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
@@ -188,7 +188,7 @@ public class HttpInput extends ServletInputStream implements Runnable
             LOG.debug("setting read listener to {} {}", readListener, this);
         if (_readListener != null)
             throw new IllegalStateException("ReadListener already set");
-        //illegal if async not started
+        // illegal if async not started
         if (!_channelState.isAsyncStarted())
             throw new IllegalStateException("Async not started");
         _readListener = Objects.requireNonNull(readListener);
@@ -244,6 +244,8 @@ public class HttpInput extends ServletInputStream implements Runnable
             Content.Chunk chunk = _contentProducer.nextChunk();
             if (chunk == null)
                 throw new IllegalStateException("read on unready input");
+
+            // Is it not empty?
             if (chunk.hasRemaining())
             {
                 int read = buffer == null ? get(chunk, b, off, len) : get(chunk, buffer);
@@ -254,6 +256,7 @@ public class HttpInput extends ServletInputStream implements Runnable
                 return read;
             }
 
+            // Is it a failure?
             if (Content.Chunk.isFailure(chunk))
             {
                 Throwable failure = chunk.getFailure();
@@ -264,10 +267,11 @@ public class HttpInput extends ServletInputStream implements Runnable
                 throw new IOException(failure);
             }
 
+            // Empty and not a failure; can only be EOF as per ContentProducer.nextChunk() contract.
             if (LOG.isDebugEnabled())
                 LOG.debug("read at EOF, setting consumed EOF to true {}", this);
             _consumedEof = true;
-            // If EOF do we need to wake for allDataRead callback?
+            // Do we need to wake for allDataRead callback?
             if (onContentProducible())
                 scheduleReadListenerNotification();
             return -1;
@@ -276,6 +280,8 @@ public class HttpInput extends ServletInputStream implements Runnable
 
     private void scheduleReadListenerNotification()
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("scheduling ReadListener notification {}", this);
         _servletChannel.execute(_servletChannel::handle);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
@@ -195,7 +195,7 @@ public class HttpInput extends ServletInputStream implements Runnable
 
         _contentProducer = _asyncContentProducer;
         // trigger content production
-        if (isReady() && _channelState.onReadEof()) // onReadEof b/c we want to transition from WAITING to WOKEN
+        if (isReady() && _channelState.onReadListenerReady()) // onReadListenerReady b/c we want to transition from WAITING to WOKEN
             scheduleReadListenerNotification(); // this is needed by AsyncServletIOTest.testStolenAsyncRead
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -388,9 +388,9 @@ public class ServletChannel
      */
     void recycle(Throwable x)
     {
-        _state.recycle();
         _httpInput.recycle();
         _httpOutput.recycle();
+        _state.recycle();
         _servletContextRequest = null;
         _request = null;
         _response = null;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -388,6 +388,7 @@ public class ServletChannel
      */
     void recycle(Throwable x)
     {
+        // _httpInput must be recycled before _state.
         _httpInput.recycle();
         _httpOutput.recycle();
         _state.recycle();

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -123,23 +123,29 @@ public class ServletChannelState
         /**
          * The 'default' state, when there is no pending demand nor a pending notification to the ReadListener.
          * There are 3 ways to transition to this state:
-         * <li>from IDLE: when an async read() is called without a preceding call to isReady()</li>
-         * <li>from READY: just before unhandle() returns Action.READ_CALLBACK to call read listener or
-         * when read() steals available content after setReadListener()</li>
-         * <li>from UNREADY: when a blocking read() got unblocked</li>
+         * <ul>
+         *  <li>from IDLE: when an async read() is called without a preceding call to isReady()</li>
+         *  <li>from READY: just before unhandle() returns Action.READ_CALLBACK to call read listener or
+         *  when read() steals available content after setReadListener()</li>
+         *  <li>from UNREADY: when a blocking read() got unblocked</li>
+         * </ul>
          */
         IDLE,
 
         /**
          * The 'demand registered' state. There is only 1 way to transition to this state:
-         * <li>from IDLE: when isReady() is called and there is no content available, so a demand is registered</li>
+         * <ul>
+         *  <li>from IDLE: when isReady() is called and there is no content available, so a demand is registered</li>
+         * </ul>
          */
         UNREADY,
 
         /**
          * The 'dispatch a notification to the ReadListener' state. There are 2 ways to transition to this state:
-         * <li>from IDLE: when setReadListener() is called while there is content available</li>
-         * <li>from UNREADY: when demand is serviced</li>
+         * <ul>
+         *  <li>from IDLE: when setReadListener() is called while there is content available</li>
+         *  <li>from UNREADY: when demand is serviced because content is now available</li>
+         * </ul>
          */
         READY
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.slf4j.Logger;
@@ -1059,7 +1060,7 @@ public class ServletChannelState
                 LOG.debug("completed {}", toStringLocked());
 
             if (_requestState != RequestState.COMPLETING)
-                throw new IllegalStateException(this.getStatusStringLocked());
+                failure = ExceptionUtil.combine(failure, new IllegalStateException(getStatusStringLocked()));
 
             if (failure != null)
                 abortResponse(failure);


### PR DESCRIPTION
Do not attempt to read from the underlying content source when there is a demand pending, i.e.: when inputState is unready, also cleanup and document the state machine.

Fixes https://github.com/jetty/jetty.project/issues/11694