### PR TITLE
Issue #11766 - null out ReadListener on recycle to aid GC.

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpInput.java
@@ -65,6 +65,7 @@ public class HttpInput extends ServletInputStream implements Runnable
                 LOG.debug("recycle {}", this);
             _blockingContentProducer.recycle();
             _contentProducer = _blockingContentProducer;
+            _readListener = null;
         }
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpInput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpInput.java
@@ -61,6 +61,7 @@ public class HttpInput extends ServletInputStream implements Runnable
             if (LOG.isDebugEnabled())
                 LOG.debug("recycle {}", this);
             _blockingContentProducer.recycle();
+            _readListener = null;
         }
     }
 


### PR DESCRIPTION
A simple null out of the field on recycle to aid in GC.

Fixes: #11766